### PR TITLE
[AGNTLOG-220] clarify source/service are recommended for Kubernetes log configs

### DIFF
--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -184,7 +184,7 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 - Specify a log configuration as Autodiscovery Annotations on a given Pod, to configure the rules for a given container *(Recommended)*
 - Specify a log configuration as a configuration file, to configure the rules for each matching container by image
 
-At minimum, these log configurations require a `source` and `service` tag. You may want to match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] to help automatically enrich your logs. You can also find a [library of pipelines in Datadog][16].
+Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 
 ### Autodiscovery annotations
 


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Jira: https://datadoghq.atlassian.net/browse/AGNTLOG-220

The current docs imply that `source` and `service` are strictly required on Kubernetes log configurations. They aren't — the Agent has a fallback chain that produces sensible defaults when these fields are omitted. This PR softens the language to "strongly recommended" and explains why you would still want to set them (out-of-the-box pipeline matching, Unified Service Tagging) along with what happens if you don't.

### Sentence being replaced (`content/en/containers/kubernetes/log.md`)

> At minimum, these log configurations require a `source` and `service` tag. You may want to match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] to help automatically enrich your logs. You can also find a [library of pipelines in Datadog][16].

### New wording

> Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.

### Agent fallback chain (source of truth)

In `pkg/logs/launchers/container/tailerfactory/defaults.go`, function `defaultSourceAndServiceInner` resolves `source` and `service` in this order:

1. Explicit `Config.Source` / `Config.Service` if set on the log configuration.
2. The standard `service:` tag from the tagger (Unified Service Tagging via the `tags.datadoghq.com/service` Pod label, `DD_TAGS`, etc.).
3. The container image short name.
4. The literal string `"kubernetes"` if no image short name is available.

So `source` and `service` are recommended (so logs match the right pipeline and participate in Unified Service Tagging), not strictly required for log collection to function.

### Translations

Per `CONTRIBUTING.md`, translated files in `content/{ja,fr,ko,es}/` are managed by an automated translation workflow and should not be edited directly. The equivalent change to `content/ja/containers/kubernetes/log.md` will be picked up by that workflow.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Draft PR — leaving in draft for review by the docs team and AGNTLOG owners before promoting.