### PR TITLE
[DBMON-6137] Add PostgreSQL 18 to supported versions (RDS, Azure, GCP Cloud SQL, AlloyDB)

### DIFF
--- a/content/en/database_monitoring/setup_postgres/alloydb.md
+++ b/content/en/database_monitoring/setup_postgres/alloydb.md
@@ -22,7 +22,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 ## Before you begin
 
 Supported PostgreSQL versions
-: 14, 15, 16, 17
+: 14, 15, 16, 17, 18
 
 Supported Agent versions
 : 7.36.1+

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -22,7 +22,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 ## Before you begin
 
 Supported PostgreSQL versions
-: 9.6, 10, 11, 12, 13, 14, 15, 16
+: 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 Supported Azure PostgreSQL deployment types
 : PostgreSQL on Azure VMs, Single Server, Flexible Server

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -22,7 +22,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 ## Before you begin
 
 Supported PostgreSQL versions
-: 10, 11, 12, 13, 14, 15, 16, 17
+: 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 Supported Agent versions
 : 7.36.1+

--- a/content/en/database_monitoring/setup_postgres/rds/_index.md
+++ b/content/en/database_monitoring/setup_postgres/rds/_index.md
@@ -30,7 +30,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 ## Before you begin
 
 Supported PostgreSQL versions
-: 9.6, 10, 11, 12, 13, 14, 15, 16, 17
+: 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 Supported Agent versions
 : 7.36.1+


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DBMON-6137

Adds PostgreSQL 18 to the supported versions list for all cloud-hosted DBM Postgres setup pages. Agent-side PG18 support was completed in integrations-core [#21947](https://github.com/DataDog/integrations-core/pull/21947) (merged Nov 2025). Self-hosted docs were updated in [#34359](https://github.com/DataDog/documentation/pull/34359) (Feb 2026). This PR closes the gap for cloud platforms.

Also adds PostgreSQL 17 to the Azure page, which was two versions behind (docs listed max 16; Azure has supported 17 since mid-2025 and 18 is now GA).

Changes:
- `rds/_index.md`: 17 → 17, 18
- `azure.md`: 16 → 16, 17, 18
- `gcsql.md`: 17 → 17, 18
- `alloydb.md`: 17 → 17, 18

Aurora and Supabase not updated — PG18 is not yet GA on those platforms.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes