### PR TITLE
[DOCS-14160] Document code-exec toolset (Preview) for MCP Server

### DIFF
--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -589,6 +589,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 
 These toolsets are in Preview. Sign up for a toolset by completing the Product Preview form or contact [Datadog support][47] to request access.
 - `apm`: ([Sign up][45]) Tools for in-depth [APM][34] trace analysis, span search, Watchdog insights, and performance investigation
+- `code-exec`: A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 
 ## Supported clients
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -484,9 +484,9 @@ Code executed by this toolset runs against your Datadog APIs using your own user
 *Permissions Required: `mcp_read` and `mcp_write`. At runtime, the sandbox also enforces your existing resource permissions (for example, `Logs Read`, `APM Read`, `Dashboards Write`) for each Datadog API call the code makes.*\
 Executes agent-authored TypeScript in a Datadog-managed sandbox. The code receives a `dd.*` namespace with helpers for querying logs, metrics, traces, services, change events, incidents, monitors, dashboards, and other Datadog APIs, and returns a structured value back to the agent.
 
-- What changed in the last two hours that could explain elevated error rates on the `checkout-api` service?
-- Compare latency trends against recent deployments for the `payments` service over the last day.
-- Show me the top 10 error patterns in `auth-service` logs from the last hour, grouped by error kind.
+- For the `checkout-api` service in the last two hours, pull error logs, latency metrics, and recent deployments together and tell me which deployment lines up with the error spike.
+- Compare error-span counts, monitor alerts, and config changes for the `payments` service over the last day, and surface anything that moved at the same time.
+- For `auth-service`, correlate the top error patterns in logs with CPU and memory metrics from the last hour to see whether errors track resource pressure.
 
 ## Dashboards
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -488,8 +488,6 @@ Executes agent-authored TypeScript in a Datadog-managed sandbox. The code receiv
 - Compare latency trends against recent deployments for the `payments` service over the last day.
 - Show me the top 10 error patterns in `auth-service` logs from the last hour, grouped by error kind.
 
-**Note**: The sandbox enforces execution time limits and code-size limits, and blocks sensitive operations. Long-running queries should be scoped to a bounded time window.
-
 ## Dashboards
 
 Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -471,6 +471,25 @@ Searches for Datadog users by email, name, or handle. Useful for finding the rig
 
 - Find the Datadog user account for jane.doe@example.com.
 
+## Code Exec
+
+A sandboxed TypeScript runtime that lets an AI agent write code with direct access to Datadog APIs, instead of issuing many sequential tool calls. A single code block can query logs, metrics, traces, services, and changes together, correlate the results inline, and return a structured summary. This reduces the number of round-trips needed for multi-signal investigations and ad-hoc data exploration.
+
+<div class="alert alert-info">The <code>code-exec</code> toolset is in Preview. Contact <a href="/help">Datadog support</a> to request access.</div>
+
+Code executed by this toolset runs against your Datadog APIs using your own user identity. The sandbox applies your existing [role permissions][56] to every API call, so an agent can only read or modify data that you can already access in Datadog.
+
+### `execute_code`
+*Toolset: **code-exec***\
+*Permissions Required: `mcp_read` and `mcp_write`. At runtime, the sandbox also enforces your existing resource permissions (for example, `Logs Read`, `APM Read`, `Dashboards Write`) for each Datadog API call the code makes.*\
+Executes agent-authored TypeScript in a Datadog-managed sandbox. The code receives a `dd.*` namespace with helpers for querying logs, metrics, traces, services, change events, incidents, monitors, dashboards, and other Datadog APIs, and returns a structured value back to the agent.
+
+- What changed in the last two hours that could explain elevated error rates on the `checkout-api` service?
+- Compare latency trends against recent deployments for the `payments` service over the last day.
+- Show me the top 10 error patterns in `auth-service` logs from the last hour, grouped by error kind.
+
+**Note**: The sandbox enforces execution time limits and code-size limits, and blocks sensitive operations. Long-running queries should be scoped to a bounded time window.
+
 ## Dashboards
 
 Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation.
@@ -1155,3 +1174,4 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [53]: /security/threats/security_signals/
 [54]: /security/misconfigurations/findings/
 [55]: /containers/monitoring/kubernetes_explorer/
+[56]: /account_management/rbac/permissions/

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -471,9 +471,9 @@ Searches for Datadog users by email, name, or handle. Useful for finding the rig
 
 - Find the Datadog user account for jane.doe@example.com.
 
-## Code Exec
+## Code Execution
 
-A sandboxed TypeScript runtime that lets an AI agent write code with direct access to Datadog APIs, instead of issuing many sequential tool calls. A single code block can query logs, metrics, traces, services, and changes together, correlate the results inline, and return a structured summary. This reduces the number of round-trips needed for multi-signal investigations and ad-hoc data exploration.
+A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call.
 
 <div class="alert alert-info">The <code>code-exec</code> toolset is in Preview. Contact <a href="/help">Datadog support</a> to request access.</div>
 
@@ -481,11 +481,11 @@ Code executed by this toolset runs against your Datadog APIs using your own user
 
 ### `execute_code`
 *Toolset: **code-exec***\
-*Permissions Required: `mcp_read` and `mcp_write`. At runtime, the sandbox also enforces your existing resource permissions (for example, `Logs Read`, `APM Read`, `Dashboards Write`) for each Datadog API call the code makes.*\
-Executes agent-authored TypeScript in a Datadog-managed sandbox. The code receives a `dd.*` namespace with helpers for querying logs, metrics, traces, services, change events, incidents, monitors, dashboards, and other Datadog APIs, and returns a structured value back to the agent.
+*Permissions Required: Any product-specific role permissions needed to access the underlying Datadog resources the executed code interacts with (for example, `Logs Read` to read logs).*\
+Executes AI agent-authored TypeScript in a Datadog-managed sandbox. The code receives a `dd.*` namespace with helpers for querying logs, metrics, traces, services, change events, incidents, monitors, dashboards, and other Datadog APIs, and returns a structured value back to the agent. This can reduce the number of round-trips needed for multi-signal investigations and ad-hoc data exploration.
 
 - For the `checkout-api` service in the last two hours, pull error logs, latency metrics, and recent deployments together and tell me which deployment lines up with the error spike.
-- Compare error-span counts, monitor alerts, and config changes for the `payments` service over the last day, and surface anything that moved at the same time.
+- Compare error-span counts, monitor alerts, and config changes for the `payments` service over the last day, and identify anything that moved at the same time.
 - For `auth-service`, correlate the top error patterns in logs with CPU and memory metrics from the last hour to see whether errors track resource pressure.
 
 ## Dashboards


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14160

Adds the new `code-exec` Preview toolset to the Datadog MCP Server documentation:

- **`setup.md`**: lists `code-exec` under **Preview toolsets**.
- **`tools.md`**: adds a `## Code Exec` section with a Preview callout and documents the `execute_code` tool (description, required permissions, example prompts, sandbox limits note).

`execute_code` is annotated as a read-write MCP tool, so both `mcp_read` and `mcp_write` are required to call it. Preview customers also need the role permissions for any underlying APIs the agent's code touches — the sandbox enforces this per call.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Mirrors the existing APM Preview toolset pattern (callout style, signup wording, location in the toolsets list). The Preview signup currently routes to Datadog support — happy to swap in a hosted product-preview form if one is created before DASH.