### PR TITLE
Update Kubernetes sample manifests from Helm chart 3.208.1

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -14,7 +14,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.208.1"
+    chart: "datadog-3.208.2"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -126,8 +126,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "0f72b63a-1e98-442c-8be9-a15cbdb5523b"
-  install_time: "1778233437"
+  install_id: "d44b9966-a683-45a9-b14a-c3c8ca6744d4"
+  install_time: "1778483124"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -308,7 +308,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",
@@ -8291,7 +8290,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.208.1"
+    chart: "datadog-3.208.2"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -6,7 +14,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.96.0"
+    chart: "datadog-3.208.1"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -63,6 +71,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -80,6 +89,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -106,8 +126,7673 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "3fe7f430-6b38-4f92-ac42-6d6f84ac6a42"
-  install_time: "1740515776"
+  install_id: "0f72b63a-1e98-442c-8be9-a15cbdb5523b"
+  install_time: "1778233437"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: false\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "chmod",
+            "chown",
+            "clock_gettime",
+            "clone",
+            "clone3",
+            "close",
+            "close_range",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "faccessat",
+            "faccessat2",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "flock",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "futimens",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getgroups",
+            "getpeername",
+            "getpgrp",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "inotify_add_watch",
+            "inotify_init",
+            "inotify_init1",
+            "inotify_rm_watch",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "madvise",
+            "memfd_create",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "mremap",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "openat2",
+            "pause",
+            "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "pread64",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "renameat",
+            "renameat2",
+            "restart_syscall",
+            "rmdir",
+            "rseq",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setitimer",
+            "setns",
+            "setpgid",
+            "setresgid",
+            "setresuid",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "shutdown",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "statx",
+            "symlinkat",
+            "sysinfo",
+            "tgkill",
+            "tkill",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "utime",
+            "utimensat",
+            "utimes",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write",
+            "writev"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        },
+        {
+          "names": [
+            "kill"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "allow process detection via kill",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -205,6 +7890,7 @@ rules:
   - nonResourceURLs:
       - "/version"
       - "/healthz"
+      - "/metrics"
     verbs:
       - get
   - apiGroups: # to get the kube-system namespace UID and generate a cluster ID
@@ -319,6 +8005,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get"]
   - apiGroups:
       - "security.openshift.io"
     resources:
@@ -328,6 +8017,56 @@ rules:
     resourceNames:
       - datadog-cluster-agent
       - hostnetwork
+  - apiGroups:
+      - "policy"
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "datadoghq.com"
+      - eks.amazonaws.com
+      - karpenter.azure.com
+      - karpenter.k8s.aws
+      - karpenter.sh
+    resources:
+      - "*"
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - helmcharts
+      - externalartifacts
+      - gitrepositories
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+      - get
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -371,6 +8110,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -419,6 +8159,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -460,6 +8214,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "update", "create"]
 ---
 # Source: datadog/templates/dca-helm-values-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -534,7 +8291,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.96.0"
+    chart: "datadog-3.208.1"
     release: "datadog"
     heritage: "Helm"
 spec:
@@ -552,7 +8309,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -563,17 +8321,21 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       securityContext:
         runAsUser: 0
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -591,6 +8353,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -599,6 +8363,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -619,6 +8385,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -630,18 +8398,35 @@ spec:
                   key: token
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: "clusterchecks endpointschecks"
             - name: DD_IGNORE_AUTOCONF
@@ -654,12 +8439,20 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
             - name: DD_KUBELET_CLIENT_CA
               value: "/etc/kubernetes/certs/kubeletserver.crt"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
+              value: "true"
           volumeMounts:
             - name: logdatadog
               mountPath: /var/log/datadog
@@ -687,6 +8480,13 @@ spec:
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -698,6 +8498,8 @@ spec:
             - name: passwd
               mountPath: /etc/passwd
               readOnly: true
+            - name: datadogrun
+              mountPath: /opt/datadog-agent/run
             - mountPath: /etc/kubernetes/certs/
               name: kubeletserver
               readOnly: true
@@ -732,9 +8534,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
-          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["trace-loader", "/etc/datadog-agent/datadog.yaml", "trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8126
@@ -752,6 +8556,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -760,6 +8566,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -835,9 +8643,142 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: system-probe
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+                - CHOWN
+                - DAC_READ_SEARCH
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Localhost
+              localhostProfile: system-probe
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW for tmp directory to instantiate self tests
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              mountPropagation: None
+              readOnly: false # Need RW for kprobe_events
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: false # Need RW for sys-probe socket
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
+            - mountPath: /etc/kubernetes/certs/
+              name: kubeletserver
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -848,7 +8789,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -870,6 +8811,10 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -882,6 +8827,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -890,8 +8837,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
+          resources: {}
+        - name: seccomp-setup
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+              readOnly: true
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
+              readOnly: false # Need RW for seccomp-root
           resources: {}
       volumes:
         - name: auth-token
@@ -917,19 +8882,82 @@ spec:
             path: /etc/os-release
           name: os-release-file
         - hostPath:
-            path: /var/run/datadog/
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
+        - hostPath:
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: apmsocket
+        - name: sysprobe-config
+          configMap:
+            name: datadog-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: datadogrun
+          emptyDir: {}
         - hostPath:
             path: /etc/kubernetes/certs
           name: kubeletserver
@@ -943,13 +8971,102 @@ spec:
       maxUnavailable: 10%
     type: RollingUpdate
 ---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+---
 # Source: datadog/templates/cluster-agent-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: datadog-cluster-agent
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: cluster-agent
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -966,6 +9083,7 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
+        agent.datadoghq.com/component: cluster-agent
       name: datadog-cluster-agent
       annotations: {}
     spec:
@@ -973,7 +9091,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
+          image: "registry.datadoghq.com/cluster-agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -986,7 +9104,7 @@ spec:
               mountPath: /opt/datadog-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
+          image: "registry.datadoghq.com/cluster-agent:7.78.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -1018,6 +9136,8 @@ spec:
                   optional: true
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1028,6 +9148,14 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_TRACE_AGENT_HOST_SOCKET_PATH
+              value: "/var/run/datadog"
+            - name: DD_DOGSTATSD_HOST_SOCKET_PATH
+              value: "/var/run/datadog"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: "datadog-webhook"
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
@@ -1065,6 +9193,8 @@ spec:
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_KUBERNETES_USE_ENDPOINT_SLICES
+              value: "true"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_KUBERNETES_EVENTS_SOURCE_DETECTION_ENABLED
               value: "false"
@@ -1173,9 +9303,9 @@ spec:
             name: datadog-cluster-agent-confd
             items:
               - key: kubernetes_state_core.yaml.default
-                path: kubernetes_state_core.yaml.default
+                path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
-                path: kubernetes_apiserver.yaml
+                path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
         - name: config
           emptyDir: {}
       affinity:

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -143,7 +143,6 @@ data:
             "capset",
             "chdir",
             "chmod",
-            "chown",
             "clock_gettime",
             "clone",
             "clone3",
@@ -287,7 +286,6 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
-            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -309,8 +307,7 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write",
-            "writev"
+            "write"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -143,6 +143,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",
@@ -286,6 +287,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -307,7 +309,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -14,7 +14,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.208.1"
+    chart: "datadog-3.208.2"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -126,8 +126,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "3219ff4e-65bd-462c-87a8-dfa1c2610c51"
-  install_time: "1778233437"
+  install_id: "3ca21460-3a8e-49f8-984b-d6cbc2d1f223"
+  install_time: "1778483125"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -309,7 +309,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",
@@ -8321,7 +8320,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.208.1"
+    chart: "datadog-3.208.2"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -6,7 +14,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.96.0"
+    chart: "datadog-3.208.1"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -63,6 +71,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -80,6 +89,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -106,8 +126,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "045fe354-fdef-4db3-bef4-ac1d759ccdca"
-  install_time: "1740515776"
+  install_id: "3219ff4e-65bd-462c-87a8-dfa1c2610c51"
+  install_time: "1778233437"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -117,7 +137,7 @@ metadata:
   namespace: default
   labels: {}
 data:
-  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nruntime_security_config:\n  enabled: true\n  fim_enabled: false\n  use_secruntime_track: true\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: true \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n"
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: true\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: true \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: true\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -143,10 +163,12 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",
             "close",
+            "close_range",
             "connect",
             "copy_file_range",
             "creat",
@@ -214,6 +236,7 @@ data:
             "inotify_rm_watch",
             "ioctl",
             "ipc",
+            "kill",
             "listen",
             "lseek",
             "lstat",
@@ -234,6 +257,8 @@ data:
             "openat2",
             "pause",
             "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
             "pipe",
             "pipe2",
             "poll",
@@ -280,12 +305,15 @@ data:
             "setitimer",
             "setns",
             "setpgid",
+            "setresgid",
+            "setresuid",
             "setrlimit",
             "setsid",
             "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -297,6 +325,7 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
+            "tkill",
             "umask",
             "uname",
             "unlink",
@@ -307,7 +336,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null
@@ -347,6 +377,7423 @@ data:
         }
       ]
     }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -444,6 +7891,7 @@ rules:
   - nonResourceURLs:
       - "/version"
       - "/healthz"
+      - "/metrics"
     verbs:
       - get
   - apiGroups: # to get the kube-system namespace UID and generate a cluster ID
@@ -558,6 +8006,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get"]
   - apiGroups:
       - ""
     resources:
@@ -580,6 +8031,7 @@ rules:
       - rolebindings
     verbs:
       - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -595,6 +8047,56 @@ rules:
     resourceNames:
       - datadog-cluster-agent
       - hostnetwork
+  - apiGroups:
+      - "policy"
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "datadoghq.com"
+      - eks.amazonaws.com
+      - karpenter.azure.com
+      - karpenter.k8s.aws
+      - karpenter.sh
+    resources:
+      - "*"
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - helmcharts
+      - externalartifacts
+      - gitrepositories
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+      - get
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -638,6 +8140,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -686,6 +8189,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -727,6 +8244,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "update", "create"]
 ---
 # Source: datadog/templates/dca-helm-values-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -801,7 +8321,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.96.0"
+    chart: "datadog-3.208.1"
     release: "datadog"
     heritage: "Helm"
 spec:
@@ -819,7 +8339,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -830,6 +8351,7 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations:
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
@@ -839,9 +8361,11 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -859,6 +8383,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -867,6 +8393,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -887,6 +8415,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -898,6 +8428,27 @@ spec:
                   key: token
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -908,8 +8459,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: "clusterchecks endpointschecks"
             - name: DD_IGNORE_AUTOCONF
@@ -922,9 +8471,21 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+            - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -1018,9 +8579,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
-          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["trace-loader", "/etc/datadog-agent/datadog.yaml", "trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8126
@@ -1039,6 +8602,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1047,6 +8612,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -1120,9 +8687,11 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           env:
             - name: DD_API_KEY
@@ -1136,6 +8705,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1144,6 +8715,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -1187,7 +8760,7 @@ spec:
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
-              readOnly: false # Need RW for UDS DSD socket
+              readOnly: true # write access to /var/run/datadog is not needed because the process agent only writes to the socket file, not to the parent directory
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
@@ -1217,7 +8790,7 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1231,11 +8804,13 @@ spec:
                 - IPC_LOCK
                 - CHOWN
                 - DAC_READ_SEARCH
+                - KILL
             privileged: false
+            readOnlyRootFilesystem: true
             seccompProfile:
               type: Localhost
               localhostProfile: system-probe
-          command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -1248,6 +8823,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1256,10 +8833,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: HOST_ROOT
+              value: "/host/root"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "true"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
           resources: {}
           volumeMounts:
             - name: auth-token
@@ -1297,6 +8882,12 @@ spec:
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /etc/group
+              readOnly: true
             - name: os-release-file
               mountPath: /host/etc/os-release
               readOnly: true
@@ -1309,12 +8900,55 @@ spec:
             - name: etc-lsb-release
               mountPath: /host/etc/lsb-release
               readOnly: true
+            - name: hostroot
+              mountPath: /host/root
+              mountPropagation: None
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
-              add: ["AUDIT_CONTROL", "AUDIT_READ"]
+              add:
+                - AUDIT_CONTROL
+                - AUDIT_READ
+            readOnlyRootFilesystem: true
           command: ["security-agent", "start", "-c=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
@@ -1329,6 +8963,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1337,6 +8973,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -1410,14 +9048,14 @@ spec:
               readOnly: true
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
-              readOnly: true
+              readOnly: false
             - name: sysprobe-config
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -1428,7 +9066,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -1466,6 +9104,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1474,11 +9114,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -1529,11 +9171,11 @@ spec:
             path: /etc/system-release
           name: etc-system-release
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: apmsocket
         - name: sysprobe-config
@@ -1554,6 +9196,41 @@ spec:
         - name: sysprobe-socket-dir
           emptyDir: {}
         - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
+        - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
@@ -1566,9 +9243,6 @@ spec:
             path: /var/run
           name: runtimesocketdir
         - hostPath:
-            path: /var/lib/datadog-agent/logs
-          name: pointerdir
-        - hostPath:
             path: /var/log/pods
           name: logpodpath
         - hostPath:
@@ -1577,6 +9251,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/lib/datadog-agent/logs
+          name: pointerdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -1587,13 +9264,102 @@ spec:
       maxUnavailable: 10%
     type: RollingUpdate
 ---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+---
 # Source: datadog/templates/cluster-agent-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: datadog-cluster-agent
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: cluster-agent
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -1610,6 +9376,7 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
+        agent.datadoghq.com/component: cluster-agent
       name: datadog-cluster-agent
       annotations: {}
     spec:
@@ -1617,7 +9384,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
+          image: "registry.datadoghq.com/cluster-agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -1630,7 +9397,7 @@ spec:
               mountPath: /opt/datadog-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
+          image: "registry.datadoghq.com/cluster-agent:7.78.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -1662,6 +9429,8 @@ spec:
                   optional: true
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1672,6 +9441,14 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_TRACE_AGENT_HOST_SOCKET_PATH
+              value: "/var/run/datadog"
+            - name: DD_DOGSTATSD_HOST_SOCKET_PATH
+              value: "/var/run/datadog"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: "datadog-webhook"
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
@@ -1709,6 +9486,8 @@ spec:
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_KUBERNETES_USE_ENDPOINT_SLICES
+              value: "true"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_KUBERNETES_EVENTS_SOURCE_DETECTION_ENABLED
               value: "false"
@@ -1821,9 +9600,9 @@ spec:
             name: datadog-cluster-agent-confd
             items:
               - key: kubernetes_state_core.yaml.default
-                path: kubernetes_state_core.yaml.default
+                path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
-                path: kubernetes_apiserver.yaml
+                path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
         - name: config
           emptyDir: {}
       affinity:

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "c30a4b65-c61e-493c-ac27-e563fe6fa1d0"
-  install_time: "1778233438"
+  install_id: "8d5fca83-84a9-4edb-9030-ddcca03318ab"
+  install_time: "1778483125"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -284,7 +284,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7673 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "5453043f-e7d8-4312-9e2b-ae011a3f3569"
-  install_time: "1740515777"
+  install_id: "c30a4b65-c61e-493c-ac27-e563fe6fa1d0"
+  install_time: "1778233438"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: false\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "chmod",
+            "chown",
+            "clock_gettime",
+            "clone",
+            "clone3",
+            "close",
+            "close_range",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "faccessat",
+            "faccessat2",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "flock",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "futimens",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getgroups",
+            "getpeername",
+            "getpgrp",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "inotify_add_watch",
+            "inotify_init",
+            "inotify_init1",
+            "inotify_rm_watch",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "madvise",
+            "memfd_create",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "mremap",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "openat2",
+            "pause",
+            "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "pread64",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "renameat",
+            "renameat2",
+            "restart_syscall",
+            "rmdir",
+            "rseq",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setitimer",
+            "setns",
+            "setpgid",
+            "setresgid",
+            "setresuid",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "shutdown",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "statx",
+            "symlinkat",
+            "sysinfo",
+            "tgkill",
+            "tkill",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "utime",
+            "utimensat",
+            "utimes",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write",
+            "writev"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        },
+        {
+          "names": [
+            "kill"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "allow process detection via kill",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7812,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7861,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7896,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,17 +7908,21 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       securityContext:
         runAsUser: 0
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -235,6 +7940,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -243,6 +7950,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -263,6 +7972,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
@@ -271,18 +7982,35 @@ spec:
               value: "true"
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -293,9 +8021,17 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -324,6 +8060,13 @@ spec:
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -335,6 +8078,8 @@ spec:
             - name: passwd
               mountPath: /etc/passwd
               readOnly: true
+            - name: datadogrun
+              mountPath: /opt/datadog-agent/run
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -366,9 +8111,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
-          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["trace-loader", "/etc/datadog-agent/datadog.yaml", "trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8126
@@ -387,6 +8134,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -395,6 +8144,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -460,9 +8211,139 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: system-probe
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+                - CHOWN
+                - DAC_READ_SEARCH
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Localhost
+              localhostProfile: system-probe
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW for tmp directory to instantiate self tests
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              mountPropagation: None
+              readOnly: false # Need RW for kprobe_events
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: false # Need RW for sys-probe socket
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -473,7 +8354,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -495,6 +8376,10 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -507,6 +8392,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -515,12 +8402,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
               value: "configmap"
+          resources: {}
+        - name: seccomp-setup
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+              readOnly: true
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
+              readOnly: false # Need RW for seccomp-root
           resources: {}
       volumes:
         - name: auth-token
@@ -546,19 +8451,82 @@ spec:
             path: /etc/os-release
           name: os-release-file
         - hostPath:
-            path: /var/run/datadog/
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
+        - hostPath:
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: apmsocket
+        - name: sysprobe-config
+          configMap:
+            name: datadog-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: datadogrun
+          emptyDir: {}
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -568,3 +8536,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "315aecca-d7a4-4d46-ace6-10e4c60076d7"
-  install_time: "1778233438"
+  install_id: "a415b2ab-106f-4db7-b786-de010de61d4e"
+  install_time: "1778483126"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -284,7 +284,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7673 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "001fca2f-aa79-476c-b47e-337e97077883"
-  install_time: "1740515777"
+  install_id: "315aecca-d7a4-4d46-ace6-10e4c60076d7"
+  install_time: "1778233438"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: false\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "chmod",
+            "chown",
+            "clock_gettime",
+            "clone",
+            "clone3",
+            "close",
+            "close_range",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "faccessat",
+            "faccessat2",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "flock",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "futimens",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getgroups",
+            "getpeername",
+            "getpgrp",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "inotify_add_watch",
+            "inotify_init",
+            "inotify_init1",
+            "inotify_rm_watch",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "madvise",
+            "memfd_create",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "mremap",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "openat2",
+            "pause",
+            "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "pread64",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "renameat",
+            "renameat2",
+            "restart_syscall",
+            "rmdir",
+            "rseq",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setitimer",
+            "setns",
+            "setpgid",
+            "setresgid",
+            "setresuid",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "shutdown",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "statx",
+            "symlinkat",
+            "sysinfo",
+            "tgkill",
+            "tkill",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "utime",
+            "utimensat",
+            "utimes",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write",
+            "writev"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        },
+        {
+          "names": [
+            "kill"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "allow process detection via kill",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7812,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7861,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7896,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,17 +7908,21 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       securityContext:
         runAsUser: 0
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -235,6 +7940,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -243,6 +7950,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -263,6 +7972,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
@@ -271,6 +7982,27 @@ spec:
               value: "true"
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: "/var/run/datadog/apm.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -281,8 +8013,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -293,9 +8023,17 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -324,6 +8062,13 @@ spec:
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -382,9 +8127,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
-          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["trace-loader", "/etc/datadog-agent/datadog.yaml", "trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8126
@@ -403,6 +8150,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -411,6 +8160,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -476,9 +8227,139 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: system-probe
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+                - CHOWN
+                - DAC_READ_SEARCH
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Localhost
+              localhostProfile: system-probe
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW for tmp directory to instantiate self tests
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              mountPropagation: None
+              readOnly: false # Need RW for kprobe_events
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: false # Need RW for sys-probe socket
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -489,7 +8370,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -511,6 +8392,10 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -523,6 +8408,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -531,12 +8418,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
               value: "configmap"
+          resources: {}
+        - name: seccomp-setup
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+              readOnly: true
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
+              readOnly: false # Need RW for seccomp-root
           resources: {}
       volumes:
         - name: auth-token
@@ -562,22 +8467,80 @@ spec:
             path: /etc/os-release
           name: os-release-file
         - hostPath:
-            path: /var/run/datadog/
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
+        - hostPath:
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: apmsocket
+        - name: sysprobe-config
+          configMap:
+            name: datadog-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
-        - hostPath:
-            path: /var/lib/datadog-agent/logs
-          name: pointerdir
         - hostPath:
             path: /var/log/pods
           name: logpodpath
@@ -587,6 +8550,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/lib/datadog-agent/logs
+          name: pointerdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -596,3 +8562,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7673 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "075a8321-fd51-4d87-a713-09bcd6f5d772"
-  install_time: "1740515777"
+  install_id: "6b0298b8-5b19-4619-a9d9-eb7cc96f84d0"
+  install_time: "1778233438"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: false\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "chmod",
+            "chown",
+            "clock_gettime",
+            "clone",
+            "clone3",
+            "close",
+            "close_range",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "faccessat",
+            "faccessat2",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "flock",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "futimens",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getgroups",
+            "getpeername",
+            "getpgrp",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "inotify_add_watch",
+            "inotify_init",
+            "inotify_init1",
+            "inotify_rm_watch",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "madvise",
+            "memfd_create",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "mremap",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "openat2",
+            "pause",
+            "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "pread64",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "renameat",
+            "renameat2",
+            "restart_syscall",
+            "rmdir",
+            "rseq",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setitimer",
+            "setns",
+            "setpgid",
+            "setresgid",
+            "setresuid",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "shutdown",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "statx",
+            "symlinkat",
+            "sysinfo",
+            "tgkill",
+            "tkill",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "utime",
+            "utimensat",
+            "utimes",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write",
+            "writev"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        },
+        {
+          "names": [
+            "kill"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "allow process detection via kill",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7812,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7861,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7896,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,17 +7908,21 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       securityContext:
         runAsUser: 0
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -235,6 +7940,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -243,6 +7950,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -263,6 +7972,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
@@ -281,8 +7992,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -293,9 +8002,17 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -324,6 +8041,13 @@ spec:
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -381,9 +8105,139 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+        - name: system-probe
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+                - CHOWN
+                - DAC_READ_SEARCH
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Localhost
+              localhostProfile: system-probe
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW for tmp directory to instantiate self tests
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              mountPropagation: None
+              readOnly: false # Need RW for kprobe_events
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: false # Need RW for sys-probe socket
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -394,7 +8248,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -416,6 +8270,10 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -428,6 +8286,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -436,12 +8296,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
               value: "configmap"
+          resources: {}
+        - name: seccomp-setup
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+              readOnly: true
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
+              readOnly: false # Need RW for seccomp-root
           resources: {}
       volumes:
         - name: auth-token
@@ -467,18 +8345,76 @@ spec:
             path: /etc/os-release
           name: os-release-file
         - hostPath:
-            path: /var/run/datadog/
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
+        - hostPath:
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
+        - name: sysprobe-config
+          configMap:
+            name: datadog-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
-        - hostPath:
-            path: /var/lib/datadog-agent/logs
-          name: pointerdir
         - hostPath:
             path: /var/log/pods
           name: logpodpath
@@ -488,6 +8424,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/lib/datadog-agent/logs
+          name: pointerdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -497,3 +8436,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "6b0298b8-5b19-4619-a9d9-eb7cc96f84d0"
-  install_time: "1778233438"
+  install_id: "3decdaab-218e-4c3d-b364-f20757cabe2b"
+  install_time: "1778483126"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -284,7 +284,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -119,6 +119,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",
@@ -262,6 +263,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -283,7 +285,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "0dc4bdee-2306-47b8-9a54-51e5cb7a124e"
-  install_time: "1740515777"
+  install_id: "cc534895-5495-4571-b09c-7f47f92f5549"
+  install_time: "1778233439"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -93,7 +113,7 @@ metadata:
   namespace: default
   labels: {}
 data:
-  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nruntime_security_config:\n  enabled: false\n  fim_enabled: false\n  use_secruntime_track: true\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n"
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -119,10 +139,12 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",
             "close",
+            "close_range",
             "connect",
             "copy_file_range",
             "creat",
@@ -210,6 +232,8 @@ data:
             "openat2",
             "pause",
             "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
             "pipe",
             "pipe2",
             "poll",
@@ -256,12 +280,15 @@ data:
             "setitimer",
             "setns",
             "setpgid",
+            "setresgid",
+            "setresuid",
             "setrlimit",
             "setsid",
             "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -273,6 +300,7 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
+            "tkill",
             "umask",
             "uname",
             "unlink",
@@ -283,7 +311,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null
@@ -323,6 +352,7423 @@ data:
         }
       ]
     }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -366,6 +7812,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -414,6 +7861,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -435,7 +7896,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -446,6 +7908,7 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations:
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
@@ -455,9 +7918,11 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -475,6 +7940,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -483,6 +7950,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -503,6 +7972,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
@@ -515,14 +7986,10 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -533,9 +8000,21 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+            - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -582,6 +8061,8 @@ spec:
             - name: passwd
               mountPath: /etc/passwd
               readOnly: true
+            - name: datadogrun
+              mountPath: /opt/datadog-agent/run
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -613,9 +8094,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           env:
             - name: DD_API_KEY
@@ -629,6 +8112,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -637,6 +8122,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -673,7 +8160,7 @@ spec:
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
-              readOnly: false # Need RW for UDS DSD socket
+              readOnly: true # write access to /var/run/datadog is not needed because the process agent only writes to the socket file, not to the parent directory
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
@@ -703,7 +8190,7 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -718,10 +8205,11 @@ spec:
                 - CHOWN
                 - DAC_READ_SEARCH
             privileged: false
+            readOnlyRootFilesystem: true
             seccompProfile:
               type: Localhost
               localhostProfile: system-probe
-          command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -734,6 +8222,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -742,6 +8232,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -795,9 +8287,45 @@ spec:
             - name: etc-lsb-release
               mountPath: /host/etc/lsb-release
               readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -808,7 +8336,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -846,6 +8374,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -854,6 +8384,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LEADER_ELECTION
@@ -862,7 +8394,7 @@ spec:
               value: "configmap"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -913,7 +8445,7 @@ spec:
             path: /etc/system-release
           name: etc-system-release
         - hostPath:
-            path: /var/run/datadog/
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
         - name: sysprobe-config
@@ -934,11 +8466,48 @@ spec:
         - name: sysprobe-socket-dir
           emptyDir: {}
         - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
+        - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: datadogrun
+          emptyDir: {}
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -948,3 +8517,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -119,7 +119,6 @@ data:
             "capset",
             "chdir",
             "chmod",
-            "chown",
             "clock_gettime",
             "clone",
             "clone3",
@@ -263,7 +262,6 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
-            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -285,8 +283,7 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write",
-            "writev"
+            "write"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "cc534895-5495-4571-b09c-7f47f92f5549"
-  install_time: "1778233439"
+  install_id: "48be35a9-02c6-455d-ac33-2110f49e8d71"
+  install_time: "1778483126"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -284,7 +284,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7673 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "a9730f5c-722e-4441-88a3-732764afb858"
-  install_time: "1740515778"
+  install_id: "477cd495-895e-4d51-819c-658aa3c1a922"
+  install_time: "1778233439"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: false\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\n  tls:\ntraceroute:\n  enabled: false\ndiscovery:\n  enabled: true\n  use_system_probe_lite: true\n  network_stats:\n    enabled: true\ngpu_monitoring:\n  enabled: false\n  configure_cgroup_perms: false\nevent_monitoring_config:\n  socket: /var/run/sysprobe/event-monitor.sock\nruntime_security_config:\n  enabled: false\n  use_secruntime_track: true\n  direct_send_from_system_probe: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n    local_storage:\n      output_directory: /var/run/sysprobe/runtime-security/profiles\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n    dir: /var/run/sysprobe/runtime-security/profiles\n  enforcement:\n    enabled: false\n  compliance_module:\n    enabled: false\ndynamic_instrumentation:\n  enabled: false\ncompliance_config:\n  enabled: false\n"
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "chmod",
+            "chown",
+            "clock_gettime",
+            "clone",
+            "clone3",
+            "close",
+            "close_range",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "faccessat",
+            "faccessat2",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "flock",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "futimens",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getgroups",
+            "getpeername",
+            "getpgrp",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "inotify_add_watch",
+            "inotify_init",
+            "inotify_init1",
+            "inotify_rm_watch",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "madvise",
+            "memfd_create",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "mremap",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "openat2",
+            "pause",
+            "perf_event_open",
+            "pidfd_open",
+            "pidfd_send_signal",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "pread64",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "renameat",
+            "renameat2",
+            "restart_syscall",
+            "rmdir",
+            "rseq",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setitimer",
+            "setns",
+            "setpgid",
+            "setresgid",
+            "setresuid",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "shutdown",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "statx",
+            "symlinkat",
+            "sysinfo",
+            "tgkill",
+            "tkill",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "utime",
+            "utimensat",
+            "utimes",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write",
+            "writev"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        },
+        {
+          "names": [
+            "kill"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "allow process detection via kill",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7812,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7861,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7896,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,17 +7908,21 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       securityContext:
         runAsUser: 0
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
+          securityContext:
+            readOnlyRootFilesystem: true
           resources: {}
           ports:
             - containerPort: 8125
@@ -235,6 +7940,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -243,6 +7950,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -263,6 +7972,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: "low"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
@@ -275,14 +7986,10 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -293,9 +8000,17 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -324,6 +8039,13 @@ spec:
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -335,6 +8057,8 @@ spec:
             - name: passwd
               mountPath: /etc/passwd
               readOnly: true
+            - name: datadogrun
+              mountPath: /opt/datadog-agent/run
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -365,9 +8089,139 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+        - name: system-probe
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+                - CHOWN
+                - DAC_READ_SEARCH
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Localhost
+              localhostProfile: system-probe
+          command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW for tmp directory to instantiate self tests
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+              mountPropagation: None
+              readOnly: false # Need RW for kprobe_events
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: false # Need RW for sys-probe socket
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              mountPropagation: None
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              mountPropagation: None
+              readOnly: true
+            - name: runtime-compiler-output-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/build
+              mountPropagation: None
+              readOnly: false
+            - name: kernel-headers-download-dir
+              mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+              readOnly: false # Need RW for sys-probe kernel headers
+            - name: apt-config-dir
+              mountPath: /host/etc/apt
+              readOnly: true
+            - name: yum-repos-dir
+              mountPath: /host/etc/yum.repos.d
+              readOnly: true
+            - name: opensuse-repos-dir
+              mountPath: /host/etc/zypp
+              readOnly: true
+            - name: public-key-dir
+              mountPath: /host/etc/pki
+              readOnly: true
+            - name: yum-vars-dir
+              mountPath: /host/etc/yum/vars
+              readOnly: true
+            - name: dnf-vars-dir
+              mountPath: /host/etc/dnf/vars
+              readOnly: true
+            - name: rhel-subscription-dir
+              mountPath: /host/etc/rhsm
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -378,7 +8232,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -400,6 +8254,10 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+              readOnly: true
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -412,6 +8270,8 @@ spec:
               value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -420,12 +8280,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
               value: "configmap"
+          resources: {}
+        - name: seccomp-setup
+          image: "registry.datadoghq.com/agent:7.78.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+              readOnly: true
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
+              readOnly: false # Need RW for seccomp-root
           resources: {}
       volumes:
         - name: auth-token
@@ -451,15 +8329,78 @@ spec:
             path: /etc/os-release
           name: os-release-file
         - hostPath:
-            path: /var/run/datadog/
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
+        - hostPath:
+            path: /var/run/datadog
             type: DirectoryOrCreate
           name: dsdsocket
+        - name: sysprobe-config
+          configMap:
+            name: datadog-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/build
+            type: DirectoryOrCreate
+          name: runtime-compiler-output-dir
+        - hostPath:
+            path: /var/tmp/datadog-agent/system-probe/kernel-headers
+            type: DirectoryOrCreate
+          name: kernel-headers-download-dir
+        - hostPath:
+            path: /etc/apt
+          name: apt-config-dir
+        - hostPath:
+            path: /etc/yum.repos.d
+          name: yum-repos-dir
+        - hostPath:
+            path: /etc/zypp
+          name: opensuse-repos-dir
+        - hostPath:
+            path: /etc/pki
+          name: public-key-dir
+        - hostPath:
+            path: /etc/yum/vars
+          name: yum-vars-dir
+        - hostPath:
+            path: /etc/dnf/vars
+          name: dnf-vars-dir
+        - hostPath:
+            path: /etc/rhsm
+          name: rhel-subscription-dir
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: datadogrun
+          emptyDir: {}
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -469,3 +8410,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "477cd495-895e-4d51-819c-658aa3c1a922"
-  install_time: "1778233439"
+  install_id: "97dc3e82-72aa-479d-b649-0d2c489b48fc"
+  install_time: "1778483127"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -284,7 +284,6 @@ data:
             "setresuid",
             "setrlimit",
             "setsid",
-            "setsidaccept4",
             "setsockopt",
             "setuid",
             "setuid32",

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "ee1c7120-a0fc-459e-8595-3ccb85621a3a"
-  install_time: "1778233440"
+  install_id: "3a05b265-5c6e-44a5-ac7c-76278ac25323"
+  install_time: "1778483127"
 ---
 # Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7425 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "c9347d65-d406-4724-9c6b-b5a65fc283da"
-  install_time: "1740515778"
+  install_id: "ee1c7120-a0fc-459e-8595-3ccb85621a3a"
+  install_time: "1778233440"
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7564,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7613,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7648,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,12 +7660,13 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -232,6 +7686,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -240,6 +7696,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -266,6 +7724,25 @@ spec:
               value: "true"
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -286,9 +7763,21 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+            - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -344,7 +7833,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -365,6 +7854,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -373,6 +7864,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -417,7 +7910,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -433,6 +7926,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -441,6 +7936,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -468,13 +7965,16 @@ spec:
             - name: logdatadog
               mountPath: C:/ProgramData/Datadog/logs
               readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: C:/ProgramData/Datadog/auth
+              readOnly: true
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -490,7 +7990,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -515,6 +8015,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -523,6 +8025,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
@@ -567,3 +8071,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7425 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "62c2b81a-ce28-4834-afe1-9dbd7f2653f8"
-  install_time: "1740515778"
+  install_id: "03bd0e2e-fb93-4d8c-927f-bac54a74008f"
+  install_time: "1778233440"
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7564,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7613,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7648,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,12 +7660,13 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -232,6 +7686,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -240,6 +7696,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -266,12 +7724,29 @@ spec:
               value: "true"
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
@@ -286,9 +7761,19 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -335,7 +7820,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -356,6 +7841,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -364,6 +7851,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -408,7 +7897,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -424,6 +7913,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -432,6 +7923,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -457,13 +7950,16 @@ spec:
             - name: logdatadog
               mountPath: C:/ProgramData/Datadog/logs
               readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: C:/ProgramData/Datadog/auth
+              readOnly: true
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -479,7 +7975,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -504,6 +8000,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -512,6 +8010,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
@@ -547,3 +8047,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "03bd0e2e-fb93-4d8c-927f-bac54a74008f"
-  install_time: "1778233440"
+  install_id: "3559c4be-7298-40fb-8cd0-fee1315ec9c6"
+  install_time: "1778483128"
 ---
 # Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7425 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "6fa35826-5e1f-46dc-a149-c5b5d3d1133b"
-  install_time: "1740515779"
+  install_id: "52d4e95e-fdd7-4b17-94e6-156c020a770a"
+  install_time: "1778233440"
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7564,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7613,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7648,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,12 +7660,13 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -232,6 +7686,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -240,6 +7696,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -266,6 +7724,25 @@ spec:
               value: "true"
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -286,9 +7763,19 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -344,7 +7831,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -365,6 +7852,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -373,6 +7862,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -417,7 +7908,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -433,6 +7924,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -441,6 +7934,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -466,13 +7961,16 @@ spec:
             - name: logdatadog
               mountPath: C:/ProgramData/Datadog/logs
               readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: C:/ProgramData/Datadog/auth
+              readOnly: true
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -488,7 +7986,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -513,6 +8011,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -521,6 +8021,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
@@ -565,3 +8067,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "52d4e95e-fdd7-4b17-94e6-156c020a770a"
-  install_time: "1778233440"
+  install_id: "f6a68949-9d3f-43ed-b005-6c027dd801cf"
+  install_time: "1778483128"
 ---
 # Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "e3d69ad7-5d8d-4f19-b7f8-1aa3fd5aecbb"
-  install_time: "1778233441"
+  install_id: "52f0971e-924f-4371-95bf-5dacd080462f"
+  install_time: "1778483129"
 ---
 # Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7425 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "12d33d3c-4d68-4eac-9722-234fb146cfc1"
-  install_time: "1740515779"
+  install_id: "e3d69ad7-5d8d-4f19-b7f8-1aa3fd5aecbb"
+  install_time: "1778233441"
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7564,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7613,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7648,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,12 +7660,13 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -232,6 +7686,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -240,6 +7696,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -286,9 +7744,19 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -344,7 +7812,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -360,6 +7828,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -368,6 +7838,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -393,13 +7865,16 @@ spec:
             - name: logdatadog
               mountPath: C:/ProgramData/Datadog/logs
               readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: C:/ProgramData/Datadog/auth
+              readOnly: true
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -415,7 +7890,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -440,6 +7915,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -448,6 +7925,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
@@ -492,3 +7971,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: datadog/charts/operator/templates/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -39,6 +47,7 @@ data:
         - deployments
         - replicasets
         - statefulsets
+        - controllerrevisions
         - cronjobs
         - jobs
         - horizontalpodautoscalers
@@ -56,6 +65,17 @@ data:
       -
         filtering_enabled: false
         unbundle_events: false
+---
+# Source: datadog/templates/datadog-endpoint-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-endpoint-config
+  namespace: default
+  labels:
+    datadoghq.com/component: endpoint-config
+data:
+  api-key-secret-name: "datadog"
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -82,8 +102,7425 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "722b77ff-5095-453c-a2a7-5a43ec6e890b"
-  install_time: "1740515779"
+  install_id: "73a3ffc8-dcff-4e79-a65e-456e632c3aaa"
+  install_time: "1778233441"
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogagents.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+      - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.agent.status
+          name: agent
+          type: string
+        - jsonPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - jsonPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        default: ""
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        failurePolicy:
+                          type: string
+                        kubernetesAdmissionEvents:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        mutateUnlabelled:
+                          type: boolean
+                        mutation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
+                          type: object
+                        registry:
+                          type: string
+                        serviceName:
+                          type: string
+                        validation:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        webhookName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        errorTrackingStandalone:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            injectionMode:
+                              enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                              type: string
+                            injector:
+                              properties:
+                                imageTag:
+                                  type: string
+                              type: object
+                            languageDetection:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            targets:
+                              items:
+                                properties:
+                                  ddTraceConfigs:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  ddTraceVersions:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      matchNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  podSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    autoscaling:
+                      properties:
+                        cluster:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        workload:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        runInSystemProbe:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        directSendFromSystemProbe:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcement:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    dataPlane:
+                      properties:
+                        dogstatsd:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        nonLocalTraffic:
+                          type: boolean
+                        originDetectionEnabled:
+                          type: boolean
+                        tagCardinality:
+                          type: string
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                        collectedEventTypes:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - kind
+                              - reasons
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        unbundleEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        registerAPIService:
+                          type: boolean
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    gpu:
+                      properties:
+                        enabled:
+                          type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
+                        privilegedMode:
+                          type: boolean
+                        requiredRuntimeClassName:
+                          type: string
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        autoMultiLineDetection:
+                          type: boolean
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        directSend:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    otelAgentGateway:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        featureGates:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otelCollector:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        coreConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            extensionTimeout:
+                              type: integer
+                            extensionURL:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                default: TCP
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                    hostPortConfig:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        version:
+                          type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            overlayFSDirectScan:
+                              type: boolean
+                            uncompressedLayersSupport:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    serviceDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    checksTagCardinality:
+                      type: string
+                    clusterAgentToken:
+                      type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    clusterName:
+                      type: string
+                    containerStrategy:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    csi:
+                      properties:
+                        autoManage:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    disableNonResourceRules:
+                      type: boolean
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    default: ""
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                                - path
+                                - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        hostCAPath:
+                          type: string
+                        podResourcesSocketPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
+                      type: object
+                    kubernetesResourcesAnnotationsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    kubernetesResourcesLabelsAsTags:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      type: object
+                    localService:
+                      properties:
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
+                      type: object
+                    logLevel:
+                      type: string
+                    namespaceAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    namespaceLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    registry:
+                      type: string
+                    secretBackend:
+                      properties:
+                        args:
+                          type: string
+                        command:
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableGlobalPermissions:
+                          type: boolean
+                        refreshInterval:
+                          format: int32
+                          type: integer
+                        roles:
+                          items:
+                            properties:
+                              namespace:
+                                type: string
+                              secrets:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - namespace
+                              - secrets
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        timeout:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                    site:
+                      type: string
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
+                    useVSock:
+                      type: boolean
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      celWorkloadExclude:
+                        items:
+                          properties:
+                            products:
+                              items:
+                                enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            rules:
+                              properties:
+                                containers:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_endpoints:
+                                  items:
+                                    type: string
+                                  type: array
+                                kube_services:
+                                  items:
+                                    type: string
+                                  type: array
+                                pods:
+                                  items:
+                                    type: string
+                                  type: array
+                                processes:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    type: string
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createPodDisruptionBudget:
+                        type: boolean
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      extraChecksd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: granular
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      runtimeClassName:
+                        type: string
+                      securityContext:
+                        properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            type: string
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            minDomains:
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      updateStrategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            image:
+                              properties:
+                                pullPolicy:
+                                  type: string
+                                reference:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                          - keyType
+                                          - signerName
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
+                otelAgentGateway:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            kubernetesAdmissionEvents:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            mutateUnlabelled:
+                              type: boolean
+                            mutation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            validation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            errorTrackingStandalone:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                injectionMode:
+                                  enum:
+                                    - auto
+                                    - init_container
+                                    - csi
+                                    - image_volume
+                                  type: string
+                                injector:
+                                  properties:
+                                    imageTag:
+                                      type: string
+                                  type: object
+                                languageDetection:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                targets:
+                                  items:
+                                    properties:
+                                      ddTraceConfigs:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      ddTraceVersions:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          matchNames:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      podSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        autoscaling:
+                          properties:
+                            cluster:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            workload:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            runInSystemProbe:
+                              type: boolean
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            directSendFromSystemProbe:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            enforcement:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dataPlane:
+                          properties:
+                            dogstatsd:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            nonLocalTraffic:
+                              type: boolean
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                            collectedEventTypes:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - kind
+                                  - reasons
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            unbundleEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        gpu:
+                          properties:
+                            enabled:
+                              type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
+                            privilegedMode:
+                              type: boolean
+                            requiredRuntimeClassName:
+                              type: string
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            autoMultiLineDetection:
+                              type: boolean
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            directSend:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otelAgentGateway:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            featureGates:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otelCollector:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            coreConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                extensionTimeout:
+                                  type: integer
+                                extensionURL:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                        hostPortConfig:
+                                          properties:
+                                            enabled:
+                                              type: boolean
+                                            hostPort:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                overlayFSDirectScan:
+                                  type: boolean
+                                uncompressedLayersSupport:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        serviceDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogdashboards_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogdashboards.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  minLength: 1
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              required:
+                - layoutType
+                - title
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadoggenericresources_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadoggenericresources.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+      - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogGenericResource is the Schema for the DatadogGenericResources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+              properties:
+                jsonSpec:
+                  description: JsonSpec is the specification of the API object
+                  type: string
+                type:
+                  description: Type is the type of the API object
+                  enum:
+                    - downtime
+                    - monitor
+                    - notebook
+                    - synthetics_api_test
+                    - synthetics_browser_test
+                  type: string
+              required:
+                - jsonSpec
+                - type
+              type: object
+            status:
+              description: DatadogGenericResourceStatus defines the observed state of DatadogGenericResource
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogGenericResource.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the object was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                    if the JsonSpec has changed and needs an update.
+                  type: string
+                id:
+                  description: Id is the object unique identifier generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API object was last force synced with the custom resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the object state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogmonitors_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogmonitors.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.monitorStateSyncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  minLength: 1
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: |-
+                        Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                        the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                        This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    groupRetentionDuration:
+                      description: |-
+                        The time span after which groups with missing data are dropped from the monitor state.
+                        The minimum value is one hour, and the maximum value is 72 hours.
+                        Example values are: "60m", "1h", and "2d".
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                      type: string
+                    groupbySimpleMonitor:
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: 'DEPRECATED: Whether or not the monitor is locked (only editable by creator and admins). Use `restricted_roles` instead.'
+                      type: boolean
+                    newGroupDelay:
+                      description: |-
+                        Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                        monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: |-
+                        The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                        monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                        is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyBy:
+                      description: |-
+                        A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                        For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                        cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                        be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                        notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    onMissingData:
+                      description: |-
+                        An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                        The default option results in different behavior depending on the monitor query type.
+                        For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                        For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                        This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
+                    renotifyInterval:
+                      description: |-
+                        The number of minutes after the last notification before a monitor re-notifies on the current status.
+                        It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+                      format: int64
+                      type: integer
+                    renotifyStatuses:
+                      description: The types of statuses for which re-notification messages should be sent. Valid values are alert, warn, no data.
+                      items:
+                        description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    requireFullWindow:
+                      description: |-
+                        A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                        recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        customSchedule:
+                          description: Configuration options for the custom schedule. If start is omitted, the monitor creation time will be used.
+                          properties:
+                            recurrence:
+                              description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence is a struct of the recurrence definition
+                              properties:
+                                rrule:
+                                  description: The recurrence rule in iCalendar format. For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                  type: string
+                                start:
+                                  description: |-
+                                    The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                    If omitted, the monitor creation time will be used.
+                                  type: string
+                                timezone:
+                                  description: The timezone in `tz database` format, in which the recurrence rule is defined. For example, `America/New_York` or `UTC`.
+                                  type: string
+                              type: object
+                          type: object
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  minLength: 1
+                  type: string
+                restrictedRoles:
+                  description: |-
+                    RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                    `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                    see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
+                    - error-tracking alert
+                  type: string
+              required:
+                - message
+                - name
+                - query
+                - type
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                    if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
+                  properties:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
+                      type: integer
+                    isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
+                      type: boolean
+                  type: object
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                primary:
+                  description: |-
+                    Primary defines whether the monitor is managed by the Kubernetes custom
+                    resource (true) or outside Kubernetes (false)
+                  type: boolean
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: |-
+                      DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                      The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogslos_v1.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogslos.datadoghq.com
+  labels: {}
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: |-
+                    Description is a user-defined description of the service level objective.
+                    Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: |-
+                    Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                    Included in service level objective responses if it is not empty.
+                    Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: |-
+                    Query is the query for a metric-based SLO. Required if type is metric.
+                    Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: |-
+                    Tags is a list of tags to associate with your service level objective.
+                    This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                    Note: it's not currently possible to filter by these tags when querying via the API.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeSlice:
+                  description: |-
+                    TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                    It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                  properties:
+                    comparator:
+                      allOf:
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                        - enum:
+                            - '>'
+                            - '>='
+                            - <
+                            - <=
+                      description: Comparator is the comparison operator used to compare the SLI value to the threshold.
+                      type: string
+                    query:
+                      description: Query is a Datadog metric query string that produces the SLI value.
+                      type: string
+                    threshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        Threshold is the value against which the SLI is compared using the comparator to determine
+                        if a time slice is good or bad.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - comparator
+                    - query
+                    - threshold
+                  type: object
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: datadog/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-operator
+  labels: {}
+rules:
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/slis
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - deployments
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/configz
+      - nodes/healthz
+      - nodes/logs
+      - nodes/metrics
+      - nodes/pods
+      - nodes/proxy
+      - nodes/spec
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+    verbs:
+      - patch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - auto.gke.io
+    resources:
+      - allowlistsynchronizers
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents
+      - datadogagents/finalizers
+      - datadoggenericresources
+      - datadoggenericresources/finalizers
+      - datadogmonitors
+      - datadogmonitors/finalizers
+      - datadogslos
+      - datadogslos/finalizers
+      - extendeddaemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagents/status
+      - datadoggenericresources/status
+      - datadogmonitors/status
+      - datadogslos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics/status
+    verbs:
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogmetrics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalerclusterprofiles
+      - datadogpodautoscalerclusterprofiles/status
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+      - karpenter.azure.com
+    resources:
+      - '*'
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - eks.amazonaws.com
+      - external.metrics.k8s.io
+      - karpenter.k8s.aws
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - envoyextensionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - externalartifacts
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -127,6 +7564,7 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+      - controllerrevisions
     verbs:
       - list
       - watch
@@ -175,6 +7613,20 @@ rules:
       - list
       - watch
 ---
+# Source: datadog/charts/operator/templates/clusterrole_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-operator
+subjects:
+  - kind: ServiceAccount
+    name: datadog-operator
+    namespace: default
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
@@ -196,7 +7648,8 @@ kind: DaemonSet
 metadata:
   name: datadog
   namespace: default
-  labels: {}
+  labels:
+    agent.datadoghq.com/component: agent
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -207,12 +7660,13 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        agent.datadoghq.com/component: agent
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -232,6 +7686,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -240,6 +7696,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
@@ -270,8 +7728,6 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "false"
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: "true"
             - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
               value: "false"
             - name: DD_HEALTH_PORT
@@ -286,9 +7742,19 @@ spec:
               value: "6000"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
+              value: "false"
             - name: DD_CONTAINER_IMAGE_ENABLED
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: "/var/lib/kubelet/pod-resources/kubelet.sock"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
           volumeMounts:
             - name: logdatadog
@@ -335,7 +7801,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -351,6 +7817,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -359,6 +7827,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
@@ -384,13 +7854,16 @@ spec:
             - name: logdatadog
               mountPath: C:/ProgramData/Datadog/logs
               readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: C:/ProgramData/Datadog/auth
+              readOnly: true
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -406,7 +7879,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
+          image: "registry.datadoghq.com/agent:7.78.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -431,6 +7904,8 @@ spec:
               value: C:/ProgramData/Datadog/auth/token
             - name: KUBERNETES
               value: "yes"
+            - name: DD_CSI_ENABLED
+              value: "false"
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -439,6 +7914,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
           resources: {}
@@ -474,3 +7951,91 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---
+# Source: datadog/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-operator
+  namespace: default
+  labels: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: datadog
+  template:
+    metadata:
+      labels: {}
+      annotations:
+        ad.datadoghq.com/operator.check_names: '["openmetrics"]'
+        ad.datadoghq.com/operator.init_configs: '[{}]'
+        ad.datadoghq.com/operator.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:8383/metrics",
+            "namespace": "datadog.operator",
+            "metrics": ["*"]
+          }]
+    spec:
+      serviceAccountName: datadog-operator
+      containers:
+        - name: operator
+          image: "registry.datadoghq.com/operator:1.26.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DD_TOOL_VERSION
+              value: helm
+            - name: DD_REGISTRY_OVERRIDE_ASIA
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_EU
+              value: "true"
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          args:
+            - "-supportExtendedDaemonset=false"
+            - "-logEncoder=json"
+            - "-metrics-addr=:8383"
+            - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
+            - "-datadogMonitorEnabled=false"
+            - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
+            - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
+            - "-datadogAgentInternalEnabled=false"
+            - "-datadogCSIDriverEnabled=false"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources: {}
+          volumeMounts:
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -102,8 +102,8 @@ metadata:
   labels: {}
 data:
   install_type: k8s_manual
-  install_id: "73a3ffc8-dcff-4e79-a65e-456e632c3aaa"
-  install_time: "1778233441"
+  install_id: "da6364a1-53f3-444b-b4ac-2144b4e661e7"
+  install_time: "1778483129"
 ---
 # Source: datadog/charts/operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Regenerates the Kubernetes sample manifest YAML files in \`static/resources/yaml/\` using the \`generate.sh\` script against [Helm chart 3.208.1](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#32081). The files were previously generated from 3.96.0.

Generated with:
\`\`\`bash
cd static/resources/yaml
PATH="$HOME/go/bin:$PATH" bash generate.sh
\`\`\`

Note: Go yq v4 is required. The system \`yq\` on this machine is Python-based and incompatible with the script.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes