### PR TITLE
bugfix $adat.servers

### DIFF
--- a/layouts/partials/api/load-specs.html
+++ b/layouts/partials/api/load-specs.html
@@ -21,7 +21,7 @@
   {{- end -}}
 
   {{- $hasDeref := isset $verData "full_spec_deref" -}}
-  {{- $spec := cond $hasDeref (index $verData "full_spec_deref") (index $verData "full_spec") -}}
+  {{- $spec = cond $hasDeref (index $verData "full_spec_deref") (index $verData "full_spec") -}}
 
   {{- if not $spec -}}
     {{- errorf "Neither full_spec_deref nor full_spec found in .Site.Data.api.%s. Place one at /data/api/%s/." $version $version -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

**Intermittent error**
```bash
Error: error building site: render: failed to render pages: render of "/go/src/github.com/DataDog/documentation/content/en/api/latest/api-management/_index.md" failed: "/go/src/github.com/DataDog/documentation/layouts/api/list.html:88:84": execute of template failed: template: api/list.html:88:84: executing "api-main" at <$adat.servers>: can't evaluate field servers in type string
```
**Why its happening**
:= declares a new variable scoped to the else block, shadowing the outer $spec.
The cache gets populated correctly, but the outer $spec is never  assigned, so return $spec returns the empty string "".  

It's render-order dependent:

  - First page to call partial "api/load-specs.html" for a given version hits the cache-miss branch and gets back "".                                                           
  - Concurrent pages that call it before the cache is populated also get "" (Hugo renders pages in parallel).
  - Once one page finishes the else block and populates hugo.Store, subsequent pages take the with branch on line 9, which uses = correctly and returns the real spec.          
                                                                                                                                                                                
Hugo's page render order varies between builds, so sometimes the api-management page happens to render after the cache is warm and succeeds; other times it's one of the unlucky early callers and crashes on $adat.servers because $adat is "" (a string). 

**The Fix**
Change := to = so it assigns to the outer variable: 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
