### PR TITLE
Update Runtime Code Analysis (IAST) documentation page

### DIFF
--- a/content/en/security/code_security/iast/_index.md
+++ b/content/en/security/code_security/iast/_index.md
@@ -104,7 +104,7 @@ Because IAST detects vulnerabilities in your first-party code, findings do not h
 
 Click any finding in the [Vulnerabilities Explorer for IAST][1] to open the vulnerability side panel, which gives developers and security engineers the full context needed to fix the issue.
 
-The panel summarizes the finding's severity, vulnerability type, due date, and runtime indicators (such as **Exposed to Attacks** and **Service In Production**), and shows where the vulnerability was confirmed in your code, when it was first and last detected, which service, environment, and team it impacts, and relevant standards references like the CWE. When the [GitHub integration][7] is enabled, Datadog also surfaces the commit that introduced the vulnerability and a snippet of the vulnerable code.
+The panel summarizes the finding's severity, vulnerability type, due date, and runtime indicators (such as **Exposed to Attacks** and **Service In Production**), and shows where the vulnerability was confirmed in your code, when it was first and last detected, which service, environment, and team it impacts, and relevant standards references like the CWE. When the [GitHub][7], [GitLab][8], or [Azure DevOps][18] integration is enabled, Datadog also surfaces the commit that introduced the vulnerability and a snippet of the vulnerable code.
 
 The side panel includes tabs for **Data Flow** (how tainted input reaches the vulnerable sink), **Remediation** (step-by-step guidance and example code for your framework), **Datadog Severity Breakdown** (how runtime context shaped the score), and **More Information** (related references). From the **Next Steps** panel on the right, you can change the finding's status, mute it, create a Jira or ServiceNow ticket, or jump straight to the remediation steps.
 
@@ -168,6 +168,8 @@ For information on disabling IAST, see [Disabling Code Security][12].
 [4]: /account_management/rbac/permissions/#integrations
 [5]: /security/code_security/iast/setup/#using-datadog-tracing-libraries
 [7]: /integrations/github/
+[8]: /integrations/gitlab/
+[18]: /integrations/azure_devops/
 [9]: /security/code_security/iast/setup/
 [10]: https://app.datadoghq.com/security/configuration/code-security/setup
 [11]: https://www.datadoghq.com/support/

--- a/content/en/security/code_security/iast/_index.md
+++ b/content/en/security/code_security/iast/_index.md
@@ -44,43 +44,43 @@ Runtime Code Analysis (IAST) uses the Datadog tracing library to follow user-con
 
 Datadog IAST detects the following code-level vulnerability types across supported languages. Coverage may vary by language and framework; for framework-level support, see [Compatibility Requirements][5].
 
-| Severity | Detection Rule                        | Code                        | Java | .NET | Node.js | Python |
-|----------|---------------------------------------|-----------------------------|------|------|---------|--------|
-| Critical | NoSQL Injection                       | NOSQL_MONGODB_INJECTION     | FALSE | TRUE | TRUE | FALSE |
-| Critical | SQL Injection                         | SQL_INJECTION               | TRUE | TRUE | TRUE | TRUE |
-| Critical | Server-Side Request Forgery (SSRF)    | SSRF                        | TRUE | TRUE | TRUE | TRUE |
-| Critical | Code Injection                        | CODE_INJECTION              | FALSE | FALSE | TRUE | FALSE |
-| Critical | Command Injection                     | COMMAND_INJECTION           | TRUE | TRUE | TRUE | TRUE |
-| High | LDAP Injection                        | LDAP_INJECTION              | TRUE | TRUE | TRUE | FALSE |
-| High | Email HTML Injection                  | EMAIL_HTML_INJECTION        | TRUE  | TRUE  | TRUE    | FALSE  |
-| High | Hardcoded Secrets                     | HARDCODED_SECRET            | TRUE | TRUE | TRUE | FALSE |
-| High | Hardcoded Passwords                   | HARDCODED_PASSWORD          | FALSE | FALSE | TRUE | FALSE |
-| High | Path Traversal                        | PATH_TRAVERSAL              | TRUE | TRUE | TRUE | TRUE |
-| High | Trust Boundary Violation              | TRUST_BOUNDARY_VIOLATION    | TRUE | TRUE | FALSE | FALSE |
-| High | Cross-Site Scripting (XSS)            | XSS                         | TRUE | TRUE | FALSE | FALSE |
-| High | Untrusted Deserialization             | UNTRUSTED_DESERIALIZATION   | TRUE | FALSE | FALSE | FALSE |
-| High | Unvalidated Redirect                  | UNVALIDATED_REDIRECT        | TRUE | TRUE | TRUE | FALSE |
-| High | XPath Injection                       | XPATH_INJECTION             | TRUE | TRUE | FALSE | FALSE |
-| High | Header Injection                      | HEADER_INJECTION            | TRUE | TRUE | TRUE | TRUE |
-| High | Directory Listing Leak                | DIRECTORY_LISTING_LEAK      | TRUE | FALSE | FALSE | FALSE |
-| High | Default HTML Escape Invalid           | DEFAULT_HTML_ESCAPE_INVALID | TRUE | FALSE | FALSE | FALSE |
-| High | Verb Tampering                        | VERB_TAMPERING              | TRUE | FALSE | FALSE | FALSE |
-| Medium | No SameSite Cookie                   | NO_SAMESITE_COOKIE          | TRUE | TRUE | TRUE | TRUE |
-| Medium | Insecure Cookie                      | INSECURE_COOKIE             | TRUE | TRUE | TRUE | TRUE |
-| Medium | No HttpOnly Cookie                   | NO_HTTPONLY_COOKIE          | TRUE | TRUE | TRUE | TRUE |
-| Medium | Weak Hashing                         | WEAK_HASH                   | TRUE | TRUE | TRUE | TRUE |
-| Medium | Weak Cipher                          | WEAK_CIPHER                 | TRUE | TRUE | TRUE | TRUE |
-| Medium | Stacktrace Leak                      | STACKTRACE_LEAK             | TRUE | TRUE | FALSE | FALSE |
-| Medium | Reflection Injection                 | REFLECTION_INJECTION        | TRUE | TRUE | FALSE | FALSE |
-| Medium | Insecure Authentication Protocol     | INSECURE_AUTH_PROTOCOL      | TRUE | TRUE | FALSE | FALSE |
-| Medium | Hardcoded Key                        | HARDCODED_KEY               | FALSE | TRUE | FALSE | FALSE |
-| Medium | Insecure JSP Layout                  | INSECURE_JSP_LAYOUT         | TRUE | FALSE | FALSE | FALSE |
-| Low | HSTS Header Missing                   | HSTS_HEADER_MISSING         | TRUE | TRUE | TRUE | FALSE |
-| Low | X-Content-Type-Options Header Missing | XCONTENTTYPE_HEADER_MISSING | TRUE | TRUE | TRUE | FALSE |
-| Low | Weak Randomness                       | WEAK_RANDOMNESS             | TRUE | TRUE | TRUE | TRUE |
-| Low | Admin Console Active                  | ADMIN_CONSOLE_ACTIVE        | TRUE | FALSE | FALSE | FALSE |
-| Low | Session Timeout                       | SESSION_TIMEOUT             | TRUE | FALSE | FALSE | FALSE |
-| Low | Session Rewriting                     | SESSION_REWRITING           | TRUE | FALSE | FALSE | FALSE |
+| Severity | Detection Rule                        | Java | .NET | Node.js | Python |
+|----------|---------------------------------------|------|------|---------|--------|
+| Critical | NoSQL Injection                       | FALSE | TRUE | TRUE | FALSE |
+| Critical | SQL Injection                         | TRUE | TRUE | TRUE | TRUE |
+| Critical | Server-Side Request Forgery (SSRF)    | TRUE | TRUE | TRUE | TRUE |
+| Critical | Code Injection                        | FALSE | FALSE | TRUE | FALSE |
+| Critical | Command Injection                     | TRUE | TRUE | TRUE | TRUE |
+| High | LDAP Injection                        | TRUE | TRUE | TRUE | FALSE |
+| High | Email HTML Injection                  | TRUE | TRUE | TRUE | FALSE |
+| High | Hardcoded Secrets                     | TRUE | TRUE | TRUE | FALSE |
+| High | Hardcoded Passwords                   | FALSE | FALSE | TRUE | FALSE |
+| High | Path Traversal                        | TRUE | TRUE | TRUE | TRUE |
+| High | Trust Boundary Violation              | TRUE | TRUE | FALSE | FALSE |
+| High | Cross-Site Scripting (XSS)            | TRUE | TRUE | FALSE | FALSE |
+| High | Untrusted Deserialization             | TRUE | FALSE | FALSE | FALSE |
+| High | Unvalidated Redirect                  | TRUE | TRUE | TRUE | FALSE |
+| High | XPath Injection                       | TRUE | TRUE | FALSE | FALSE |
+| High | Header Injection                      | TRUE | TRUE | TRUE | TRUE |
+| High | Directory Listing Leak                | TRUE | FALSE | FALSE | FALSE |
+| High | Default HTML Escape Invalid           | TRUE | FALSE | FALSE | FALSE |
+| High | Verb Tampering                        | TRUE | FALSE | FALSE | FALSE |
+| Medium | No SameSite Cookie                   | TRUE | TRUE | TRUE | TRUE |
+| Medium | Insecure Cookie                      | TRUE | TRUE | TRUE | TRUE |
+| Medium | No HttpOnly Cookie                   | TRUE | TRUE | TRUE | TRUE |
+| Medium | Weak Hashing                         | TRUE | TRUE | TRUE | TRUE |
+| Medium | Weak Cipher                          | TRUE | TRUE | TRUE | TRUE |
+| Medium | Stacktrace Leak                      | TRUE | TRUE | FALSE | FALSE |
+| Medium | Reflection Injection                 | TRUE | TRUE | FALSE | FALSE |
+| Medium | Insecure Authentication Protocol     | TRUE | TRUE | FALSE | FALSE |
+| Medium | Hardcoded Key                        | FALSE | TRUE | FALSE | FALSE |
+| Medium | Insecure JSP Layout                  | TRUE | FALSE | FALSE | FALSE |
+| Low | HSTS Header Missing                   | TRUE | TRUE | TRUE | FALSE |
+| Low | X-Content-Type-Options Header Missing | TRUE | TRUE | TRUE | FALSE |
+| Low | Weak Randomness                       | TRUE | TRUE | TRUE | TRUE |
+| Low | Admin Console Active                  | TRUE | FALSE | FALSE | FALSE |
+| Low | Session Timeout                       | TRUE | FALSE | FALSE | FALSE |
+| Low | Session Rewriting                     | TRUE | FALSE | FALSE | FALSE |
 
 ## Key capabilities
 

--- a/content/en/security/code_security/iast/_index.md
+++ b/content/en/security/code_security/iast/_index.md
@@ -10,15 +10,39 @@ further_reading:
   - link: https://www.datadoghq.com/blog/code-security-secret-scanning
     tag: Blog
     text: Detect and block exposed credentials with Datadog Secret Scanning
+  - link: /security/code_security/iast/setup/
+    tag: Documentation
+    text: Set up Runtime Code Analysis (IAST)
+  - link: /security/code_security/iast/security_controls/
+    tag: Documentation
+    text: Security Controls
+  - link: /security/ticketing_integrations
+    tag: Documentation
+    text: Ticketing integrations
+  - link: /security/automation_pipelines/
+    tag: Documentation
+    text: Automation Pipelines
+  - link: /security/notifications/
+    tag: Documentation
+    text: Security Notifications
 ---
 
 ## Overview
 
-Datadog Runtime Code Analysis (IAST) identifies code-level vulnerabilities in your services, using an Interactive Application Security Testing (IAST) approach to find vulnerabilities within your application code based on your Datadog application instrumentation.
+Datadog Runtime Code Analysis (IAST) identifies code-level vulnerabilities in your services, using an Interactive Application Security Testing (IAST) approach to find vulnerabilities within your application code based on your Datadog application instrumentation. IAST enables Datadog to identify vulnerabilities using legitimate application traffic instead of relying on external tests that could require extra configuration or periodic scheduling. It also monitors your code's interactions with other components of your stack, such as libraries and infrastructure, providing an up-to-date view of your attack surface area.
 
-IAST enables Datadog to identify vulnerabilities using legitimate application traffic instead of relying on external tests that could require extra configuration or periodic scheduling. It also monitors your code’s interactions with other components of your stack, such as libraries and infrastructure, providing an up-to-date view of your attack surface area.
+## How it works
 
-For a list of supported services, see the [Library Compatibility Requirements][5]. IAST detection rules support the following languages:
+Runtime Code Analysis (IAST) uses the Datadog tracing library to follow user-controlled data as it flows through your application at runtime. A vulnerability is only reported when IAST can confirm that tainted input reaches a vulnerable point in the code, which keeps findings actionable.
+
+- **Tracking data sources:** IAST observes data entering your application from external sources such as request URLs, bodies, or headers. These inputs are tagged and tracked throughout their lifecycle.
+- **Analyzing data flow:** The Datadog tracing library tracks how input data moves through the application, even when it is transformed, split, or combined. This allows IAST to understand if and how the original input reaches sensitive parts of the code.
+- **Identifying vulnerable points:** IAST detects code locations where user-controlled inputs are used in potentially insecure ways—for example, in SQL queries, dynamic code execution, or HTML rendering.
+- **Confirming the vulnerability:** A vulnerability is only reported when IAST can confirm that tainted input actually reaches a vulnerable point in the code. This approach minimizes false positives and keeps findings actionable.
+
+## Supported vulnerability types
+
+Datadog IAST detects the following code-level vulnerability types across supported languages. Coverage may vary by language and framework; for framework-level support, see [Compatibility Requirements][5].
 
 | Severity | Detection Rule                        | Code                        | Java | .NET | Node.js | Python |
 |----------|---------------------------------------|-----------------------------|------|------|---------|--------|
@@ -28,7 +52,7 @@ For a list of supported services, see the [Library Compatibility Requirements][5
 | Critical | Code Injection                        | CODE_INJECTION              | FALSE | FALSE | TRUE | FALSE |
 | Critical | Command Injection                     | COMMAND_INJECTION           | TRUE | TRUE | TRUE | TRUE |
 | High | LDAP Injection                        | LDAP_INJECTION              | TRUE | TRUE | TRUE | FALSE |
-| High | Email HTML Injection | EMAIL_HTML_INJECTION                            | TRUE  | TRUE  | TRUE    | FALSE  |
+| High | Email HTML Injection                  | EMAIL_HTML_INJECTION        | TRUE  | TRUE  | TRUE    | FALSE  |
 | High | Hardcoded Secrets                     | HARDCODED_SECRET            | TRUE | TRUE | TRUE | FALSE |
 | High | Hardcoded Passwords                   | HARDCODED_PASSWORD          | FALSE | FALSE | TRUE | FALSE |
 | High | Path Traversal                        | PATH_TRAVERSAL              | TRUE | TRUE | TRUE | TRUE |
@@ -41,16 +65,16 @@ For a list of supported services, see the [Library Compatibility Requirements][5
 | High | Directory Listing Leak                | DIRECTORY_LISTING_LEAK      | TRUE | FALSE | FALSE | FALSE |
 | High | Default HTML Escape Invalid           | DEFAULT_HTML_ESCAPE_INVALID | TRUE | FALSE | FALSE | FALSE |
 | High | Verb Tampering                        | VERB_TAMPERING              | TRUE | FALSE | FALSE | FALSE |
-| Medium | No SameSite Cookie                    | NO_SAMESITE_COOKIE          | TRUE | TRUE | TRUE | TRUE |
-| Medium | Insecure Cookie                       | INSECURE_COOKIE             | TRUE | TRUE | TRUE | TRUE |
-| Medium | No HttpOnly Cookie                    | NO_HTTPONLY_COOKIE          | TRUE | TRUE | TRUE | TRUE |
-| Medium | Weak Hashing                          | WEAK_HASH                   | TRUE | TRUE | TRUE | TRUE |
-| Medium | Weak Cipher                           | WEAK_CIPHER                 | TRUE | TRUE | TRUE | TRUE |
-| Medium | Stacktrace Leak                       | STACKTRACE_LEAK             | TRUE | TRUE | FALSE | FALSE |
-| Medium | Reflection Injection                  | REFLECTION_INJECTION        | TRUE | TRUE | FALSE | FALSE |
-| Medium | Insecure Authentication Protocol      | INSECURE_AUTH_PROTOCOL      | TRUE | TRUE | FALSE | FALSE |
-| Medium | Hardcoded Key                         | HARDCODED_KEY               | FALSE | TRUE | FALSE | FALSE |
-| Medium | Insecure JSP Layout                   | INSECURE_JSP_LAYOUT         | TRUE | FALSE | FALSE | FALSE |
+| Medium | No SameSite Cookie                   | NO_SAMESITE_COOKIE          | TRUE | TRUE | TRUE | TRUE |
+| Medium | Insecure Cookie                      | INSECURE_COOKIE             | TRUE | TRUE | TRUE | TRUE |
+| Medium | No HttpOnly Cookie                   | NO_HTTPONLY_COOKIE          | TRUE | TRUE | TRUE | TRUE |
+| Medium | Weak Hashing                         | WEAK_HASH                   | TRUE | TRUE | TRUE | TRUE |
+| Medium | Weak Cipher                          | WEAK_CIPHER                 | TRUE | TRUE | TRUE | TRUE |
+| Medium | Stacktrace Leak                      | STACKTRACE_LEAK             | TRUE | TRUE | FALSE | FALSE |
+| Medium | Reflection Injection                 | REFLECTION_INJECTION        | TRUE | TRUE | FALSE | FALSE |
+| Medium | Insecure Authentication Protocol     | INSECURE_AUTH_PROTOCOL      | TRUE | TRUE | FALSE | FALSE |
+| Medium | Hardcoded Key                        | HARDCODED_KEY               | FALSE | TRUE | FALSE | FALSE |
+| Medium | Insecure JSP Layout                  | INSECURE_JSP_LAYOUT         | TRUE | FALSE | FALSE | FALSE |
 | Low | HSTS Header Missing                   | HSTS_HEADER_MISSING         | TRUE | TRUE | TRUE | FALSE |
 | Low | X-Content-Type-Options Header Missing | XCONTENTTYPE_HEADER_MISSING | TRUE | TRUE | TRUE | FALSE |
 | Low | Weak Randomness                       | WEAK_RANDOMNESS             | TRUE | TRUE | TRUE | TRUE |
@@ -58,89 +82,98 @@ For a list of supported services, see the [Library Compatibility Requirements][5
 | Low | Session Timeout                       | SESSION_TIMEOUT             | TRUE | FALSE | FALSE | FALSE |
 | Low | Session Rewriting                     | SESSION_REWRITING           | TRUE | FALSE | FALSE | FALSE |
 
-## How IAST detects vulnerabilities
-Datadog Runtime Code Analysis (IAST) utilizes the same SDKs as Datadog APM, enabling it to monitor live application traffic and detect code-level vulnerabilities in real time. It follows this process:
+## Key capabilities
 
-- **Tracking data sources:**: IAST observes data entering your application from external sources such as request URLs, bodies, or headers. These inputs are tagged and monitored throughout their lifecycle.
-- **Analyzing data flow**: The Datadog SDK tracks how the input data moves through the application—even if it's transformed, split, or combined. This allows IAST to understand if and how the original input reaches sensitive parts of the code.
-- **Identifying vulnerable points**: IAST detects code locations where user-controlled inputs are used in potentially insecure ways—for example, in SQL queries, dynamic code execution, or HTML rendering.
-- **Confirming the vulnerability**: A vulnerability is only reported when IAST can confirm that tainted input reaches a vulnerable point in the code. This approach minimizes false positives and ensures that findings are actionable.
+### Review and prioritize vulnerabilities
 
-## Explore and manage code vulnerabilities
+The [Vulnerabilities Explorer for IAST][1] provides a dedicated, vulnerability-centric view of the code-level vulnerabilities detected by IAST. All findings in this explorer correspond to vulnerabilities confirmed in services running with the Datadog tracing library and IAST enabled. Each Code Security capability has its own explorer (SAST, SCA, IAST, Secrets Scanning, and IaC), so IAST findings are not mixed with other types in this view.
 
-The [Vulnerability Explorer][1] uses real-time threat data to help you understand vulnerabilities endangering your system. Vulnerabilities are ordered by severity.
+Each finding includes a short description, the impacted services, the vulnerability type, the first and last detection times, and the exact file, method, and line number where the issue was confirmed. You can filter results by service, team, environment, severity, and other facets to focus on the work that matters to your group.
 
-{{< img src="/code_security/vulnerability_explorer_code_vulnerabilities.png" alt="Code Security in the Vulnerability Explorer" style="width:100%;" >}}
+#### Datadog severity score
 
-To triage vulnerabilities, each vulnerability contains a brief description of the issue, including:
+Because IAST detects vulnerabilities in your first-party code, findings do not have a public CVE or CVSS score. Datadog assigns a **base severity** for each vulnerability type (for example, Command Injection or SQL Injection), and then adjusts that base into the **Datadog Severity Score** based on runtime context and exploitability signals observed in your environment. These factors help distinguish theoretical risk from vulnerabilities that are more likely to be exploited in real-world environments. The table below describes how each factor influences the final score.
 
-- Impacted services.
-- Vulnerability type.
-- First detection.
-- The exact file and line number where the vulnerability was found.
+| Risk factor | How it is evaluated | Impact on the score |
+|---|---|---|
+| Base severity | Defined by Datadog based on the vulnerability type (for example, Command Injection, SQL Injection). | Starting point for the severity score. |
+| Production runtime context | Whether the affected service is running in a production environment. | Decreased if the service is not running in production. |
+| Under attack | Evidence of active attack activity targeting the service. | Decreased if there is no observed attack activity. |
 
-{{< img src="/code_security/vulnerability-details.png" alt="Code Security vulnerability details" style="width:100%;" >}}
+### Remediate a code vulnerability
 
-Each vulnerability detail includes a risk score (see screenshot below) and a severity rating: critical, high, medium, or low.
+Click any finding in the [Vulnerabilities Explorer for IAST][1] to open the vulnerability side panel, which gives developers and security engineers the full context needed to fix the issue.
 
-The risk score is tailored to the specific runtime context, including factors such as where the vulnerability is deployed and whether the service is targeted by active attacks.
+The panel summarizes the finding's severity, vulnerability type, due date, and runtime indicators (such as **Exposed to Attacks** and **Service In Production**), and shows where the vulnerability was confirmed in your code, when it was first and last detected, which service, environment, and team it impacts, and relevant standards references like the CWE. When the [GitHub integration][7] is enabled, Datadog also surfaces the commit that introduced the vulnerability and a snippet of the vulnerable code.
 
-{{< img src="/code_security/vulnerability_prioritization.png" alt="Code Security vulnerability prioritization" style="width:100%;" >}}
+The side panel includes tabs for **Data Flow** (how tainted input reaches the vulnerable sink), **Remediation** (step-by-step guidance and example code for your framework), **Datadog Severity Breakdown** (how runtime context shaped the score), and **More Information** (related references). From the **Next Steps** panel on the right, you can change the finding's status, mute it, create a Jira or ServiceNow ticket, or jump straight to the remediation steps.
 
-## Remediate a code vulnerability
+For repeatable workflows, use **Set up Automation** to apply the same actions automatically to new and existing findings that match your criteria. See [Automate triage and remediation](#automate-triage-and-remediation) for details.
 
-Datadog Code Security automatically provides the information teams need to identify where a vulnerability is in an application, from the affected filename down to the exact method and line number.
+### Create tickets from findings
 
-{{< img src="/code_security/code_security_remediation.png" alt="Code Security vulnerability remediation" style="width:100%;" >}}
+You can create a bidirectional ticket in Jira or ServiceNow directly from any IAST finding to track and remediate issues in your existing workflows. Ticket status remains synced between Datadog and your ticketing tool, so updates made in either system stay aligned. For more information, see [Ticketing integrations][13].
 
-When the [GitHub integration][7] is enabled, Code Security shows the first impacted version of a service, the commit that introduced the vulnerability, and a snippet of the vulnerable code. This information gives teams insight into where and when a vulnerability occurred and helps to prioritize their work.
+To create tickets in bulk or as part of a repeatable process, use [Automation Pipelines][14] to automatically open tickets for findings that match conditions such as severity, service, environment, or team.
 
-{{< img src="/code_security/vulnerability_code_snippet.png" alt="Code vulnerability snippet" style="width:100%;" >}}
+### Mute findings
 
-Detailed remediation steps are provided for each detected vulnerability.
+To suppress a finding, click **Mute** in the finding details panel. This opens a workflow where you can [create an Automation Rule][15] for context-aware filtering by tag values (for example, by `service` or `env`). Muting a finding hides it from active triage and excludes it from reports.
 
-{{< img src="/code_security/remediation_recommendations.png" alt="Remediation recommendations" style="width:100%;" >}}
+To restore a muted finding, click **Unmute** in the details panel. You can also use the **Status** filter on the [Vulnerabilities Explorer for IAST][1] to review muted findings.
 
-Recommendations enable you to change the status of a vulnerability, assign it to a team member for review, and create a Jira issue for tracking.
+### Notify on new findings
 
-{{< img src="/code_security/vulnerability_jira_ticket.png" alt="creating a Jira ticket from a vulnerability" style="width:100%;" >}}
+Route new IAST findings to the right team as soon as they are detected. Datadog notifications support Slack, Microsoft Teams, email, PagerDuty, webhooks, and more, so each team can receive findings where they already work. For setup details, see [Security Notifications][16].
 
-**Note:** To create Jira issues for vulnerabilities, you must configure the Jira integration, and have the `manage_integrations` permission. For detailed instructions, see the [Jira integration][3] documentation, as well as the [Role Based Access Control][4] documentation.
+### Automate triage and remediation
+
+Use [Automation Pipelines][14] to apply consistent triage and remediation actions to new and existing IAST findings, without manual intervention. From the **Set up Automation** menu in the finding side panel—or from the Automation Pipelines settings page—you can:
+
+- [Mute findings][15] that match conditions such as service, environment, or vulnerability type.
+- [Set a due date][14] based on severity and runtime context, so remediation SLAs are enforced automatically.
+- [Add findings to the Security Inbox][14] to focus your team on the highest-priority work.
+- [Create tickets][13] in Jira or ServiceNow for matching findings.
+- [Notify][16] the right team in Slack, Microsoft Teams, email, or other channels.
+
+Automation Pipelines apply to both newly detected findings and findings that already exist in Datadog, so policy changes are enforced retroactively across your environment.
+
+### Code-level vulnerability context in APM
+
+IAST enriches the information that Application Performance Monitoring (APM) already collects by flagging services where code-level vulnerabilities have been confirmed. Vulnerable services are highlighted directly in the Security view in the [APM Software Catalog][17], so you can pivot from a vulnerable service to its traces, logs, and infrastructure context in a single click.
 
 ## Vulnerability lifecycle
 
-Datadog automatically manages the lifecycle of vulnerabilities detected by IAST to ensure findings remain accurate and relevant over time.
+Datadog tracks IAST vulnerabilities at the **service** level, based on what the Datadog tracing libraries confirm in your running applications. A vulnerability is opened when IAST confirms a code-level vulnerability in a running service. A vulnerability is closed when Datadog no longer detects it according to the life cycle rules below.
 
-- **Automatic closure:**
-Vulnerabilities detected by IAST are automatically closed by Datadog when they haven't been observed for **14 days** since their last detection.
+| Product | Scope | Scenario | When a vulnerability is opened | When a vulnerability is closed |
+|---|---|---|---|---|
+| IAST | Service | Running service | Datadog confirms a code-level vulnerability in a running service. | After 14 days, if the vulnerability is not detected again during that period. |
+| IAST | Service | New service version deployed | Datadog confirms a code-level vulnerability in a running service. | 24 hours after the vulnerability is no longer detected in the new version, in the environment where it was originally detected. |
 
-- **Service version updates:**
-If a new version of the service is deployed in the environment where the vulnerability was originally detected, the vulnerability is automatically closed **24 hours** after it is no longer seen in that new version.
+If a previously closed vulnerability is detected again within 15 months, Datadog automatically reopens it so that recurring issues are not lost.
 
-- **Reopening logic:**
-If a vulnerability that was previously closed is detected again within the following **15 months**, Datadog automatically reopens it.
+## Set up Runtime Code Analysis (IAST)
 
-## Enable Runtime Code Analysis (IAST)
+To enable IAST, configure the Datadog Tracing Library for your service. Detailed, language-specific instructions are available in [Set up Runtime Code Analysis (IAST)][9]. If you need additional help, contact [Datadog support][11].
 
-To enable IAST, configure the [Datadog SDK][9]. Detailed instructions for both methods can be found in the [**Security > Code Security > Settings**][10] section.
-
-If you need additional help, contact [Datadog support][11].
-
-## Disable Code Security
 For information on disabling IAST, see [Disabling Code Security][12].
 
-## Further reading
+## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/security/appsec/vm/code
-[2]: /security/code_security/iast/setup/java/
 [3]: /integrations/jira/
 [4]: /account_management/rbac/permissions/#integrations
 [5]: /security/code_security/iast/setup/#using-datadog-tracing-libraries
-[6]: https://docs.google.com/forms/d/1wsgbd80eImvJSjXe5y5VCjAW0zzn5p3CoCLsOy0vqsk/
 [7]: /integrations/github/
 [9]: /security/code_security/iast/setup/
 [10]: https://app.datadoghq.com/security/configuration/code-security/setup
 [11]: https://www.datadoghq.com/support/
 [12]: /security/code_security/troubleshooting
+[13]: /security/ticketing_integrations
+[14]: /security/automation_pipelines/
+[15]: /security/automation_pipelines/mute
+[16]: /security/notifications/
+[17]: https://app.datadoghq.com/services?lens=Security

--- a/content/en/security/code_security/iast/security_controls/_index.md
+++ b/content/en/security/code_security/iast/security_controls/_index.md
@@ -43,25 +43,25 @@ This format uses specific separators to structure each security control entry.
 
 ### Secure marks
 
-The available secure marks correspond to the codes associated with each injection-related vulnerability. These codes and their availability for each language can be found in [supported vulnerabilities][1].
+Secure marks correspond to injection-related vulnerability types. Use the code from the **Code** column when configuring the `SECURE_MARKS` field. Use `*` to apply a control to all supported vulnerability types.
 
-The injection-related vulnerabilities are:
-
-* Code Injection
-* Command Injection
-* Email HTML Injection
-* Header Injection
-* LDAP Injection
-* NoSQL Injection
-* Path Traversal
-* Reflection Injection
-* Server-Side Request Forgery (SSRF)
-* SQL Injection
-* Trust Boundary Violation
-* Untrusted Deserialization
-* Unvalidated Redirect
-* XPath Injection
-* Cross-Site Scripting (XSS)
+| Vulnerability type | Code | Java | .NET | Node.js | Python |
+|---|---|---|---|---|---|
+| Code Injection | `CODE_INJECTION` | | | TRUE | |
+| Command Injection | `COMMAND_INJECTION` | TRUE | TRUE | TRUE | TRUE |
+| Cross-Site Scripting (XSS) | `XSS` | TRUE | TRUE | | |
+| Email HTML Injection | `EMAIL_HTML_INJECTION` | TRUE | TRUE | TRUE | |
+| Header Injection | `HEADER_INJECTION` | TRUE | TRUE | TRUE | TRUE |
+| LDAP Injection | `LDAP_INJECTION` | TRUE | TRUE | TRUE | |
+| NoSQL Injection | `NOSQL_MONGODB_INJECTION` | | TRUE | TRUE | |
+| Path Traversal | `PATH_TRAVERSAL` | TRUE | TRUE | TRUE | TRUE |
+| Reflection Injection | `REFLECTION_INJECTION` | TRUE | TRUE | | |
+| Server-Side Request Forgery (SSRF) | `SSRF` | TRUE | TRUE | TRUE | TRUE |
+| SQL Injection | `SQL_INJECTION` | TRUE | TRUE | TRUE | TRUE |
+| Trust Boundary Violation | `TRUST_BOUNDARY_VIOLATION` | TRUE | TRUE | | |
+| Untrusted Deserialization | `UNTRUSTED_DESERIALIZATION` | TRUE | | | |
+| Unvalidated Redirect | `UNVALIDATED_REDIRECT` | TRUE | TRUE | TRUE | |
+| XPath Injection | `XPATH_INJECTION` | TRUE | TRUE | | |
 
 ## Compatibility requirements
 
@@ -449,5 +449,3 @@ The following security control definition affects the `sanitize_sql` method from
 `SANITIZER:SQL_INJECTION:secure_db.sanitizers:SQLSanitizer.sanitize_sql`
 
 {{% /collapse-content %}}
-
-[1]: /security/code_security/iast/#overview


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Runtime Code Analysis (IAST) page at `/security/code_security/iast/` with the following changes:

- Rewrites the overview as a single paragraph
- Renames "How IAST detects vulnerabilities" to "How it works" with updated prose
- Extracts the detection rules table into a dedicated "Supported vulnerability types" section with an introductory paragraph
- Replaces "Explore and manage code vulnerabilities" with a new "Key capabilities" section covering:
  - Review and prioritize vulnerabilities (with a new Datadog severity score breakdown table)
  - Remediate a code vulnerability (rewritten to describe the side panel tabs and next steps)
  - Create tickets from findings
  - Mute findings
  - Notify on new findings
  - Automate triage and remediation
  - Code-level vulnerability context in APM
- Rewrites the vulnerability lifecycle section as a structured table
- Consolidates the setup and disable sections into one
- Updates `further_reading` links to include Setup, Security Controls, Ticketing integrations, Automation Pipelines, and Security Notifications

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes