### PR TITLE
Add static defaults to region-param shortcode for OTel LLM Obs docs

### DIFF
--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -28,7 +28,7 @@ Set the following environment variables in your application:
 
 ```
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT={{< region-param key="otlp_trace_endpoint" code="true" >}}
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT={{< region-param key="otlp_trace_endpoint" code="true" text="https://otlp.datadoghq.com/v1/traces" >}}
 OTEL_EXPORTER_OTLP_TRACES_HEADERS=dd-api-key=<YOUR_API_KEY>,dd-otlp-source=llmobs
 ```
 
@@ -153,7 +153,7 @@ os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
 
 # Configure OTLP endpoint to send traces to Datadog LLM Observability
 os.environ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
-os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "{{< region-param key="otlp_trace_endpoint" code="true" >}}"
+os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "{{< region-param key="otlp_trace_endpoint" code="true" text="https://otlp.datadoghq.com/v1/traces" >}}"
 os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"dd-api-key={os.getenv('DD_API_KEY')},dd-otlp-source=llmobs"
 
 # Initialize telemetry with OTLP exporter
@@ -184,7 +184,7 @@ from opentelemetry.sdk.resources import Resource, SERVICE_NAME
 from openai import OpenAI
 
 # Configure OpenTelemetry to send traces to Datadog
-os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "{{< region-param key="otlp_trace_endpoint" code="true" >}}"
+os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "{{< region-param key="otlp_trace_endpoint" code="true" text="https://otlp.datadoghq.com/v1/traces" >}}"
 os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = "dd-api-key=<YOUR_DATADOG_API_KEY>,dd-otlp-source=llmobs"
 os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
 
@@ -286,7 +286,7 @@ provider = TracerProvider(resource=resource)
 trace.set_tracer_provider(provider)
 
 exporter = OTLPSpanExporter(
-    endpoint="{{< region-param key="otlp_trace_endpoint" code="true" >}}",
+    endpoint="{{< region-param key="otlp_trace_endpoint" code="true" text="https://otlp.datadoghq.com/v1/traces" >}}",
     headers={
         "dd-api-key": "<YOUR_DATADOG_API_KEY>",
         "dd-ml-app": "simple-openllmetry-test",

--- a/layouts/partials/region-param.html
+++ b/layouts/partials/region-param.html
@@ -1,9 +1,9 @@
 {{ $dot := . }}
 {{- if  not ($dot.key) -}}{{ errorf "region-param shortcode error: Missing value for param 'key': %s" $dot.Position }}{{- end -}}
 {{- if eq ($dot.code) "true" -}}
-    <code class="js-region-param region-param" data-region-param="{{ $dot.key }}"></code>
+    <code class="js-region-param region-param" data-region-param="{{ $dot.key }}">{{ $dot.text }}</code>
 {{- else if eq ($dot.link) "true" -}}
     <a class="js-region-param region-param" data-region-param="{{ $dot.key }}" href="">{{ $dot.text }}</a>
 {{- else -}}
-    <span class="js-region-param region-param" data-region-param="{{ $dot.key }}"></span>
+    <span class="js-region-param region-param" data-region-param="{{ $dot.key }}">{{ $dot.text }}</span>
 {{- end -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `region-param` shortcode renders an empty `<code>` (or `<span>`) element that is populated client-side by JavaScript based on the visitor's region selection. Readers that don't execute JavaScript — LLMs, AI assistants, search bots — see an empty string, which makes code samples like the OTLP trace endpoint configuration look broken or ambiguous.

This PR:

1. Extends `layouts/partials/region-param.html` so the existing `text=` parameter is used as the element's inner content for the `code` and `span` variants (it was already used for the `link` variant). The change is backward-compatible — usages without `text=` continue to render empty elements.
2. Adds `text="https://otlp.datadoghq.com/v1/traces"` to every `region-param` call in `content/en/llm_observability/instrumentation/otel_instrumentation.md` so the OTLP endpoint renders with a sensible US default in static HTML. JavaScript still swaps in the correct region-specific value for users with JS enabled.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Claude session: \`e51e8def-07e3-46ff-a673-98ef4988878b\`
Resume: \`claude --resume e51e8def-07e3-46ff-a673-98ef4988878b\`