### PR TITLE
[codex] Fix Feature Flags documentation guidance

### DIFF
--- a/content/en/feature_flags/_index.md
+++ b/content/en/feature_flags/_index.md
@@ -32,7 +32,7 @@ further_reading:
 
 Datadog Feature Flags is Datadog's flag management product. You create flags in Datadog, deliver flag configuration to Datadog Feature Flags SDKs, and evaluate variants in your application through Datadog or OpenFeature APIs.
 
-Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. If you're new to OpenFeature concepts like providers, evaluation context, and hooks, see the [OpenFeature concepts documentation](https://openfeature.dev/docs/category/concepts).
 
 Feature flags enable you to toggle features on and off, conduct A/B/n testing, gradually roll out new functionality, and personalize user experiences without the need for extensive code deployments. With feature flags, you can empower your team to make dynamic changes, iterate rapidly, and deliver enhanced user experiences.
 
@@ -47,8 +47,6 @@ Use a client-side SDK when the flag is evaluated in a browser, mobile app, or ga
 | Client token | Browser, mobile, and game SDKs | Client application configuration | No — safe to ship in public client code |
 | Application ID | Browser and RUM-backed client SDKs | Client application configuration | No — public identifier |
 | API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Yes — keep server-side only |
-| Application ID | Browser and RUM-backed client SDKs | Client application configuration | Public-shipping identifier |
-| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Secret |
 
 Do not put API keys in browser, mobile, or game applications.
 

--- a/content/en/feature_flags/_index.md
+++ b/content/en/feature_flags/_index.md
@@ -30,7 +30,9 @@ further_reading:
 
 ## Overview
 
-Datadog Feature Flags is Datadog's flag management product. You create flags in Datadog, deliver flag configuration to Datadog SDKs, and evaluate variants in your application through Datadog or OpenFeature APIs.
+Datadog Feature Flags is Datadog's flag management product. You create flags in Datadog, deliver flag configuration to Datadog Feature Flags SDKs, and evaluate variants in your application through Datadog or OpenFeature APIs.
+
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
 
 Feature flags enable you to toggle features on and off, conduct A/B/n testing, gradually roll out new functionality, and personalize user experiences without the need for extensive code deployments. With feature flags, you can empower your team to make dynamic changes, iterate rapidly, and deliver enhanced user experiences.
 

--- a/content/en/feature_flags/_index.md
+++ b/content/en/feature_flags/_index.md
@@ -54,7 +54,7 @@ Do not put API keys in browser, mobile, or game applications.
 
 Evaluation context attributes are the flat string, number, and Boolean values that Datadog uses for targeting rules and rollout bucketing. Set a stable `targetingKey`, such as a user ID, session ID, or device ID, so percentage rollouts are consistent.
 
-Feature Flags telemetry includes exposure events, flag evaluation metrics, and optional RUM correlation depending on the SDK and configuration. For third-party feature flag providers, use [RUM Feature Flag Tracking](/real_user_monitoring/feature_flag_tracking/) to send evaluated variants to RUM without migrating flag management to Datadog.
+Feature Flags telemetry includes exposure events, flag evaluation metrics, and optional RUM correlation depending on the SDK and configuration.
 
 ## Further reading
 

--- a/content/en/feature_flags/_index.md
+++ b/content/en/feature_flags/_index.md
@@ -38,13 +38,15 @@ Feature flags enable you to toggle features on and off, conduct A/B/n testing, g
 
 If your flags are managed by LaunchDarkly, Split, ConfigCat, or another provider and you only want Datadog to record evaluated variants in RUM, see [RUM Feature Flag Tracking](/real_user_monitoring/feature_flag_tracking/) instead.
 
-Use a client-side SDK when the flag must be evaluated in a browser, mobile app, or game client. Use a server-side SDK when the decision should happen in a backend service and the flag configuration can be delivered through the Datadog Agent and Remote Configuration.
+Use a client-side SDK when the flag is evaluated in a browser, mobile app, or game client. Use a server-side SDK when the flag is evaluated in a backend service that receives flag configuration through the Datadog Agent and Remote Configuration.
 
 ### Credentials at a glance
 
 | Credential | Used by | Where it goes | Sensitive? |
 | --- | --- | --- | --- |
-| Client token | Browser, mobile, and game SDKs | Client application configuration | Public-shipping token |
+| Client token | Browser, mobile, and game SDKs | Client application configuration | No — safe to ship in public client code |
+| Application ID | Browser and RUM-backed client SDKs | Client application configuration | No — public identifier |
+| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Yes — keep server-side only |
 | Application ID | Browser and RUM-backed client SDKs | Client application configuration | Public-shipping identifier |
 | API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Secret |
 

--- a/content/en/feature_flags/_index.md
+++ b/content/en/feature_flags/_index.md
@@ -30,7 +30,29 @@ further_reading:
 
 ## Overview
 
-Feature flags enable you to toggle features on and off, conduct A/B/n testing, gradually roll out new functionality, and personalize user experiences—all without the need for extensive code deployments. With feature flags, you can empower your team to make dynamic changes, iterate rapidly, and deliver enhanced user experiences.
+Datadog Feature Flags is Datadog's flag management product. You create flags in Datadog, deliver flag configuration to Datadog SDKs, and evaluate variants in your application through Datadog or OpenFeature APIs.
+
+Feature flags enable you to toggle features on and off, conduct A/B/n testing, gradually roll out new functionality, and personalize user experiences without the need for extensive code deployments. With feature flags, you can empower your team to make dynamic changes, iterate rapidly, and deliver enhanced user experiences.
+
+If your flags are managed by LaunchDarkly, Split, ConfigCat, or another provider and you only want Datadog to record evaluated variants in RUM, see [RUM Feature Flag Tracking](/real_user_monitoring/feature_flag_tracking/) instead.
+
+Use a client-side SDK when the flag must be evaluated in a browser, mobile app, or game client. Use a server-side SDK when the decision should happen in a backend service and the flag configuration can be delivered through the Datadog Agent and Remote Configuration.
+
+### Credentials at a glance
+
+| Credential | Used by | Where it goes | Sensitive? |
+| --- | --- | --- | --- |
+| Client token | Browser, mobile, and game SDKs | Client application configuration | Public-shipping token |
+| Application ID | Browser and RUM-backed client SDKs | Client application configuration | Public-shipping identifier |
+| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Secret |
+
+Do not put API keys in browser, mobile, or game applications.
+
+### Evaluation context and telemetry
+
+Evaluation context attributes are the flat string, number, and Boolean values that Datadog uses for targeting rules and rollout bucketing. Set a stable `targetingKey`, such as a user ID, session ID, or device ID, so percentage rollouts are consistent.
+
+Feature Flags telemetry includes exposure events, flag evaluation metrics, and optional RUM correlation depending on the SDK and configuration. For third-party feature flag providers, use [RUM Feature Flag Tracking](/real_user_monitoring/feature_flag_tracking/) to send evaluated variants to RUM without migrating flag management to Datadog.
 
 ## Further reading
 

--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -19,6 +19,8 @@ further_reading:
 
 Set up Datadog Feature Flags for your applications. Follow the platform-specific guides below to integrate feature flags into your application and start collecting feature flag data:
 
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
+
 {{< card-grid card_width="200px">}}
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_large.svg" alt="Android" >}}
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_tv_large.svg" alt="Android TV" >}}
@@ -30,6 +32,18 @@ Set up Datadog Feature Flags for your applications. Follow the platform-specific
   {{< image-card href="/feature_flags/client/ios/" src="integrations_logos/tv_os_large.svg" alt="tvOS" >}}
   {{< image-card href="/feature_flags/client/unity/" src="integrations_logos/rum-unity_large.svg" alt="Unity" >}}
 {{< /card-grid >}}
+
+## Telemetry options by platform
+
+The web, mobile, and Unity providers expose similar telemetry controls with platform-specific option names. When a telemetry option is exposed, its default value is `true`.
+
+| Concept | Web (`@datadog/openfeature-browser`) | Android (`dd-sdk-android-flags`) | iOS (`DatadogFlags`) | React Native | Unity |
+|---|---|---|---|---|---|
+| Send exposure events | `enableExposureLogging` | `trackExposures` | `trackExposures` | `trackExposures` | `trackExposures` |
+| Send aggregated evaluation telemetry | `enableFlagEvaluationTracking` | `trackEvaluations` | `trackEvaluations` | Not exposed | `trackEvaluations` |
+| Attach evaluations to RUM | `enableRumFeatureFlagTracking` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | Not exposed |
+
+<div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift">dd-openfeature-provider-swift</a>) is currently in development. For production iOS workloads, use the <code>FlagsClient</code> API directly.</div>
 
 ## Testing with in-memory providers
 

--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -43,7 +43,7 @@ The web, mobile, and Unity providers expose similar telemetry controls with plat
 | Send aggregated evaluation telemetry | `enableFlagEvaluationTracking` | `trackEvaluations` | `trackEvaluations` | Not exposed | `trackEvaluations` |
 | Attach evaluations to RUM | `enableRumFeatureFlagTracking` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | Not exposed |
 
-<div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift">dd-openfeature-provider-swift</a>) is currently in development. For production iOS workloads, use the <code>FlagsClient</code> API directly.</div>
+<div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift">dd-openfeature-provider-swift</a>) is available for use as a pre-1.0 package. Until it reaches 1.0, version updates may include breaking changes. For the most stable iOS API surface, use the <code>FlagsClient</code> API directly.</div>
 
 ## Testing with in-memory providers
 

--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -19,7 +19,7 @@ further_reading:
 
 Set up Datadog Feature Flags for your applications. Follow the platform-specific guides below to integrate feature flags into your application and start collecting feature flag data:
 
-Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. If you're new to OpenFeature concepts like providers, evaluation context, and hooks, see the [OpenFeature concepts documentation](https://openfeature.dev/docs/category/concepts).
 
 {{< card-grid card_width="200px">}}
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_large.svg" alt="Android" >}}
@@ -37,13 +37,37 @@ Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature
 
 The web, mobile, and Unity providers expose similar telemetry controls with platform-specific option names. Each exposed option defaults to `true`, so the listed behaviors are on by default; set the option to `false` to opt out.
 
-| Concept | Default | Web (`@datadog/openfeature-browser`) | Android (`dd-sdk-android-flags`) | iOS (`DatadogFlags`) | React Native | Unity |
-|---|---|---|---|---|---|---|
-| Send exposure events | `true` | `enableExposureLogging` | `trackExposures` | `trackExposures` | `trackExposures` | `trackExposures` |
-| Send aggregated evaluation telemetry | `true` | `enableFlagEvaluationTracking` | `trackEvaluations` | `trackEvaluations` | Not exposed | `trackEvaluations` |
-| Attach evaluations to RUM | `true` | `enableRumFeatureFlagTracking` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | Not exposed |
-
 <div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift">dd-openfeature-provider-swift</a>) is available for use as a pre-1.0 package. Until it reaches 1.0, version updates may include breaking changes. For the most stable iOS API surface, use the <code>FlagsClient</code> API directly.</div>
+
+### Send exposure events
+
+Default: `true`. Set to `false` to disable.
+
+- **Web** (`@datadog/openfeature-browser`): `enableExposureLogging`
+- **Android** (`dd-sdk-android-flags`): `trackExposures`
+- **iOS** (`DatadogFlags`): `trackExposures`
+- **React Native**: `trackExposures`
+- **Unity**: `trackExposures`
+
+### Send aggregated evaluation telemetry
+
+Default: `true`. Set to `false` to disable.
+
+- **Web** (`@datadog/openfeature-browser`): `enableFlagEvaluationTracking`
+- **Android** (`dd-sdk-android-flags`): `trackEvaluations`
+- **iOS** (`DatadogFlags`): `trackEvaluations`
+- **React Native**: Not exposed
+- **Unity**: `trackEvaluations`
+
+### Attach evaluations to RUM
+
+Default: `true`. Set to `false` to disable.
+
+- **Web** (`@datadog/openfeature-browser`): `enableRumFeatureFlagTracking`
+- **Android** (`dd-sdk-android-flags`): `rumIntegrationEnabled`
+- **iOS** (`DatadogFlags`): `rumIntegrationEnabled`
+- **React Native**: `rumIntegrationEnabled`
+- **Unity**: Not exposed
 
 ## Testing with in-memory providers
 

--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -35,13 +35,13 @@ Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature
 
 ## Telemetry options by platform
 
-The web, mobile, and Unity providers expose similar telemetry controls with platform-specific option names. When a telemetry option is exposed, its default value is `true`.
+The web, mobile, and Unity providers expose similar telemetry controls with platform-specific option names. Each exposed option defaults to `true`, so the listed behaviors are on by default; set the option to `false` to opt out.
 
-| Concept | Web (`@datadog/openfeature-browser`) | Android (`dd-sdk-android-flags`) | iOS (`DatadogFlags`) | React Native | Unity |
-|---|---|---|---|---|---|
-| Send exposure events | `enableExposureLogging` | `trackExposures` | `trackExposures` | `trackExposures` | `trackExposures` |
-| Send aggregated evaluation telemetry | `enableFlagEvaluationTracking` | `trackEvaluations` | `trackEvaluations` | Not exposed | `trackEvaluations` |
-| Attach evaluations to RUM | `enableRumFeatureFlagTracking` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | Not exposed |
+| Concept | Default | Web (`@datadog/openfeature-browser`) | Android (`dd-sdk-android-flags`) | iOS (`DatadogFlags`) | React Native | Unity |
+|---|---|---|---|---|---|---|
+| Send exposure events | `true` | `enableExposureLogging` | `trackExposures` | `trackExposures` | `trackExposures` | `trackExposures` |
+| Send aggregated evaluation telemetry | `true` | `enableFlagEvaluationTracking` | `trackEvaluations` | `trackEvaluations` | Not exposed | `trackEvaluations` |
+| Attach evaluations to RUM | `true` | `enableRumFeatureFlagTracking` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | `rumIntegrationEnabled` | Not exposed |
 
 <div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift">dd-openfeature-provider-swift</a>) is available for use as a pre-1.0 package. Until it reaches 1.0, version updates may include breaking changes. For the most stable iOS API surface, use the <code>FlagsClient</code> API directly.</div>
 

--- a/content/en/feature_flags/client/android.md
+++ b/content/en/feature_flags/client/android.md
@@ -30,7 +30,7 @@ Here's a minimal example to get feature flags working in your Android app:
 ```kotlin
 // 1. Add dependencies (see Installation section)
 
-// 2. Initialize Datadog SDK (in Application.onCreate)
+// 2. Initialize the Datadog Android SDK (in Application.onCreate)
 val configuration = Configuration.Builder(
     clientToken = "<CLIENT_TOKEN>",
     env = "<ENV_NAME>",
@@ -94,7 +94,7 @@ Datadog.initialize(this, configuration, TrackingConsent.GRANTED)
 
 ## Enable flags
 
-After initializing Datadog, enable `Flags` to attach it to the current Datadog SDK instance and prepare for provider creation and flag evaluation:
+After initializing Datadog, enable `Flags` to attach it to the current Datadog Android SDK instance and prepare for provider creation and flag evaluation:
 
 {{< code-block lang="kotlin" >}}
 import com.datadog.android.flags.Flags

--- a/content/en/feature_flags/client/android.md
+++ b/content/en/feature_flags/client/android.md
@@ -128,7 +128,7 @@ OpenFeatureAPI.setProviderAndWait(provider)
 
 Define who or what the flag evaluation applies to using an `ImmutableContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Set this before evaluating flags to help ensure proper targeting.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="kotlin" >}}
 import dev.openfeature.kotlin.sdk.ImmutableContext

--- a/content/en/feature_flags/client/android.md
+++ b/content/en/feature_flags/client/android.md
@@ -128,6 +128,8 @@ OpenFeatureAPI.setProviderAndWait(provider)
 
 Define who or what the flag evaluation applies to using an `ImmutableContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Set this before evaluating flags to help ensure proper targeting.
 
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+
 {{< code-block lang="kotlin" >}}
 import dev.openfeature.kotlin.sdk.ImmutableContext
 import dev.openfeature.kotlin.sdk.Value
@@ -143,7 +145,7 @@ OpenFeatureAPI.setEvaluationContext(
 )
 {{< /code-block >}}
 
-<div class="alert alert-info">All attribute values must use a <code>Value.String()</code> wrapper. The targeting key should be consistent for the same user to help ensure consistent flag evaluation across sessions. For anonymous users, use a persistent UUID stored, for example, in <code>SharedPreferences</code>.</div>
+<div class="alert alert-info">OpenFeature attributes must use flat <code>Value</code> primitives such as <code>Value.String()</code>, <code>Value.Integer()</code>, <code>Value.Double()</code>, or <code>Value.Boolean()</code>. The targeting key should be consistent for the same user to help ensure consistent flag evaluation across sessions. For anonymous users, use a persistent UUID stored, for example, in <code>SharedPreferences</code>.</div>
 
 ## Evaluate flags
 
@@ -288,6 +290,7 @@ You can configure individual providers with custom endpoints before creating the
 val provider = FlagsClient.Builder()
     .useCustomFlagEndpoint("https://your-proxy.example.com/flags")
     .useCustomExposureEndpoint("https://your-proxy.example.com/exposure")
+    .useCustomEvaluationEndpoint("https://your-proxy.example.com/evaluations")
     .build()
     .asOpenFeatureProvider()
 

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -52,7 +52,7 @@ pnpm add @datadog/openfeature-browser @openfeature/angular-sdk @openfeature/web-
 
 Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Note: Browser Feature Flags are currently not supported on GovCloud sites.
+<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
 
 ```typescript
 import { DatadogProvider } from '@datadog/openfeature-browser';
@@ -502,7 +502,7 @@ The Angular provider uses the Datadog browser provider, which also supports thes
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Enabling this option can increase RUM-billed event counts. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -74,7 +74,7 @@ Import the `OpenFeatureModule` in your Angular module and configure it using the
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 <div class="alert alert-info">The <code>targetingKey</code> is used as the randomization subject for percentage-based targeting. When a flag targets a percentage of subjects (for example, 50%), the <code>targetingKey</code> determines which "bucket" a user falls into. Users with the same <code>targetingKey</code> always receive the same variant for a given flag.</div>
 

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -50,12 +50,15 @@ pnpm add @datadog/openfeature-browser @openfeature/angular-sdk @openfeature/web-
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance with your Datadog credentials. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+
+Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
 
 ```typescript
 import { DatadogProvider } from '@datadog/openfeature-browser';
 
 const provider = new DatadogProvider({
+  // Required client-side Datadog credentials
   applicationId: '<APPLICATION_ID>',
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
@@ -70,6 +73,8 @@ Import the `OpenFeatureModule` in your Angular module and configure it using the
 ## Set the evaluation context
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 <div class="alert alert-info">The <code>targetingKey</code> is used as the randomization subject for percentage-based targeting. When a flag targets a percentage of subjects (for example, 50%), the <code>targetingKey</code> determines which "bucket" a user falls into. Users with the same <code>targetingKey</code> always receive the same variant for a given flag.</div>
 
@@ -489,10 +494,67 @@ export class MyComponent {
 }
 {{< /code-block >}}
 
+## Configure browser provider options
+
+The Angular provider uses the Datadog browser provider, which also supports these optional settings:
+
+| Option | Default | Use |
+| --- | --- | --- |
+| `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
+| `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
+| `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
+| `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |
+| `customHeaders` | unset | Add headers to flag-fetch requests. |
+| `overwriteRequestHeaders` | `false` | Replace default request headers with `customHeaders`. |
+
+## Testing
+
+You can test against a dedicated Datadog test environment with the real `DatadogProvider`, or swap it for OpenFeature's `TypedInMemoryProvider` to control flag values directly in test code. This section shows the in-memory approach, which keeps tests hermetic and offline. `TypedInMemoryProvider` is exported from `@openfeature/web-sdk`, which is already installed for Angular Feature Flags.
+
+{{< code-block lang="typescript" >}}
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { FeatureFlagService, OpenFeatureModule } from '@openfeature/angular-sdk';
+import { TypedInMemoryProvider } from '@openfeature/web-sdk';
+
+const flags = {
+  new_checkout_button: {
+    variants: { on: true, off: false },
+    defaultVariant: 'on',
+    disabled: false,
+  },
+};
+
+beforeEach(async () => {
+  await TestBed.configureTestingModule({
+    imports: [
+      OpenFeatureModule.forRoot({
+        provider: new TypedInMemoryProvider(flags),
+        context: { targetingKey: 'test-user' },
+      }),
+    ],
+  }).compileComponents();
+});
+
+afterEach(() => {
+  TestBed.resetTestingModule();
+});
+
+it('uses in-memory flag values', async () => {
+  const flagService = TestBed.inject(FeatureFlagService);
+  const details = await firstValueFrom(flagService.getBooleanDetails('new_checkout_button', false));
+
+  expect(details.value).toBe(true);
+});
+{{< /code-block >}}
+
+The Web SDK flag shape requires `variants`, `defaultVariant`, and `disabled`. Register the in-memory provider before injecting services or rendering components that read flags.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://openfeature.dev/docs/reference/sdks/client/web/angular/
 [2]: /account_management/api-app-keys/#client-tokens
-

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -52,7 +52,7 @@ pnpm add @datadog/openfeature-browser @openfeature/angular-sdk @openfeature/web-
 
 Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
+{{< site-region region="gov,gov2" >}}<div class="alert alert-danger">Browser Feature Flags are not supported for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>{{< /site-region >}}
 
 ```typescript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -52,7 +52,7 @@ pnpm add @datadog/openfeature-browser @openfeature/angular-sdk @openfeature/web-
 
 Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
+Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
 ```typescript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -50,7 +50,7 @@ pnpm add @datadog/openfeature-browser @openfeature/angular-sdk @openfeature/web-
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
 Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
@@ -502,7 +502,7 @@ The Angular provider uses the Datadog browser provider, which also supports thes
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -502,7 +502,7 @@ The Angular provider uses the Datadog browser provider, which also supports thes
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -94,7 +94,7 @@ Datadog.initialize(
 
 ## Enable flags
 
-After initializing Datadog, enable `Flags` to attach it to the current Datadog SDK instance and prepare for client creation and flags evaluation:
+After initializing Datadog, enable `Flags` to attach it to the current Datadog iOS SDK instance and prepare for client creation and flags evaluation:
 
 {{< code-block lang="swift" >}}
 import DatadogFlags

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -131,6 +131,8 @@ let flagsClient = FlagsClient.shared(named: "checkout")
 
 Define who or what the flag evaluation applies to using a `FlagsEvaluationContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Call this method before evaluating flags to ensure proper targeting.
 
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+
 {{< code-block lang="swift" >}}
 flagsClient.setEvaluationContext(
     FlagsEvaluationContext(
@@ -240,7 +242,7 @@ When you need more than just the flag value, use the `get<Type>Details` APIs. Th
 For example:
 
 {{< code-block lang="swift" >}}
-let details = flags.getStringDetails(
+let details = flagsClient.getStringDetails(
     key: "paywall.layout",
     defaultValue: "control"
 )
@@ -387,12 +389,15 @@ Flags.enable(with: config)
 `customExposureEndpoint`
 : Configures a custom server URL for sending flags exposure data.
 
+`customEvaluationEndpoint`
+: Configures a custom server URL for sending flag evaluation telemetry.
+
 `customFlagsHeaders`
 : Sets additional HTTP headers to attach to requests made to `customFlagsEndpoint`. It can be useful for authentication or routing when using your own flags service.
 
 ## Testing
 
-The examples above use Datadog's `FlagsClient` API directly. If you prefer to drive feature flags through the [OpenFeature](https://openfeature.dev/) standard API, Datadog ships an OpenFeature bridge for iOS at [dd-openfeature-provider-swift](https://github.com/DataDog/dd-openfeature-provider-swift). Use the bridge's `DatadogProvider` in production, and for code-controlled flag values in tests, substitute an in-memory provider.
+The examples above use Datadog's `FlagsClient` API directly. Use `FlagsClient` for production workloads. If you are prototyping against the [OpenFeature](https://openfeature.dev/) bridge or writing tests around the OpenFeature API, substitute an in-memory provider for code-controlled flag values.
 
 You can test against a dedicated Datadog test environment with the real `DatadogProvider`, or swap it for an in-memory `FeatureProvider` to control flag values directly in test code. This section shows the in-memory approach, which keeps tests hermetic and offline. The OpenFeature Swift SDK does not ship an `InMemoryProvider`, so tests use a small custom `FeatureProvider` instead.
 

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -259,7 +259,7 @@ Flag details may help you debug evaluation behavior and understand why a user re
 
 The examples above use Datadog's `FlagsClient` API directly. If you prefer the [OpenFeature](https://openfeature.dev/) standard API, Datadog ships an OpenFeature provider for iOS that wraps `FlagsClient` and exposes it through `OpenFeatureAPI.shared`. The same flag data is served through either surface; pick whichever API fits your app.
 
-<div class="alert alert-warning">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift"><code>dd-openfeature-provider-swift</code></a>) is in development and not recommended for production use. Use the <code>FlagsClient</code> API shown above for production workloads; use this section to prototype OpenFeature integrations or to structure tests around the OpenFeature API.</div>
+<div class="alert alert-info">The iOS OpenFeature bridge (<a href="https://github.com/DataDog/dd-openfeature-provider-swift"><code>dd-openfeature-provider-swift</code></a>) is available for use as a pre-1.0 package. Until it reaches 1.0, version updates may include breaking changes. Use this section to integrate through OpenFeature; use <code>FlagsClient</code> directly for the most stable iOS API surface.</div>
 
 ### Install the OpenFeature provider
 
@@ -397,7 +397,7 @@ Flags.enable(with: config)
 
 ## Testing
 
-The examples above use Datadog's `FlagsClient` API directly. Use `FlagsClient` for production workloads. If you are prototyping against the [OpenFeature](https://openfeature.dev/) bridge or writing tests around the OpenFeature API, substitute an in-memory provider for code-controlled flag values.
+The examples above use Datadog's `FlagsClient` API directly. If you use the [OpenFeature](https://openfeature.dev/) bridge or write tests around the OpenFeature API, substitute an in-memory provider for code-controlled flag values.
 
 You can test against a dedicated Datadog test environment with the real `DatadogProvider`, or swap it for an in-memory `FeatureProvider` to control flag values directly in test code. This section shows the in-memory approach, which keeps tests hermetic and offline. The OpenFeature Swift SDK does not ship an `InMemoryProvider`, so tests use a small custom `FeatureProvider` instead.
 

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -131,7 +131,7 @@ let flagsClient = FlagsClient.shared(named: "checkout")
 
 Define who or what the flag evaluation applies to using a `FlagsEvaluationContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Call this method before evaluating flags to ensure proper targeting.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="swift" >}}
 flagsClient.setEvaluationContext(

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -45,7 +45,7 @@ pnpm add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
 Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
@@ -212,7 +212,7 @@ The web provider also supports these optional settings:
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Note: Browser Feature Flags are currently not supported on GovCloud sites.
+<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';
@@ -212,7 +212,7 @@ The web provider also supports these optional settings:
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Enabling this option can increase RUM-billed event counts. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -66,7 +66,7 @@ const provider = new DatadogProvider({
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="javascript" >}}
 const evaluationContext = {

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -212,7 +212,7 @@ The web provider also supports these optional settings:
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Create a `DatadogProvider` instance with your Datadog credentials. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
+{{< site-region region="gov,gov2" >}}<div class="alert alert-danger">Browser Feature Flags are not supported for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>{{< /site-region >}}
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -45,13 +45,16 @@ pnpm add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance with your Datadog credentials. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+
+Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';
 import { OpenFeature } from '@openfeature/web-sdk';
 
 const provider = new DatadogProvider({
+  // Required client-side Datadog credentials
   applicationId: '<APPLICATION_ID>',
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
@@ -62,6 +65,8 @@ const provider = new DatadogProvider({
 ## Set the evaluation context
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="javascript" >}}
 const evaluationContext = {
@@ -199,6 +204,21 @@ await OpenFeature.setContext({
 });
 {{< /code-block >}}
 
+## Configure browser provider options
+
+The web provider also supports these optional settings:
+
+| Option | Default | Use |
+| --- | --- | --- |
+| `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
+| `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
+| `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
+| `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |
+| `customHeaders` | unset | Add headers to flag-fetch requests. |
+| `overwriteRequestHeaders` | `false` | Replace default request headers with `customHeaders`. |
+
 ## Testing
 
 You can test against a dedicated Datadog test environment with the real `DatadogProvider`, or swap it for OpenFeature's `InMemoryProvider` to control flag values directly in test code. This section shows the in-memory approach, which keeps tests hermetic and offline. `InMemoryProvider` is exported directly from `@openfeature/web-sdk`, so no additional dependency is required.
@@ -249,4 +269,3 @@ The Web SDK flag shape requires `variants`, `defaultVariant`, and `disabled`. Om
 
 [1]: https://openfeature.dev/
 [2]: /account_management/api-app-keys/#client-tokens
-

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Create a `DatadogProvider` instance with your Datadog credentials. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
+Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sd
 
 Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
+Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -65,7 +65,7 @@ const provider = new DatadogProvider({
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 Set the provider along with the evaluation context:
 

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sd
 
 Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-Note: Browser Feature Flags are currently not supported on GovCloud sites.
+<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';
@@ -305,7 +305,7 @@ The React provider uses the Datadog browser provider, which also supports these 
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Enabling this option can increase RUM-billed event counts. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -180,7 +180,7 @@ Built-in [suspense](https://react.dev/reference/react/Suspense) support allows y
 For example:
 
 {{< code-block lang="jsx" >}}
-import { useBooleanFlag } from '@openfeature/react-sdk';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Suspense } from 'react';
 
 function Content() {
@@ -193,7 +193,7 @@ function Content() {
 }
 
 function WelcomeMessage() {
-  const { value: showNewMessage } = useBooleanFlag('show-new-welcome-message', false, { suspend: true });
+  const showNewMessage = useBooleanFlagValue('show-new-welcome-message', false, { suspend: true });
 
   return (
     <>

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -305,7 +305,7 @@ The React provider uses the Datadog browser provider, which also supports these 
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -26,31 +26,34 @@ Install the Datadog OpenFeature provider and the OpenFeature React SDK using you
 {{< tabs >}}
 {{% tab "npm" %}}
 {{< code-block lang="bash" >}}
-npm install @datadog/openfeature-browser @openfeature/react-sdk @openfeature/core
+npm install @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
 {{< /code-block >}}
 {{% /tab %}}
 
 {{% tab "yarn" %}}
 {{< code-block lang="bash" >}}
-yarn add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/core
+yarn add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
 {{< /code-block >}}
 {{% /tab %}}
 
 {{% tab "pnpm" %}}
 {{< code-block lang="bash" >}}
-pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/core
+pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
 {{< /code-block >}}
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+
+Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';
 
 const provider = new DatadogProvider({
+  // Required client-side Datadog credentials
   applicationId: '<APPLICATION_ID>',
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
@@ -61,6 +64,8 @@ const provider = new DatadogProvider({
 ## Set the evaluation context
 
 Define who or what the flag evaluation applies to using an evaluation context. The evaluation context includes user or session information used to determine which flag variations should be returned. Reference these attributes in your targeting rules to control who sees each variant.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 Set the provider along with the evaluation context:
 
@@ -178,7 +183,6 @@ For example:
 import { useBooleanFlag } from '@openfeature/react-sdk';
 import { Suspense } from 'react';
 
-import
 function Content() {
   // Display a loading message if the component uses feature flags and the provider is not ready
   return (
@@ -292,6 +296,21 @@ await OpenFeature.setContext({
   plan: user.plan,
 });
 {{< /code-block >}}
+
+## Configure browser provider options
+
+The React provider uses the Datadog browser provider, which also supports these optional settings:
+
+| Option | Default | Use |
+| --- | --- | --- |
+| `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
+| `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
+| `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
+| `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |
+| `customHeaders` | unset | Add headers to flag-fetch requests. |
+| `overwriteRequestHeaders` | `false` | Replace default request headers with `customHeaders`. |
 
 ## Testing
 

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -45,7 +45,7 @@ pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sd
 
 ## Initialize the provider
 
-Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
+Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
 Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
@@ -305,7 +305,7 @@ The React provider uses the Datadog browser provider, which also supports these 
 | --- | --- | --- |
 | `enableExposureLogging` | `true` | Send exposure events to the exposures intake. |
 | `enableFlagEvaluationTracking` | `true` | Send aggregated evaluation telemetry. |
-| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events. This is the setting that can affect RUM usage. |
+| `enableRumFeatureFlagTracking` | `true` | Add flag evaluations to RUM events when Browser RUM is available. Available in `@datadog/openfeature-browser` v1.1.0 and later. This is the setting that can affect RUM usage. |
 | `flagEvaluationTrackingInterval` | `10000` ms | Flush interval for evaluation telemetry. |
 | `initialFlagsConfiguration` | `{}` | Bootstrap with precomputed flags. |
 | `flaggingProxy` | unset | Fetch flags through a proxy instead of `site`. |

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -47,7 +47,7 @@ pnpm add @datadog/openfeature-browser @openfeature/react-sdk @openfeature/web-sd
 
 Create a `DatadogProvider` instance and register it with OpenFeature. Do this as early as possible in your application, before rendering your React components. For live Browser Feature Flags configuration, `applicationId`, `clientToken`, `site`, and `env` are required. To create a client token, see [Client tokens][2].
 
-<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
+{{< site-region region="gov,gov2" >}}<div class="alert alert-danger">Browser Feature Flags are not supported for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>{{< /site-region >}}
 
 ```javascript
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/feature_flags/client/reactnative.md
+++ b/content/en/feature_flags/client/reactnative.md
@@ -269,7 +269,7 @@ function Content() {
 }
 
 function WelcomeMessage() {
-  const { value: showNewMessage } = useBooleanFlagValue('show-new-welcome-message', false, { suspend: true });
+  const showNewMessage = useBooleanFlagValue('show-new-welcome-message', false, { suspend: true });
 
   return (
     <>
@@ -438,6 +438,50 @@ OpenFeature.setContext({
     features: ['beta', 'analytics']  // array - NOT SUPPORTED
 });
 {{< /code-block >}}
+
+## Testing
+
+You can test against a dedicated Datadog test environment with the real `DatadogOpenFeatureProvider`, or swap it for OpenFeature's `TypedInMemoryProvider` to control flag values directly in test code. This section shows the in-memory approach, which keeps tests hermetic and offline. `TypedInMemoryProvider` is exported from `@openfeature/web-sdk`, which is already installed for React Native Feature Flags.
+
+{{< code-block lang="tsx" >}}
+import { render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { OpenFeature, OpenFeatureProvider, useBooleanFlagValue } from '@openfeature/react-sdk';
+import { TypedInMemoryProvider } from '@openfeature/web-sdk';
+
+const flags = {
+    new_checkout_button: {
+        variants: { on: true, off: false },
+        defaultVariant: 'on',
+        disabled: false,
+    },
+};
+
+beforeEach(async () => {
+    await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(flags));
+});
+
+afterAll(async () => {
+    await OpenFeature.close();
+});
+
+function CheckoutButton() {
+    const enabled = useBooleanFlagValue('new_checkout_button', false);
+    return <Text>{enabled ? 'New checkout' : 'Legacy checkout'}</Text>;
+}
+
+test('new checkout button is enabled', () => {
+    render(
+        <OpenFeatureProvider>
+            <CheckoutButton />
+        </OpenFeatureProvider>
+    );
+
+    expect(screen.getByText('New checkout')).toBeTruthy();
+});
+{{< /code-block >}}
+
+The Web SDK flag shape requires `variants`, `defaultVariant`, and `disabled`. Use `setProviderAndWait` before rendering components so hooks do not evaluate against the default provider.
 
 ## Troubleshooting
 

--- a/content/en/feature_flags/client/reactnative.md
+++ b/content/en/feature_flags/client/reactnative.md
@@ -68,7 +68,7 @@ buildscript {
 
 ## Initialize the SDK
 
-The Datadog OpenFeature provider for React Native requires the core Datadog SDK to be initialized first, followed by enabling the Feature Flags feature. To create a client token, see [Client tokens][2].
+The Datadog OpenFeature provider for React Native requires the core Datadog React Native SDK to be initialized first, followed by enabling the Feature Flags feature. To create a client token, see [Client tokens][2].
 
 ### Option 1: Using DatadogProvider component
 
@@ -489,7 +489,7 @@ The Web SDK flag shape requires `variants`, `defaultVariant`, and `disabled`. Us
 
 If flag evaluations return default values:
 
-1. Verify the Datadog SDK is initialized before calling `DdFlags.enable()`.
+1. Verify the Datadog React Native SDK is initialized before calling `DdFlags.enable()`.
 2. Confirm `DdFlags.enable()` completed before setting the OpenFeature provider.
 3. Check that the evaluation context is set before evaluating flags.
 4. Confirm the flag exists and is enabled in your Datadog Feature Flags dashboard.
@@ -519,7 +519,7 @@ end
 
 If you see an error about Feature Flags not being initialized, verify the initialization order:
 
-1. Initialize the core Datadog SDK first (`DdSdkReactNative.initialize()` or `DatadogProvider`).
+1. Initialize the core Datadog React Native SDK first (`DdSdkReactNative.initialize()` or `DatadogProvider`).
 2. Call `DdFlags.enable()` after SDK initialization.
 3. Create and set the `DatadogOpenFeatureProvider` after enabling flags.
 

--- a/content/en/feature_flags/client/unity.md
+++ b/content/en/feature_flags/client/unity.md
@@ -25,7 +25,7 @@ Declare the Datadog Unity SDK as a dependency in your project. The Datadog Unity
 
 1. Install the [External Dependency Manager for Unity (EDM4U)][1]. This can be done using [Open UPM][2].
 
-2. Add the [Datadog SDK Unity package][3] using its Git URL `https://github.com/DataDog/unity-package.git`.
+2. Add the [Datadog Unity SDK package][3] using its Git URL `https://github.com/DataDog/unity-package.git`.
 
 3. (Android only) Configure your project to use [Gradle templates][4], and enable both {{< ui >}}Custom Main Template{{< /ui >}} and {{< ui >}}Custom Gradle Properties Template{{< /ui >}}.
 
@@ -47,7 +47,7 @@ For more information about setting up the Unity SDK, see [Unity Monitoring Setup
 
 ## Enable flags
 
-After initializing Datadog, enable `Flags` to attach it to the current Datadog SDK instance and prepare for client creation and flag evaluation:
+After initializing Datadog, enable `Flags` to attach it to the current Datadog Unity SDK instance and prepare for client creation and flag evaluation:
 
 {{< code-block lang="csharp" >}}
 using Datadog.Unity.Flags;
@@ -182,6 +182,7 @@ When you need more than just the flag value, use the `Get<Type>Details` methods.
 * `GetStringDetails(key, defaultValue)` -> `FlagDetails<string>`
 * `GetIntegerDetails(key, defaultValue)` -> `FlagDetails<int>`
 * `GetDoubleDetails(key, defaultValue)` -> `FlagDetails<double>`
+* `GetDetails<T>(key, defaultValue)` -> `FlagDetails<T>` for object or custom detail results
 
 For example:
 

--- a/content/en/feature_flags/client/unity.md
+++ b/content/en/feature_flags/client/unity.md
@@ -77,6 +77,8 @@ var checkoutClient = DdFlags.Instance.CreateClient("checkout");
 
 Define who or what the flag evaluation applies to using a `FlagsEvaluationContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Call this method before evaluating flags to help ensure proper targeting.
 
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+
 {{< code-block lang="csharp" >}}
 client.SetEvaluationContext(
     new FlagsEvaluationContext(
@@ -223,6 +225,50 @@ DdFlags.Enable(new FlagsConfiguration(
 
 `customEvaluationEndpoint`
 : Configures a custom server URL for sending flags evaluation telemetry.
+
+## Testing
+
+You can test against a dedicated Datadog test environment with the real `IFlagsClient`, or isolate game logic behind a small application interface and substitute a fake implementation in unit tests. This section shows the fake approach, which keeps tests hermetic and offline.
+
+{{< code-block lang="csharp" >}}
+public interface ICheckoutFlags
+{
+    bool NewCheckoutEnabled();
+}
+
+public sealed class DatadogCheckoutFlags : ICheckoutFlags
+{
+    private readonly IFlagsClient client;
+
+    public DatadogCheckoutFlags(IFlagsClient client)
+    {
+        this.client = client;
+    }
+
+    public bool NewCheckoutEnabled()
+    {
+        return client.GetBooleanValue("new-checkout-flow", false);
+    }
+}
+
+public sealed class TestCheckoutFlags : ICheckoutFlags
+{
+    public bool NewCheckoutEnabled()
+    {
+        return true;
+    }
+}
+
+[Test]
+public void FakeFlagValueCanDriveGameLogic()
+{
+    ICheckoutFlags flags = new TestCheckoutFlags();
+
+    Assert.IsTrue(flags.NewCheckoutEnabled());
+}
+{{< /code-block >}}
+
+Keep calls to `DdFlags.Instance.CreateClient()` at your application boundary. This lets tests replace flag values without initializing the Datadog Unity SDK.
 
 ## Further reading
 

--- a/content/en/feature_flags/client/unity.md
+++ b/content/en/feature_flags/client/unity.md
@@ -77,7 +77,7 @@ var checkoutClient = DdFlags.Instance.CreateClient("checkout");
 
 Define who or what the flag evaluation applies to using a `FlagsEvaluationContext`. The evaluation context includes user or session information used to determine which flag variations should be returned. Call this method before evaluating flags to help ensure proper targeting.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="csharp" >}}
 client.SetEvaluationContext(

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -27,7 +27,7 @@ curl -sSL https://coterm.datadoghq.com/mcp-cli/install.sh | bash
 Then follow the instructions below to add the MCP Server to your specific client.
 
 <div class="alert alert-info">
-  The Feature Flags MCP Server endpoint uses <code>/api/unstable/</code>. This API is in preview.
+  The Feature Flags toolset is generally available on the Datadog MCP Server. The MCP Server endpoint currently uses the <code>/api/unstable/</code> path.
 </div>
 
 ### Claude Code

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -57,7 +57,7 @@ Add this to `~/.cursor/mcp.json` (remember to save the file):
 The MCP Server includes tools to help you manage feature flags in your codebase. The following use cases provide sample prompts for using the tools.
 
 <div class="alert alert-info">
-  The code-implementation tools, such as <code>check-flag-implementation</code>, currently target React applications. Other tools, such as <code>list-feature-flags</code> and <code>update-feature-flag-environment</code>, are framework-agnostic.
+  The code-implementation tools, such as <code>check-flag-implementation</code>, target React applications. Other tools, such as <code>list-feature-flags</code> and <code>update-feature-flag-environment</code>, are framework-agnostic.
 </div>
 
 ### Create feature flags

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -26,6 +26,10 @@ curl -sSL https://coterm.datadoghq.com/mcp-cli/install.sh | bash
 
 Then follow the instructions below to add the MCP Server to your specific client.
 
+<div class="alert alert-info">
+  The Feature Flags MCP Server endpoint uses <code>/api/unstable/</code>. This API is in preview.
+</div>
+
 ### Claude Code
 
 ```bash
@@ -53,7 +57,7 @@ Add this to `~/.cursor/mcp.json` (remember to save the file):
 The MCP Server includes tools to help you manage feature flags in your codebase. The following use cases provide sample prompts for using the tools.
 
 <div class="alert alert-info">
-  The MCP Server only supports React applications.
+  The code-implementation tools, such as <code>check-flag-implementation</code>, currently target React applications. Other tools, such as <code>list-feature-flags</code> and <code>update-feature-flag-environment</code>, are framework-agnostic.
 </div>
 
 ### Create feature flags

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -27,7 +27,7 @@ curl -sSL https://coterm.datadoghq.com/mcp-cli/install.sh | bash
 Then follow the instructions below to add the MCP Server to your specific client.
 
 <div class="alert alert-info">
-  The Feature Flags toolset is generally available on the Datadog MCP Server. The MCP Server endpoint currently uses the <code>/api/unstable/</code> path.
+  The Feature Flags toolset is generally available on the Datadog MCP Server. The MCP Server endpoint uses the <code>/api/unstable/</code> path.
 </div>
 
 ### Claude Code

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -76,7 +76,8 @@ After installation, ensure you have initialized the Datadog provider with your c
 import com.datadog.android.flags.FlagsClient
 import com.datadog.android.flags.EvaluationContext
 
-val flagsClient = FlagsClient.getDefault()
+FlagsClient.Builder().build()
+val flagsClient = FlagsClient.get()
 
 // Set evaluation context
 flagsClient.setEvaluationContext(
@@ -105,7 +106,7 @@ if (showNewFeature) {
 {{< code-block lang="swift" >}}
 import DatadogFlags
 
-let flagsClient = FlagsClient.shared()
+let flagsClient = FlagsClient.create()
 
 // Set evaluation context
 flagsClient.setEvaluationContext(
@@ -119,8 +120,8 @@ flagsClient.setEvaluationContext(
 )
 
 // Evaluate flag
-let showNewFeature = flagsClient.resolveBooleanValue(
-    flagKey: "show-new-feature",
+let showNewFeature = flagsClient.getBooleanValue(
+    key: "show-new-feature",
     defaultValue: false
 )
 
@@ -332,11 +333,17 @@ Implement a wrapper function that provides a fallback mechanism to use the Launc
 import com.launchdarkly.sdk.LDContext
 import com.launchdarkly.sdk.android.LDClient
 import com.launchdarkly.sdk.android.LDConfig
+import android.app.Application
+import com.datadog.android.Datadog
+import com.datadog.android.DatadogSite
+import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.flags.Flags
 import com.datadog.android.flags.FlagsClient
 import com.datadog.android.flags.EvaluationContext
+import com.datadog.android.privacy.TrackingConsent
 
 class FallbackWrapper(
+    private val application: Application,
     userId: String,
     evaluationContext: Map<String, String>
 ) {
@@ -345,7 +352,7 @@ class FallbackWrapper(
 
     init {
         val ldConfig = LDConfig.Builder()
-            .mobileKey('YOUR_LD_MOBILE_KEY')
+            .mobileKey("YOUR_LD_MOBILE_KEY")
             .build()
 
         val cb = LDContext.builder(userId)
@@ -353,14 +360,17 @@ class FallbackWrapper(
             cb.set(key, value)
         }
         val ldContext = cb.build()
-        ldClient = LDClient.init(this@BaseApplication, ldConfig, ldContext, 5)
+        ldClient = LDClient.init(application, ldConfig, ldContext, 5)
 
         val ddConfig = Configuration.Builder(
-            clientToken = 'YOUR_DD_CLIENT_TOKEN',
-            env = 'DD_ENV',
-            variant = 'APP_VARIANT_NAME'
+            clientToken = "YOUR_DD_CLIENT_TOKEN",
+            env = "DD_ENV",
+            variant = "APP_VARIANT_NAME"
         )
+            .useSite(DatadogSite.US1)
+            .build()
 
+        Datadog.initialize(application, ddConfig, TrackingConsent.GRANTED)
         Flags.enable()
 
         ddClient = FlagsClient.Builder().build()
@@ -401,11 +411,14 @@ class FallbackWrapper {
     private let ldClient: LDClient
     private let ddClient: FlagsClient
 
-    init(userId: String, evaluationContext: [String: AnyValue] = [:]) {
-        let ldConfig = LDConfig(mobileKey: 'YOUR_LD_MOBILE_KEY', autoEnvAttributes: .enabled)
-        var ldContext = LDContextBuilder(key: userId)
+    init(userId: String, evaluationContext: [String: String] = [:]) {
+        let ldConfig = LDConfig(mobileKey: "YOUR_LD_MOBILE_KEY", autoEnvAttributes: .enabled)
+        var ldContextBuilder = LDContextBuilder(key: userId)
         for (key, value) in evaluationContext {
-            ldContext.trySetValue(key, value)
+            ldContextBuilder.trySetValue(key, LDValue.string(value))
+        }
+        guard let ldContext = try? ldContextBuilder.build().get() else {
+            fatalError("Invalid LaunchDarkly context")
         }
         LDClient.start(config: ldConfig, context: ldContext)
 
@@ -426,21 +439,23 @@ class FallbackWrapper {
         self.ddClient.setEvaluationContext(
             FlagsEvaluationContext(
                 targetingKey: userId,
-                attributes: evaluationContext
+                attributes: evaluationContext.mapValues { .string($0) }
             )
         )
     }
 
     func getBooleanFlag(flagKey: String, defaultValue: Bool) -> Bool {
-        do {
-            return self.ddClient.resolveBooleanValue(
-                flagKey: flagKey,
-                defaultValue: defaultValue
-            )
-        } catch {
-            print("Falling back to LaunchDarkly for flag: \(flagKey)")
-            return self.ldClient.boolVariation(forKey: flagKey, defaultValue: defaultValue)
+        let details = self.ddClient.getBooleanDetails(
+            key: flagKey,
+            defaultValue: defaultValue
+        )
+
+        if details.error == nil {
+            return details.value
         }
+
+        print("Falling back to LaunchDarkly for flag: \(flagKey)")
+        return self.ldClient.boolVariation(forKey: flagKey, defaultValue: defaultValue)
     }
 }
 {{< /code-block >}}
@@ -453,13 +468,14 @@ import { OpenFeature } from '@openfeature/web-sdk';
 import { DatadogProvider } from '@datadog/openfeature-browser';
 
 class FallbackWrapper {
-    private ldClient;
-    private ddClient;
+    ldClient;
+    ddClient;
     async initialize(userId, evaluationContext = {}) {
         try {
             const ddProvider = new DatadogProvider({
                 applicationId: 'YOUR_APP_ID',
                 clientToken: 'YOUR_CLIENT_TOKEN',
+                site: 'datadoghq.com',
                 env: 'ENV_NAME',
             });
 
@@ -487,7 +503,7 @@ class FallbackWrapper {
             }
             return this.ddClient.getBooleanValue(flagKey, defaultValue);
         } catch (e) {
-            console.warn(`Falling back to LaunchDarkly for flag: ${flagKey});
+            console.warn(`Falling back to LaunchDarkly for flag: ${flagKey}`);
             return this.ldClient.variation(flagKey, defaultValue);
         }
     }

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -76,8 +76,7 @@ After installation, ensure you have initialized the Datadog provider with your c
 import com.datadog.android.flags.FlagsClient
 import com.datadog.android.flags.EvaluationContext
 
-FlagsClient.Builder().build()
-val flagsClient = FlagsClient.get()
+val flagsClient = FlagsClient.Builder().build()
 
 // Set evaluation context
 flagsClient.setEvaluationContext(
@@ -475,7 +474,7 @@ class FallbackWrapper {
             const ddProvider = new DatadogProvider({
                 applicationId: 'YOUR_APP_ID',
                 clientToken: 'YOUR_CLIENT_TOKEN',
-                site: 'datadoghq.com',
+                site: '{{< region-param key="dd_site" code="true" >}}',
                 env: 'ENV_NAME',
             });
 

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -408,7 +408,7 @@ import DatadogCore
 
 class FallbackWrapper {
     private let ldClient: LDClient
-    private let ddClient: FlagsClient
+    private let ddClient: FlagsClientProtocol
 
     init(userId: String, evaluationContext: [String: String] = [:]) {
         let ldConfig = LDConfig(mobileKey: "YOUR_LD_MOBILE_KEY", autoEnvAttributes: .enabled)

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -17,7 +17,7 @@ further_reading:
 
 This guide walks you through the process of migrating feature flags from LaunchDarkly to [Datadog Feature Flags][1]. Follow these general steps:
 
-1. [Install the Datadog SDK.](#install-sdk)
+1. [Install the Datadog Feature Flags provider.](#install-sdk)
 2. [Create a feature flag in Datadog and verify its functionality.](#set-up-flag)
 3. [Identify critical feature flags in LaunchDarkly.](#identify-critical-flags)
 4. [For all non-critical flags, remove existing code.](#remove-non-critical-flags)
@@ -27,7 +27,7 @@ This guide walks you through the process of migrating feature flags from LaunchD
 
 ## Migration process
 
-### 1. Install the Datadog SDK {#install-sdk}
+### 1. Install the Datadog Feature Flags provider {#install-sdk}
 
 Datadog Feature Flags are built on the [OpenFeature][2] standard, which provides vendor-agnostic feature flag APIs. You need to install both the OpenFeature SDK and the Datadog provider for your platform.
 
@@ -323,7 +323,7 @@ end
 
 Implement a wrapper function that provides a fallback mechanism to use the LaunchDarkly flag values if the application experiences issues fetching the Datadog flag.
 
-<div class="alert alert-info">LaunchDarkly and Datadog SDKs use strongly typed methods for flag evaluation (for example, <code>getBooleanValue</code>, <code>getStringValue</code>, <code>getIntegerValue</code>). The examples below demonstrate Boolean flag evaluation. You will need to create similar wrapper functions for each flag type used in your application.</div>
+<div class="alert alert-info">LaunchDarkly and Datadog Feature Flags SDKs use strongly typed methods for flag evaluation (for example, <code>getBooleanValue</code>, <code>getStringValue</code>, <code>getIntegerValue</code>). The examples below demonstrate Boolean flag evaluation. You will need to create similar wrapper functions for each flag type used in your application.</div>
 
 {{< tabs >}}
 {{% tab "Client-side SDKs" %}}

--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -74,7 +74,7 @@ DD_METRICS_OTEL_ENABLED=true
 
 <div class="alert alert-warning">The <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code> environment variable is required to enable the feature flagging provider. Java also supports the system property <code>-Ddd.experimental.flagging.provider.enabled=true</code>, and Ruby and Node.js support code-based configuration as an alternative. See the SDK-specific documentation for details.</div>
 
-<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. On supported Agent versions it is enabled by default. Only set SDK-level Remote Configuration variables, such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>, if your tracer has Remote Configuration disabled and you need to override that setting.</div>
+<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. It is enabled by default on Agent 7.47.0 and later. Only set SDK-level Remote Configuration variables (such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>) if your tracer has Remote Configuration disabled and you need to override that setting.</div>
 
 <div class="alert alert-info">Set <code>DD_METRICS_OTEL_ENABLED=true</code> to enable flag evaluation metrics. Without this, the SDK does not emit metrics for flag evaluations. When enabled, each evaluation records a <code>feature_flag.evaluations</code> counter metric tagged with the flag key, result variant, and evaluation reason.</div>
 

--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -36,7 +36,7 @@ Before setting up server-side feature flags, ensure you have:
 
 ## Agent configuration
 
-Server-side feature flags use [Remote Configuration][1] to deliver flag configurations to your application. Enable Remote Configuration in your Datadog Agent by setting `DD_REMOTE_CONFIGURATION_ENABLED=true` or adding `remote_configuration.enabled: true` to your `datadog.yaml`.
+Server-side feature flags use [Remote Configuration][1] to deliver flag configurations to your application. Remote Configuration is enabled by default in Agent 7.47.0 and later. If your Agent has Remote Configuration disabled, re-enable it by setting `DD_REMOTE_CONFIGURATION_ENABLED=true` or adding `remote_configuration.enabled: true` to your `datadog.yaml`.
 
 See the [Remote Configuration documentation][1] for detailed setup instructions across different deployment environments.
 
@@ -63,17 +63,16 @@ DD_VERSION=<YOUR_APP_VERSION>
 DD_AGENT_HOST=localhost
 DD_TRACE_AGENT_PORT=8126
 
-# Enable Remote Configuration in the SDK
-DD_REMOTE_CONFIG_ENABLED=true
-
-# Enable the feature flagging provider (required for most SDKs)
+# Required: Enable the feature flagging provider
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
-# Enable flag evaluation metrics (required for flag evaluation tracking)
+# Optional: Enable flag evaluation metrics
 DD_METRICS_OTEL_ENABLED=true
 {{< /code-block >}}
 
 <div class="alert alert-warning">The <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code> environment variable is required to enable the feature flagging provider. Java also supports the system property <code>-Ddd.experimental.flagging.provider.enabled=true</code>, and Ruby and Node.js support code-based configuration as an alternative. See the SDK-specific documentation for details.</div>
+
+<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. On supported Agent versions it is enabled by default. Only set SDK-level Remote Configuration variables, such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>, if your tracer has Remote Configuration disabled and you need to override that setting.</div>
 
 <div class="alert alert-info">Set <code>DD_METRICS_OTEL_ENABLED=true</code> to enable flag evaluation metrics. Without this, the SDK does not emit metrics for flag evaluations. When enabled, each evaluation records a <code>feature_flag.evaluations</code> counter metric tagged with the flag key, result variant, and evaluation reason.</div>
 

--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -12,7 +12,9 @@ further_reading:
 
 ## Overview
 
-Datadog Feature Flags for server-side applications allow you to remotely control feature availability, run experiments, and roll out new functionality with confidence. Server-side SDKs integrate with the Datadog SDK and use Remote Configuration to receive flag updates in real time.
+Datadog Feature Flags for server-side applications allow you to remotely control feature availability, run experiments, and roll out new functionality with confidence. Server-side SDKs integrate with the Datadog tracer for your language and use Remote Configuration to receive flag updates in real time.
+
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
 
 This guide covers the common setup required for all server-side SDKs, including Agent configuration and application environment variables. Select your language or framework to view SDK-specific setup instructions:
 

--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 Datadog Feature Flags for server-side applications allow you to remotely control feature availability, run experiments, and roll out new functionality with confidence. Server-side SDKs integrate with the Datadog tracer for your language and use Remote Configuration to receive flag updates in real time.
 
-Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. See OpenFeature's getting-started guide if you're new to OpenFeature concepts like providers, evaluation context, and hooks.
+Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature.dev/docs/reference/intro/), an open-source, vendor-neutral specification for feature flag APIs. If you're new to OpenFeature concepts like providers, evaluation context, and hooks, see the [OpenFeature concepts documentation](https://openfeature.dev/docs/category/concepts).
 
 This guide covers the common setup required for all server-side SDKs, including Agent configuration and application environment variables. Select your language or framework to view SDK-specific setup instructions:
 

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -32,10 +32,15 @@ Set the following environment variables:
 # Required: Enable the feature flags provider
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
+# Optional: Enable flag evaluation metrics
+DD_METRICS_OTEL_ENABLED=true
+
 # Required: Service identification
 DD_SERVICE=<YOUR_SERVICE_NAME>
 DD_ENV=<YOUR_ENVIRONMENT>
 {{< /code-block >}}
+
+<div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
 ## Installation
 
@@ -108,6 +113,8 @@ var client = Api.Instance.GetClient("my-service");
 ## Set the evaluation context
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="csharp" >}}
 using OpenFeature.Model;

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your .NET application with the Datadog Feature Flags SDK. The .NET SDK integrates with [OpenFeature][1], an open standard for feature flag management, and uses the Datadog SDK's Remote Configuration to receive flag updates in real time.
+This page describes how to instrument your .NET application with the Datadog Feature Flags SDK. The .NET SDK integrates with [OpenFeature][1], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog .NET tracer (`dd-trace-dotnet`).
 
 This guide explains how to install and enable the SDK, create an OpenFeature client, and evaluate feature flags in your application.
 
@@ -62,7 +62,7 @@ Or add them to your `.csproj` file:
 
 ## Initialize the SDK
 
-Register the Datadog OpenFeature provider with the OpenFeature API. The provider connects to the Datadog SDK's Remote Configuration system to receive flag configurations.
+Register the Datadog OpenFeature provider with the OpenFeature API. The provider connects to the Datadog .NET tracer's Remote Configuration system to receive flag configurations.
 
 ### Blocking initialization
 

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -114,7 +114,7 @@ var client = Api.Instance.GetClient("my-service");
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="csharp" >}}
 using OpenFeature.Model;

--- a/content/en/feature_flags/server/go.md
+++ b/content/en/feature_flags/server/go.md
@@ -159,7 +159,7 @@ client := openfeature.NewClient("my-service")
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="go" >}}
 evalCtx := openfeature.NewEvaluationContext(

--- a/content/en/feature_flags/server/go.md
+++ b/content/en/feature_flags/server/go.md
@@ -20,7 +20,7 @@ This guide explains how to install and enable the SDK, create an OpenFeature cli
 
 Before setting up the Go Feature Flags SDK, ensure you have:
 
-- **Datadog Agent** with [Remote Configuration][2] enabled
+- **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
 - **Datadog Go SDK** `dd-trace-go` version 2.4.0 or later
 
@@ -30,10 +30,15 @@ Set the following environment variables:
 # Required: Enable the feature flags provider
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
+# Optional: Enable flag evaluation metrics
+DD_METRICS_OTEL_ENABLED=true
+
 # Required: Service identification
 DD_SERVICE=<YOUR_SERVICE_NAME>
 DD_ENV=<YOUR_ENVIRONMENT>
 {{< /code-block >}}
+
+<div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
 ## Installation
 
@@ -153,6 +158,8 @@ client := openfeature.NewClient("my-service")
 ## Set the evaluation context
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="go" >}}
 evalCtx := openfeature.NewEvaluationContext(

--- a/content/en/feature_flags/server/go.md
+++ b/content/en/feature_flags/server/go.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your Go application with the Datadog Feature Flags SDK. The Go SDK integrates with [OpenFeature][1], an open standard for feature flag management, and uses the Datadog SDK's Remote Configuration to receive flag updates in real time.
+This page describes how to instrument your Go application with the Datadog Feature Flags SDK. The Go SDK integrates with [OpenFeature][1], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog Go tracer (`dd-trace-go`).
 
 This guide explains how to install and enable the SDK, create an OpenFeature client, and evaluate feature flags in your application.
 
@@ -56,7 +56,7 @@ go get github.com/open-feature/go-sdk/openfeature
 
 ## Initialize the SDK
 
-Start the Datadog SDK and register the Datadog OpenFeature provider. The SDK must be started first because it enables Remote Configuration, which delivers flag configurations to your application.
+Start the Datadog Go tracer and register the Datadog OpenFeature provider. The tracer must be started first because it enables Remote Configuration, which delivers flag configurations to your application.
 
 ### Blocking initialization
 

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -241,7 +241,7 @@ api.setProvider(new Provider());
 
 The evaluation context defines the subject (user, device, session) for flag evaluation. It determines which flag variations are returned based on targeting rules.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="java" >}}
 import dev.openfeature.sdk.EvaluationContext;

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -26,7 +26,7 @@ The Datadog Feature Flags SDK for Java requires:
 - **Java 11 or higher**
 - **Datadog Java SDK**: Version **1.57.0** or later
 - **OpenFeature SDK**: Version **1.18.2** or later
-- **Datadog Agent**: Version **7.x or later** with [Remote Configuration][1] enabled
+- **Datadog Agent**: Version **7.55 or later** with [Remote Configuration][1] enabled
 - **Datadog [API key][7]**: Configured on the Agent (not the application) for Remote Configuration
 
 For a full list of Datadog's Java version and framework support, read [Compatibility Requirements](/tracing/trace_collection/compatibility/java/).
@@ -110,19 +110,19 @@ api_key: <YOUR_API_KEY>
 
 ### Application configuration
 
-If your application already runs with `-javaagent:dd-java-agent.jar` and has Remote Configuration enabled (`DD_REMOTE_CONFIG_ENABLED=true`), you only need to add the feature flagging variable (`DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`). Skip the SDK download and JVM configuration steps.
+If your application already runs with `-javaagent:dd-java-agent.jar` and Remote Configuration is available, you only need to add the feature flagging variable (`DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`). Skip the SDK download and JVM configuration steps.
 
 Configure your Java application with the required environment variables or system properties:
 
 {{< tabs >}}
 {{% tab "Environment Variables" %}}
 {{< code-block lang="bash" >}}
-# Required: Enable Remote Configuration in the SDK
-export DD_REMOTE_CONFIG_ENABLED=true
-
 # Required: Enable the feature flagging provider
 # The EXPERIMENTAL_ prefix is historical; the provider is no longer experimental.
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+export DD_METRICS_OTEL_ENABLED=true
 
 # Required: Service name
 export DD_SERVICE=<YOUR_SERVICE_NAME>
@@ -141,8 +141,8 @@ java -javaagent:path/to/dd-java-agent.jar -jar your-application.jar
 {{% tab "System Properties" %}}
 {{< code-block lang="bash" >}}
 java -javaagent:path/to/dd-java-agent.jar \
-  -Ddd.remote.config.enabled=true \
   -Ddd.experimental.flagging.provider.enabled=true \
+  -Ddd.metrics.otel.enabled=true \
   -Ddd.service=<YOUR_SERVICE_NAME> \
   -Ddd.env=<YOUR_ENVIRONMENT> \
   -Ddd.version=<YOUR_APP_VERSION> \
@@ -151,17 +151,19 @@ java -javaagent:path/to/dd-java-agent.jar \
 {{% /tab %}}
 {{< /tabs >}}
 
-The Datadog feature flagging system starts automatically when the tracer is initialized with both Remote Configuration and the feature flagging provider enabled. No additional initialization code is required in your application.
+The Datadog feature flagging system starts automatically when the tracer is initialized with Remote Configuration available and the feature flagging provider enabled. No additional initialization code is required in your application.
 
-<div class="alert alert-danger">Feature flagging requires both <code>DD_REMOTE_CONFIG_ENABLED=true</code> and <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. Without these settings, the feature flagging system does not start and the <code>Provider</code> returns the programmatic default.</div>
+<div class="alert alert-danger">Feature flagging requires <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code> and Remote Configuration connectivity. Without the provider setting, the feature flagging system does not start and the <code>Provider</code> returns the programmatic default.</div>
+
+<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. On supported Agent versions it is enabled by default. Only set SDK-level Remote Configuration variables, such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>, if your tracer has Remote Configuration disabled and you need to override that setting.</div>
 
 ### Add the Java tracer to the JVM
 
 For instructions on how to add the `-javaagent` argument to your application server or framework, see [Add the Java SDK to the JVM](/tracing/trace_collection/automatic_instrumentation/dd_libraries/java/#add-the-java-sdk-to-the-jvm).
 
 Make sure to include the feature flagging configuration flags:
-- `-Ddd.remote.config.enabled=true`
 - `-Ddd.experimental.flagging.provider.enabled=true`
+- `-Ddd.metrics.otel.enabled=true` if you want flag evaluation metrics
 
 ## Initialize the OpenFeature provider
 
@@ -238,6 +240,8 @@ api.setProvider(new Provider());
 ## Set the evaluation context
 
 The evaluation context defines the subject (user, device, session) for flag evaluation. It determines which flag variations are returned based on targeting rules.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="java" >}}
 import dev.openfeature.sdk.EvaluationContext;
@@ -556,7 +560,7 @@ Before checking infrastructure, confirm the flag itself is set up correctly:
 
 Remote Configuration delivers flag configurations from the Datadog backend to the Agent.
 
-1. **RC is enabled on the Agent**: Set `remote_configuration.enabled: true` in `datadog.yaml` or `DD_REMOTE_CONFIG_ENABLED=true`. See [Remote Configuration][1].
+1. **RC is enabled on the Agent**: Agent 7.47.0 and later enable Remote Configuration by default. If it has been disabled, set `remote_configuration.enabled: true` in `datadog.yaml` or `DD_REMOTE_CONFIGURATION_ENABLED=true`. See [Remote Configuration][1].
 2. **`DD_API_KEY` is valid on the Agent** and belongs to the target organization.
 3. **`DD_SITE` is set correctly** on the Agent (`site` in `datadog.yaml` or `DD_SITE` env var). See [Agent Site Issues][3].
 4. **Fleet Automation**: Open [{{< ui >}}Fleet Automation{{< /ui >}}][4], select the Agent your application connects to, and confirm Remote Configuration is active.
@@ -565,7 +569,7 @@ Remote Configuration delivers flag configurations from the Datadog backend to th
 ### 3. Agent: Verify Agent health and connectivity
 
 1. **Agent is running and reachable**: See [APM Connection Errors][2] for steps to verify Agent connectivity from the tracer.
-2. **Agent version**: Feature flagging requires Agent 7.x or later with EVP Proxy support.
+2. **Agent version**: Feature flagging requires Agent 7.55 or later with EVP Proxy support.
 3. **EVP proxy is available**: Query the Agent's info endpoint and confirm the response includes `evp_proxy/v4/` and `v0.7/config` in the `endpoints` array:
    ```bash
    curl http://localhost:8126/info

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -155,7 +155,7 @@ The Datadog feature flagging system starts automatically when the tracer is init
 
 <div class="alert alert-danger">Feature flagging requires <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code> and Remote Configuration connectivity. Without the provider setting, the feature flagging system does not start and the <code>Provider</code> returns the programmatic default.</div>
 
-<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. On supported Agent versions it is enabled by default. Only set SDK-level Remote Configuration variables, such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>, if your tracer has Remote Configuration disabled and you need to override that setting.</div>
+<div class="alert alert-info">Remote Configuration must be available for server-side Feature Flags. It is enabled by default on Agent 7.47.0 and later. Only set SDK-level Remote Configuration variables (such as <code>DD_REMOTE_CONFIG_ENABLED=true</code>) if your tracer has Remote Configuration disabled and you need to override that setting.</div>
 
 ### Add the Java tracer to the JVM
 

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -16,7 +16,7 @@ further_reading:
 
 This page describes how to instrument a Java application with the Datadog Feature Flags SDK. Datadog feature flags provide a unified way to remotely control feature availability in your app, experiment safely, and deliver new experiences with confidence.
 
-The Java SDK integrates feature flags directly into the Datadog SDK and implements the [OpenFeature](https://openfeature.dev/) standard for maximum flexibility and compatibility.
+The Java SDK integrates feature flags directly into the Datadog Java tracer (`dd-trace-java`) and implements the [OpenFeature](https://openfeature.dev/) standard for maximum flexibility and compatibility.
 
 <div class="alert alert-info">If you're using Datadog APM and your application already has the Datadog Java SDK and Remote Configuration enabled, skip to <a href="#initialize-the-openfeature-provider">Initialize the OpenFeature provider</a>. You only need to add the OpenFeature dependencies and initialize the provider.</div>
 
@@ -167,7 +167,7 @@ Make sure to include the feature flagging configuration flags:
 
 ## Initialize the OpenFeature provider
 
-Initialize the Datadog OpenFeature provider in your application startup code. The provider connects to the feature flagging system running in the Datadog SDK.
+Initialize the Datadog OpenFeature provider in your application startup code. The provider connects to the feature flagging system running in the Datadog Java tracer.
 
 {{< code-block lang="java" >}}
 import dev.openfeature.sdk.OpenFeatureAPI;

--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -130,7 +130,7 @@ app.get('/my-endpoint', async (req, res) => {
 
 Define who or what the flag evaluation applies to using an `EvaluationContext`. The evaluation context can include user or session information used to determine which flag variations should be returned. Call the `OpenFeature.setContext` method before evaluating flags to ensure proper targeting.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 ## Evaluate flags
 

--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your Node.js application with the Datadog Feature Flags SDK. The Node.js SDK integrates with [OpenFeature][2], an open standard for feature flag management, and uses the Datadog SDK's Remote Configuration to receive flag updates in real time.
+This page describes how to instrument your Node.js application with the Datadog Feature Flags SDK. The Node.js SDK integrates with [OpenFeature][2], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog Node.js tracer (`dd-trace`).
 
 ## Prerequisites
 

--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -21,7 +21,7 @@ This page describes how to instrument your Node.js application with the Datadog 
 
 Before setting up the Node.js Feature Flags SDK, ensure you have:
 
-- **Datadog Agent** with [Remote Configuration](/agent/remote_config/) enabled. See [Agent Configuration](/feature_flags/server#agent-configuration) for details.
+- **Datadog Agent** version 7.55 or later with [Remote Configuration](/agent/remote_config/) enabled. See [Agent Configuration](/feature_flags/server#agent-configuration) for details.
 - **Datadog [API key][3]** configured on the Agent
 - **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later
 - **@openfeature/server-sdk** version ~1.20.0
@@ -33,6 +33,20 @@ Feature Flagging is provided by Application Performance Monitoring (APM). To int
 ```shell
 npm install dd-trace @openfeature/server-sdk
 ```
+
+Enable the provider with environment variables:
+
+```shell
+# Required: Enable the feature flags provider
+DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+DD_METRICS_OTEL_ENABLED=true
+```
+
+<div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
+
+Or enable the provider in code:
 
 ```javascript
 import { OpenFeature } from '@openfeature/server-sdk'
@@ -115,6 +129,8 @@ app.get('/my-endpoint', async (req, res) => {
 ## Set the evaluation context
 
 Define who or what the flag evaluation applies to using an `EvaluationContext`. The evaluation context can include user or session information used to determine which flag variations should be returned. Call the `OpenFeature.setContext` method before evaluating flags to ensure proper targeting.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 ## Evaluate flags
 

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -82,7 +82,7 @@ client = api.get_client()
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="python" >}}
 from openfeature.evaluation_context import EvaluationContext

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -20,10 +20,10 @@ This guide explains how to install and enable the SDK, create an OpenFeature cli
 
 Before setting up the Python Feature Flags SDK, ensure you have:
 
-- **Datadog Agent** with [Remote Configuration][2] enabled
+- **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
 - **Datadog Python SDK** `ddtrace` version 3.19.0 or later
-- **OpenFeature Python SDK** `openfeature-sdk` version 0.5.0 or later
+- **OpenFeature Python SDK** `openfeature-sdk` version 0.7.0 or later if you use provider event handlers to wait for initialization. If you do not use that pattern, version 0.5.0 or later is sufficient.
 
 Set the following environment variables:
 
@@ -31,10 +31,15 @@ Set the following environment variables:
 # Required: Enable the feature flags provider
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
+# Optional: Enable flag evaluation metrics
+export DD_METRICS_OTEL_ENABLED=true
+
 # Required: Service identification
 export DD_SERVICE=<YOUR_SERVICE_NAME>
 export DD_ENV=<YOUR_ENVIRONMENT>
 {{< /code-block >}}
+
+<div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
 ## Installation
 
@@ -76,6 +81,8 @@ client = api.get_client()
 ## Set the evaluation context
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< code-block lang="python" >}}
 from openfeature.evaluation_context import EvaluationContext

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -23,7 +23,7 @@ Before setting up the Python Feature Flags SDK, ensure you have:
 - **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
 - **Datadog Python SDK** `ddtrace` version 3.19.0 or later
-- **OpenFeature Python SDK** `openfeature-sdk` version 0.7.0 or later if you use provider event handlers to wait for initialization. If you do not use that pattern, version 0.5.0 or later is sufficient.
+- **OpenFeature Python SDK** `openfeature-sdk`: version 0.5.0 or later (version 0.7.0 or later required if you use provider event handlers to wait for initialization)
 
 Set the following environment variables:
 

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your Python application with the Datadog Feature Flags SDK. The Python SDK integrates with [OpenFeature][1], an open standard for feature flag management, and uses the Datadog SDK's Remote Configuration to receive flag updates in real time.
+This page describes how to instrument your Python application with the Datadog Feature Flags SDK. The Python SDK integrates with [OpenFeature][1], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog Python tracer (`ddtrace`).
 
 This guide explains how to install and enable the SDK, create an OpenFeature client, and evaluate feature flags in your application.
 
@@ -58,7 +58,7 @@ openfeature-sdk>=0.5.0
 
 ## Initialize the SDK
 
-Register the Datadog OpenFeature provider with the OpenFeature API. The provider connects to the Datadog SDK's Remote Configuration system to receive flag configurations.
+Register the Datadog OpenFeature provider with the OpenFeature API. The provider connects to the Datadog Python tracer's Remote Configuration system to receive flag configurations.
 
 {{< code-block lang="python" >}}
 from ddtrace import tracer

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your Ruby application with the Datadog Feature Flags SDK. The Ruby SDK integrates with [OpenFeature][3], an open standard for feature flag management, and uses the Datadog SDK's Remote Configuration to receive flag updates in real time.
+This page describes how to instrument your Ruby application with the Datadog Feature Flags SDK. The Ruby SDK integrates with [OpenFeature][3], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog Ruby tracer (`datadog` gem).
 
 ## Prerequisites
 
@@ -26,7 +26,7 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Datadog Ruby SDK** `datadog` version 2.24.0 or later
 - **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later if you need flag evaluation metrics support
 - **Service and environment configured** - Feature flags are targeted by service and environment
-- **Supported operating system** - Feature flags are only [supported on Linux operating systems][2]. Windows and macOS are not natively supported, but Dockerized Linux environments running on those operating systems are.
+- **Supported operating system** - Production support is currently limited to [Linux operating systems][2]. macOS can be used for local development when a compatible prebuilt native artifact is available. Windows and macOS are not natively supported production targets, but Dockerized Linux environments running on those operating systems are.
 
 
 ## Installing and initializing
@@ -279,7 +279,7 @@ If feature flags unexpectedly always return default values, check the following:
 
 ### Remote Configuration connection issues
 
-Check the Datadog SDK logs for Remote Configuration status:
+Check the Datadog Ruby tracer logs for Remote Configuration status:
 
 ```ruby
 # Enable startup and debug logging

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -21,10 +21,10 @@ This page describes how to instrument your Ruby application with the Datadog Fea
 
 Before setting up the Ruby Feature Flags SDK, ensure you have:
 
-- **Datadog Agent** with [Remote Configuration][1] enabled
+- **Datadog Agent** version 7.55 or later with [Remote Configuration][1] enabled
 - **Datadog [API key][4]** configured on the Agent
-- **Datadog Ruby SDK** `datadog` version 2.23.0 or later
-- **OpenFeature Ruby SDK** `openfeature-sdk` version 0.4.1 or later
+- **Datadog Ruby SDK** `datadog` version 2.24.0 or later
+- **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later if you need flag evaluation metrics support
 - **Service and environment configured** - Feature flags are targeted by service and environment
 - **Supported operating system** - Feature flags are only [supported on Linux operating systems][2]. Windows and macOS are not natively supported, but Dockerized Linux environments running on those operating systems are.
 
@@ -34,8 +34,22 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 Feature Flagging is provided by Application Performance Monitoring (APM). To integrate APM into your application with feature flagging support, install the required gems and configure Remote Configuration with OpenFeature support.
 
 ```shell
-gem install ddtrace openfeature-sdk
+gem install datadog openfeature-sdk
 ```
+
+You can enable Feature Flags with environment variables:
+
+```shell
+# Required: Enable the feature flags provider
+DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+DD_METRICS_OTEL_ENABLED=true
+```
+
+<div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
+
+Or enable the provider in code:
 
 ```ruby
 require 'datadog'
@@ -68,6 +82,8 @@ Using `set_provider_and_wait` blocks your application from proceeding until the 
 ## Set the evaluation context
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 ```ruby
 context = OpenFeature::SDK::EvaluationContext.new(

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -83,7 +83,7 @@ Using `set_provider_and_wait` blocks your application from proceeding until the 
 
 Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 ```ruby
 context = OpenFeature::SDK::EvaluationContext.new(

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -26,7 +26,7 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Datadog Ruby SDK** `datadog` version 2.24.0 or later
 - **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later if you need flag evaluation metrics support
 - **Service and environment configured** - Feature flags are targeted by service and environment
-- **Supported operating system** - Production support is currently limited to [Linux operating systems][2]. macOS can be used for local development when a compatible prebuilt native artifact is available. Windows and macOS are not natively supported production targets, but Dockerized Linux environments running on those operating systems are.
+- **Supported operating system** - Production support is limited to [Linux operating systems][2]. macOS and Windows are not natively supported production targets, but Dockerized Linux environments running on those operating systems are. For local development on macOS, you can use a compatible prebuilt native artifact when one is available.
 
 
 ## Installing and initializing

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -254,7 +254,7 @@ Go to [{{< ui >}}Create Feature Flag{{< /ui >}}][2] in Datadog and configure the
 
 In your application code, use the SDK to evaluate the flag and gate the new feature.
 
-<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 {{< tabs >}}
 {{% tab "JavaScript browser" %}}

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -228,9 +228,9 @@ client = api.get_client()
 
 | Credential | Used by | Where it goes | Sensitive? |
 | --- | --- | --- | --- |
-| Client token | Browser, mobile, and game SDKs | Client application configuration | Public-shipping token |
-| Application ID | Browser and RUM-backed client SDKs | Client application configuration | Public-shipping identifier |
-| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Secret |
+| Client token | Browser, mobile, and game SDKs | Client application configuration | No — safe to ship in public client code |
+| Application ID | Browser and RUM-backed client SDKs | Client application configuration | No — public identifier |
+| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Yes — keep server-side only |
 
 Do not put API keys in browser, mobile, or game applications.
 

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -85,7 +85,7 @@ yarn add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Then, add the following to your project to initialize the SDK:
 
-<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
+{{< site-region region="gov,gov2" >}}<div class="alert alert-danger">Browser Feature Flags are not supported for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>{{< /site-region >}}
 
 {{< code-block lang="javascript" >}}
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -372,6 +372,7 @@ Monitor the feature rollout from the feature flag details page, which provides r
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+[1]: https://openfeature.dev/docs/reference/technologies/client/web/
 [2]: https://app.datadoghq.com/feature-flags/create
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [4]: /feature_flags/concepts/environments/

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -29,7 +29,7 @@ Datadog feature flags offer a powerful, integrated way to manage feature deliver
 
 - **Real-time metrics:** Understand who's receiving each variant, as well as how your flag impacts the health & performance of your application—all in real time.
 
-- **Supports common flag types:** Use Boolean, string, numeric, or JSON variants. Some SDKs expose integer and floating-point methods separately, while JavaScript uses `getNumberValue()` for numeric variants.
+- **Supports common flag types:** Use Boolean, string, integer, numeric (float/double), or JSON variants. JavaScript SDKs use `getNumberValue()` for both integer and numeric variants, while Java, Swift, Kotlin, and Python expose separate integer and floating-point evaluation methods.
 
 - **Built for experimentation:** Target specific audiences for A/B tests, roll out features gradually with canary releases, and automatically roll back when regressions are detected.
 
@@ -72,17 +72,22 @@ Your organization likely already has pre-configured environments for Development
 
 ### Step 1: Import and initialize the SDK
 
-First, install `@datadog/openfeature-browser`, `@openfeature/web-sdk`, and `@openfeature/core` as dependencies in your project:
+Choose the SDK that matches where the flag is evaluated and initialize the Datadog Feature Flags provider.
 
-```
+{{< tabs >}}
+{{% tab "JavaScript browser" %}}
+
+Install `@datadog/openfeature-browser`, `@openfeature/web-sdk`, and `@openfeature/core` as dependencies in your project:
+
+{{< code-block lang="bash" >}}
 yarn add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
-```
+{{< /code-block >}}
 
 Then, add the following to your project to initialize the SDK:
 
 Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
 
-```js
+{{< code-block lang="javascript" >}}
 import { DatadogProvider } from '@datadog/openfeature-browser';
 import { OpenFeature } from '@openfeature/web-sdk';
 
@@ -99,9 +104,125 @@ const provider = new DatadogProvider({
 
 // Set the provider
 await OpenFeature.setProviderAndWait(provider);
-```
+{{< /code-block >}}
 
 <div class="alert alert-info">The browser SDK emits three independent telemetry streams, all enabled by default. <code>enableExposureLogging</code> sends per-evaluation exposure events to the exposures intake. <code>enableFlagEvaluationTracking</code> sends aggregated evaluation telemetry to the flag-evaluation intake. <code>enableRumFeatureFlagTracking</code> attaches flag evaluations to RUM events and is the setting that can affect RUM usage. Disable only the stream you do not need.</div>
+
+{{% /tab %}}
+{{% tab "Node.js server" %}}
+
+Install `dd-trace` and the OpenFeature server SDK:
+
+{{< code-block lang="bash" >}}
+npm install dd-trace @openfeature/server-sdk
+{{< /code-block >}}
+
+Enable the provider with environment variables:
+
+{{< code-block lang="bash" >}}
+# Required: Enable the feature flags provider
+DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+DD_METRICS_OTEL_ENABLED=true
+{{< /code-block >}}
+
+Or enable the provider in code:
+
+{{< code-block lang="javascript" >}}
+import { OpenFeature } from '@openfeature/server-sdk'
+import tracer from 'dd-trace';
+
+tracer.init({
+  experimental: {
+    flaggingProvider: {
+      enabled: true,
+    }
+  }
+});
+
+OpenFeature.setProvider(tracer.openfeature);
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Java" %}}
+
+Add the OpenFeature SDK and Datadog OpenFeature provider dependencies:
+
+{{< code-block lang="groovy" filename="build.gradle" >}}
+dependencies {
+    // OpenFeature SDK for flag evaluation
+    implementation 'dev.openfeature:sdk:1.18.2'
+
+    // Datadog OpenFeature Provider
+    implementation 'com.datadoghq:dd-openfeature:1.57.0'
+}
+{{< /code-block >}}
+
+Enable the provider and start your application with the Java tracer:
+
+{{< code-block lang="bash" >}}
+# Required: Enable the feature flagging provider
+# The EXPERIMENTAL_ prefix is historical; the provider is no longer experimental.
+export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+export DD_METRICS_OTEL_ENABLED=true
+
+java -javaagent:path/to/dd-java-agent.jar -jar your-application.jar
+{{< /code-block >}}
+
+Register the Datadog OpenFeature provider:
+
+{{< code-block lang="java" >}}
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import datadog.trace.api.openfeature.Provider;
+
+OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+api.setProviderAndWait(new Provider());
+Client client = api.getClient("my-app");
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Python" %}}
+
+Enable the provider with environment variables:
+
+{{< code-block lang="bash" >}}
+# Required: Enable the feature flags provider
+export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Optional: Enable flag evaluation metrics
+export DD_METRICS_OTEL_ENABLED=true
+{{< /code-block >}}
+
+Install the Datadog Python SDK and OpenFeature SDK:
+
+{{< code-block lang="bash" >}}
+pip install ddtrace openfeature-sdk
+{{< /code-block >}}
+
+Register the Datadog OpenFeature provider:
+
+{{< code-block lang="python" >}}
+from ddtrace import tracer
+from openfeature import api
+from ddtrace.openfeature import DataDogProvider
+
+# Initialize the tracer (required for Remote Configuration)
+tracer.configure()
+
+# Create and register the Datadog provider
+provider = DataDogProvider()
+api.set_provider(provider)
+
+# Create an OpenFeature client
+client = api.get_client()
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Credentials at a glance
 
@@ -135,7 +256,10 @@ In your application code, use the SDK to evaluate the flag and gate the new feat
 
 <div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
-```js
+{{< tabs >}}
+{{% tab "JavaScript browser" %}}
+
+{{< code-block lang="javascript" >}}
 import { OpenFeature } from '@openfeature/web-sdk';
 
 const client = OpenFeature.getClient();
@@ -157,9 +281,76 @@ const showFeature = await client.getBooleanValue('show-new-feature', fallback);
 if (showFeature) {
     // Feature code here
 }
-```
+{{< /code-block >}}
 
-After you've completed this step, redeploy the application to pick up these changes. Additional usage examples can be found in the SDK's [documentation][1].
+{{% /tab %}}
+{{% tab "Node.js server" %}}
+
+{{< code-block lang="javascript" >}}
+const evaluationContext = {
+  targetingKey: req.session?.userID ?? 'unknown',
+  companyID: req.session?.companyID
+};
+
+const isNewCheckoutEnabled = await client.getBooleanValue(
+    'new-checkout-flow', // flag key
+    false, // default value
+    evaluationContext, // context
+);
+
+if (isNewCheckoutEnabled) {
+    showNewCheckoutFlow();
+} else {
+    showLegacyCheckout();
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Java" %}}
+
+{{< code-block lang="java" >}}
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.MutableContext;
+
+EvaluationContext context = new MutableContext("user-123")
+    .add("email", "user@example.com")
+    .add("tier", "premium");
+
+boolean enabled = client.getBooleanValue("checkout.new", false, context);
+
+if (enabled) {
+    // New checkout flow
+} else {
+    // Old checkout flow
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Python" %}}
+
+{{< code-block lang="python" >}}
+from openfeature.evaluation_context import EvaluationContext
+
+eval_ctx = EvaluationContext(
+    targeting_key="user-123",
+    attributes={
+        "email": "user@example.com",
+        "tier": "premium"
+    }
+)
+
+enabled = client.get_boolean_value("new-checkout-flow", False, eval_ctx)
+
+if enabled:
+    show_new_checkout()
+else:
+    show_legacy_checkout()
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+After you've completed this step, redeploy the application to pick up these changes. Additional usage examples can be found in the platform-specific SDK pages linked above.
 
 ### Step 4: Define targeting rules and enable the feature flag
 
@@ -181,7 +372,6 @@ Monitor the feature rollout from the feature flag details page, which provides r
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://openfeature.dev/docs/reference/technologies/client/web/
 [2]: https://app.datadoghq.com/feature-flags/create
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [4]: /feature_flags/concepts/environments/

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -96,7 +96,7 @@ const provider = new DatadogProvider({
     // Required client-side Datadog credentials
     applicationId: '<APPLICATION_ID>',
     clientToken: '<CLIENT_TOKEN>',
-    site: 'datadoghq.com',
+    site: '{{< region-param key="dd_site" code="true" >}}',
     env: '<YOUR_ENV>', // Same environment normally passed to the RUM SDK
     service: '<SERVICE_NAME>',
     version: '1.0.0'

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -29,7 +29,7 @@ Datadog feature flags offer a powerful, integrated way to manage feature deliver
 
 - **Real-time metrics:** Understand who's receiving each variant, as well as how your flag impacts the health & performance of your application—all in real time.
 
-- **Supports any data type:** Use Booleans, strings, numbers or full JSON objects—whatever your use case requires.
+- **Supports common flag types:** Use Boolean, string, numeric, or JSON variants. Some SDKs expose integer and floating-point methods separately, while JavaScript uses `getNumberValue()` for numeric variants.
 
 - **Built for experimentation:** Target specific audiences for A/B tests, roll out features gradually with canary releases, and automatically roll back when regressions are detected.
 
@@ -80,15 +80,17 @@ yarn add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Then, add the following to your project to initialize the SDK:
 
+Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
+
 ```js
 import { DatadogProvider } from '@datadog/openfeature-browser';
 import { OpenFeature } from '@openfeature/web-sdk';
 
 // Initialize the provider
 const provider = new DatadogProvider({
-    clientToken: '<CLIENT_TOKEN>',
+    // Required client-side Datadog credentials
     applicationId: '<APPLICATION_ID>',
-    enableExposureLogging: true, // Can impact RUM costs if enabled
+    clientToken: '<CLIENT_TOKEN>',
     site: 'datadoghq.com',
     env: '<YOUR_ENV>', // Same environment normally passed to the RUM SDK
     service: '<SERVICE_NAME>',
@@ -99,7 +101,17 @@ const provider = new DatadogProvider({
 await OpenFeature.setProviderAndWait(provider);
 ```
 
-<div class="alert alert-warning">Setting <code>enableExposureLogging</code> to <code>true</code> can impact <a href="https://docs.datadoghq.com/real_user_monitoring/">RUM</a> costs, as it sends exposure events to Datadog through RUM. You can disable it if you don't need to track feature exposure or guardrail metric status.</div>
+<div class="alert alert-info">The browser SDK emits three independent telemetry streams, all enabled by default. <code>enableExposureLogging</code> sends per-evaluation exposure events to the exposures intake. <code>enableFlagEvaluationTracking</code> sends aggregated evaluation telemetry to the flag-evaluation intake. <code>enableRumFeatureFlagTracking</code> attaches flag evaluations to RUM events and is the setting that can affect RUM usage. Disable only the stream you do not need.</div>
+
+### Credentials at a glance
+
+| Credential | Used by | Where it goes | Sensitive? |
+| --- | --- | --- | --- |
+| Client token | Browser, mobile, and game SDKs | Client application configuration | Public-shipping token |
+| Application ID | Browser and RUM-backed client SDKs | Client application configuration | Public-shipping identifier |
+| API key | Datadog Agent for server-side Remote Configuration | Agent configuration only | Secret |
+
+Do not put API keys in browser, mobile, or game applications.
 
 More information about OpenFeature SDK configuration options can be found in its [documentation][1]. For more information on creating client tokens and application IDs, see [API and Application Keys][3].
 
@@ -120,6 +132,8 @@ Go to [{{< ui >}}Create Feature Flag{{< /ui >}}][2] in Datadog and configure the
 ### Step 3: Evaluate the flag and write feature code
 
 In your application code, use the SDK to evaluate the flag and gate the new feature.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation-context attributes to be flat primitive values: strings, numbers, and Booleans. Do not pass nested objects or arrays; they are not supported and can cause exposure data to be dropped.</div>
 
 ```js
 import { OpenFeature } from '@openfeature/web-sdk';

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -85,7 +85,7 @@ yarn add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Then, add the following to your project to initialize the SDK:
 
-Supported browser Feature Flags sites are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `datadoghq.eu`. Browser Feature Flags are not supported on GovCloud sites.
+Note: Browser Feature Flags are currently not supported on GovCloud sites.
 
 {{< code-block lang="javascript" >}}
 import { DatadogProvider } from '@datadog/openfeature-browser';

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -85,7 +85,7 @@ yarn add @datadog/openfeature-browser @openfeature/web-sdk @openfeature/core
 
 Then, add the following to your project to initialize the SDK:
 
-Note: Browser Feature Flags are currently not supported on GovCloud sites.
+<div class="alert alert-info">Browser Feature Flags are not supported on GovCloud sites.</div>
 
 {{< code-block lang="javascript" >}}
 import { DatadogProvider } from '@datadog/openfeature-browser';


### PR DESCRIPTION
> 🤖 Generated by Codex from the Datadog Feature Flags documentation audit and source verification.

## What changed

This updates Datadog Feature Flags docs after auditing the current docs against the public SDK/provider implementations.

- Clarifies that unsupported OpenFeature evaluation types return typed provider errors across the SDK docs.
- Adds missing custom-evaluation-endpoint guidance for Android and iOS.
- Documents mobile fallback/default-value behavior and iOS fallback-context handling.
- Calls out the web provider's private custom context fields.
- Aligns server-side setup pages around Remote Configuration availability and provider package / API prerequisites.
- Adds provider-version and API details that were missing from Python, Ruby, Java, .NET, Go, Node.js, Android, iOS, Unity, and JavaScript docs.
- Updates the server-side navigation hub so the Datadog agent/tracer relationship is clearer and links to each supported SDK page are available.

## Validation

- Manually compared docs against public Datadog SDK/provider source.
- Verified changed files are limited to Feature Flags documentation pages.

Could not run full local Hugo/Vale validation because this checkout does not have `node_modules`, `hugo`, or `vale` installed.
