### PR TITLE
Add AIX to integration OS labels

### DIFF
--- a/layouts/partials/integration-labels/integration-labels.html
+++ b/layouts/partials/integration-labels/integration-labels.html
@@ -60,6 +60,11 @@
                             {{ partial "img.html" (dict "root" $dot "src" "os-ibm-zos.png" "class" "static" "alt" "IBM Z/OS" "width" "80") }}
                         </span>
                     {{ end }}
+                    {{ if eq . "aix" }}
+                        <span>
+                            {{ partial "img.html" (dict "root" $dot "src" "icons/platform_aix.png" "class" "static" "alt" "AIX" "width" "48") }}
+                        </span>
+                    {{ end }}
                 {{ end }}
             </p>
         </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds AIX to the list of supported OS icons rendered on integration pages. The `Supported OS::AIX` classifier tag was recently added to integrations-core ([DataDog/integrations-core#23484](https://github.com/DataDog/integrations-core/pull/23484)); this makes it show up correctly on the docs site. The icon (`icons/platform_aix.png`) was already present in the repo.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code.

### Additional notes

Suggested in https://dd.slack.com/archives/C9WBCH0AF/p1778762370340459.