### PR TITLE
(Network Monitoring) Visual Comparison is GA now 

### DIFF
--- a/content/en/network_monitoring/network_path/path_view.md
+++ b/content/en/network_monitoring/network_path/path_view.md
@@ -52,8 +52,6 @@ Drag the latency reachability health bar to observe a snapshot of the end-to-end
 
 ## Visual comparison
 
-<div class="alert alert-info">Visual Comparison for Network Path is in Preview. To request access, contact your Datadog representative.</div>
-
 Use the visual comparison view to compare two path visualizations side-by-side and identify what changed before and after an incident.
 
 The comparison view provides:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

Fixes https://datadoghq.atlassian.net/browse/DOCS-14433

This PR removes the preview banner for Visual Comparison for Network Path. This feature will be included in the June newsletter.

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### AI assistance
N/A
