### PR TITLE
[DOCS-14408] Recommend worker count for Network Path tests on the Agent

### DIFF
--- a/content/en/synthetics/network_path_tests/_index.md
+++ b/content/en/synthetics/network_path_tests/_index.md
@@ -104,6 +104,8 @@ Requires [Agent version][7] `7.72` or higher.
        workers: 4 # default
    ```
 
+   **Note**: Set `workers` to a value greater than or equal to the number of Network Path tests running concurrently on the Agent.
+
 3. Ensure the API key used for the Datadog Agent has [Remote Configuration][6] enabled. All newly created API keys have Remote Configuration enabled by default.
 
 4. [Restart the Agent][8] for it to appear in the list of available test locations.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14408

Adds a note under the `synthetics: collector` Agent configuration on the Network Path tests page recommending that `workers` be set to a value greater than or equal to the number of Network Path tests running concurrently on the Agent.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes