### PR TITLE
Bits AI Dev Agent: update integrated products' docs

### DIFF
--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -50,7 +50,7 @@ Bits Code can suggest code improvements in the following Datadog products:
 | [Bits Chat][16]   | Suggests code changes arising from Bits Chat conversations |
 | [Cloud Cost][22]          | Generates code changes for [Cloud Cost Recommendations][23] |
 | [Error Tracking][1]       | Diagnoses issues and generates code fixes on-demand or autonomously |
-| [Code Security][2]        | Remediates code vulnerabilities individually or in bulk  |
+| [Code Security][2]        | Remediates [SAST vulnerabilities][15] individually or in bulk  |
 | [Test Optimization][4]    | Provides code fixes for [flaky tests][24] and verifies that tests remain stable  |
 | [Continuous Profiler][3]  | Provides code changes for [Automated Analysis][10] insights   |
 | [Containers][12]          | Provides code changes for [Kubernetes Remediations][13]  |
@@ -140,7 +140,7 @@ Datadog Code Security uses Bits AI to enhance static analysis and generate remed
 [12]: /containers/
 [13]: /containers/bits_ai_kubernetes_remediation
 [14]: https://app.datadoghq.com/code/settings
-[15]: /security/code_security/static_analysis/ai_enhanced_sast/
+[15]: /security/code_security/static_analysis/ai_enhanced_sast/#remediation
 [16]: /bits_ai/bits_assistant/
 [17]: /bits_ai/bits_ai_sre/
 [18]: #start-a-code-session
@@ -149,4 +149,4 @@ Datadog Code Security uses Bits AI to enhance static analysis and generate remed
 [21]: /tracing/recommendations/
 [22]: /cloud_cost_management/
 [23]: /cloud_cost_management/recommendations
-[24]: /tests/flaky_management#ai-powered-flaky-test-fixes
+[24]: /tests/flaky_management#bits-ai-powered-flaky-test-fixes

--- a/content/en/containers/bits_ai_kubernetes_remediation.md
+++ b/content/en/containers/bits_ai_kubernetes_remediation.md
@@ -27,7 +27,7 @@ You can launch Bits AI Kubernetes Remediation from multiple locations within Dat
 Any one of these actions opens a side panel with remediation information, including:
 
 - An AI-powered explanation for root cause, based on collected telemetry and known patterns
-- Recommended next steps, which you may be able to [perform directly from Datadog](#remediate-from-datadog) using the [Bits AI Dev Agent][5]
+- Recommended next steps, which you may be able to [perform directly from Datadog](#remediate-from-datadog) using [Bits Code][5]
 - Related information on an adjustable timeframe: recent deployments, error logs, Kubernetes events, etc., including relevant metrics based on specific issue type
 
 {{< img src="containers/remediation/side_panel2.png" alt="Remediation side panel opened for a workload with a CrashLoopBackOff error. Displays a What Happened section with a Bits AI-powered explanation of the error's root cause. Below, a Recommended Next Steps section where the user can inspect the workload manifest. Step-by-step instructions for a suggested fix are also displayed." style="width:80%;" >}}
@@ -39,7 +39,7 @@ Any one of these actions opens a side panel with remediation information, includ
 Automated fixes from Bits AI Kubernetes Remediation is in Preview. To sign up, click <strong>Request Access</strong> and complete the form.
 {{< /callout >}}
 
-If your repositories are [connected to Datadog][4], and an error can be fixed by changing code in one of these connected repositories, then you can use the [Bits AI Dev Agent][5] to remediate directly from Datadog. For other problem scenarios, Bits AI provides a detailed list of remediation steps to follow.
+If your repositories are [connected to Datadog][4] and an error can be fixed by changing code in one of these connected repositories, then you can use [Bits Code][5] to remediate directly from Datadog. For other problem scenarios, Bits AI provides a detailed list of remediation steps to follow.
 
 {{% collapse-content title="Example: Increasing memory limit for a deployment" level="h4" expanded=true id="example-pr" %}}
 

--- a/content/en/containers/bits_ai_kubernetes_remediation.md
+++ b/content/en/containers/bits_ai_kubernetes_remediation.md
@@ -20,14 +20,14 @@ The following Kubernetes errors are supported:
 ## Usage
 
 You can launch Bits AI Kubernetes Remediation from multiple locations within Datadog:
-- **From a Kubernetes monitor**: In the _Troubleshooting_ section, select a workload under _Problematic Workloads_.
-- **From [Kubernetes Explorer][2]**: Hover over a pod status with an error to see more information about the alert and the affected workload(s), and click _Start Remediation_.
+- **From a Kubernetes monitor**: In the **Troubleshooting** section, select a workload under **Problematic Workloads**.
+- **From [Kubernetes Explorer][2]**: Hover over a pod status with an error to see more information about the alert and the affected workload(s), and click **Start Remediation**.
 - **From the [Kubernetes Remediation][1] tab**: Select a workload from the list.
 
-Any one of these actions opens a Remediation side panel that displays:
+Any one of these actions opens a side panel with remediation information, including:
 
 - An AI-powered explanation for root cause, based on collected telemetry and known patterns
-- Recommended next steps, which you may be able to [perform directly from Datadog](#remediate-from-datadog)
+- Recommended next steps, which you may be able to [perform directly from Datadog](#remediate-from-datadog) using the [Bits AI Dev Agent][5]
 - Related information on an adjustable timeframe: recent deployments, error logs, Kubernetes events, etc., including relevant metrics based on specific issue type
 
 {{< img src="containers/remediation/side_panel2.png" alt="Remediation side panel opened for a workload with a CrashLoopBackOff error. Displays a What Happened section with a Bits AI-powered explanation of the error's root cause. Below, a Recommended Next Steps section where the user can inspect the workload manifest. Step-by-step instructions for a suggested fix are also displayed." style="width:80%;" >}}
@@ -39,7 +39,7 @@ Any one of these actions opens a Remediation side panel that displays:
 Automated fixes from Bits AI Kubernetes Remediation is in Preview. To sign up, click <strong>Request Access</strong> and complete the form.
 {{< /callout >}}
 
-If your repositories are [connected to Datadog][4], and an error can be fixed by changing code in one of these connected repositories, then you can use Bits AI to perform the remediation action directly from Datadog. For other problem scenarios, Bits AI provides a detailed list of remediation steps to follow.
+If your repositories are [connected to Datadog][4], and an error can be fixed by changing code in one of these connected repositories, then you can use the [Bits AI Dev Agent][5] to remediate directly from Datadog. For other problem scenarios, Bits AI provides a detailed list of remediation steps to follow.
 
 {{% collapse-content title="Example: Increasing memory limit for a deployment" level="h4" expanded=true id="example-pr" %}}
 
@@ -63,3 +63,4 @@ When a pod is terminated because the memory usage exceeded its limit, you may be
 [2]: https://app.datadoghq.com/orchestration/explorer/pod
 [3]: https://app.datadoghq.com/code?tab=my-sessions
 [4]: https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=githubsaasonprem#connect-your-git-repositories-to-datadog
+[5]: /bits_ai/bits_ai_dev_agent/

--- a/content/en/profiler/automated_analysis.md
+++ b/content/en/profiler/automated_analysis.md
@@ -20,7 +20,7 @@ Automated Analysis automatically detects performance issues in your applications
 
 - A high-level summary explaining the issue and why it matters
 - Contextual insights from profiling data (for example, affected methods, packages, or processes)
-- Recommended next steps to help you resolve the issue
+- Recommended next steps to help you resolve the issue, with optional auto-generated fixes from [Bits AI Dev Agent][2]
 
 This reduces the profiling expertise needed to identify and resolve performance issues in your applications that might otherwise go unnoticed.
 
@@ -52,6 +52,9 @@ Each row represents an insight type, summarizing:
 - Priority (high, medium or low)
 
 You can filter insights by insight name, runtime, service, or environment to narrow the list to the most important insights. Teams often use this view to identify patterns, such as multiple services affected by the same inefficiency. Clicking on an insight opens its detail panel.
+
+## Take action on insights
+While viewing an insight, see **Next Steps** to view Datadog recommendations for improvements. Alternatively, click **Fix with Bits** to have [Bits AI Dev Agent][2] generate a fix.
 
 ## Supported insights
 
@@ -135,4 +138,5 @@ Automated Analysis supports finding the following insights:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/profiling/explorer
+[2]: /bits_ai/bits_ai_dev_agent/
 

--- a/content/en/profiler/automated_analysis.md
+++ b/content/en/profiler/automated_analysis.md
@@ -20,7 +20,7 @@ Automated Analysis automatically detects performance issues in your applications
 
 - A high-level summary explaining the issue and why it matters
 - Contextual insights from profiling data (for example, affected methods, packages, or processes)
-- Recommended next steps to help you resolve the issue, with optional auto-generated fixes from [Bits AI Dev Agent][2]
+- Recommended next steps to help you resolve the issue, with optional auto-generated fixes from [Bits Code][2]
 
 This reduces the profiling expertise needed to identify and resolve performance issues in your applications that might otherwise go unnoticed.
 
@@ -54,7 +54,7 @@ Each row represents an insight type, summarizing:
 You can filter insights by insight name, runtime, service, or environment to narrow the list to the most important insights. Teams often use this view to identify patterns, such as multiple services affected by the same inefficiency. Clicking on an insight opens its detail panel.
 
 ## Take action on insights
-While viewing an insight, see **Next Steps** to view Datadog recommendations for improvements. Alternatively, click **Fix with Bits** to have [Bits AI Dev Agent][2] generate a fix.
+While viewing an insight, see **Next Steps** to view Datadog recommendations for improvements. Alternatively, click **Fix with Bits** to have [Bits Code][2] generate a fix.
 
 ## Supported insights
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -158,7 +158,7 @@ This method avoids unnecessary CI failures and saves developer time.
 
 After Test Optimization detects a flaky test, [Bits Code][16] can automatically diagnose and fix it. Bits Code analyzes the test's failure patterns and generates production-ready code changes. You can then create a GitHub pull request directly from Bits Code's suggestions.
 
-For Bits AI Dev Agent to create a fix, the flaky test must meet the following criteria:
+For Bits Code to create a fix, the flaky test must meet the following criteria:
 - **Failure rate**: At least 5%
 - **Wasted time**: At least 2 hours
 - **Failed pipelines**: At least 2 pipelines
@@ -171,7 +171,7 @@ For Bits AI Dev Agent to create a fix, the flaky test must meet the following cr
 
 To allow Bits Code to suggest flaky test fixes, enable Bits Code for Test Optimization by following the setup instructions in the [Bits Code documentation][16]. Bits Code automatically creates fixes for flaky tests detected by Test Optimization.
 
-After you have enabled Bits AI Dev Agent, when viewing a flaky test, click **Generate fix**.
+After you have enabled Bits Code, when viewing a flaky test, click **Generate fix**.
 
 ## AI-powered flaky test categorization
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -154,23 +154,24 @@ A 14-day grace period applies to every flaky test with a successful fix after us
 
 This method avoids unnecessary CI failures and saves developer time.
 
-## AI-powered flaky test fixes
+## Bits AI-powered flaky test fixes
 
-Bits Code can automatically diagnose and fix flaky tests that have been detected by Test Optimization. When a flaky test is identified, Bits AI analyzes the test failure patterns and generates production-ready fixes that can be submitted as GitHub pull requests.
+After Test Optimization detects a flaky test, [Bits Code][16] can automatically diagnose and fix it. Bits Code analyzes the test's failure patterns and generates production-ready code changes. You can then create a GitHub pull request directly from Bits Code's suggestions.
 
-For Bits AI to create a fix, the flaky test must meet the following criteria:
+For Bits AI Dev Agent to create a fix, the flaky test must meet the following criteria:
 - **Failure rate**: At least 5%
 - **Wasted time**: At least 2 hours
 - **Failed pipelines**: At least 2 pipelines
 - **Branch**: Must have flaked in the default branch
+- **Failed executions**: Must have at least 1 failed execution that includes both `@error.message` and `@test.source.file` tags
 
 {{< img src="tests/bits_ai_flaky_test_fixes-2.png" alt="Bits Code displaying a proposed fix for a flaky test" style="width:100%;" >}}
 
 ### Setup
 
-To enable AI-powered flaky test fixes, enable Bits Code for Test Optimization by following the setup instructions in the [Bits Code documentation][16]. Bits Code automatically create fixes for flaky tests detected by Test Optimization.
+To allow Bits Code to suggest flaky test fixes, enable Bits Code for Test Optimization by following the setup instructions in the [Bits Code documentation][16]. Bits Code automatically creates fixes for flaky tests detected by Test Optimization.
 
-<div class="alert alert-info">A flaky test must have at least one failed execution that includes both <code>@error.message</code> and <code>@test.source.file</code> tags to be eligible for a fix. Generating a fix may take some time.</div>
+After you have enabled Bits AI Dev Agent, when viewing a flaky test, click **Generate fix**.
 
 ## AI-powered flaky test categorization
 

--- a/content/en/tracing/recommendations/_index.md
+++ b/content/en/tracing/recommendations/_index.md
@@ -140,7 +140,7 @@ AI-driven recommendation types are now available, expanding the set of [optimiza
 
 Certain recommendations rely on specific Datadog products. Use the **Recommendation Prerequisite** dropdown to filter recommendations by the Datadog products in your setup.
 
-If you plan to use [Bits AI Dev Agent][3] to implement recommendations, you must [complete its setup][4].
+If you plan to use [Bits Code][3] to implement recommendations, you must [complete its setup][4].
 
 ## How it works
 
@@ -162,7 +162,7 @@ To review recommendations that need your attention:
 2. Filter your recommendations by status or type.
 3. Select a recommendation from the list to see a detailed description of the issue.
 4. Review the problem, impact, and Datadog's recommendation for resolving it.
-5. (Optional) To use [Bits AI Dev Agent][3] to generate a code fix, under **Next Steps**, click **Fix with Bits**.
+5. (Optional) To use [Bits AI Code][3] to generate a code fix, under **Next Steps**, click **Fix with Bits**.
 6. (Optional) To track the fix in Jira or Case Management, under **Triage**, click **Add Jira Ticket** or **Add Case**.
 
 After you've reviewed the recommendation, you can use the **FOR REVIEW** dropdown to change the recommendation status to **REVIEWED**, **IGNORED**, or **RESOLVED**.

--- a/content/en/tracing/recommendations/_index.md
+++ b/content/en/tracing/recommendations/_index.md
@@ -162,7 +162,7 @@ To review recommendations that need your attention:
 2. Filter your recommendations by status or type.
 3. Select a recommendation from the list to see a detailed description of the issue.
 4. Review the problem, impact, and Datadog's recommendation for resolving it.
-5. (Optional) To use [Bits AI Code][3] to generate a code fix, under **Next Steps**, click **Fix with Bits**.
+5. (Optional) To use [Bits Code][3] to generate a code fix, under **Next Steps**, click **Fix with Bits**.
 6. (Optional) To track the fix in Jira or Case Management, under **Triage**, click **Add Jira Ticket** or **Add Case**.
 
 After you've reviewed the recommendation, you can use the **FOR REVIEW** dropdown to change the recommendation status to **REVIEWED**, **IGNORED**, or **RESOLVED**.

--- a/content/en/tracing/recommendations/_index.md
+++ b/content/en/tracing/recommendations/_index.md
@@ -140,6 +140,8 @@ AI-driven recommendation types are now available, expanding the set of [optimiza
 
 Certain recommendations rely on specific Datadog products. Use the **Recommendation Prerequisite** dropdown to filter recommendations by the Datadog products in your setup.
 
+If you plan to use [Bits AI Dev Agent][3] to implement recommendations, you must [complete its setup][4].
+
 ## How it works
 
 Recommendations are based on data collected from different parts of your stack:
@@ -160,8 +162,10 @@ To review recommendations that need your attention:
 2. Filter your recommendations by status or type.
 3. Select a recommendation from the list to see a detailed description of the issue.
 4. Review the problem, impact, and Datadog's recommendation for resolving it.
+5. (Optional) To use [Bits AI Dev Agent][3] to generate a code fix, under **Next Steps**, click **Fix with Bits**.
+6. (Optional) To track the fix in Jira or Case Management, under **Triage**, click **Add Jira Ticket** or **Add Case**.
 
-After you've reviewed the recommendation, you can use the **FOR REVIEW** dropdown to change the recommendation status to *Reviewed*, *Ignored*, or *Resolved*. Alternatively, you can assign the recommendation to an owner and track related work in Case Management or Jira.
+After you've reviewed the recommendation, you can use the **FOR REVIEW** dropdown to change the recommendation status to **REVIEWED**, **IGNORED**, or **RESOLVED**.
 
 ## Supported recommendations
 
@@ -177,3 +181,5 @@ After you've reviewed the recommendation, you can use the **FOR REVIEW** dropdow
 
 [1]: https://app.datadoghq.com/apm/recommendations
 [2]: /database_monitoring/recommendations/
+[3]: /bits_ai/bits_ai_dev_agent/
+[4]: /bits_ai/bits_ai_dev_agent/setup/


### PR DESCRIPTION

### What does this PR do? What is the motivation?
In docs for products that have integrated Bits AI Dev Agent, adds or modifies mention of the Dev Agent:
- on Bits AI Kubernetes Remediation, adds references/links to the Bits AI _Dev Agent_ 
- on Automated Analysis, adds a "## Take action on insights" section that mentions the Dev Agent (also added mention in Overview)
- on Flaky Test Management, links "Bits AI Dev Agent" to its docs, condensed requirements for a fix to be generated
- on APM Recommendations, added mentions of Bits AI Dev Agent

Also, on the Bits AI Dev Agent "homepage," updates reference for Code Security integration to the more specific SAST page

This work is part of what's outlined on https://datadoghq.atlassian.net/browse/DOCS-14242—there will be additional PRs for that ticket

### Merge instructions
merge-able!

Merge readiness:
- [x] Ready for merge

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance
used Claude to do some comprehensive searching

### Additional notes

