### PR TITLE
Document 50 MB response size limit for Export API pagination

### DIFF
--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -122,7 +122,7 @@ Method
 | sort | string | Sort order. Allowed values: timestamp, -timestamp |
 | include_attachments | boolean | Whether to retrieve truncated input and output content. Defaults to True. |
 | page[cursor] | string | List following results with a cursor provided in the previous query. |
-| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. |
+| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. If your spans contain large inputs or outputs, use a lower limit and paginate with `page[cursor]`. |
 
 #### Code example
 
@@ -298,7 +298,7 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 
 | Field | Type | Description |
 |-------|------|-------------|
-| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. |
+| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. If your spans contain large inputs or outputs, use a lower limit and paginate with `cursor`. |
 | cursor | string | List following results with a cursor provided in the previous query. |
 
 ### SearchedSpanResource


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a note to the `page[limit]` and `limit` fields on the Export API page clarifying that responses are subject to a 50 MB size limit. Users setting a high pagination limit on orgs with large spans (long inputs, outputs, or tool results) can receive errors. The note recommends using a lower limit and paginating with `cursor` if this applies.

**Before**
<img width="558" height="225" alt="image" src="https://github.com/user-attachments/assets/dd9470ab-7d71-4c9a-b817-25a745c4f569" />


**After**
<img width="782" height="225" alt="image" src="https://github.com/user-attachments/assets/afb86143-fc61-4b6e-99f0-e24606d37a2e" />
<img width="811" height="191" alt="image" src="https://github.com/user-attachments/assets/fdd6a150-fd04-4c14-9a70-797b644c8f3d" />

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes