### PR TITLE
LLMObs Metrics: disambiguate Datadog Metrics vs span data vs evals

### DIFF
--- a/content/en/llm_observability/monitoring/metrics.md
+++ b/content/en/llm_observability/monitoring/metrics.md
@@ -15,6 +15,16 @@ further_reading:
 
 After you instrument your application with LLM Observability, you can access LLM Observability metrics for use in dashboards and monitors. These metrics capture span counts, error counts, token usage, and latency measures for your LLM applications. These metrics are calculated based on 100% of the application's traffic.
 
+<div class="alert alert-info">
+The <code>ml_obs.*</code> entries on this page are <a href="/metrics/">Datadog Metrics</a>: numerical values that describe an aspect of your LLM application over time, derived from your LLM spans (counts, distributions of cost, tokens, latency, errors). They are 100%-sampled, follow standard <a href="/developers/guide/data-collection-resolution-retention/">Datadog metric retention</a> (15 months at full granularity), and are queryable from dashboards, monitors, and notebooks like any other Datadog metric.
+<br><br>
+They are distinct from two other things in LLM Observability:
+<ul>
+<li><strong>Per-span operational data</strong> (cost, tokens, latency, errors on each individual trace or span): the raw values these metrics roll up from. Stored with spans, follow <a href="/llm_observability/setup/#data-retention">LLM Observability trace retention</a>, and are queried from the Traces explorer rather than as metrics.</li>
+<li><strong><a href="/llm_observability/evaluations/">Evaluation scores</a></strong> (also called "evals"): quality and safety judgments (for example, hallucination, faithfulness, custom LLM-as-a-judge) attached to individual spans or experiment rows. These are not derived from operational telemetry, and follow LLM Observability trace and experiment retention rather than Datadog metric retention.</li>
+</ul>
+</div>
+
 <div class="alert alert-info">Other tags set on spans are not available as tags on LLM Observability metrics.</div>
 
 ### Span metrics


### PR DESCRIPTION
## Summary
- Add a callout at the top of the LLM Observability Metrics page clarifying what the `ml_obs.*` entries are and what they are not.
- Distinguishes Datadog Metrics (15-month metric retention, dashboards/monitors) from per-span operational data (cost/tokens/latency on traces, trace retention) and from evaluation scores ("evals", quality/safety judgments on spans and experiment rows).
- Uses the [Datadog Metrics definition](https://docs.datadoghq.com/metrics/) ("numerical values that describe an aspect of your application over time") rather than "time series."

## Motivation
Users frequently conflate the `ml_obs.*` metrics with evaluation scores, and separately conflate them with the raw cost/token/latency fields on individual spans. This callout heads off both confusions.

## Test plan
- [ ] Preview renders cleanly (callout, links, bulleted list)
- [ ] Internal links resolve: `/metrics/`, `/developers/guide/data-collection-resolution-retention/`, `/llm_observability/setup/#data-retention`, `/llm_observability/evaluations/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)