### PR TITLE
Add SOFA RPC to Java networking framework compatibility

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -176,6 +176,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | OkHTTP                             | 2.2+        | Fully Supported                                        | `okhttp`, `okhttp-2`,`okhttp-3`                         |
 | Play WSClient                      | 1.0+        | Fully Supported                                        | `play-ws`                                               |
 | Rabbit AMQP                        | 2.7+        | Fully Supported                                        | `amqp`, `rabbitmq`                                      |
+| SOFA RPC                           | 5.0+        | Fully Supported                                        | `sofarpc`                                               |
 | Spring SessionAwareMessageListener | 3.1+        | Fully Supported                                        | `spring-jms-3.1`                                        |
 | Spring WebClient                   | 5.0+        | Fully Supported                                        | `spring-webflux`, `spring-webflux-client`               |
 
@@ -184,6 +185,8 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 **JMS Note**: Datadog's JMS integration automatically adds and reads message object properties `x__dash__datadog__dash__trace__dash__id` and `x__dash__datadog__dash__parent__dash__id` to maintain context propagation between consumer and producer services.
 
 **Camel Note**: Distributed trace propagation over Camel routes is not supported.
+
+**SOFA RPC Note**: Datadog's SOFA RPC integration supports the Bolt, Triple, and REST transport protocols. Triple uses gRPC transport; distributed tracing for Triple calls requires the `grpc` integration to remain enabled.
 
 Don't see your desired networking framework? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds SOFA RPC to the Java networking framework compatibility table. SOFA RPC (sofa-rpc-all 5.0+) is now fully supported by dd-java-agent, covering the Bolt, Triple, and REST transport protocols. Added a short note clarifying that the Triple protocol depends on the grpc integration remaining enabled, since Triple is gRPC-based under the hood.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code for drafting.

### Additional notes

The instrumentation name for configuration is sofarpc. No existing content was modified - this is a pure addition.
