### PR TITLE
Update bits ai sre source config link

### DIFF
--- a/content/en/bits_ai/bits_ai_sre/configure.md
+++ b/content/en/bits_ai/bits_ai_sre/configure.md
@@ -144,7 +144,7 @@ You can trigger and retrieve investigation details programmatically [via API][16
 [11]: /account_management/audit_trail/events/#bits-ai-sre
 [12]: /integrations/microsoft-teams/?tab=datadogapprecommended
 [13]: /integrations/github/
-[14]: /integrations/source_code/service-mapping/?tab=go
+[14]: /source_code/service-mapping
 [15]: /actions/workflows/actions/
 
 <!-- Commenting out until API Docs are merged


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Bits AI SRE had a dead link in it's documentation that pointed to [https://docs.datadoghq.com/integrations/source_code/service-mapping/?tab=go](https://docs.datadoghq.com/integrations/source_code/service-mapping/?tab=go) 

The new fixed link should be
[https://docs.datadoghq.com/source_code/service-mapping](https://docs.datadoghq.com/source_code/service-mapping)
