### PR TITLE
[GCP-3635] Clarify Additional Locations field for GCP region filtering

### DIFF
--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -347,7 +347,7 @@ To apply granular metric filtering for enabled services, click on the service in
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="Limit metric collection by Google Cloud region, and by global resources" level="h4" %}}
+{{% collapse-content title="Limit metric collection by Google Cloud region and by global resources" level="h4" %}}
 
 Under the **Metric Collection** tab in Datadog's [Google Cloud integration page][11], deselect which regions to exclude from metrics collection.
 

--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -351,7 +351,7 @@ To apply granular metric filtering for enabled services, click on the service in
 
 Under the **Metric Collection** tab in Datadog's [Google Cloud integration page][11], deselect which regions to exclude from metrics collection.
 
-If a region, zone, or location value isn't shown in the checkboxes, add it in the **Additional Locations** field. The filter performs an exact match against the label value reported by Google Cloud, so enter values exactly as they appear on your resources (for example, `us-central`).
+If a region or location value isn't shown in the checkboxes, add it in the **Additional Locations** field. The filter performs an exact match against the label value reported by Google Cloud, so enter values exactly as they appear on your resources (for example, `us-central`).
 
 You can also disable any global metrics not associated with a region.
 

--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -351,7 +351,9 @@ To apply granular metric filtering for enabled services, click on the service in
 
 Under the **Metric Collection** tab in Datadog's [Google Cloud integration page][11], deselect which regions to exclude from metrics collection.
 
-You can also specify additional locations not listed and disable any global metrics not associated with a region.
+If a region, zone, or location value isn't shown in the checkboxes, add it in the **Additional Locations** field. The filter performs an exact match against the label value reported by Google Cloud, so enter values exactly as they appear on your resources (for example, `us-central` or `us-central1-f`).
+
+You can also disable any global metrics not associated with a region.
 
 {{< img src="integrations/google_cloud_platform/metric_region_filtering.png" alt="The metric collection tab in the Datadog Google Cloud integration page, with the Enable Global Metrics option highlighted and a subset of regions selected. The Additional Locations option is also highlighted with a multi-region filter defined" style="width:80%;">}}
 

--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -351,7 +351,7 @@ To apply granular metric filtering for enabled services, click on the service in
 
 Under the **Metric Collection** tab in Datadog's [Google Cloud integration page][11], deselect which regions to exclude from metrics collection.
 
-If a region, zone, or location value isn't shown in the checkboxes, add it in the **Additional Locations** field. The filter performs an exact match against the label value reported by Google Cloud, so enter values exactly as they appear on your resources (for example, `us-central` or `us-central1-f`).
+If a region, zone, or location value isn't shown in the checkboxes, add it in the **Additional Locations** field. The filter performs an exact match against the label value reported by Google Cloud, so enter values exactly as they appear on your resources (for example, `us-central`).
 
 You can also disable any global metrics not associated with a region.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Addresses [GCP-3635](https://datadoghq.atlassian.net/browse/GCP-3635)

Customers configuring region filtering on the Google Cloud integration sometimes have region, zone, or location label values that don't match the standard checkboxes (for example, `us-central` instead of `us-central1`). The previous copy mentioned the **Additional Locations** field only briefly and didn't explain that the filter is an exact match, so customers weren't realizing they could resolve mismatches by entering the precise label value there.

This PR rewords the region-filtering section to:

- Call out region, zone, and location values explicitly.
- State that the filter performs an exact match against the label reported by Google Cloud.
- Give concrete examples (`us-central`, `us-central1-f`) so customers know to use the precise value from their resources.
- Keep the global-metrics sentence separate so each idea reads cleanly.

[GCP-3635]: https://datadoghq.atlassian.net/browse/GCP-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Preview link: https://docs-staging.datadoghq.com/sujay.desai/gcp-3635-region-filter-docs/getting_started/integrations/google_cloud/?tab=orglevel#google-cloud-integrations