### PR TITLE
Update GKE Autopilot billing to reflect Serverless Apps SKU

### DIFF
--- a/content/en/account_management/billing/containers.md
+++ b/content/en/account_management/billing/containers.md
@@ -20,7 +20,7 @@ Fargate is charged based on the concurrent number of monitored tasks in ECS Farg
 
 ### GKE Autopilot
 
-Billing of [GKE Autopilot][5] environments is the same as that of [GKE Standard][6].
+[GKE Autopilot][5] is billed as a Serverless Apps workload, priced per monthly active pod rather than per container or host. Use [Container Discovery Management][8] to control the number of billable pods. **Note**: all containers in a given Pod must be excluded from metric collection for that Pod to avoid billable usage. For current pricing, see the [Serverless Monitoring pricing page][9].
 
 ## Frequently asked questions
 
@@ -65,3 +65,4 @@ For billing questions, contact your [Customer Success][3] Manager.
 [6]: /integrations/google_kubernetes_engine/
 [7]: /help/
 [8]: /containers/guide/container-discovery-management
+[9]: https://www.datadoghq.com/pricing/?product=serverless-monitoring&tab=gke-autopilot#products


### PR DESCRIPTION
## Summary

- GKE Autopilot transitioned to the Serverless Apps SKU on 5/1/2026 (per [Serverless Apps SKU Rollout FAQ](https://datadoghq.atlassian.net/wiki/spaces/GTMSEH/pages/4895801813)). The existing copy on the Containers billing page said Autopilot billing was the same as GKE Standard, which is no longer accurate.
- Rewrite the GKE Autopilot section to describe the new per-active-pod model and point readers to Container Discovery Management for controlling the number of billable pods.
- Add the explicit note that **all containers in a given Pod must be excluded from metric collection for that Pod to avoid billable usage**.
- Link to the [Serverless Monitoring pricing page (GKE Autopilot tab)](https://www.datadoghq.com/pricing/?product=serverless-monitoring&tab=gke-autopilot#products) for current pricing.

## Out of scope

A broader Serverless Apps section on the Serverless billing page (covering Azure App Service / Functions / Container Apps, GCP Cloud Run / Functions, AWS Fargate, plus app instance definition and metering) is being drafted separately as a suggestion to share with the Serverless team. This PR is scoped to the GKE Autopilot billing correction only.

## Test plan

- [ ] Hugo build succeeds (no broken refs)
- [ ] Rendered page: GKE Autopilot section reads cleanly and links to Container Discovery Management and the Serverless Monitoring pricing page

Made with [Cursor](https://cursor.com)