### PR TITLE
Add Java to OpenTelemetry Logs API support page

### DIFF
--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -12,7 +12,6 @@ aliases:
   - /opentelemetry/instrument/api_support/go/metrics
   - /opentelemetry/instrument/api_support/go/traces
   - /opentelemetry/instrument/api_support/java
-  - /opentelemetry/instrument/api_support/java/logs
   - /opentelemetry/instrument/api_support/java/metrics
   - /opentelemetry/instrument/api_support/java/traces
   - /opentelemetry/instrument/api_support/nodejs/
@@ -917,8 +916,8 @@ If you encounter an issue after upgrading `@opentelemetry/api-logs`, [open an is
 - **OpenTelemetry Rust SDK**: The SDK provides the logs implementation automatically.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- **Datadog SDK**: dd-trace-java version 1.62.0 or later.
-- **OpenTelemetry API**: `opentelemetry-api` version 1.27.0 or later (the version that introduced the stable Logs API).
+- **Datadog SDK**: `dd-trace-java` version 1.62.0 or later.
+- **OpenTelemetry API**: `opentelemetry-api` version 1.27.0 (the version that introduced the stable Logs API) or later.
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel logs.
 

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -919,6 +919,7 @@ If you encounter an issue after upgrading `@opentelemetry/api-logs`, [open an is
 {% if equals($prog_lang, "java") %}
 - **Datadog SDK**: `dd-trace-java` version 1.62.0 or later.
 
+
 - **OpenTelemetry API**: `opentelemetry-api` version 1.27.0 (the version that introduced the stable Logs API) or later.
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel logs.

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -12,6 +12,7 @@ aliases:
   - /opentelemetry/instrument/api_support/go/metrics
   - /opentelemetry/instrument/api_support/go/traces
   - /opentelemetry/instrument/api_support/java
+  - /opentelemetry/instrument/api_support/java/logs
   - /opentelemetry/instrument/api_support/java/metrics
   - /opentelemetry/instrument/api_support/java/traces
   - /opentelemetry/instrument/api_support/nodejs/
@@ -56,15 +57,6 @@ further_reading:
 <!-- ============================================== -->
 <!-- SIGNAL AVAILABILITY NOTICES -->
 <!-- ============================================== -->
-
-<!-- Java has traces and metrics only -->
-{% if equals($prog_lang, "java") %}
-{% if equals($platform, "logs") %}
-{% alert level="danger" %}
-OpenTelemetry API support for logs is not available for this language. Use [Datadog Log Collection][210] instead.
-{% /alert %}
-{% /if %}
-{% /if %}
 
 <!-- PHP has traces and metrics only -->
 {% if equals($prog_lang, "php") %}
@@ -875,14 +867,14 @@ Here is the minimum version required for each instrument type:
 {% if equals($platform, "logs") %}
 
 <!-- Show content only for languages that support logs -->
-{% if includes($prog_lang, ["dot_net", "node_js", "python", "go", "rust"]) %}
+{% if includes($prog_lang, ["dot_net", "node_js", "python", "go", "rust", "java"]) %}
 
 ## Overview
 
 Use the OpenTelemetry Logs API with Datadog SDKs to send custom application logs. This is an alternative to Datadog's traditional log injection.
 
-<!-- Native implementation (.NET, Node.js, Go, Rust) -->
-{% if includes($prog_lang, ["dot_net", "node_js", "go", "rust"]) %}
+<!-- Native implementation (.NET, Node.js, Go, Rust, Java) -->
+{% if includes($prog_lang, ["dot_net", "node_js", "go", "rust", "java"]) %}
 
 The Datadog SDK provides a native implementation of the OpenTelemetry API. This means you can write code against the standard OTel interfaces without needing the official OpenTelemetry SDK.
 
@@ -923,6 +915,11 @@ If you encounter an issue after upgrading `@opentelemetry/api-logs`, [open an is
 - **Datadog SDK**: `datadog-opentelemetry` crate version 0.2.1 or later.
 - **Rust**: MSRV 1.84.1 or later.
 - **OpenTelemetry Rust SDK**: The SDK provides the logs implementation automatically.
+{% /if %}
+{% if equals($prog_lang, "java") %}
+- **Datadog SDK**: `dd-trace-java` version 1.62.0 or later.
+- **OpenTelemetry Logs API**: Requires the `io.opentelemetry:opentelemetry-api` artifact version 1.27.0 or later (this is the version that introduced the stable logs API).
+- **OTLP transport**: Java exports OTel logs only over OTLP HTTP/protobuf. Your OTLP destination must accept logs on port 4318.
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel logs.
 
@@ -1047,6 +1044,15 @@ Follow these steps to enable OTel Logs API support in your application.
 
     // Shutdown to flush remaining logs
     let _ = logger_provider.shutdown();
+    ```
+{% /if %}
+
+{% if equals($prog_lang, "java") %}
+1. Add the Datadog SDK (`dd-trace-java`) to your project and [enable its instrumentation][207].
+2. Make sure you only depend on the OpenTelemetry API (and not the OpenTelemetry SDK).
+3. Enable OTel logs export by setting the following environment variable:
+    ```sh
+    export DD_LOGS_OTEL_ENABLED=true
     ```
 {% /if %}
 
@@ -1342,6 +1348,57 @@ logger.emit(log_record);
 ```
 {% /if %}
 
+{% if equals($prog_lang, "java") %}
+### Emitting a log {% #emitting-log-java %}
+
+After the Datadog SDK is initialized, you can use the standard OpenTelemetry Logs API to get a logger and emit log records.
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+
+Logger logger = GlobalOpenTelemetry.get().getLogsBridge().get("my-service");
+
+logger.logRecordBuilder()
+    .setBody("User clicked the checkout button.")
+    .setSeverity(Severity.INFO)
+    .setSeverityText("INFO")
+    .setAttribute(AttributeKey.stringKey("cart.id"), "c-12345")
+    .setAttribute(AttributeKey.stringKey("user.id"), "u-54321")
+    .emit();
+```
+
+### Trace and log correlation {% #trace-log-correlation-java %}
+
+Trace and log correlation is automatic. When you emit a log using the OTel Logs API within an active Datadog trace, the `trace_id` and `span_id` are automatically added to the log record.
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
+Tracer tracer = GlobalOpenTelemetry.getTracer("my-service");
+Logger logger = GlobalOpenTelemetry.get().getLogsBridge().get("my-service");
+
+Span span = tracer.spanBuilder("process.user.request").startSpan();
+try (Scope scope = span.makeCurrent()) {
+    // This log is automatically correlated with the active span
+    logger.logRecordBuilder()
+        .setBody("Processing user request for ID: 12345")
+        .setSeverity(Severity.INFO)
+        .setSeverityText("INFO")
+        .emit();
+} finally {
+    span.end();
+}
+```
+{% /if %}
+
 ## Supported configuration
 
 To enable this feature, you must set `DD_LOGS_OTEL_ENABLED=true`.
@@ -1398,6 +1455,13 @@ The Datadog SDK programmatically configures the OTel SDK for you.
 4. Set the `DD_LOGS_OTEL_ENABLED=true` environment variable.
 {% /if %}
 
+{% if equals($prog_lang, "java") %}
+1. Add the Datadog SDK (`dd-trace-java`) to your project and [enable its instrumentation][207].
+2. Remove any code that manually configures `SdkLoggerProvider` or an OTLP log record exporter (such as `OtlpHttpLogRecordExporter`). The Datadog SDK handles this configuration automatically.
+3. Remove the `opentelemetry-sdk` and `opentelemetry-exporter-otlp` artifacts from your project's dependencies. Keep `opentelemetry-api`.
+4. Set the `DD_LOGS_OTEL_ENABLED=true` environment variable.
+{% /if %}
+
 ### Existing Datadog log injection
 
 If you are using Datadog's traditional log injection (where `DD_LOGS_INJECTION=true` adds trace context to text logs) and an Agent to tail log files:
@@ -1433,6 +1497,11 @@ If you are using Datadog's traditional log injection (where `DD_LOGS_INJECTION=t
 - Verify that a transport feature (`logs-grpc` or `logs-http`) is enabled in your `Cargo.toml` file.
 - Verify `datadog_opentelemetry::logs().init()` is called before using the logger.
 - Check protocol configuration. Only `grpc` and `http/protobuf` protocols are supported. HTTP/JSON is not supported.
+{% /if %}
+{% if equals($prog_lang, "java") %}
+- Verify `DD_LOGS_OTEL_ENABLED=true` is set. Logs are disabled by default in dd-trace-java.
+- Verify Datadog automatic instrumentation is active. This feature relies on Datadog's automatic instrumentation to function.
+- Verify your application only depends on the OpenTelemetry API. The Datadog SDK provides the OpenTelemetry SDK implementation.
 {% /if %}
 
 {% /if %}

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -182,7 +182,7 @@ The OpenTelemetry Metrics SDK for Ruby is currently in [alpha implementation](ht
 - **Rust**: MSRV 1.84 or later.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- **Datadog SDK**: dd-trace-java version 1.61.0 or later.
+- **Datadog SDK**: `dd-trace-java` version 1.61.0 or later.
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel metrics.
 {% if includes($prog_lang, ["dot_net", "node_js", "python", "ruby", "go", "java"]) %}

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -1497,7 +1497,6 @@ If you are using Datadog's traditional log injection (where `DD_LOGS_INJECTION=t
 - Check protocol configuration. Only `grpc` and `http/protobuf` protocols are supported. HTTP/JSON is not supported.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- Verify `DD_LOGS_OTEL_ENABLED=true` is set. Logs are disabled by default in dd-trace-java.
 - Verify Datadog automatic instrumentation is active. This feature relies on Datadog's automatic instrumentation to function.
 {% /if %}
 

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -12,6 +12,7 @@ aliases:
   - /opentelemetry/instrument/api_support/go/metrics
   - /opentelemetry/instrument/api_support/go/traces
   - /opentelemetry/instrument/api_support/java
+  - /opentelemetry/instrument/api_support/java/logs
   - /opentelemetry/instrument/api_support/java/metrics
   - /opentelemetry/instrument/api_support/java/traces
   - /opentelemetry/instrument/api_support/nodejs/

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -917,9 +917,8 @@ If you encounter an issue after upgrading `@opentelemetry/api-logs`, [open an is
 - **OpenTelemetry Rust SDK**: The SDK provides the logs implementation automatically.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- **Datadog SDK**: `dd-trace-java` version 1.62.0 or later.
-- **OpenTelemetry Logs API**: Requires the `io.opentelemetry:opentelemetry-api` artifact version 1.27.0 or later (this is the version that introduced the stable logs API).
-- **OTLP transport**: Java exports OTel logs only over OTLP HTTP/protobuf. Your OTLP destination must accept logs on port 4318.
+- **Datadog SDK**: dd-trace-java version 1.62.0 or later.
+- **OpenTelemetry API**: `opentelemetry-api` version 1.27.0 or later (the version that introduced the stable Logs API).
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel logs.
 
@@ -1050,10 +1049,10 @@ Follow these steps to enable OTel Logs API support in your application.
 {% if equals($prog_lang, "java") %}
 1. Add the Datadog SDK (`dd-trace-java`) to your project and [enable its instrumentation][207].
 2. Make sure you only depend on the OpenTelemetry API (and not the OpenTelemetry SDK).
-3. Enable OTel logs export by setting the following environment variable:
-    ```sh
-    export DD_LOGS_OTEL_ENABLED=true
-    ```
+3. Enable OTel logs by setting the following environment variable:
+   ```sh
+   export DD_LOGS_OTEL_ENABLED=true
+   ```
 {% /if %}
 
 ## Examples
@@ -1457,9 +1456,8 @@ The Datadog SDK programmatically configures the OTel SDK for you.
 
 {% if equals($prog_lang, "java") %}
 1. Add the Datadog SDK (`dd-trace-java`) to your project and [enable its instrumentation][207].
-2. Remove any code that manually configures `SdkLoggerProvider` or an OTLP log record exporter (such as `OtlpHttpLogRecordExporter`). The Datadog SDK handles this configuration automatically.
-3. Remove the `opentelemetry-sdk` and `opentelemetry-exporter-otlp` artifacts from your project's dependencies. Keep `opentelemetry-api`.
-4. Set the `DD_LOGS_OTEL_ENABLED=true` environment variable.
+2. Make sure you only depend on the OpenTelemetry API (and not the OpenTelemetry SDK).
+3. Set the `DD_LOGS_OTEL_ENABLED=true` environment variable.
 {% /if %}
 
 ### Existing Datadog log injection
@@ -1501,7 +1499,6 @@ If you are using Datadog's traditional log injection (where `DD_LOGS_INJECTION=t
 {% if equals($prog_lang, "java") %}
 - Verify `DD_LOGS_OTEL_ENABLED=true` is set. Logs are disabled by default in dd-trace-java.
 - Verify Datadog automatic instrumentation is active. This feature relies on Datadog's automatic instrumentation to function.
-- Verify your application only depends on the OpenTelemetry API. The Datadog SDK provides the OpenTelemetry SDK implementation.
 {% /if %}
 
 {% /if %}

--- a/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md
@@ -830,7 +830,7 @@ If you are currently using the Datadog DogStatsD client and want to migrate to t
 - Verify `DD_METRICS_OTEL_ENABLED=true` is set before initializing the meter provider.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- Verify Datadog automatic instrumentation is active. This feature relies on Datadog's automatic instrumentation to function.
+- Verify the `dd-trace-java` javaagent is running. The javaagent registers itself as the global OTel MeterProvider at startup; without it, OTel API calls fall through to no-op providers and no data is sent.
 {% /if %}
 
 {% if equals($prog_lang, "dot_net") %}
@@ -918,6 +918,7 @@ If you encounter an issue after upgrading `@opentelemetry/api-logs`, [open an is
 {% /if %}
 {% if equals($prog_lang, "java") %}
 - **Datadog SDK**: `dd-trace-java` version 1.62.0 or later.
+
 - **OpenTelemetry API**: `opentelemetry-api` version 1.27.0 (the version that introduced the stable Logs API) or later.
 {% /if %}
 - **An OTLP-compatible destination**: You must have a destination (Agent or Collector) listening on ports 4317 (gRPC) or 4318 (HTTP) to receive OTel logs.
@@ -1497,7 +1498,7 @@ If you are using Datadog's traditional log injection (where `DD_LOGS_INJECTION=t
 - Check protocol configuration. Only `grpc` and `http/protobuf` protocols are supported. HTTP/JSON is not supported.
 {% /if %}
 {% if equals($prog_lang, "java") %}
-- Verify Datadog automatic instrumentation is active. This feature relies on Datadog's automatic instrumentation to function.
+- Verify the `dd-trace-java` javaagent is running. The javaagent registers itself as the global OTel LoggerProvider at startup; without it, OTel API calls fall through to no-op providers and no data is sent.
 {% /if %}
 
 {% /if %}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

`dd-trace-java` 1.62.0 ships native [OpenTelemetry Logs API](https://github.com/DataDog/dd-trace-java/pull/11224) support and [OTLP/HTTP log export](https://github.com/DataDog/dd-trace-java/pull/11253). This PR updates the [OpenTelemetry API Support](https://docs.datadoghq.com/opentelemetry/instrument/dd_sdks/api_support/?platform=logs&prog_lang=java) page so the Java + Logs filter combination no longer shows "not available."

Specifically, in `content/en/opentelemetry/instrument/dd_sdks/api_support.mdoc.md`:

- Removes the Java-logs "not available" alert.
- Adds `java` to the `includes()` guards for the logs section and the native-implementation note.
- Adds Java content to Prerequisites (dd-trace-java 1.62.0+, opentelemetry-api 1.27.0+, OTLP HTTP/protobuf only), Setup, Examples (emitting a log + trace/log correlation), Migrate from other setups, and Troubleshooting.
- Adds a `/opentelemetry/instrument/api_support/java/logs` alias.

Requested in [the SDK Capabilities fortnightly status thread](https://dd.slack.com/archives/C08NCCPPXE3/p1778793457659369?thread_ts=1778099870.997299&cid=C08NCCPPXE3).

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Drafted with Claude Code. Java code examples verified against the OTel Logs API and the dd-trace-java 1.62.0 implementation; pre-push code review (two reviewer agents + Codex adversarial review) applied before pushing.

### Additional notes

No DOCS Jira ticket filed for this one — happy to add one if the team prefers.