### PR TITLE
[DOCS-13922] Add OpenTelemetry setup for Kubernetes Explorer

### DIFF
--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -75,6 +75,213 @@ For manual setup, see [Set up Kubernetes Explorer with a DaemonSet][5].
 
 [5]: /infrastructure/faq/set-up-orchestrator-explorer-daemonset
 {{% /tab %}}
+{{% tab "OpenTelemetry" %}}
+
+<div class="alert alert-info">Native OpenTelemetry support for the Kubernetes Explorer is in Preview. Feature flags must be enabled for your Datadog instance. Contact your account team to request access.</div>
+
+You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline instead of the Datadog Agent. This setup uses the [`k8sobjects`][10] receiver to collect Kubernetes resource data and forwards it through the [Datadog Exporter's][11] orchestrator explorer functionality.
+
+#### Prerequisites
+
+- OpenTelemetry Collector Contrib [v0.142.0][12] or later.
+- Feature flags enabled on your Datadog instance. Contact your account team to verify activation.
+
+#### Limitations
+
+The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][13]). In large clusters, the OTel Collector may overwhelm the Kubernetes API server due to the volume and frequency of requests. Enable this feature in smaller clusters first, and monitor API server load before scaling up.
+
+#### Create a Datadog API key secret
+
+Create a Kubernetes secret to store your Datadog API key:
+
+```sh
+export DD_API_KEY="<YOUR_DATADOG_API_KEY>"
+kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
+```
+
+#### Configure the cluster collector
+
+Create a `deployment-collector.yaml` file with the following configuration. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][14] and `<YOUR_CLUSTER_NAME>` with your cluster name:
+
+```yaml
+mode: deployment
+replicaCount: 1
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+  tag: 0.142.0
+  pullPolicy: IfNotPresent
+
+clusterRole:
+  create: true
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - namespaces
+        - nodes
+        - nodes/spec
+        - nodes/stats
+        - pods
+        - pods/status
+        - replicationcontrollers
+        - replicationcontrollers/status
+        - resourcequotas
+        - services
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - apps
+      resources:
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - extensions
+      resources:
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - batch
+      resources:
+        - jobs
+        - cronjobs
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - autoscaling
+      resources:
+        - horizontalpodautoscalers
+      verbs:
+        - get
+        - list
+        - watch
+
+config:
+  exporters:
+    datadog:
+      api:
+        site: <YOUR_DATADOG_SITE>
+        key: ${env:DD_API_KEY}
+      orchestrator_explorer:
+        enabled: true
+
+  receivers:
+    k8sobjects:
+      auth_type: serviceAccount
+      objects:
+        - name: namespaces
+          mode: pull
+          interval: 3m
+        - name: namespaces
+          mode: watch
+        - name: pods
+          mode: pull
+          interval: 3m
+        - name: pods
+          mode: watch
+        - name: nodes
+          mode: pull
+          interval: 3m
+        - name: nodes
+          mode: watch
+        - name: replicasets
+          mode: pull
+          interval: 3m
+        - name: replicasets
+          mode: watch
+        - name: daemonsets
+          mode: pull
+          interval: 3m
+        - name: daemonsets
+          mode: watch
+        - name: statefulsets
+          mode: pull
+          interval: 3m
+          group: apps
+        - name: statefulsets
+          mode: watch
+          group: apps
+        - name: cronjobs
+          mode: pull
+          interval: 3m
+        - name: cronjobs
+          mode: watch
+        - name: jobs
+          mode: pull
+          interval: 3m
+        - name: jobs
+          mode: watch
+        - name: services
+          mode: pull
+          interval: 3m
+        - name: services
+          mode: watch
+        - name: deployments
+          mode: pull
+          interval: 3m
+          group: apps
+        - name: deployments
+          mode: watch
+          group: apps
+
+  processors:
+    resource/add-cluster-name:
+      attributes:
+        - key: k8s.cluster.name
+          value: <YOUR_CLUSTER_NAME>
+          action: upsert
+
+  service:
+    pipelines:
+      logs/orchestrator:
+        receivers: [k8sobjects]
+        processors: [resource/add-cluster-name]
+        exporters: [datadog]
+```
+
+#### Deploy with Helm
+
+Install the OpenTelemetry Collector using your configuration file:
+
+```sh
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+
+helm install deployment-collector open-telemetry/opentelemetry-collector \
+  --values ./deployment-collector.yaml
+```
+
+#### Configure the Datadog exporter
+
+Follow the [Datadog Exporter installation guide][11] to complete the exporter configuration for the rest of your pipeline (traces, metrics, and logs).
+
+#### Verify the installation
+
+Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
+
+[10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
+[11]: /opentelemetry/setup/collector_exporter/install/#2---configure-the-datadog-exporter-and-connector
+[12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
+[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
+[14]: /getting_started/site/
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Collect custom resources

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -148,6 +148,9 @@ clusterRole:
         - replicationcontrollers/status
         - resourcequotas
         - services
+        - persistentvolumes
+        - persistentvolumeclaims
+        - serviceaccounts
       verbs: ["get", "list", "watch"]
     - apiGroups: ["apps"]
       resources:
@@ -171,6 +174,26 @@ clusterRole:
     - apiGroups: ["autoscaling"]
       resources:
         - horizontalpodautoscalers
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["policy"]
+      resources:
+        - poddisruptionbudgets
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["storage.k8s.io"]
+      resources:
+        - storageclasses
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["networking.k8s.io"]
+      resources:
+        - networkpolicies
+        - ingresses
       verbs: ["get", "list", "watch"]
     - apiGroups: ["apiextensions.k8s.io"]
       resources:
@@ -258,6 +281,84 @@ The [`k8sobjects`][100] receiver collects Kubernetes resource data using two mod
         - name: deployments
           mode: watch
           group: apps
+        - name: horizontalpodautoscalers
+          mode: pull
+          interval: 3m
+          group: autoscaling
+        - name: horizontalpodautoscalers
+          mode: watch
+          group: autoscaling
+        - name: roles
+          mode: pull
+          interval: 3m
+          group: rbac.authorization.k8s.io
+        - name: roles
+          mode: watch
+          group: rbac.authorization.k8s.io
+        - name: rolebindings
+          mode: pull
+          interval: 3m
+          group: rbac.authorization.k8s.io
+        - name: rolebindings
+          mode: watch
+          group: rbac.authorization.k8s.io
+        - name: clusterroles
+          mode: pull
+          interval: 3m
+          group: rbac.authorization.k8s.io
+        - name: clusterroles
+          mode: watch
+          group: rbac.authorization.k8s.io
+        - name: clusterrolebindings
+          mode: pull
+          interval: 3m
+          group: rbac.authorization.k8s.io
+        - name: clusterrolebindings
+          mode: watch
+          group: rbac.authorization.k8s.io
+        - name: storageclasses
+          mode: pull
+          interval: 3m
+          group: storage.k8s.io
+        - name: storageclasses
+          mode: watch
+          group: storage.k8s.io
+        - name: networkpolicies
+          mode: pull
+          interval: 3m
+          group: networking.k8s.io
+        - name: networkpolicies
+          mode: watch
+          group: networking.k8s.io
+        - name: ingresses
+          mode: pull
+          interval: 3m
+          group: networking.k8s.io
+        - name: ingresses
+          mode: watch
+          group: networking.k8s.io
+        - name: persistentvolumes
+          mode: pull
+          interval: 3m
+        - name: persistentvolumes
+          mode: watch
+        - name: persistentvolumeclaims
+          mode: pull
+          interval: 3m
+        - name: persistentvolumeclaims
+          mode: watch
+        - name: poddisruptionbudgets
+          mode: pull
+          interval: 3m
+          group: policy
+        - name: poddisruptionbudgets
+          mode: watch
+          group: policy
+        - name: serviceaccounts
+          mode: pull
+          interval: 3m
+        - name: serviceaccounts
+          mode: watch
         - name: customresourcedefinitions
           mode: pull
           interval: 3m

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -90,7 +90,7 @@ You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline i
 
 The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][13]). In large clusters, the OTel Collector may overwhelm the Kubernetes API server due to the volume and frequency of requests. Enable this feature in smaller clusters first, and monitor API server load before scaling up.
 
-#### Create a Datadog API key secret
+#### 1. Create a Datadog API key secret
 
 Create a Kubernetes secret to store your Datadog API key:
 
@@ -99,7 +99,7 @@ export DD_API_KEY="<YOUR_DATADOG_API_KEY>"
 kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
 ```
 
-#### Configure the cluster collector
+#### 2. Configure the cluster collector
 
 This setup deploys the OTel Collector as a Kubernetes Deployment. Create a `deployment-collector.yaml` file and add each of the following configuration sections.
 
@@ -282,7 +282,7 @@ Add a `resourcedetection/kubeadm` processor to detect the cluster UID, and a `re
 
 The `resourcedetection/kubeadm` processor detects the cluster UID (`k8s.cluster.uid`), which the Datadog Exporter requires for orchestrator data. Cluster name detection is disabled so the manually set name from `resource/add-cluster-name` takes precedence.
 
-#### Deploy with Helm
+#### 3. Deploy with Helm
 
 Install the OpenTelemetry Collector using your configuration file:
 
@@ -294,17 +294,13 @@ helm install deployment-collector open-telemetry/opentelemetry-collector \
   --values ./deployment-collector.yaml
 ```
 
-#### Configure the Datadog exporter
-
-Follow the [Datadog Exporter installation guide][11] to complete the exporter configuration for the rest of your pipeline (traces, metrics, and logs).
-
-#### Verify the installation
+#### 4. Verify the installation
 
 Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
 
 [1]: https://app.datadoghq.com/orchestration/overview
 [10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
-[11]: /opentelemetry/setup/collector_exporter/install/#2---configure-the-datadog-exporter-and-connector
+[11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
 [13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
 [14]: /getting_started/site/

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -88,7 +88,7 @@ You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline i
 
 #### Limitations
 
-The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][103]). In large clusters, it can place significant load on the Kubernetes API server.
+The open source `k8sobjects` receiver can place significant load on a cluster's Kubernetes API server. Modify the time interval in [Resource collection](#resource-collection) if you experience issues.
 
 Recommendations:
 1. Use Kubernetes 1.33 or later, which includes [streaming list improvements][106] that reduce API server impact.
@@ -449,7 +449,6 @@ Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name.
 [100]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 [101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [102]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.152.0
-[103]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
 [104]: /getting_started/site/
 [105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 [106]: https://kubernetes.io/blog/2025/05/09/kubernetes-v1-33-streaming-list-responses/

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -101,7 +101,11 @@ kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
 
 #### Configure the cluster collector
 
-Create a `deployment-collector.yaml` file with the following configuration. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][14] and `<YOUR_CLUSTER_NAME>` with your cluster name:
+This setup deploys the OTel Collector as a Kubernetes Deployment. Create a `deployment-collector.yaml` file and add each of the following configuration sections.
+
+##### Collector image and mode
+
+Set the Collector to run as a single-replica Deployment using the Contrib distribution:
 
 ```yaml
 mode: deployment
@@ -111,12 +115,17 @@ image:
   repository: otel/opentelemetry-collector-contrib
   tag: 0.142.0
   pullPolicy: IfNotPresent
+```
 
+##### RBAC permissions
+
+The `k8sobjects` receiver needs read access to the Kubernetes API. Grant `get`, `list`, and `watch` permissions for each resource type you want to appear in the Explorer:
+
+```yaml
 clusterRole:
   create: true
   rules:
-    - apiGroups:
-        - ""
+    - apiGroups: [""]
       resources:
         - namespaces
         - nodes
@@ -128,50 +137,37 @@ clusterRole:
         - replicationcontrollers/status
         - resourcequotas
         - services
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - apps
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["apps"]
       resources:
         - daemonsets
         - deployments
         - replicasets
         - statefulsets
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - extensions
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["extensions"]
       resources:
         - daemonsets
         - deployments
         - replicasets
         - statefulsets
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - batch
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["batch"]
       resources:
         - jobs
         - cronjobs
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - autoscaling
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["autoscaling"]
       resources:
         - horizontalpodautoscalers
-      verbs:
-        - get
-        - list
-        - watch
+      verbs: ["get", "list", "watch"]
+```
 
+##### Datadog exporter
+
+Enable the `orchestrator_explorer` option in the Datadog Exporter. This is the setting that sends Kubernetes object data to the Explorer. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][14]:
+
+```yaml
 config:
   exporters:
     datadog:
@@ -180,7 +176,15 @@ config:
         key: ${env:DD_API_KEY}
       orchestrator_explorer:
         enabled: true
+```
 
+##### Resource collection
+
+The [`k8sobjects`][10] receiver collects Kubernetes resource data using two modes for each resource type:
+- **`pull`**: Periodically fetches a full snapshot of the resource (every 3 minutes).
+- **`watch`**: Streams real-time updates as changes occur.
+
+```yaml
   receivers:
     k8sobjects:
       auth_type: serviceAccount
@@ -239,7 +243,13 @@ config:
         - name: deployments
           mode: watch
           group: apps
+```
 
+##### Processor and pipeline
+
+Add a resource processor to tag all data with your cluster name, and wire the components together in a `logs/orchestrator` pipeline. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
+
+```yaml
   processors:
     resource/add-cluster-name:
       attributes:

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -83,7 +83,7 @@ You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline i
 
 #### Prerequisites
 
-- OpenTelemetry Collector Contrib [v0.142.0][102] or later.
+- OpenTelemetry Collector Contrib [v0.152.0][102] or later.
 - Access enabled on your Datadog instance. Contact your account representative to verify activation.
 
 #### Limitations
@@ -117,7 +117,7 @@ replicaCount: 1
 
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.142.0
+  tag: 0.152.0
   pullPolicy: IfNotPresent
 
 extraEnvs:
@@ -448,7 +448,7 @@ Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name.
 [1]: https://app.datadoghq.com/orchestration/overview
 [100]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 [101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
-[102]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
+[102]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.152.0
 [103]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
 [104]: /getting_started/site/
 [105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -77,14 +77,14 @@ For manual setup, see [Set up Kubernetes Explorer with a DaemonSet][5].
 {{% /tab %}}
 {{% tab "OpenTelemetry" %}}
 
-<div class="alert alert-info">Native OpenTelemetry support for the Kubernetes Explorer is in Preview. Feature flags must be enabled for your Datadog instance. Contact your account team to request access.</div>
+<div class="alert alert-info">Native OpenTelemetry support for the Kubernetes Explorer is in Preview. Contact your account representative to request access.</div>
 
 You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline instead of the Datadog Agent. This setup uses the [`k8sobjects`][10] receiver to collect Kubernetes resource data and forwards it through the [Datadog Exporter's][11] orchestrator explorer functionality.
 
 #### Prerequisites
 
 - OpenTelemetry Collector Contrib [v0.142.0][12] or later.
-- Feature flags enabled on your Datadog instance. Contact your account team to verify activation.
+- Access enabled on your Datadog instance. Contact your account representative to verify activation.
 
 #### Limitations
 
@@ -300,7 +300,7 @@ Follow the [Datadog Exporter installation guide][11] to complete the exporter co
 
 #### Verify the installation
 
-Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
+Open the [Kubernetes Explorer](https://app.datadoghq.com/orchestration/overview) and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
 
 [10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 [11]: /opentelemetry/setup/collector_exporter/install/#2---configure-the-datadog-exporter-and-connector

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -88,7 +88,11 @@ You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline i
 
 #### Limitations
 
-The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][13]). In large clusters, the OTel Collector may overwhelm the Kubernetes API server due to the volume and frequency of requests. Enable this feature in smaller clusters first, and monitor API server load before scaling up.
+The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][13]). In large clusters, it can place significant load on the Kubernetes API server.
+
+Recommendations:
+1. Use Kubernetes 1.33 or later, which includes [streaming list improvements][16] that reduce API server impact.
+2. Start with smaller clusters. Limit the number of objects per resource type to fewer than 5,000 as a starting point, and scale up gradually while monitoring cluster health.
 
 #### 1. Create a Datadog API key secret
 
@@ -167,6 +171,10 @@ clusterRole:
     - apiGroups: ["autoscaling"]
       resources:
         - horizontalpodautoscalers
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources:
+        - customresourcedefinitions
       verbs: ["get", "list", "watch"]
 ```
 
@@ -250,22 +258,62 @@ The [`k8sobjects`][10] receiver collects Kubernetes resource data using two mode
         - name: deployments
           mode: watch
           group: apps
+        - name: customresourcedefinitions
+          mode: pull
+          interval: 3m
+          group: apiextensions.k8s.io
+        - name: customresourcedefinitions
+          mode: watch
+          group: apiextensions.k8s.io
 ```
 
 ##### Processors and pipeline
 
-Add a `resourcedetection/kubeadm` processor to detect the cluster UID, and a `resource/add-cluster-name` processor to tag all data with your cluster name. Then wire the components together in a `logs/orchestrator` pipeline. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
+Add a [`resourcedetection`][15] processor to detect the cluster UID and name.
+
+- The `kubeadm` detector is required to detect the cluster UID (`k8s.cluster.uid`).
+- Cluster name detection depends on your cloud provider. Check the [`resourcedetection` processor documentation][15] for supported providers (EKS, AKS, GCP) and required permissions.
+- If your provider is not supported, use a `resource/add-cluster-name` processor to set the cluster name manually. Replace `<YOUR_CLUSTER_NAME>` with your cluster name.
+
+Then wire the components together in a `logs/orchestrator` pipeline.
+
+The following examples show two approaches. Use the cloud provider example if you run on EKS, AKS, or GCP. Use the manual fallback if your provider is not supported.
+
+**Cloud provider detection (EKS example):**
 
 ```yaml
   processors:
-    resourcedetection/kubeadm:
-      detectors: [kubeadm]
-      timeout: 2s
+    resourcedetection:
+      detectors: [kubeadm, eks]
       override: false
       kubeadm:
         resource_attributes:
           k8s.cluster.name:
             enabled: false
+      eks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+
+  service:
+    pipelines:
+      logs/orchestrator:
+        receivers: [k8sobjects]
+        processors: [resourcedetection]
+        exporters: [datadog]
+```
+
+Replace `eks` with your provider's detector (`aks`, `gcp`). See the [`resourcedetection` processor documentation][15] for provider-specific configuration.
+
+**Manual fallback:**
+
+If the `resourcedetection` processor does not support your cloud provider, set the cluster name manually. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
+
+```yaml
+  processors:
+    resourcedetection:
+      detectors: [kubeadm]
+      override: false
     resource/add-cluster-name:
       attributes:
         - key: k8s.cluster.name
@@ -276,11 +324,9 @@ Add a `resourcedetection/kubeadm` processor to detect the cluster UID, and a `re
     pipelines:
       logs/orchestrator:
         receivers: [k8sobjects]
-        processors: [resourcedetection/kubeadm, resource/add-cluster-name]
+        processors: [resourcedetection, resource/add-cluster-name]
         exporters: [datadog]
 ```
-
-The `resourcedetection/kubeadm` processor detects the cluster UID (`k8s.cluster.uid`), which the Datadog Exporter requires for orchestrator data. Cluster name detection is disabled so the manually set name from `resource/add-cluster-name` takes precedence.
 
 #### 3. Deploy with Helm
 
@@ -296,7 +342,7 @@ helm install deployment-collector open-telemetry/opentelemetry-collector \
 
 #### 4. Verify the installation
 
-Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
+Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. All core Kubernetes resource sections should populate, along with **Custom Resources > CRD**. The **Custom Resources > Resources** section is not supported with this setup.
 
 [1]: https://app.datadoghq.com/orchestration/overview
 [10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
@@ -304,6 +350,8 @@ Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name.
 [12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
 [13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
 [14]: /getting_started/site/
+[15]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+[16]: https://kubernetes.io/blog/2025/05/09/kubernetes-v1-33-streaming-list-responses/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -79,19 +79,19 @@ For manual setup, see [Set up Kubernetes Explorer with a DaemonSet][5].
 
 <div class="alert alert-info">Native OpenTelemetry support for the Kubernetes Explorer is in Preview. Contact your account representative to request access.</div>
 
-You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline instead of the Datadog Agent. This setup uses the [`k8sobjects`][10] receiver to collect Kubernetes resource data and forwards it through the [Datadog Exporter's][11] orchestrator explorer functionality.
+You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline instead of the Datadog Agent. This setup uses the [`k8sobjects`][100] receiver to collect Kubernetes resource data and forwards it through the [Datadog Exporter's][101] orchestrator explorer functionality.
 
 #### Prerequisites
 
-- OpenTelemetry Collector Contrib [v0.142.0][12] or later.
+- OpenTelemetry Collector Contrib [v0.142.0][102] or later.
 - Access enabled on your Datadog instance. Contact your account representative to verify activation.
 
 #### Limitations
 
-The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][13]). In large clusters, it can place significant load on the Kubernetes API server.
+The `k8sobjects` receiver has known scalability issues (see [open-telemetry/opentelemetry-collector-contrib#43602][103]). In large clusters, it can place significant load on the Kubernetes API server.
 
 Recommendations:
-1. Use Kubernetes 1.33 or later, which includes [streaming list improvements][16] that reduce API server impact.
+1. Use Kubernetes 1.33 or later, which includes [streaming list improvements][106] that reduce API server impact.
 2. Start with smaller clusters. Limit the number of objects per resource type to fewer than 5,000 as a starting point, and scale up gradually while monitoring cluster health.
 
 #### 1. Create a Datadog API key secret
@@ -180,7 +180,7 @@ clusterRole:
 
 ##### Datadog exporter
 
-Enable the `orchestrator_explorer` option in the Datadog Exporter. This is the setting that sends Kubernetes object data to the Explorer. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][14]:
+Enable the `orchestrator_explorer` option in the Datadog Exporter. This is the setting that sends Kubernetes object data to the Explorer. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][104]:
 
 ```yaml
 config:
@@ -195,7 +195,7 @@ config:
 
 ##### Resource collection
 
-The [`k8sobjects`][10] receiver collects Kubernetes resource data using two modes for each resource type:
+The [`k8sobjects`][100] receiver collects Kubernetes resource data using two modes for each resource type:
 - **`pull`**: Periodically fetches a full snapshot of the resource (every 3 minutes).
 - **`watch`**: Streams real-time updates as changes occur.
 
@@ -269,10 +269,10 @@ The [`k8sobjects`][10] receiver collects Kubernetes resource data using two mode
 
 ##### Processors and pipeline
 
-Add a [`resourcedetection`][15] processor to detect the cluster UID and name.
+Add a [`resourcedetection`][105] processor to detect the cluster UID and name.
 
 - The `kubeadm` detector is required to detect the cluster UID (`k8s.cluster.uid`).
-- Cluster name detection depends on your cloud provider. Check the [`resourcedetection` processor documentation][15] for supported providers (EKS, AKS, GCP) and required permissions.
+- Cluster name detection depends on your cloud provider. Check the [`resourcedetection` processor documentation][105] for supported providers (EKS, AKS, GCP) and required permissions.
 - If your provider is not supported, use a `resource/add-cluster-name` processor to set the cluster name manually. Replace `<YOUR_CLUSTER_NAME>` with your cluster name.
 
 Then wire the components together in a `logs/orchestrator` pipeline.
@@ -303,7 +303,7 @@ The following examples show two approaches. Use the cloud provider example if yo
         exporters: [datadog]
 ```
 
-Replace `eks` with your provider's detector (`aks`, `gcp`). See the [`resourcedetection` processor documentation][15] for provider-specific configuration.
+Replace `eks` with your provider's detector (`aks`, `gcp`). See the [`resourcedetection` processor documentation][105] for provider-specific configuration.
 
 **Manual fallback:**
 
@@ -345,13 +345,13 @@ helm install deployment-collector open-telemetry/opentelemetry-collector \
 Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. All core Kubernetes resource sections should populate, along with **Custom Resources > CRD**. The **Custom Resources > Resources** section is not supported with this setup.
 
 [1]: https://app.datadoghq.com/orchestration/overview
-[10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
-[11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
-[12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
-[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
-[14]: /getting_started/site/
-[15]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
-[16]: https://kubernetes.io/blog/2025/05/09/kubernetes-v1-33-streaming-list-responses/
+[100]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
+[101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
+[102]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0
+[103]: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602
+[104]: /getting_started/site/
+[105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+[106]: https://kubernetes.io/blog/2025/05/09/kubernetes-v1-33-streaming-list-responses/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -300,8 +300,9 @@ Follow the [Datadog Exporter installation guide][11] to complete the exporter co
 
 #### Verify the installation
 
-Open the [Kubernetes Explorer](https://app.datadoghq.com/orchestration/overview) and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
+Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. Your pod and namespace data should appear in the Explorer.
 
+[1]: https://app.datadoghq.com/orchestration/overview
 [10]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 [11]: /opentelemetry/setup/collector_exporter/install/#2---configure-the-datadog-exporter-and-connector
 [12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.142.0

--- a/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/content/en/containers/monitoring/kubernetes_explorer.md
@@ -16,7 +16,7 @@ further_reading:
 
 Datadog's [Kubernetes Explorer][1] allows you to monitor the state of pods, deployments, and other Kubernetes resources. You can also view resource specifications for failed pods within a deployment, correlate node activity with related logs, track resource utilization, automatically scale workloads, and remediate errors.
 
-<div class="alert alert-info">Kubernetes Explorer requires Datadog Agent 7.27.0+ and Datadog Cluster Agent 1.11.0+. <br/>If you are using Kubernetes 1.25+, then Cluster Agent 7.40.0+ is required.</div>
+<div class="alert alert-info">When using the Datadog Agent, Kubernetes Explorer requires Agent 7.27.0+ and Cluster Agent 1.11.0+. If you are using Kubernetes 1.25+, then Cluster Agent 7.40.0+ is required. For OpenTelemetry-based setup, see the <strong>OpenTelemetry</strong> tab below.</div>
 
 
 ## Configuration
@@ -115,6 +115,13 @@ image:
   repository: otel/opentelemetry-collector-contrib
   tag: 0.142.0
   pullPolicy: IfNotPresent
+
+extraEnvs:
+  - name: DD_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secret
+        key: api-key
 ```
 
 ##### RBAC permissions
@@ -245,12 +252,20 @@ The [`k8sobjects`][10] receiver collects Kubernetes resource data using two mode
           group: apps
 ```
 
-##### Processor and pipeline
+##### Processors and pipeline
 
-Add a resource processor to tag all data with your cluster name, and wire the components together in a `logs/orchestrator` pipeline. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
+Add a `resourcedetection/kubeadm` processor to detect the cluster UID, and a `resource/add-cluster-name` processor to tag all data with your cluster name. Then wire the components together in a `logs/orchestrator` pipeline. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
 
 ```yaml
   processors:
+    resourcedetection/kubeadm:
+      detectors: [kubeadm]
+      timeout: 2s
+      override: false
+      kubeadm:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: false
     resource/add-cluster-name:
       attributes:
         - key: k8s.cluster.name
@@ -261,9 +276,11 @@ Add a resource processor to tag all data with your cluster name, and wire the co
     pipelines:
       logs/orchestrator:
         receivers: [k8sobjects]
-        processors: [resource/add-cluster-name]
+        processors: [resourcedetection/kubeadm, resource/add-cluster-name]
         exporters: [datadog]
 ```
+
+The `resourcedetection/kubeadm` processor detects the cluster UID (`k8s.cluster.uid`), which the Datadog Exporter requires for orchestrator data. Cluster name detection is disabled so the manually set name from `resource/add-cluster-name` takes precedence.
 
 #### Deploy with Helm
 

--- a/content/en/opentelemetry/compatibility.md
+++ b/content/en/opentelemetry/compatibility.md
@@ -38,7 +38,7 @@ The following table shows feature compatibility across different setups:
 | [Database Monitoring][14] (DBM) | {{< X >}} | {{< X >}} |  |  |
 | [Infrastructure Host List][30] | {{< X >}} | {{< X >}} | {{< X >}} |  |
 | [Cloud Network Monitoring][21] (CNM) | {{< X >}} | {{< X >}} | | |
-| [Live Container Monitoring/Kubernetes Explorer][20] | {{< X >}} | {{< X >}} | {{< tooltip text="Preview" tooltip="Kubernetes Explorer support for the OSS Collector is in Preview. Contact your account team to request access." >}} | |
+| [Live Container Monitoring/Kubernetes Explorer][20] | {{< X >}} | {{< X >}} | {{< tooltip text="Preview" tooltip="Kubernetes Explorer support for the OSS Collector is in Preview. Contact your account representative to request access." >}} | |
 | [Live Processes][16] | {{< X >}} | {{< X >}} | | |
 | [Universal Service Monitoring][17] (USM) | {{< X >}} | {{< X >}} | | |
 | [App and API Protection][11] (AAP) | {{< X >}} | | | |

--- a/content/en/opentelemetry/compatibility.md
+++ b/content/en/opentelemetry/compatibility.md
@@ -38,7 +38,7 @@ The following table shows feature compatibility across different setups:
 | [Database Monitoring][14] (DBM) | {{< X >}} | {{< X >}} |  |  |
 | [Infrastructure Host List][30] | {{< X >}} | {{< X >}} | {{< X >}} |  |
 | [Cloud Network Monitoring][21] (CNM) | {{< X >}} | {{< X >}} | | |
-| [Live Container Monitoring/Kubernetes Explorer][20] | {{< X >}} | {{< X >}} | | |
+| [Live Container Monitoring/Kubernetes Explorer][20] | {{< X >}} | {{< X >}} | {{< tooltip text="Preview" tooltip="Kubernetes Explorer support for the OSS Collector is in Preview. Contact your account team to request access." >}} | |
 | [Live Processes][16] | {{< X >}} | {{< X >}} | | |
 | [Universal Service Monitoring][17] (USM) | {{< X >}} | {{< X >}} | | |
 | [App and API Protection][11] (AAP) | {{< X >}} | | | |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

DOCS-13922

[PREVIEW LINK](https://docs-staging.datadoghq.com/brett.blue/otel-kubernetes-explorer/containers/monitoring/kubernetes_explorer/?tab=opentelemetry)

Adds native OpenTelemetry setup instructions for the Kubernetes Explorer. This feature is in Preview and uses the `k8sobjects` receiver with the Datadog Exporter's orchestrator explorer to populate the Explorer UI without the Datadog Agent.

Changes:
- Add an "OpenTelemetry" tab to the Kubernetes Explorer configuration section (`containers/monitoring/kubernetes_explorer.md`) with full setup: prerequisites, limitations, collector YAML config, Helm deployment, and verification steps
- Update the OTel compatibility table to show "Preview" for Kubernetes Explorer under the OSS Collector column

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- Content is based on the early access setup doc provided by the OTel K8s team
- The setup uses a `logs/orchestrator` pipeline (not metrics), which is why this lives as a tab on the Explorer page rather than a standalone OTel integration page
- Feature requires internal feature flags to be enabled per-instance