### PR TITLE
Update Workflow Automation Billing

### DIFF
--- a/content/en/account_management/billing/workflow_automation.md
+++ b/content/en/account_management/billing/workflow_automation.md
@@ -4,7 +4,7 @@ title: Workflow Automation
 
 ## Overview
 
-Datadog [Workflow Automation][8] billing is based on the number of **workflow executions**. Workflow executions are recorded whenever a published workflow runs, regardless of its run method (manually, programmatically, or automatically).
+Datadog [Workflow Automation][8] billing is based on the number of **workflow executions**. Workflow executions are recorded whenever a published workflow runs, regardless of its run method (manually, programmatically, or automatically), except for the cases listed under "Included automations" below.
 
 ## Summary
 - **Billing metric**: You incur a cost per committed execution or on-demand execution, depending on your billing plan. Specific pricing can be found on the [Workflow Automation pricing page][13].
@@ -17,12 +17,12 @@ Datadog [Workflow Automation][8] billing is based on the number of **workflow ex
 ## Pricing model
 
 ### Definition of workflow execution
-A workflow execution refers to one full run of a published workflow, regardless of how many steps or actions it includes. Executions can be triggered through:
+A workflow execution refers to one full run of a published workflow, regardless of how many steps, actions, iterations, or retries it includes. Billing is recorded once when an execution starts. Runs that are rejected before starting — for example, due to spec validation errors, admission limits, or a workflow being marked inactive — are not billed. Executions can be triggered through:
 - Manual starts in the Datadog UI
 - API or programmatic triggers
 - Event-based triggers (monitors, incidents, etc.)
 - Workflows triggered from other workflows
-    - **Note**: If one workflow triggers another workflow, they are both counted for billing.
+    - **Note**: When a workflow triggers another workflow, billing is determined by the original (root) trigger of the chain. If the root trigger is a billed source (e.g., a monitor or API call), every workflow in the chain is billed. If the root trigger is a free source (e.g., Incident Management, On-Call, or App Builder), the entire chain is free, regardless of depth.
 
 Unpublished (test or draft) runs are **not billed**.
 
@@ -36,7 +36,7 @@ Failed executions are not exempt from billing. All published executions are bill
 </div>
 
 ### Billing metrics
-Workflow Automation is billed **per execution**. This means that each complete workflow run counts toward your bill.
+Workflow Automation is billed **per execution**. This means that each workflow run counts toward your bill.
 
 The two billing options are committed executions and on-demand executions. Committed executions are purchased in advance, while on-demand executions are billed as they occur. Prepaid executions cost less than on-demand executions.
 

--- a/content/en/account_management/billing/workflow_automation.md
+++ b/content/en/account_management/billing/workflow_automation.md
@@ -4,7 +4,7 @@ title: Workflow Automation
 
 ## Overview
 
-Datadog [Workflow Automation][8] billing is based on the number of **workflow executions**. Workflow executions are recorded whenever a published workflow runs, regardless of its run method (manually, programmatically, or automatically), except for the cases listed under "Included automations" below.
+Datadog [Workflow Automation][8] billing is based on the number of **workflow executions**. Workflow executions are recorded whenever a published workflow runs, regardless of its run method (manually, programmatically, or automatically), except for the cases listed under [Included automations](#included-automations).
 
 ## Summary
 - **Billing metric**: You incur a cost per committed execution or on-demand execution, depending on your billing plan. Specific pricing can be found on the [Workflow Automation pricing page][13].

--- a/content/en/account_management/billing/workflow_automation.md
+++ b/content/en/account_management/billing/workflow_automation.md
@@ -17,7 +17,7 @@ Datadog [Workflow Automation][8] billing is based on the number of **workflow ex
 ## Pricing model
 
 ### Definition of workflow execution
-A workflow execution refers to one full run of a published workflow, regardless of how many steps, actions, iterations, or retries it includes. Billing is recorded once when an execution starts. Runs that are rejected before starting — for example, due to spec validation errors, admission limits, or a workflow being marked inactive — are not billed. Executions can be triggered through:
+A workflow execution refers to one full run of a published workflow, regardless of how many steps, actions, iterations, or retries it includes. Billing is recorded one time when an execution starts. Runs that are rejected before starting—for example, due to spec validation errors, admission limits, or a workflow being marked inactive—are not billed. Executions can be triggered through:
 - Manual starts in the Datadog UI
 - API or programmatic triggers
 - Event-based triggers (monitors, incidents, etc.)

--- a/content/en/account_management/billing/workflow_automation.md
+++ b/content/en/account_management/billing/workflow_automation.md
@@ -22,7 +22,7 @@ A workflow execution refers to one full run of a published workflow, regardless 
 - API or programmatic triggers
 - Event-based triggers (monitors, incidents, etc.)
 - Workflows triggered from other workflows
-    - **Note**: When a workflow triggers another workflow, billing is determined by the original (root) trigger of the chain. If the root trigger is a billed source (e.g., a monitor or API call), every workflow in the chain is billed. If the root trigger is a free source (e.g., Incident Management, On-Call, or App Builder), the entire chain is free, regardless of depth.
+    - **Note**: When a workflow triggers another workflow, billing is determined by the original (root) trigger of the chain. If the root trigger is a billed source (such as a monitor or API call), every workflow in the chain is billed. If the root trigger is a free source (for example, Incident Management, On-Call, or App Builder), the entire chain is free, regardless of depth.
 
 Unpublished (test or draft) runs are **not billed**.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR makes some clarifications and corrections to Workflow Automation billing. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
