### PR TITLE
LLMObs MCP docs: hoist Setup to top and restructure for style guide

### DIFF
--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -17,8 +17,145 @@ further_reading:
 
 The [Datadog MCP Server][1] enables AI agents to access your [LLM Observability][2] data through the Model Context Protocol (MCP). The `llmobs` toolset provides tools for searching and analyzing traces, inspecting span details and content, and evaluating experiment results directly from AI-powered clients like Cursor, Claude Code, or OpenAI Codex.
 
+## Setup
+
+Connect an MCP-compatible client to the Datadog MCP Server with the `llmobs` toolset enabled.
+
+<div class="alert alert-info">For full setup instructions, including Cursor and VS Code extension configuration, see <a href="/bits_ai/mcp_server/setup/">Set up the Datadog MCP Server</a>.</div>
+
+### Prerequisites
+
+- A Datadog account with permission to access LLM Observability data.
+- An MCP-compatible client (for example, Claude Code, Codex CLI, Cursor, Gemini CLI, or Kiro CLI).
+
+### Endpoint
+
+The MCP Server endpoint depends on your [Datadog site][5]. Use the {{< ui >}}Datadog Site{{< /ui >}} selector to display the endpoint for your site. Append `?toolsets=llmobs,core` to enable the LLM Observability and core toolsets.
+
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+Endpoint for your selected site ({{< region-param key="dd_site_name" >}}):
+<pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core</code></pre>
+{{< /site-region >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+### Connect
+
+Choose remote authentication when possible. Use local binary authentication if your environment blocks the remote OAuth flow.
+
+{{< tabs >}}
+{{% tab "Remote authentication" %}}
+
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+Remote authentication uses the MCP specification's [Streamable HTTP][1] transport.
+
+**Claude Code** (command line):
+
+<pre><code>claude mcp add --transport http datadog-mcp "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"</code></pre>
+
+**Codex CLI** (`~/.codex/config.toml`):
+
+<pre><code>[mcp_servers.datadog]
+url = "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"
+</code></pre>
+
+After adding the configuration, run `codex mcp login datadog` to complete the OAuth flow.
+
+**Gemini CLI, Kiro CLI, and other MCP-compatible clients**:
+
+<pre><code>{
+  "mcpServers": {
+    "datadog": {
+      "type": "http",
+      "url": "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"
+    }
+  }
+}
+</code></pre>
+
+[1]: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http
+{{< /site-region >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+{{% /tab %}}
+
+{{% tab "Local binary authentication" %}}
+
+Local binary authentication uses the MCP specification's [stdio][2] transport. Use this method if remote authentication is unavailable.
+
+1. Install the Datadog MCP Server binary:
+
+    ```bash
+    curl -sSL https://coterm.datadoghq.com/mcp-cli/install.sh | bash
+    ```
+
+    The binary installs to `~/.local/bin/datadog_mcp_cli`.
+
+2. Complete the OAuth login flow:
+
+    ```bash
+    datadog_mcp_cli login
+    ```
+
+3. Configure your AI client. For Claude Code, add the following to `~/.claude.json`, replacing `<USERNAME>` in the command path:
+
+    ```json
+    {
+      "mcpServers": {
+        "datadog": {
+          "type": "stdio",
+          "command": "/Users/<USERNAME>/.local/bin/datadog_mcp_cli",
+          "args": [],
+          "env": {}
+        }
+      }
+    }
+    ```
+
+    Alternatively, add the server with the Claude Code CLI:
+
+    ```bash
+    claude mcp add datadog --scope user -- ~/.local/bin/datadog_mcp_cli
+    ```
+
+[2]: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
+{{% /tab %}}
+{{< /tabs >}}
+
+### Authenticate with API keys
+
+The MCP Server uses OAuth 2.0 by default. If OAuth is unavailable, send a Datadog [API key and application key][6] as the `DD_API_KEY` and `DD_APPLICATION_KEY` HTTP headers:
+
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+<pre><code>{
+  "mcpServers": {
+    "datadog": {
+      "type": "http",
+      "url": "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core",
+      "headers": {
+          "DD_API_KEY": "&lt;YOUR_API_KEY&gt;",
+          "DD_APPLICATION_KEY": "&lt;YOUR_APPLICATION_KEY&gt;"
+      }
+    }
+  }
+}
+</code></pre>
+{{< /site-region >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+For security, scope the API key and application key to a [service account][7] with only the required permissions.
+
 ## Agent skills
-A set of agent skills that make use of these MCP endpoints can be found in the [datadog-labs/agent-skills](https://github.com/datadog-labs/agent-skills) repo. These help automate some of the manual work associated with the below use cases.  
+
+A set of agent skills that use these MCP endpoints is available in the [datadog-labs/agent-skills](https://github.com/datadog-labs/agent-skills) repository. These skills automate some of the manual work for the use cases below.
 
 ## Use cases
 
@@ -114,7 +251,7 @@ The `llmobs` toolset includes the following tools:
 
 ## Example prompts
 
-After you are connected, try prompts like:
+After connecting, try prompts like:
 
 - Review error traces for my `customer-support-bot` app over the past week. Summarize the most common failure patterns, how often they occur, and recommend which ones to fix first.
 - Find traces where my agent's responses were flagged by evaluations as low quality. Look at the inputs and outputs, then suggest specific changes to my system prompt to improve response quality.
@@ -141,127 +278,6 @@ For custom visualizations that go beyond standard Datadog widgets, like comparis
 
 - Analyze experiment `exp-456`, compare the `accuracy` scores across each prompt version, and export the results to a Datadog Notebook that includes a Mermaid bar chart of the average score for each version.
 - Analyze experiment `exp-456` and export a Datadog Notebook that plots each prompt version on a Mermaid quadrant chart with `relevance` on one axis and `accuracy` on the other. Identify which versions are underperforming on both dimensions.
-
-## Setup
-
-To use the LLM Observability tools, connect to the Datadog MCP Server with the `llmobs` toolset enabled.
-
-<div class="alert alert-info">For full setup instructions, including Cursor and VS Code extension configuration, see <a href="/bits_ai/mcp_server/setup/">Set Up the Datadog MCP Server</a>.</div>
-
-Add the `toolsets=llmobs,core` query parameter to the MCP Server endpoint for your [Datadog site][5]. For the correct instructions, use the {{< ui >}}Datadog Site{{< /ui >}} selector on the right side of this documentation page to select your site.
-
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-Your selected endpoint ({{< region-param key="dd_site_name" >}}):
-<pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core</code></pre>
-{{< /site-region >}}
-
-For example:
-- **US1**: `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs,core`
-- **EU1**: `https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp?toolsets=llmobs,core`
-
-{{< tabs >}}
-{{% tab "Remote authentication" %}}
-
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-This method uses the MCP specification's [Streamable HTTP][1] transport.
-
-**Claude Code** (command line):
-
-<pre><code>claude mcp add --transport http datadog-mcp "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"</code></pre>
-
-**Codex CLI** (`~/.codex/config.toml`):
-
-<pre><code>[mcp_servers.datadog]
-url = "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"
-</code></pre>
-
-After adding the configuration, run `codex mcp login datadog` to complete the OAuth flow.
-
-**Gemini CLI, Kiro CLI, or other MCP-compatible clients**:
-
-<pre><code>{
-  "mcpServers": {
-    "datadog": {
-      "type": "http",
-      "url": "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core"
-    }
-  }
-}
-</code></pre>
-
-[1]: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http
-{{< /site-region >}}
-
-{{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
-{{% /tab %}}
-
-{{% tab "Local binary authentication" %}}
-
-This method uses the MCP specification's [stdio][2] transport. Use this if direct remote authentication is not available for you.
-
-1. Install the Datadog MCP Server binary:
-
-    ```bash
-    curl -sSL https://coterm.datadoghq.com/mcp-cli/install.sh | bash
-    ```
-
-    This installs the binary to `~/.local/bin/datadog_mcp_cli`.
-
-2. Run `datadog_mcp_cli login` to complete the OAuth login flow.
-
-3. Configure your AI client. For Claude Code, add the following code to `~/.claude.json`, making sure to replace `<USERNAME>` in the command path:
-
-    ```json
-    {
-      "mcpServers": {
-        "datadog": {
-          "type": "stdio",
-          "command": "/Users/<USERNAME>/.local/bin/datadog_mcp_cli",
-          "args": [],
-          "env": {}
-        }
-      }
-    }
-    ```
-
-    Or run:
-
-    ```bash
-    claude mcp add datadog --scope user -- ~/.local/bin/datadog_mcp_cli
-    ```
-
-[2]: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
-{{% /tab %}}
-{{< /tabs >}}
-
-### Authentication
-
-The MCP Server uses OAuth 2.0 for authentication. If you cannot go through the OAuth flow, provide a Datadog [API key and application key][6] as `DD_API_KEY` and `DD_APPLICATION_KEY` HTTP headers:
-
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-<pre><code>{
-  "mcpServers": {
-    "datadog": {
-      "type": "http",
-      "url": "{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core",
-      "headers": {
-          "DD_API_KEY": "&lt;YOUR_API_KEY&gt;",
-          "DD_APPLICATION_KEY": "&lt;YOUR_APPLICATION_KEY&gt;"
-      }
-    }
-  }
-}
-</code></pre>
-{{< /site-region >}}
-
-{{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
-For security, use a scoped API key and application key from a [service account][7] that has only the required permissions.
 
 ## Further reading
 


### PR DESCRIPTION
## What

Reformats [`content/en/llm_observability/mcp_server.md`](content/en/llm_observability/mcp_server.md) so the install/setup instructions are the first thing a reader sees, and tightens the Setup section against the docs style guide.

## Why

Setup was buried below **Use cases**, **Available tools**, **Recommended workflows**, and **Example prompts**, which is the opposite of what someone landing on the page actually wants ("how do I connect this?"). The Setup section itself was a single block with one `### Authentication` heading and a misleading hard-coded US1/EU1 endpoint list that confused users on other sites.

## Changes

**Structural**
- Move `## Setup` directly under `## Overview`. New page order: Overview → Setup → Agent skills → Use cases → Available tools → Recommended workflows → Example prompts → Combine with other Datadog tools → Further reading.
- Split Setup into four H3 subsections so they surface in the TOC: **Prerequisites**, **Endpoint**, **Connect**, **Authenticate with API keys**.
- Drop the hard-coded US1/EU1 endpoint list. The region-aware `{{< region-param >}}` block above it already prints the correct endpoint per selected site, so the list was misleading for AP1/AP2/US3/US5 users.
- Pull the gov-region "not supported" alert up into the **Endpoint** subsection so users on unsupported sites learn earlier.
- Add a one-line guidance sentence under **Connect** explaining when to pick remote vs. local binary authentication.

**Style guide**
- Active voice and imperative steps throughout.
- "After you are connected" → "After connecting".
- "making sure to replace `<USERNAME>`" → "replacing `<USERNAME>`".
- "Use this if direct remote authentication is not available for you" → "Use this method if remote authentication is unavailable".
- "If you cannot go through the OAuth flow, provide..." → "If OAuth is unavailable, send...".
- "A set of agent skills that make use of these MCP endpoints can be found in the [...] repo" → "A set of agent skills that use these MCP endpoints is available in the [...] repository".
- Rename `### Authentication` (which only documented the API-key fallback) to `### Authenticate with API keys` for clarity.

## AI assistance

Drafted with Claude Code (Opus 4.7). All content reviewed and edited by hand against [CONTRIBUTING.md](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md). No factual claims about the product changed; only structure and wording.

Claude session: `060f3c26-fc6a-46e7-8e81-4e8ef880f67f`
Resume: `claude --resume 060f3c26-fc6a-46e7-8e81-4e8ef880f67f`