### PR TITLE
Add DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED env var

### DIFF
--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -101,6 +101,9 @@ The following environment variables are supported:
 `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
 : When true, the leader Cluster Agent collects stats from the cluster-level check runners to optimize check dispatching logic. Default: `true` for Agent v7.73 or later (`false` for earlier versions).
 
+`DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED`
+: Enables Kubernetes State Metrics Resource Type Sharding that automatically splits the `kubernetes_state_core` cluster check into multiple shards based on resource type groups, enabling parallel execution across multiple Cluster Check Runners (CLC runners) for improved performance and scalability in large Kubernetes clusters. Requires Agent v7.74 or higher and `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` to be set to `true`.
+
 `DD_CLUSTER_CHECKS_CLC_RUNNERS_PORT`
 : The port used by the Cluster Agent client to reach cluster-level check runners and collect their stats. Default: `5005`.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Document `DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED` publicly mainly for users that have large Kubernetes clusters. See PR for this feature: https://github.com/DataDog/datadog-agent/pull/42606

Merge readiness:
- [x] Ready for merge