### PR TITLE
Add BYOC Logs Production Best Practices to left nav

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7162,25 +7162,25 @@ menu:
       parent: cloudprem_operate
       identifier: cloudprem_operate_sizing
       weight: 600
-    - name: Production Best Practices
-      url: /byoc-logs/operate/best_practices
-      parent: cloudprem_operate
-      identifier: cloudprem_operate_best_practices
-      weight: 601
     - name: Monitoring
       url: /byoc-logs/operate/monitoring
       parent: cloudprem_operate
       identifier: cloudprem_operate_monitoring
-      weight: 602
-    - name: Troubleshooting
-      url: /byoc-logs/operate/troubleshooting
-      parent: cloudprem_operate
-      identifier: cloudprem_operate_troubleshooting
-      weight: 603
+      weight: 601
     - name: Search Logs
       url: /byoc-logs/operate/search_logs
       parent: cloudprem_operate
       identifier: cloudprem_operate_search
+      weight: 602
+    - name: Production Best Practices
+      url: /byoc-logs/operate/best_practices
+      parent: cloudprem_operate
+      identifier: cloudprem_operate_best_practices
+      weight: 603
+    - name: Troubleshooting
+      url: /byoc-logs/operate/troubleshooting
+      parent: cloudprem_operate
+      identifier: cloudprem_operate_troubleshooting
       weight: 604
     - name: Guides
       url: /byoc-logs/guides/

--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7162,21 +7162,26 @@ menu:
       parent: cloudprem_operate
       identifier: cloudprem_operate_sizing
       weight: 600
+    - name: Production Best Practices
+      url: /byoc-logs/operate/best_practices
+      parent: cloudprem_operate
+      identifier: cloudprem_operate_best_practices
+      weight: 601
     - name: Monitoring
       url: /byoc-logs/operate/monitoring
       parent: cloudprem_operate
       identifier: cloudprem_operate_monitoring
-      weight: 601
+      weight: 602
     - name: Troubleshooting
       url: /byoc-logs/operate/troubleshooting
       parent: cloudprem_operate
       identifier: cloudprem_operate_troubleshooting
-      weight: 602
+      weight: 603
     - name: Search Logs
       url: /byoc-logs/operate/search_logs
       parent: cloudprem_operate
       identifier: cloudprem_operate_search
-      weight: 603
+      weight: 604
     - name: Guides
       url: /byoc-logs/guides/
       parent: cloudprem

--- a/content/en/byoc-logs/operate/_index.md
+++ b/content/en/byoc-logs/operate/_index.md
@@ -15,8 +15,8 @@ Manage your BYOC Logs deployment with guides on sizing, monitoring, and troubles
 
 {{< whatsnext desc="Operate BYOC Logs:">}}
   {{< nextlink href="/byoc-logs/operate/sizing/" >}}Sizing Guide{{< /nextlink >}}
-  {{< nextlink href="/byoc-logs/operate/best_practices/" >}}Production Best Practices{{< /nextlink >}}
-  {{< nextlink href="/byoc-logs/operate/search_logs/" >}}Search Logs{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/monitoring/" >}}Monitor BYOC Logs{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/operate/search_logs/" >}}Search Logs{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/operate/best_practices/" >}}Production Best Practices{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/troubleshooting/" >}}Troubleshooting{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #36052. Adds the new BYOC Logs Production Best Practices page to the left navigation, updates the ordering of the other left hand nav pages, and updates the ordering on [Operate index page](https://github.com/DataDog/documentation/blob/master/content/en/byoc-logs/operate/_index.md) to match.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes