### PR TITLE
Tweak agents.md etc, add note about http methods

### DIFF
--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -75,7 +75,19 @@ Configure the Dev Agent's runtime environment, including network access policies
 
 By default, the Dev Agent has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to **Bits AI Dev** > **Settings** > [**General**][6], and find the **Internet Access** section. Choose from the following access policies: **No Internet Access**, **Default Allowlist**, **Custom + Default Allowlist**, or **Custom Allowlist**.
 
-The default allowlist will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
+The default allowlist includes the following domains. This list will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
+
+| Language | Domains |
+|---|---|
+| Clojure/JVM | `repo.clojars.org` |
+| Go | `pkg.go.dev`, `proxy.golang.org`, `sum.golang.org`, `vuln.go.dev` |
+| Java/JVM | `repo1.maven.org` |
+| JavaScript/TypeScript | `registry.npmjs.org`, `registry.yarnpkg.com` |
+| .NET/C# | `api.nuget.org` |
+| PHP | `packagist.org`, `repo.packagist.org` |
+| Python | `files.pythonhosted.org`, `pypi.org`, `pypi.python.org`, `pythonhosted.org` |
+| Rust | `index.crates.io`, `static.crates.io` |
+| Ubuntu | `archive.ubuntu.com`, `ports.ubuntu.com`, `security.ubuntu.com` |
 
 Any HTTP method can be used with allowed domains. This allows the agent to publish packages.
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -59,13 +59,11 @@ To enable auto-push, so the Dev Agent can push commits directly to a branch, nav
 
 The Dev Agent ingests custom instruction files from your repository, including:
 
+- `AGENTS.md`
+- `CLAUDE.md`
 - `.cursorrules`
 - `.windsurfrules`
 - `copilot-instructions.md`
-- `CLAUDE.md`
-- `AGENTS.md`
-- `agent.md`
-
 
 You can also define global custom instructions, which apply to all Dev Agent sessions, in **Bits AI Dev** > **Settings** > [**General**][6], in the **Global Agent Instructions** section.
 
@@ -77,19 +75,9 @@ Configure the Dev Agent's runtime environment, including network access policies
 
 By default, the Dev Agent has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to **Bits AI Dev** > **Settings** > [**General**][6], and find the **Internet Access** section. Choose from the following access policies: **No Internet Access**, **Default Allowlist**, **Custom + Default Allowlist**, or **Custom Allowlist**.
 
-The default allowlist includes the following domains. This list will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
+The default allowlist will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
 
-| Language | Domains |
-|---|---|
-| Clojure/JVM | `repo.clojars.org` |
-| Go | `pkg.go.dev`, `proxy.golang.org`, `sum.golang.org`, `vuln.go.dev` |
-| Java/JVM | `repo1.maven.org` |
-| JavaScript/TypeScript | `registry.npmjs.org`, `registry.yarnpkg.com` |
-| .NET/C# | `api.nuget.org` |
-| PHP | `packagist.org`, `repo.packagist.org` |
-| Python | `files.pythonhosted.org`, `pypi.org`, `pypi.python.org`, `pythonhosted.org` |
-| Rust | `index.crates.io`, `static.crates.io` |
-| Ubuntu | `archive.ubuntu.com`, `ports.ubuntu.com`, `security.ubuntu.com` |
+Any HTTP method can be used with allowed domains. This allows the agent to publish packages.
 
 ### Configure repository environment
 
@@ -108,7 +96,7 @@ To configure a repository environment:
 
 The Dev Agent runs the setup command at startup and can use any tools installed in your environment. The setup command runs with network access enabled to download dependencies. After setup is complete, your [internet access](#configure-internet-access) policy controls outbound network access during agent execution. Because setup commands execute against code in your repository, enable them only if you trust the repository's code.
 
-**Note**: For best results, add a [custom instructions file](#configure-custom-instructions) (like `claude.md`) to your repository with instructions on how to build and test your code.
+**Note**: For best results, add a [custom instructions file](#configure-custom-instructions) (like `AGENTS.md`) to your repository with instructions on how to build and test your code.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Originally meant to add the note about http methods.

Then tweaked custom instruction files. Put AGENTS.md first since it's very commend and agent-agnostic.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
