### PR TITLE
Add NetFlow and Network Path to Network Monitoring landing page

### DIFF
--- a/content/en/network_monitoring/_index.md
+++ b/content/en/network_monitoring/_index.md
@@ -38,6 +38,8 @@ cascade:
     {{< nextlink href="network_monitoring/cloud_network_monitoring" >}}<u>Cloud Network Monitoring</u>: Explore metrics for point to point communication on your infrastructure.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/dns" >}}<u>DNS Monitoring</u>: Diagnose and debug DNS server issues.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/devices" >}}<u>Network Device Monitoring</u>: Gain visibility into your network-connected devices, such as routers, switches, servers, and firewalls.{{< /nextlink >}}
+    {{< nextlink href="network_monitoring/netflow" >}}<u>NetFlow Monitoring</u>: Analyze network traffic flows to identify top talkers and bandwidth usage across your infrastructure.{{< /nextlink >}}
+    {{< nextlink href="network_monitoring/network_path" >}}<u>Network Path</u>: Investigate the routes network traffic follows from source to destination to pinpoint network issues.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds NetFlow Monitoring and Network Path links to the `whatsnext` block on the Network Monitoring landing page (`/network_monitoring/`). Both products have docs sections but weren't surfaced from the parent page, so visitors couldn't discover them without going through the side nav.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code to draft the entries based on existing description style and target page overviews.

### Additional notes