### PR TITLE
Document official Datadog OpenCode plugin for MCP Server

### DIFF
--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -379,38 +379,59 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 
 {{% tab "OpenCode" %}}
 
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1]. For the correct instructions, use the {{< ui >}}Datadog Site{{< /ui >}} selector on the right side of this documentation page to select your site.
+Connect [OpenCode][3] to the Datadog MCP Server with the official [Datadog OpenCode Plugin][2] (in Preview). The plugin writes and maintains the MCP Server entry in your `opencode.json` and exposes the `ddsetup`, `ddconfig`, and `ddtoolsets` tools that the agent uses to handle setup, site changes, and [toolset](#toolsets) selection.
 
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
-1. Add the following to your `opencode.json` configuration file:
+1. Add the plugin to your `opencode.json` configuration file. Create the file if it doesn't exist:
+
     <pre><code>{
-     "mcp": {
-       "datadog": {
-         "type": "remote",
-         "url": "{{< region-param key="mcp_server_endpoint" >}}",
-         "enabled": true
-       }
-     }
-   }</code></pre>
+      "plugin": ["@datadog/opencode-plugin"]
+    }</code></pre>
 
-1. To enable [product-specific tools](#toolsets), include the `toolsets` query parameter at the end of the endpoint URL. For example, this URL enables _only_ APM and LLM Observability tools:
+    If your `opencode.json` already has a `plugin` array, append `"@datadog/opencode-plugin"` to it.
 
-   <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
-   
-   To enable all generally available toolsets, use `toolsets=all`. This works best for clients that support tool filtering.
+    If you previously configured the Datadog MCP Server manually in `opencode.json`, remove or disable that entry to avoid conflicts with the plugin.
+
+1. Restart OpenCode. The package is fetched from npm at startup, so no separate install step is needed.
+
+1. Ask the agent a Datadog-related question, or tell it to run `ddsetup`. The plugin walks through site selection and writes the MCP Server configuration to `opencode.json`.
+
+1. Restart OpenCode again to activate the MCP Server, and complete the OAuth login flow when prompted.
 
 1. Verify that you have the required [permissions](#required-permissions) for the Datadog resources you want to access.
 
+After setup, ask the agent to run `ddconfig` to change your Datadog site or troubleshoot the connection, or `ddtoolsets` to enable or disable groups of [tools](#toolsets).
+
+{{% collapse-content title="Manual configuration" level="h4" expanded=false id="opencode-manual" %}}
+To configure the MCP Server without the plugin, add the following to your `opencode.json` configuration file. Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
+
+<pre><code>{
+  "mcp": {
+    "datadog": {
+      "type": "remote",
+      "url": "{{< region-param key="mcp_server_endpoint" >}}",
+      "enabled": true
+    }
+  }
+}</code></pre>
+
+To enable [product-specific tools](#toolsets), include the `toolsets` query parameter at the end of the endpoint URL. For example, this URL enables _only_ APM and LLM Observability tools:
+
+<pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
+
+To enable all generally available toolsets, use `toolsets=all`. This works best for clients that support tool filtering.
+{{% /collapse-content %}}
+
 [1]: /getting_started/site/
+[2]: https://github.com/datadog-labs/opencode-plugin
+[3]: https://opencode.ai/
 {{< /site-region >}}
 
 {{< site-region region="gov,gov2" >}}
 <div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-[1]: /getting_started/site/
 {{% /tab %}}
 
 {{% tab "VS Code" %}}
@@ -579,6 +600,7 @@ These toolsets are in Preview. Sign up for a toolset by completing the Product P
 | [JetBrains IDEs][18] | JetBrains | [Datadog plugin][18] recommended. |
 | [Kiro][9], [Kiro CLI][10] | Amazon Web Services | |
 | [Goose][8] | Agentic AI Foundation | |
+| [OpenCode][52] | SST | Datadog [OpenCode plugin][53] recommended. |
 | [Cline][11] | Various | See the {{< ui >}}Other{{< /ui >}} tab above. Use local binary authentication for Cline if remote authentication is unreliable. |
 
 <div class="alert alert-info">The Datadog MCP Server is under significant development, and additional supported clients may become available.</div>
@@ -739,3 +761,5 @@ Local authentication is recommended for Cline and when remote authentication is 
 [49]: /bits_ai/mcp_server/tools
 [50]: https://github.com/google-gemini/gemini-cli
 [51]: /containers/monitoring/kubernetes_explorer/
+[52]: https://opencode.ai/
+[53]: https://github.com/datadog-labs/opencode-plugin

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -385,9 +385,9 @@ Connect [OpenCode][3] to the Datadog MCP Server with the official [Datadog OpenC
 
 1. Add the plugin to your `opencode.json` configuration file. Create the file if it doesn't exist:
 
-    <pre><code>{
-      "plugin": ["@datadog/opencode-plugin"]
-    }</code></pre>
+   <pre><code>{
+     "plugin": ["@datadog/opencode-plugin"]
+   }</code></pre>
 
     If your `opencode.json` already has a `plugin` array, append `"@datadog/opencode-plugin"` to it.
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -424,14 +424,14 @@ To enable all generally available toolsets, use `toolsets=all`. This works best 
 {{% /collapse-content %}}
 
 [1]: /getting_started/site/
-[2]: https://github.com/datadog-labs/opencode-plugin
-[3]: https://opencode.ai/
 {{< /site-region >}}
 
 {{< site-region region="gov,gov2" >}}
 <div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
+[2]: https://github.com/datadog-labs/opencode-plugin
+[3]: https://opencode.ai/
 {{% /tab %}}
 
 {{% tab "VS Code" %}}

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -389,22 +389,26 @@ Connect [OpenCode][3] to the Datadog MCP Server with the official [Datadog OpenC
      "plugin": ["@datadog/opencode-plugin"]
    }</code></pre>
 
-    If your `opencode.json` already has a `plugin` array, append `"@datadog/opencode-plugin"` to it.
+    If a `plugin` array already exists, add `"@datadog/opencode-plugin"` to it.
 
     If you previously configured the Datadog MCP Server manually in `opencode.json`, remove or disable that entry to avoid conflicts with the plugin.
 
-1. Restart OpenCode. The package is fetched from npm at startup, so no separate install step is needed.
+1. Restart OpenCode. The package is fetched from npm at startup.
 
-1. Ask the agent a Datadog-related question, or tell it to run `ddsetup`. The plugin walks through site selection and writes the MCP Server configuration to `opencode.json`.
+1. Ask the agent to run `ddsetup`. The plugin walks through site selection.
 
 1. Restart OpenCode again to activate the MCP Server, and complete the OAuth login flow when prompted.
 
 1. Verify that you have the required [permissions](#required-permissions) for the Datadog resources you want to access.
 
-After setup, ask the agent to run `ddconfig` to change your Datadog site or troubleshoot the connection, or `ddtoolsets` to enable or disable groups of [tools](#toolsets).
+1. To enable [product-specific tools](#toolsets), ask the agent to run `ddtoolsets`.
+
+After setup, ask the agent to run `ddconfig` to change your Datadog site or troubleshoot the connection.
 
 {{% collapse-content title="Manual configuration" level="h4" expanded=false id="opencode-manual" %}}
-To configure the MCP Server without the plugin, add the following to your `opencode.json` configuration file. Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
+To configure the MCP Server without the plugin, add the following to your `opencode.json` configuration file.
+
+Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
 <pre><code>{
   "mcp": {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Datadog MCP Server setup page to reflect the new official [Datadog OpenCode plugin](https://github.com/datadog-labs/opencode-plugin) (Preview):

- Rewrites the **OpenCode** tab on `bits_ai/mcp_server/setup` to lead with the plugin install flow (add `@datadog/opencode-plugin` to `opencode.json` → restart → run `ddsetup` → restart → OAuth). Manual MCP configuration is preserved as a collapsible fallback for users who prefer to configure the server directly.
- Adds **OpenCode** (SST) to the **Supported clients** table.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes