### PR TITLE
Hide AI Guard callout on gov sites

### DIFF
--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -41,11 +41,11 @@ algolia:
   tags: ["asm", "App and API Protection"]
 ---
 
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+{{% site-region region="us,us3,us5,eu,ap1,ap2" %}}
 {{< learning-center-callout header="Get real-time security guardrails for your AI apps and agents" btn_title="Join the preview" hide_image="true" btn_url="https://www.datadoghq.com/product-preview/ai-security/">}}
   AI Guard helps secure your AI apps and agents in real time against prompt injection, jailbreaking, tool misuse, and sensitive data exfiltration attacks. Try it today!
 {{< /learning-center-callout >}}
-{{< /site-region >}}
+{{% /site-region %}}
 
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 

--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -41,9 +41,11 @@ algolia:
   tags: ["asm", "App and API Protection"]
 ---
 
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 {{< learning-center-callout header="Get real-time security guardrails for your AI apps and agents" btn_title="Join the preview" hide_image="true" btn_url="https://www.datadoghq.com/product-preview/ai-security/">}}
   AI Guard helps secure your AI apps and agents in real time against prompt injection, jailbreaking, tool misuse, and sensitive data exfiltration attacks. Try it today!
 {{< /learning-center-callout >}}
+{{< /site-region >}}
 
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 

--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -42,9 +42,11 @@ algolia:
 ---
 
 {{% site-region region="us,us3,us5,eu,ap1,ap2" %}}
-{{< learning-center-callout header="Get real-time security guardrails for your AI apps and agents" btn_title="Join the preview" hide_image="true" btn_url="https://www.datadoghq.com/product-preview/ai-security/">}}
-  AI Guard helps secure your AI apps and agents in real time against prompt injection, jailbreaking, tool misuse, and sensitive data exfiltration attacks. Try it today!
-{{< /learning-center-callout >}}
+
+<div class="alert alert-info">
+AI Guard is in Preview. Get real-time security guardrails for your AI apps and agents. AI Guard helps secure your AI apps and agents in real time against prompt injection, jailbreaking, tool misuse, and sensitive data exfiltration attacks. Fill out this <a href="https://www.datadoghq.com/product-preview/ai-security/">form</a> to request access.
+</div>
+
 {{% /site-region %}}
 
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

AI Guard is not available on gov/gov2 sites so it doesn't make sense to advertise for it. Wrap the AI Guard preview callout on the AAP landing page in a `site-region` shortcode so it only renders on `us,us3,us5,eu,ap1,ap2`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes