### PR TITLE
Add Data Streams Monitoring callout to Kafka tracing guide

### DIFF
--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -14,7 +14,9 @@ further_reading:
   text: "Data Streams Monitoring"
 ---
 
-*Tracing your Kafka producers and consumers? **[Data Streams Monitoring for Kafka][7]** adds end-to-end lag, throughput, and message lineage tracking on top of your APM data.*
+{{< callout url="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide" btn_hidden="false" header="Learn more" >}}
+**Data Streams Monitoring for Kafka** &mdash; track end-to-end producer/consumer lag, throughput, and message lineage on top of your APM data.
+{{< /callout >}}
 
 ## Overview
 
@@ -127,4 +129,3 @@ If you want to disable Kafka tracing on an application, set the appropriate [lan
 [4]: /tracing/trace_collection/compatibility/
 [5]: /tracing/trace_collection/
 [6]: /tracing/trace_collection/library_config/
-[7]: /data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide

--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -14,9 +14,12 @@ further_reading:
   text: "Data Streams Monitoring"
 ---
 
-{{< callout url="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide" btn_hidden="false" header="Learn more" >}}
-**Data Streams Monitoring for Kafka** &mdash; track end-to-end producer/consumer lag, throughput, and message lineage on top of your APM data.
-{{< /callout >}}
+<div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
+  <p style="margin:0;line-height:1.5;">
+    <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
+    <strong>Kafka Monitoring</strong> tracks end-to-end producer/consumer lag, throughput, and message lineage on top of your APM data. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try it &rarr;</a>
+  </p>
+</div>
 
 ## Overview
 

--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -17,7 +17,7 @@ further_reading:
 <div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
   <p style="margin:0;line-height:1.5;">
     <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
-    <strong>Kafka Monitoring</strong> tracks end-to-end producer/consumer lag, throughput, and message lineage on top of your APM data. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try it &rarr;</a>
+    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try it &rarr;</a>
   </p>
 </div>
 

--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -17,7 +17,7 @@ further_reading:
 <div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
   <p style="margin:0;line-height:1.5;">
     <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
-    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try it &rarr;</a>
+    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try Kafka Monitoring &rarr;</a>
   </p>
 </div>
 

--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -14,6 +14,8 @@ further_reading:
   text: "Data Streams Monitoring"
 ---
 
+*Tracing your Kafka producers and consumers? **[Data Streams Monitoring for Kafka][7]** adds end-to-end lag, throughput, and message lineage tracking on top of your APM data.*
+
 ## Overview
 
 In event-driven pipelines, queuing and streaming technologies such as Kafka are essential to the successful operation of your systems. Ensuring that messages are being reliably and quickly conveyed between services can be difficult due to the many technologies and teams involved in such an environment. The Datadog Kafka integration and APM enable your team to monitor the health and efficiency of your infrastructure and pipelines.
@@ -125,3 +127,4 @@ If you want to disable Kafka tracing on an application, set the appropriate [lan
 [4]: /tracing/trace_collection/compatibility/
 [5]: /tracing/trace_collection/
 [6]: /tracing/trace_collection/library_config/
+[7]: /data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a one-line italicized callout at the top of the **Monitoring Kafka Queues** tracing guide, pointing readers to the new `/data_streams/kafka` page (Data Streams Monitoring for Kafka).

This is one of the top 5 Datadog pages returned by Google for "kafka datadog". The DSM-for-Kafka capability is already mentioned mid-page (`### Data Stream Monitoring`), but the new callout surfaces it above-the-fold so readers see it before scrolling.

**Tracking:** The destination link includes UTM parameters (`utm_campaign=DocsCTA-DSMKafka-TracingGuide`) so click-through from this specific page can be attributed in web analytics. The same campaign rollup (`DSMKafka`) is being added to four other high-traffic Kafka pages in separate PRs, so we can compare which surfacings drive the most traffic.

### After
<img width="811" height="296" alt="image" src="https://github.com/user-attachments/assets/b0655b97-dc0c-4a42-b0fb-e1b57b051070" />



### Links

- **Production page being edited:** https://docs.datadoghq.com/tracing/guide/monitor-kafka-queues/
- **Branch preview (with this PR's changes):** https://docs-staging.datadoghq.com/jj.botha/kafka-dsm-callout-tracing-guide/tracing/guide/monitor-kafka-queues/

  _(The preview takes a few minutes to build after each push. If it 404s, wait for the `preview-link` check to complete, then refresh.)_

- **Destination page being promoted:** https://docs.datadoghq.com/data_streams/kafka

### Merge instructions

Merge readiness:
- [x] Ready for merge

This is opened as a draft so the team can review the placement, wording, and UTM scheme before we replicate the pattern across the other four PRs (integrations-core, websites-blog x2, corp-hugo).

### AI assistance

Drafted with Claude Code (Claude Opus 4.7). Wording, placement, and UTM scheme reviewed by the author before submission.

