### PR TITLE
[APM] [.NET] Add known bug to list

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -152,6 +152,7 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, 3.0, and 3.1, and on .NET 5 an
 | JIT Compiler bug                                                               | All versions of .NET                                     | No current workaround                                                              | [dotnet/runtime/issues/85777][17]       |
 | .NET runtime bug causing crashes when used with runtime metrics | 6.0.0-6.0.10 | Upgrade .NET 6.0.11 or above, or disable runtime metrics | [dotnet/runtime/pull/76431][18]                                                    |                                         |
 | JIT Compiler bug causing crashes                                               | 2.x, 3.x, 5.x, 6.x, 7.x, 8.x                             | Upgrade .NET to 9.0.0 or above                                                     | [dotnet/runtime/pull/95653][22]         |
+| JIT Compiler bug causing crashes                                               | 2.x, 3.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x                  | No current workaround                                                              | [dotnet/runtime/issues/127957][23]      |
 
 ## Supported Datadog Agent versions
 
@@ -209,3 +210,4 @@ Version updates imply the following changes to runtime support:
 [20]: https://www.gnu.org/software/libc/
 [21]: https://musl.libc.org/
 [22]: https://github.com/dotnet/runtime/issues/95653
+[23]: https://github.com/dotnet/runtime/issues/127957


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Documents a known .NET-runtime bug that can causes crashes when instrumenting with the Datadog .NET library.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
