### PR TITLE
Improve grouped item listing accessibility and keyboard support

### DIFF
--- a/assets/scripts/components/grouped-item-listings.js
+++ b/assets/scripts/components/grouped-item-listings.js
@@ -138,9 +138,13 @@ export function initializeGroupedListings() {
         });
     }
 
-    allGroupHeaders.forEach(elm => {
-        elm.addEventListener("click", e => {
-            e.currentTarget.classList.toggle('active');
+    allGroupHeaders.forEach(header => {
+        const group = header.closest('.js-group')
+        const content = group.querySelector('.group-content')
+        header.addEventListener("click", e => {
+            header.classList.toggle('active');
+            header.setAttribute('aria-expanded', header.getAttribute('aria-expanded') === 'false'); // evaluates and toggles state
+            content.classList.toggle('d-none');
         });
     });
 
@@ -183,10 +187,10 @@ export function initializeGroupedListings() {
     // Copy anchor - event listener
     const copyButtons = document.querySelectorAll('.group-header-text button')
 
-    copyButtons.forEach(e => {
-        e.addEventListener('click', (e) => {
+    copyButtons.forEach(button => {
+        button.addEventListener('click', (e) => {
             e.stopPropagation()
-            copyActionHref(e.currentTarget)
+            copyActionHref(button)
         })
     })
 

--- a/assets/scripts/components/grouped-item-listings.js
+++ b/assets/scripts/components/grouped-item-listings.js
@@ -140,10 +140,11 @@ export function initializeGroupedListings() {
 
     allGroupHeaders.forEach(header => {
         const group = header.closest('.js-group')
-        const content = group.querySelector('.group-content')
+        const content = group?.querySelector('.group-content')
         header.addEventListener("click", e => {
+            if(!group || !content) return;
             header.classList.toggle('active');
-            header.setAttribute('aria-expanded', header.getAttribute('aria-expanded') === 'false'); // evaluates and toggles state
+            header.setAttribute('aria-expanded', header.getAttribute('aria-expanded') === 'false');
             content.classList.toggle('d-none');
         });
     });
@@ -181,6 +182,8 @@ export function initializeGroupedListings() {
                 linkIcon.style.display = 'inline';
                 checkIcon.style.display = '';
             }, 1000)
+        }).catch(() => {
+            console.error('Failed to copy anchor to clipboard');
         })
     }
 

--- a/assets/scripts/components/grouped-item-listings.js
+++ b/assets/scripts/components/grouped-item-listings.js
@@ -159,34 +159,34 @@ export function initializeGroupedListings() {
 
     /**
      * Copy href of a term
-     * @param {object} event 
+     * @param {object} button
      */
-    const copyActionHref = (event) => {
-        const clickableIconWrapper = event.currentTarget.parentElement
-        const copyConfirmedIconWrapper = clickableIconWrapper.nextElementSibling
-        const anchor = clickableIconWrapper.dataset.anchor
+    const copyActionHref = (button) => {
+        const linkIcon = button.querySelector('.icon-link-wui')
+        const checkIcon = button.querySelector('.icon-check-bold')
+        const anchor = button.dataset.anchor
         const {pathname, origin} = window.location
         const path = new URL(`${origin}${pathname}${anchor}`)
 
         const Clipboard = navigator.clipboard
         // write href to clipboard
         Clipboard.writeText(path.href).then(() => {
-            clickableIconWrapper.classList.add('d-none');
-            copyConfirmedIconWrapper.classList.remove('d-none')
+            linkIcon.style.display = 'none';
+            checkIcon.style.display = 'inline';
             setTimeout(function() {
-                clickableIconWrapper.classList.remove('d-none');
-                copyConfirmedIconWrapper.classList.add('d-none')
+                linkIcon.style.display = 'inline';
+                checkIcon.style.display = '';
             }, 1000)
         })
     }
 
     // Copy anchor - event listener
-    const copyIcons = document.querySelectorAll('.group-header-text .icon-click')
+    const copyButtons = document.querySelectorAll('.group-header-text button')
 
-    copyIcons.forEach(e => {
+    copyButtons.forEach(e => {
         e.addEventListener('click', (e) => {
             e.stopPropagation()
-            copyActionHref(e)
+            copyActionHref(e.currentTarget)
         })
     })
 

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -23,7 +23,7 @@
 
   .group-header-text {
     position: absolute;
-    left: 67px;
+    left: 67px; // positioning within .js-group-header
     bottom: 2px;
     button.copy-anchor {
       background: none;

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -41,53 +41,54 @@
       }
     }
   }
-}
-
-.js-group-header {
-  background: none;
-  border: none;
-  padding: 0;
-  width: 100%;
-  transition: box-shadow 0.125s;
-  position: relative;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
-  margin-bottom: 9px;
-  border-radius: 4px;
-  cursor: pointer;
-  overflow: hidden;
-  height: 28px;
-
-  &:hover {
-    box-shadow: 0 2px 3px rgba(0,0,0,0.3);
+  
+  .js-group-header {
+    background: none;
+    border: none;
+    padding: 0;
+    width: 100%;
+    transition: box-shadow 0.125s;
+    position: relative;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+    margin-bottom: 9px;
+    border-radius: 4px;
+    cursor: pointer;
+    overflow: hidden;
+    height: 28px;
+  
+    &:hover {
+      box-shadow: 0 2px 3px rgba(0,0,0,0.3);
+    }
+    
+    &.active {
+      .js-group-header__arrow {
+        right: 12px !important;
+        transform: rotate(-90deg) !important;
+      }
+    }
   }
   
-  &.active {
-    .js-group-header__arrow {
-      right: 12px !important;
-      transform: rotate(-90deg) !important;
+  .js-group-header__icon {
+    background: rgba(0,0,0,0.05);
+  }
+  
+  .js-group-header__arrow {
+    transition: transform 0.125s;
+    top: 1px;
+    right: 7px;
+    position: absolute;
+    font-weight: 700;
+    font-size: 18px;
+    transform: rotate(90deg);
+  
+    // Point arrow inwards when collapsed
+    .js-group-header:not(.active) & {
+      transform: rotate(180deg);
+      top: 3px;
     }
   }
 }
 
-.js-group-header__icon {
-  background: rgba(0,0,0,0.05);
-}
-
-.js-group-header__arrow {
-  transition: transform 0.125s;
-  top: 1px;
-  right: 7px;
-  position: absolute;
-  font-weight: 700;
-  font-size: 18px;
-  transform: rotate(90deg);
-
-  // Point arrow inwards when collapsed
-  .js-group-header:not(.active) & {
-    transform: rotate(180deg);
-    top: 3px;
-  }
-}
 
 .rule-specification {
   p {

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -16,22 +16,14 @@
     margin-top: -100px;
     pointer-events: none;
   }
-}
 
-.js-group-header {
-  transition: box-shadow 0.125s;
   position: relative;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
-  margin-bottom: 9px;
-  border-radius: 4px;
-  cursor: pointer;
-  overflow: hidden;
-  height: 28px;
 
   .group-header-text {
-    margin-top: -1px;
-
-    button {
+    position: absolute;
+    left: 67px;
+    bottom: 2px;
+    button.copy-anchor {
       background: none;
       border: none;
       opacity: 0.5;
@@ -45,9 +37,23 @@
       &:hover {
         opacity: 1;
       }
-      
     }
   }
+}
+
+.js-group-header {
+  background: none;
+  border: none;
+  padding: 0;
+  width: 100%;
+  transition: box-shadow 0.125s;
+  position: relative;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+  margin-bottom: 9px;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  height: 28px;
 
   &:hover {
     box-shadow: 0 2px 3px rgba(0,0,0,0.3);

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -30,11 +30,22 @@
 
   .group-header-text {
     margin-top: -1px;
-    i{
-      cursor: copy;
-      position: relative;
-      top: 4px;
-      margin-left: 4px;
+
+    button {
+      background: none;
+      border: none;
+      opacity: 0.5;
+      i{
+        position: relative;
+        top: 2px;
+        &.icon-check-bold {
+          display: none;
+        }
+      }
+      &:hover {
+        opacity: 1;
+      }
+      
     }
   }
 

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -16,7 +16,9 @@
     margin-top: -100px;
     pointer-events: none;
   }
+}
 
+.group-header-container {
   position: relative;
 
   .group-header-text {
@@ -58,9 +60,7 @@
   &:hover {
     box-shadow: 0 2px 3px rgba(0,0,0,0.3);
   }
-  &.active + div {
-    display: block !important;
-  }
+  
   &.active {
     .js-group-header__arrow {
       right: 12px !important;

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -20,15 +20,19 @@
 
 .group-header-container {
   position: relative;
-
+  isolation: isolate; // creates a new stacking context so child z-index values don't compete outside this container
+  
   .group-header-text {
     position: absolute;
     left: 67px; // positioning within .js-group-header
     bottom: 2px;
+
     button.copy-anchor {
       background: none;
       border: none;
       opacity: 0.5;
+      position: relative;
+      z-index: 2; // position above button.js-group-header
       i{
         position: relative;
         top: 2px;
@@ -55,6 +59,7 @@
     cursor: pointer;
     overflow: hidden;
     height: 28px;
+    z-index: 1; // position above .group-header-text
   
     &:hover {
       box-shadow: 0 2px 3px rgba(0,0,0,0.3);

--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -93,29 +93,29 @@
       {{ $logo_path := partialCached "integrations-logo.html" (dict "context" $dot "basename" $icon_id "variant" "avatar" "fallback" "cloud") $icon_id "avatar" }}
       {{ $default_dd_logo_path := partialCached "integrations-logo.html" (dict "context" $dot "basename" "_datadog" "variant" "avatar" "fallback" "cloud") "_datadog" "avatar" }}
       <div class="js-group js-group-{{ $workflow_title | anchorize }}" id="{{ $workflow_title | anchorize }}">
-        <div class="js-group-header mb-1 d-flex align-items-center" id="">
+        <div class="group-header-text font-semibold">
+          <span>{{ $workflow_title }}</span>
+          <button class="copy-anchor" aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
+            {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
+            {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+          </button>
+        </div>
+        <button class="js-group-header mb-1 d-flex align-items-center" id="">
           <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
             {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
           </div>
-          <div class="font-semibold ms-1 group-header-text">
-            <span>{{ $workflow_title }}</span>
-            <button aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
-              {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
-              {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
-            </button>
-          </div>
           <div class="js-group-header__arrow">></div>
-        </div>
+        </button>
         <div class="group-{{ $workflow_title }} mb-2 ms-4 d-none">
           {{ range $action_name, $action_data := .actions }}
-            {{ $base_url := "https://app.datadoghq.com/actions/action-catalog#" }}
-            {{ $full_url := print $base_url $workflow_name "/" $workflow_name "." $action_name }}
-
-            <a class="mb-1 font-semibold mix js-single-rule" href="{{ $full_url }}" data-name="{{ lower $workflow_title }} {{ lower $action_name }} {{ .File.TranslationBaseName }}">
-              {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
-              <span class="ps-1">{{ .title }}</span>
-              <br>
-            </a>
+          {{ $base_url := "https://app.datadoghq.com/actions/action-catalog#" }}
+          {{ $full_url := print $base_url $workflow_name "/" $workflow_name "." $action_name }}
+          
+          <a class="mb-1 font-semibold mix js-single-rule" href="{{ $full_url }}" data-name="{{ lower $workflow_title }} {{ lower $action_name }} {{ .File.TranslationBaseName }}">
+            {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
+            <span class="ps-1">{{ .title }}</span>
+            <br>
+          </a>
           {{ end }}
         </div>
       </div>

--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -93,20 +93,22 @@
       {{ $logo_path := partialCached "integrations-logo.html" (dict "context" $dot "basename" $icon_id "variant" "avatar" "fallback" "cloud") $icon_id "avatar" }}
       {{ $default_dd_logo_path := partialCached "integrations-logo.html" (dict "context" $dot "basename" "_datadog" "variant" "avatar" "fallback" "cloud") "_datadog" "avatar" }}
       <div class="js-group js-group-{{ $workflow_title | anchorize }}" id="{{ $workflow_title | anchorize }}">
-        <div class="group-header-text font-semibold">
-          <span>{{ $workflow_title }}</span>
-          <button class="copy-anchor" aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
-            {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
-            {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+        <div class="group-header-container">
+          <div class="group-header-text font-semibold">
+            <span>{{ $workflow_title }}</span>
+            <button class="copy-anchor" aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
+              {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
+              {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+            </button>
+          </div>
+          <button class="js-group-header mb-1 d-flex align-items-center" aria-expanded=false aria-label="Toggle {{ $workflow_title }} content">
+            <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
+              {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
+            </div>
+            <div class="js-group-header__arrow" aria-hidden="true">></div>
           </button>
         </div>
-        <button class="js-group-header mb-1 d-flex align-items-center" id="">
-          <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
-            {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
-          </div>
-          <div class="js-group-header__arrow">></div>
-        </button>
-        <div class="group-{{ $workflow_title }} mb-2 ms-4 d-none">
+        <div class="group-content group-{{ $workflow_title }} mb-2 ms-4 d-none">
           {{ range $action_name, $action_data := .actions }}
           {{ $base_url := "https://app.datadoghq.com/actions/action-catalog#" }}
           {{ $full_url := print $base_url $workflow_name "/" $workflow_name "." $action_name }}

--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -99,8 +99,10 @@
           </div>
           <div class="font-semibold ms-1 group-header-text">
             <span>{{ $workflow_title }}</span>
-            <span class="icon-wrapper" data-anchor="#{{ $workflow_title | anchorize }}">{{ partial "icon" (dict "name" "click" "title" (printf "copy anchor for %s" $workflow_title)) }}</span>
-            <span class="icon-wrapper d-none">{{ partial "icon" (dict "name" "check-bold" "color" "#7c3eb9") }}</span>
+            <button aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
+              {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
+              {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+            </button>
           </div>
           <div class="js-group-header__arrow">></div>
         </div>

--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -101,7 +101,7 @@
               {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
             </button>
           </div>
-          <button class="js-group-header mb-1 d-flex align-items-center" aria-expanded=false aria-label="Toggle {{ $workflow_title }} content">
+          <button class="js-group-header mb-1 d-flex align-items-center" aria-expanded="false" aria-label="Toggle {{ $workflow_title }} content">
             <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
               {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
             </div>

--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -94,19 +94,21 @@
       {{ $default_dd_logo_path := partialCached "integrations-logo.html" (dict "context" $dot "basename" "_datadog" "variant" "avatar" "fallback" "cloud") "_datadog" "avatar" }}
       <div class="js-group js-group-{{ $workflow_title | anchorize }}" id="{{ $workflow_title | anchorize }}">
         <div class="group-header-container">
-          <div class="group-header-text font-semibold">
-            <span>{{ $workflow_title }}</span>
-            <button class="copy-anchor" aria-label="Copy anchor for {{ $workflow_title }}" data-anchor="#{{ $workflow_title | anchorize }}">
-              {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
-              {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
-            </button>
-          </div>
           <button class="js-group-header mb-1 d-flex align-items-center" aria-expanded="false" aria-label="Toggle {{ $workflow_title }} content">
             <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
               {{ partial "get-action-catalog-icon" (dict "page_ctx" $dot "icon_name" $icon_name "icon_type" $icon_type "logo_path" $logo_path "workflow_title" $workflow_title "dd_logo_path" $default_dd_logo_path) }}
             </div>
             <div class="js-group-header__arrow" aria-hidden="true">></div>
           </button>
+          <div class="group-header-text font-semibold">
+            <span>{{ $workflow_title }}</span>
+            <button class="copy-anchor" data-anchor="#{{ $workflow_title | anchorize }}" aria-label="copy anchor for {{ $workflow_title }}">
+              <span aria-hidden="true">
+                {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $workflow_title)) }}
+                {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+              </span>
+            </button>
+          </div>
         </div>
         <div class="group-content group-{{ $workflow_title }} mb-2 ms-4 d-none">
           {{ range $action_name, $action_data := .actions }}

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -21,44 +21,50 @@
 <div>
   <div class="js-empty-results d-none font-semibold"></div>
   {{ range $i, $v := $listGroups }}
+  {{$groupHeaderText := ""}}
+  {{ if $transformGroupTitle }}
+    <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
+    {{ $words := (split (humanize $v.Key) " ") }}
+    {{ range $index, $word := $words }}
+      {{ if (and (eq $index 0) (eq (len $word) 3)) }}
+        {{ $groupHeaderText = $word | upper }}
+      {{ else }}
+        <!-- concatenate -->
+        {{ $groupHeaderText = (trim (printf "%s %s" $groupHeaderText ($word | title )) " ") }}
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    {{ $groupHeaderText = $v.Key }}
+  {{ end }}
   <div class="js-group js-group-{{ $i }}" id="{{ $v.Key | anchorize }}">
-    <div class="js-group-header mb-1 d-flex align-items-center {{$activeAttr}}" id="">
-      <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
-        {{ range last 1 $v.Pages }}
-          {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
-          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename "avatar" }}
-          {{ if $int_logo }}
-            <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
-          {{ else }}
-            <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
-          {{ end }}
-        {{ end }}
-      </div>
-      {{$groupHeaderText := ""}}
-      <div class="font-semibold ms-1 group-header-text">
-        {{ if $transformGroupTitle }}
-          <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
-          {{ $words := (split (humanize $v.Key) " ") }}
-          {{ range $index, $word := $words }}
-            {{ if (and (eq $index 0) (eq (len $word) 3)) }}
-              {{ $groupHeaderText = $word | upper }}
+    <div class="group-header-container">
+      <button class="js-group-header mb-1 d-flex align-items-center {{$activeAttr}}" aria-expanded="false" aria-label="Toggle {{ $groupHeaderText }} content">
+        <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
+          {{ range last 1 $v.Pages }}
+            {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
+            {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename "avatar" }}
+            {{ if $int_logo }}
+              <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
             {{ else }}
-              <!-- concatenate -->
-              {{ $groupHeaderText = (trim (printf "%s %s" $groupHeaderText ($word | title )) " ") }}
+              <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
             {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $groupHeaderText = $v.Key }}
-        {{ end }}
+        </div>
+        <div class="js-group-header__arrow" aria-hidden="true">></div>
+      </button>
+      <div class="group-header-text font-semibold">
         <span>{{ $groupHeaderText }}</span>
         {{ if $groupHeaderText }}
-          <span class="icon-wrapper" data-anchor="#{{$v.Key | anchorize}}">{{ partial "icon" (dict "name" "click" "title" (printf "copy anchor for %s" $groupHeaderText) ) }}</span>
-          <span class="icon-wrapper d-none">{{ partial "icon" (dict "name" "check-bold" "color" "#7c3eb9" ) }}</span>
+          <button class="copy-anchor" data-anchor="#{{$v.Key | anchorize}}" aria-label="copy anchor for {{ $groupHeaderText }}">
+            <span aria-hidden="true">
+              {{ partial "icon" (dict "name" "link-wui" "size" "14px" "title" (printf "copy anchor for %s" $groupHeaderText)) }}
+              {{ partial "icon" (dict "name" "check-bold" "color" "#632ca6" "size" "14px") }}
+            </span>
+          </button>
         {{ end }}
       </div>
-      <div class="js-group-header__arrow">></div>
     </div>
-    <div class="group-{{ .Key }} mb-2 ms-4 d-none">
+    <div class="group-content group-{{ $v.Key }} mb-2 ms-4 d-none">
       {{ range $v.Pages }}
         <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ lower $groupHeaderText }} {{ .File.TranslationBaseName }}">
           {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Refactors the **action catalog** and **security rules** group header listings to improve accessibility, keyboard support, and click behavior:

- Converts the group header `div` to a `<button>` with `aria-expanded` and `aria-label` so screen reader users know the element is interactive and can determine expand/collapse state 
- Avoids nested interactive elements by moving the copy URL button to be a sibling of the group header button in html. Copy button is now visually positioned inside the group header button via CSS 
- Uses new `link-wui` icon for copy URL button
- Converts the copy element `<span>` to a `<button>` with `aria-label`; wraps icons in `aria-hidden` to suppress redundant accessible names from SVG titles
- Adds `aria-hidden="true"` to the decorative arrow element

**motivation**: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-9025
**preview**: 
- https://docs-staging.datadoghq.com/stefon.simmons/action-catalog-cpy-anchor-icon/actions/actions_catalog/
- https://docs-staging.datadoghq.com/stefon.simmons/action-catalog-cpy-anchor-icon/security/default_rules/?category=all#all

**testing**:
- should be able to focus and trigger the group headers and copy buttons via keyboard and mouse clicks.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Used Claude Code for accessibility review and iterative code review during development.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->