### PR TITLE
Add security response section to Workload Protection overview

### DIFF
--- a/content/en/security/workload_protection/_index.md
+++ b/content/en/security/workload_protection/_index.md
@@ -60,6 +60,21 @@ Workload Protection Threats uses the Datadog Agent to monitor your environment. 
 3. **DNS Activity Monitoring** to watch network traffic for malicious activity on hosts and containers in real-time.
 4. **Kernel Activity Monitoring** to watch for kernel-layer attacks like process hijacking, container breakouts, and more in real-time.
 
+## Respond to threats
+
+When a threat is confirmed, you can contain it directly from the Workload Protection signal side panel. This shortens response time and helps preserve forensic state while an investigation continues.
+
+Four response actions are available from any Workload Protection signal:
+
+- **Kill process** to terminate the offending process.
+- **Kill container** to terminate the offending container.
+- **Isolate process from network** to block network access for the process, with the option to block all traffic, all traffic except localhost, or only public traffic.
+- **Isolate container from network** to block network access for the container, with the same level of control.
+
+Response actions are manual and per-signal. Action status is reported in the signal's response table, investigation graph, and events timeline, and every action is recorded in the audit trail.
+
+To use response actions, you need the Datadog Agent v7.78.1 or later, [Remote Configuration][11] enabled, and the **Cloud Workload Security Agent Actions** [RBAC permission][12].
+
 ## Proactively block threats with Active Protection
 
 By default, all OOTB Agent crypto mining threat detection rules are enabled and actively monitoring for threats.
@@ -113,3 +128,5 @@ Datadog is introducing a new feature called Active Protection to address the cry
 [8]: /security/workload_protection/security_signals
 [9]: /network_monitoring/performance/
 [10]: /security/workload_protection/guide/active-protection
+[11]: /agent/remote_config/
+[12]: /account_management/rbac/permissions/#cloud-security-platform


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a new "Respond to threats" section to the Workload Protection overview page documenting the ability to kill or isolate processes and containers directly from the signal side panel.

The section covers:
- The four available response actions (kill process, kill container, isolate process from network, isolate container from network)
- Where action status is reported (response table, investigation graph, events timeline)
- Requirements (Datadog Agent v7.78.1+, Remote Configuration, RBAC permission)

Related web-ui PR: https://github.com/DataDog/web-ui/pull/303236

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes