### PR TITLE
Add Enable Anthropic Prompt Caching recommendation

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -45,6 +45,12 @@ multifiltersearch:
     - name: Recommendation Prerequisites
       id: recommendation_prerequisites
   data:
+    - category: Configure
+      cloud_provider: Anthropic
+      resource_type: Anthropic API Key
+      recommendation_type: Enable Anthropic Prompt Caching
+      recommendation_description: Identifies Anthropic API keys with no prompt caching usage and recommends enabling prompt caching to reduce input token costs.
+      recommendation_prerequisites: '[Anthropic integration](/integrations/anthropic/)'
     - category: Migrate
       cloud_provider: AWS
       resource_type: Auto Scaling Group
@@ -602,6 +608,7 @@ Below are the available cloud cost recommendation categories and their descripti
 | Migrate | Resources with moderately low utilization signals or other inefficiencies. Consider adjusting the instance type or other parameters. |
 | Downsize | Resources that are under-utilized or over-provisioned. Consider adjusting the size or other parameters to reduce costs. |
 | Purchase | Resources with on-demand charges and extended uptime. Purchasing a reservation or Savings Plan can reduce the amortized cost of the resource. |
+| Configure | Resources with configuration options that can be adjusted to reduce costs without changing capacity or terminating the resource. |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Adds a new data entry for the **Enable Anthropic Prompt Caching** recommendation to the Cloud Cost Recommendations table
- Adds a **Configure** category row to the "Recommendation categories" table, which this rec uses

The recommendation was released in [dd-source `domains/cloud_cost_management/optimize/internal/anthropic/enable_prompt_caching.go`](https://github.com/DataDog/dd-source/blob/main/domains/cloud_cost_management/optimize/internal/anthropic/enable_prompt_caching.go) but the docs table was not updated at release. The entry values are pulled directly from the recommender's `RecommenderMeta`.

The prerequisite links to the [Anthropic integration](/integrations/anthropic/), matching the existing convention used by other recommendations (Datadog Agent, Amazon EC2 integration, etc.).

## Test plan

- [ ] Preview build: verify the new row appears in the Cloud Cost Recommendations table with filters working for `category: Configure` and `cloud_provider: Anthropic`
- [ ] Verify the new `Configure` row renders correctly in the categories table

🤖 Generated with [Claude Code](https://claude.com/claude-code)