### PR TITLE
Add Serverless Apps section to Serverless billing page

### DIFF
--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -53,6 +53,41 @@ Datadog bills based on the average number of functions per hour across the month
 
 Billing for serverless APM is based on the sum of AWS Lambda invocations connected to APM ingested spans in a given month. You are also billed for the total number of [indexed spans][4] submitted to the Datadog APM service exceeding the bundled quantity at the end of the month. There are no billable [APM Hosts][4] when using serverless.
 
+## Serverless Apps
+
+Serverless Apps billing applies to serverless-managed compute platforms where Datadog charges per active app instance rather than per host or container. Supported workloads include:
+
+- Azure App Service
+- Azure Functions
+- Azure Container Apps
+- Google Cloud Run
+- Google Cloud Functions
+- Google Kubernetes Engine (GKE) Autopilot
+- AWS Fargate
+
+For current pricing, see the [Serverless Monitoring pricing page][16].
+
+### App instance definition
+
+An app instance is a deployable unit that runs on a serverless-managed compute platform—for example, an Azure Web App, an Azure Function App, a Cloud Run container replica, or a Kubernetes pod on GKE Autopilot. Each combination of app name, region, and environment counts as a separate app instance.
+
+### Metering
+
+Datadog samples usage in 5-minute intervals and calculates the average number of concurrent active app instances over the month. An app instance observed in an active state during one or more intervals contributes to the monthly average proportional to the time it ran.
+
+Two billable categories apply:
+
+- **Serverless Apps (Infra)**: billed when Datadog receives metrics from the workload, through a cloud integration's crawled metrics, a sidecar Agent (Fargate), or the Datadog Agent (GKE Autopilot).
+- **Serverless Apps APM**: billed when an app instance generates APM spans. Logs-only workloads are not counted.
+
+### Controlling Serverless Apps usage
+
+For Azure and GCP workloads monitored through cloud integrations, use the integration's metric collection controls to limit which resources are monitored.
+
+For GKE Autopilot, use [Container Discovery Management][17] to selectively instrument the pods you want to monitor. **Note**: all containers in a given Pod must be excluded from metric collection for that Pod to avoid billable usage.
+
+To stop billing for a specific workload entirely, see [Disable Serverless Monitoring][18].
+
 ## Troubleshooting
 
 For technical questions, contact [Datadog support][7].
@@ -73,4 +108,7 @@ For more information about billing or your plan and usage contact, contact your 
 [13]: /integrations/amazon_lambda/
 [14]: /serverless/aws_lambda
 [15]: /serverless/installation/
+[16]: https://www.datadoghq.com/pricing/?product=serverless-monitoring#products
+[17]: /containers/guide/container-discovery-management
+[18]: /serverless/guide/disable_serverless/
 


### PR DESCRIPTION
> Draft — sharing with @Piyali and @Nakul (Serverless PMs) as a suggestion. Not ready for review/merge.

## Summary

- Adds a new `## Serverless Apps` section to `account_management/billing/serverless.md` describing the Serverless Apps billing model that now covers Azure App Service / Functions / Container Apps, GCP Cloud Run / Functions, GKE Autopilot, and AWS Fargate.
- Captures the app instance definition, the 5-minute-interval metering methodology, and how to control usage (Container Discovery Management for GKE Autopilot, cloud integration metric collection controls for Azure/GCP, and the existing disable-serverless guide).
- Links to the [Serverless Monitoring pricing page](https://www.datadoghq.com/pricing/?product=serverless-monitoring#products) for current pricing rather than restating list prices.

## Why

GKE Autopilot moved to the Serverless Apps SKU on 5/1/2026 (see [Serverless Apps SKU Rollout FAQ](https://datadoghq.atlassian.net/wiki/spaces/GTMSEH/pages/4895801813)). The companion fix to the Containers billing page is in #36616 and currently points readers to the public pricing page only, because there is no internal docs section yet describing the Serverless Apps model. This PR fills that gap so the Containers page can later cross-link to an internal anchor.

## Open questions for Serverless PMs

- Tone/scope: kept this product-shaped (definitions, metering, controls). Should we also surface SKU codes (`SERVERLESS_APPS`, `SERVERLESS_APPS_APM`), per-instance inclusions (20 custom metrics for Infra, 30 GB ingested + 195K indexed spans for APM), or list prices on the docs page, or keep those in the pricing page only?
- Wording for the Fargate bullet: this page now lists Fargate under Serverless Apps, while `account_management/billing/containers.md` still describes Fargate billing under Containers. Do we want to cross-link or eventually consolidate?
- Page placement: section is added between `## Active functions definition` (Lambda-specific) and `## Troubleshooting`. Open to restructuring the page into `## AWS Lambda` + `## Serverless Apps` sub-areas if that reads better.
- Anything else worth adding (FAQ entries, links to enablement docs, supported integrations matrix, etc.)?

## Follow-up if this lands

In `account_management/billing/containers.md` (from #36616) the GKE Autopilot paragraph currently reads:

> [GKE Autopilot][5] is billed as a Serverless Apps workload, ... For current pricing, see the [Serverless Monitoring pricing page][9].

Repoint "Serverless Apps" at the new internal anchor:

```
[GKE Autopilot][5] is billed as a [Serverless Apps][NN] workload, ...
[NN]: /account_management/billing/serverless/#serverless-apps
```

## Test plan

- [ ] Hugo build succeeds (no broken refs)
- [ ] Rendered page: `## Serverless Apps` renders cleanly with subheadings, list, and link refs
- [ ] PM review from Piyali and Nakul on accuracy of definitions/metering wording

Made with [Cursor](https://cursor.com)