### PR TITLE
Sync URL hash with collapsible section state

### DIFF
--- a/assets/scripts/components/accordion-auto-open.js
+++ b/assets/scripts/components/accordion-auto-open.js
@@ -10,7 +10,21 @@ function openAccordion() {
 	}
 }
 
+function syncHashOnToggle(details) {
+	details.addEventListener('toggle', () => {
+		if (!details.id) return;
+
+		if (details.open) {
+			history.replaceState(null, '', `#${details.id}`);
+		} else if (location.hash.substring(1) === details.id) {
+			history.replaceState(null, '', location.pathname + location.search);
+		}
+	});
+}
+
 window.addEventListener('hashchange', openAccordion);
 openAccordion();
+
+document.querySelectorAll('details.collapsible-section[id]').forEach(syncHashOnToggle);
 
 export {openAccordion};


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Update `assets/scripts/components/accordion-auto-open.js` so that the URL hash reflects the state of `collapse-content` accordions:

- Opening a section with an `id` updates the URL to `#<id>` (using `history.replaceState`, so no scroll jump and no history clutter).
- Closing a section clears the hash if it currently points to that section.
- Existing behavior is preserved: loading a page with `#<id>` still auto-opens the matching section, and `hashchange` events still expand the target.

This makes it easier for users to copy a URL that links directly to an open collapsible section.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes