### PR TITLE
Replace id-for-anchoring placeholders in collapse-content shortcodes

### DIFF
--- a/content/en/agent/fleet_automation/remote_management.md
+++ b/content/en/agent/fleet_automation/remote_management.md
@@ -46,7 +46,7 @@ Datadog suggests at least 2 GB for the initial Agent install and an additional 2
 
 ### Upgrade steps 
 
-{{% collapse-content title=" How to upgrade Agents remotely" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="How to upgrade Agents remotely" level="h4" expanded=false id="upgrade-agents-remotely" %}}
 
 1. From the [{{< ui >}}Upgrade Agents{{< /ui >}}][4] tab, click {{< ui >}}Upgrade Now{{< /ui >}}.
 
@@ -64,7 +64,7 @@ Datadog suggests at least 2 GB for the initial Agent install and an additional 2
 {{% /collapse-content %}}
 
 
-{{% collapse-content title="How to schedule Agent upgrades" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="How to schedule Agent upgrades" level="h4" expanded=false id="schedule-agent-upgrades" %}}
 
 1. From the [{{< ui >}}Upgrade Agents{{< /ui >}} tab][4], click {{< ui >}}+ Create Schedule{{< /ui >}}.
 
@@ -170,7 +170,7 @@ Fleet Automation allows you to roll out and manage Datadog Agent configuration a
 - Manage Agent tags
 - Apply consistent configuration across environments
 
-{{% collapse-content title="Configure multiple Agents" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Configure multiple Agents" level="h4" expanded=false id="configure-multiple-agents" %}}
 
 1. In Fleet Automation, open the [Configure Agents][16] tab and click {{< ui >}}Configure Agents{{< /ui >}}.
 1. Scope the configuration to the target Agents. You can target a group of Agents by filtering on host information or tags.
@@ -185,7 +185,7 @@ Fleet Automation allows you to roll out and manage Datadog Agent configuration a
 1. Click {{< ui >}}Deploy Configuration{{< /ui >}} to start the deployment and track its progress from the [Deployments page][10].
 {{% /collapse-content %}}
 
-{{% collapse-content title="Edit configuration of a single Agent" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Edit configuration of a single Agent" level="h4" expanded=false id="edit-single-agent-configuration" %}}
 1. In the Datadog UI, navigate to the [Fleet Automation][18] page and select {{< ui >}}View Agents{{< /ui >}}. 
 
 1. (Optional) You can target a group of Agents by filtering on host information or tags.

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -114,7 +114,7 @@ These checks can be used in Datadog to visualize the Agent status through monito
 
 ## Advanced configurations and features
 
-{{% collapse-content title="Differences between Agent for hosts and containers" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Differences between Agent for hosts and containers" level="h4" expanded=false id="agent-hosts-vs-containers" %}}
 
 There are key differences between installing Agents on a host and in a containerized environment: 
 
@@ -135,7 +135,7 @@ Additionally, see the [Docker Agent][12] or [Kubernetes][13] for a walkthrough o
 {{% /collapse-content %}} 
 
 
-{{% collapse-content title="Setting tags through the Agent configuration file" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Setting tags through the Agent configuration file" level="h4" expanded=false id="setting-tags-agent-config-file" %}}
 
 Tags add an additional layer of metadata to your metrics and events. They allow you to scope and compare your data in Datadog visualizations. When data is sent to Datadog from multiple hosts, tagging this information allows you to scope down to the data you are most interested in visualizing.
 
@@ -190,7 +190,7 @@ For example, let's say you have data that is collected from different teams and 
 
 {{% /collapse-content %}} 
 
-{{% collapse-content title="Finding metrics in the Datadog UI" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Finding metrics in the Datadog UI" level="h4" expanded=false id="finding-metrics-in-the-datadog-ui" %}}
 
 You can confirm the Agent is running correctly by checking its default metrics in the Datadog UI. Go to the [Metrics Summary page][22] and search for the metric `datadog.agent.started` or the metric `datadog.agent.running`. If these metrics are not visible right away, it may take a few minutes for the Agent to send the data to Datadog.
 
@@ -200,14 +200,14 @@ Explore other default metrics such as `ntp.offset` or `system.cpu.idle`.
 {{% /collapse-content %}} 
 
 
-{{% collapse-content title="Agent overhead" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Agent overhead" level="h4" expanded=false id="agent-overhead" %}}
 
 The amount of space and resources the Agent takes up depends on the configuration and what data the Agent is sending. At the onset, you can expect around 0.08% CPU used on average with a disk space of roughly 880MB to 1.3GB.
 
 See [Agent Overhead][2] to learn more about these benchmarks.
 {{% /collapse-content %}}
 
-{{% collapse-content title="Additional configuration options" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Additional configuration options" level="h4" expanded=false id="additional-configuration-options" %}}
 
 The collection of [logs][27], [traces][28], and [processes][29] data can be enabled through the Agent configuration file. These features are not enabled by default. For example, in the configuration file, the `logs_enabled` parameter is set to false.
 

--- a/content/en/internal_developer_portal/integrations.md
+++ b/content/en/internal_developer_portal/integrations.md
@@ -45,7 +45,7 @@ When you configure a service account for a [Datadog integration][1], you can inc
 
 ### Setup examples
 
-{{% collapse-content title="PagerDuty" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="PagerDuty" level="h4" expanded=false id="pagerduty-setup" %}}
 
 You can connect any service in your [PagerDuty Service Directory][63]. You can map one PagerDuty service to each service in Software Catalog.
 
@@ -65,7 +65,7 @@ You can connect any service in your [PagerDuty Service Directory][63]. You can m
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="OpsGenie" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="OpsGenie" level="h4" expanded=false id="opsgenie-setup" %}}
 
 To add OpsGenie metadata to an entity definition: 
 

--- a/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
+++ b/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
@@ -123,7 +123,7 @@ V3.0 contains the following changes from v2.2:
 
 ### Example YAML files
 
-{{% collapse-content title="Component of <code>kind:system</code>" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Component of <code>kind:system</code>" level="h4" expanded=false id="component-of-kind-system" %}}
 {{< code-block lang="yaml" filename="entity.datadog.yaml" collapsible="true" >}}
 apiVersion: v3
 kind: system
@@ -194,7 +194,7 @@ datadog:
 {{< /code-block >}}
 {{% /collapse-content %}}
 
-{{% collapse-content title="Component of <code>kind:library</code>" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Component of <code>kind:library</code>" level="h4" expanded=false id="component-of-kind-library" %}}
 {{< code-block lang="yaml" filename="entity.datadog.yaml" collapsible="true" >}}
 apiVersion: v3
 kind: library
@@ -233,7 +233,7 @@ metadata:
 {{< /code-block >}}
 {{% /collapse-content %}}
 
-{{% collapse-content title="Components that are part of multiple systems" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Components that are part of multiple systems" level="h4" expanded=false id="components-in-multiple-systems" %}}
 If a single component is part of multiple systems, you must specify that component in the YAML for each system. For example, if the datastore `orders-postgres` is a component of both a postgres fleet and a web application, specify two YAMLs:
 
 For the postgres fleet (`managed-postgres`), specify a definition for `kind:system`:

--- a/content/en/internal_developer_portal/software_catalog/entity_model/native_entities.md
+++ b/content/en/internal_developer_portal/software_catalog/entity_model/native_entities.md
@@ -260,7 +260,7 @@ Datastore entities can be:
 
 ### Example YAML definitions
 
-{{% collapse-content title="YAML definition for an inferred datastore" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="YAML definition for an inferred datastore" level="h4" expanded=false id="yaml-inferred-datastore" %}}
 
 This example shows a `kind:datastore` definition for a database automatically detected by APM.
 
@@ -295,7 +295,7 @@ spec:
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="YAML definition for a manually defined datastore" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="YAML definition for a manually defined datastore" level="h4" expanded=false id="yaml-manual-datastore" %}}
 
 This example shows a `kind:datastore` definition for a manually declared datastore.
 

--- a/content/en/observability_pipelines/sources/datadog_agent.md
+++ b/content/en/observability_pipelines/sources/datadog_agent.md
@@ -74,13 +74,13 @@ Use the Agent configuration file or the Agent Helm chart values file to connect 
 
 **Note**: If your Agent is running in a Docker container, you must exclude Observability Pipelines logs using the `DD_CONTAINER_EXCLUDE_LOGS` environment variable. For Helm, use `datadog.containerExcludeLogs`. This prevents duplicate logs, as the Worker also sends its own logs directly to Datadog. See [Docker Log Collection][1] or [Setting environment variables for Helm][2] for more information.
 
-{{% collapse-content title="Agent configuration file" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Agent configuration file" level="h4" expanded=false id="logs-agent-config-file" %}}
 
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="Agent Helm values file" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Agent Helm values file" level="h4" expanded=false id="logs-agent-helm-values-file" %}}
 
 {{% observability_pipelines/log_source_configuration/datadog_agent_kubernetes %}}
 
@@ -97,7 +97,7 @@ Use the Agent configuration file or the Agent Helm chart values file to connect 
 
 **Note**: If your Agent is running in a Docker container, you must exclude Observability Pipelines metrics, such as utilization and events in/out metrics, using the `DD_CONTAINER_EXCLUDE_METRICS` environment variable. For Helm, use `datadog.containerExcludeMetrics`. This prevents duplicate metrics, as the Worker also sends its own metrics directly to Datadog. See [Docker Metrics Collection][1] or [Setting environment variables for Helm][2] for more information.
 
-{{% collapse-content title="Agent configuration file" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Agent configuration file" level="h4" expanded=false id="metrics-agent-config-file" %}}
 
 To send Datadog Agent metrics to the Observability Pipelines Worker, update your [Agent configuration file][1] with the following:
 
@@ -122,7 +122,7 @@ After you [restart the Agent][2], your observability data should be going to the
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="Agent Helm values file" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Agent Helm values file" level="h4" expanded=false id="metrics-agent-helm-values-file" %}}
 
 To send Datadog Agent metrics to the Observability Pipelines Worker, update your Datadog Helm chart [datadog-values.yaml][1] with the following environment variables. See [Agent Environment Variables][2] for more information.
 

--- a/content/en/product_analytics/profiles.md
+++ b/content/en/product_analytics/profiles.md
@@ -33,7 +33,7 @@ The [User Profiles][7] page lists the users who are interacting with your applic
 Each profile has attributes to help you better segment your users. You can conduct a full-text search or sort and filter based on any of these attributes. You can also customize this page with attributes relevant to your analytic needs. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how.
 
 
-{{% collapse-content title="List of user profile attributes" level="h5" expanded=true id="id-for-anchoring" %}}
+{{% collapse-content title="List of user profile attributes" level="h5" expanded=true id="user-profile-attributes" %}}
 
 <!-- #### User attributes  -->
 User ID `REQUIRED`

--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -156,7 +156,7 @@ This functionality is supported only when using the [Datadog SBOM Generator][1] 
 
 Reachability analysis is available exclusively for Java projects and applies only to a defined set of vetted security advisories. Vulnerabilities not included in this set are excluded from reachability evaluation.
 
-{{% collapse-content title="Supported advisories" level="h4" expanded=true id="id-for-anchoring" %}}
+{{% collapse-content title="Supported advisories" level="h4" expanded=true id="supported-advisories" %}}
 Static reachability analysis is available for the following advisories:
 - [GHSA-h7v4-7xg3-hxcc](https://osv.dev/vulnerability/GHSA-h7v4-7xg3-hxcc)
 - [GHSA-jfh8-c2jp-5v3q](https://osv.dev/vulnerability/GHSA-jfh8-c2jp-5v3q)

--- a/content/en/tracing/trace_collection/proxy_setup/apigateway.md
+++ b/content/en/tracing/trace_collection/proxy_setup/apigateway.md
@@ -85,7 +85,7 @@ To create inferred spans, API Gateway must pass the following headers to your ba
 
 To pass in the required headers, you can use the AWS CDK or AWS Console:
 
-{{% collapse-content title="AWS CDK" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="AWS CDK" level="h4" expanded=false id="aws-cdk" %}}
 
 Add the headers under `requestParameters` and use `$context` variables:
 
@@ -113,7 +113,7 @@ const api = new apigateway.RestApi(this, "MyApi", {
 {{% /collapse-content %}}
 
 
-{{% collapse-content title="AWS Console" level="h4" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="AWS Console" level="h4" expanded=false id="aws-console" %}}
 
 
 1. In the AWS Management Console, navigate to API Gateway and go to your API's **Resources** page. 

--- a/content/en/tracing/trace_collection/single-step-apm/kubernetes.md
+++ b/content/en/tracing/trace_collection/single-step-apm/kubernetes.md
@@ -759,7 +759,7 @@ After you enable SSI, all supported processes in the cluster are automatically i
 
 To control where APM is activated and reduce overhead, consider the following best practices.
 
-{{% collapse-content title="Use opt-in labels for controlled APM rollout" level="h3" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Use opt-in labels for controlled APM rollout" level="h3" expanded=false id="opt-in-labels-controlled-apm-rollout" %}}
 
 #### Default vs. opt-in instrumentation
 | Mode    | Behavior    | When to use |
@@ -819,7 +819,7 @@ See [instrumentation rules][4] for additional examples.
 {{% /collapse-content %}}
 
 
-{{% collapse-content title="Control which Datadog SDKs are loaded" level="h3" expanded=false id="id-for-anchoring" %}}
+{{% collapse-content title="Control which Datadog SDKs are loaded" level="h3" expanded=false id="control-loaded-datadog-sdks" %}}
 
 Use `ddTraceVersions` in your Agent Helm config to control both the language and the version of the Datadog SDK. This prevents unnecessary SDKs from being downloaded, which minimizes init-container footprint, reduces image size, and allows for more deliberate tracer upgrades (for example, to meet compliance requirements or simplify debugging).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Several `collapse-content` shortcodes still had the template's `id="id-for-anchoring"` placeholder. This PR replaces each one with a descriptive, page-unique ID derived from the expander's title so the anchors actually work and don't collide.

Updated pages:
- ` /agent/fleet_automation/remote_management`
- `/getting_started/agent/`
- `/internal_developer_portal/integrations`
- `/internal_developer_portal/software_catalog/entity_model/`
- `/internal_developer_portal/software_catalog/entity_model/native_entities`
- `/observability_pipelines/sources/datadog_agent`
- `/product_analytics/profiles`
- `/security/code_security/software_composition_analysis/setup_static/`
- `/tracing/trace_collection/proxy_setup/apigateway`
- `/tracing/trace_collection/single-step-apm/kubernetes`

Also removed a stray leading space in one expander title (`" How to upgrade Agents remotely"` → `"How to upgrade Agents remotely"`).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes