### PR TITLE
(AAA) fix TOC and heading anchors on Manage Your Support Tickets page

### DIFF
--- a/content/en/account_management/guide/manage-your-support-tickets.md
+++ b/content/en/account_management/guide/manage-your-support-tickets.md
@@ -104,7 +104,7 @@ further_reading:
 
 <p><strong>Note</strong>: To receive registration verification codes, password reset emails, and case notification emails, add the <code>ddog-gov.com</code> domain to your email allowlist. This includes <code>help@ddog-gov.com</code> and <code>support@ddog-gov.com</code>.</p>
 
-## Create a new case
+## Create a case
 
 <p>To create a new case:</p>
 

--- a/content/en/account_management/guide/manage-your-support-tickets.md
+++ b/content/en/account_management/guide/manage-your-support-tickets.md
@@ -13,7 +13,7 @@ further_reading:
 
 <div class="alert alert-info">Select your Datadog site to see instructions for your support portal.</div>
 
-{{% site-region region="us,us3,us5,eu,ap1" %}}
+{{% site-region region="us,us3,us5,eu,ap1,ap2" %}}
 
 ## Create a support ticket
 

--- a/content/en/account_management/guide/manage-your-support-tickets.md
+++ b/content/en/account_management/guide/manage-your-support-tickets.md
@@ -13,19 +13,19 @@ further_reading:
 
 <div class="alert alert-info">Select your Datadog site to see instructions for your support portal.</div>
 
-{{< site-region region="us,us3,us5,eu,ap1" >}}
+{{% site-region region="us,us3,us5,eu,ap1" %}}
 
-<h2>Create a support ticket</h2>
+## Create a support ticket
 
 <p>To create a new support ticket, navigate to the <a href="https://help.datadoghq.com/">Datadog support site</a>. At the bottom of the page, click <strong>Create a New Ticket</strong> to fill out a ticket form.</p>
 
 <p>You can also access this form through Datadog. From the left navigation, hover over <strong>Help</strong> and click <strong>Support</strong>. Alternatively, navigate to the <a href="https://app.datadoghq.com/help">Datadog help page</a> and click <strong>New Support Ticket</strong>.</p>
 
-<h2>Access existing tickets</h2>
+## Access existing tickets
 
 <p>If you have opened at least one Datadog support ticket, follow this process to access all your Datadog support tickets:</p>
 <ol>
-    <li>From the Support page click <strong>Sign in</strong> on the top right.</li>
+    <li>From the <a href="https://help.datadoghq.com/">Support page</a>, click <strong>Sign in</strong> on the top right.</li>
     <li>If this is your first time signing into your Datadog Zendesk account, click <strong>New to your Datadog Zendesk account? Sign up</strong>.</li>
     <li>If you have previously emailed Datadog support, click <strong>Emailed us for support? Get a password</strong> and enter the email address you used to contact Datadog support.</li>
     <li>After you receive the password in your email, log in and click <strong>Manage your tickets</strong> to see your requests.</li>
@@ -33,11 +33,7 @@ further_reading:
     <li>To view your entire organization's tickets, submit a request to Datadog support.</li>
 </ol>
 
-{{< whatsnext desc="Support Page by Datadog Site:">}}
-    {{< nextlink href="https://help.datadoghq.com/" >}} US1, US3, US5, EU, AP1, AP2 {{< /nextlink >}}
-{{< /whatsnext >}}
-
-<h2>Password requirements</h2>
+## Password requirements
 
 <p>To ensure the security of your account, any password used to sign in to Datadog's Zendesk support portal must meet the following requirements:</p>
 <ol>
@@ -73,29 +69,25 @@ further_reading:
     </li>
 </ol>
 
-<h2>Troubleshooting</h2>
+## Troubleshooting
 
-<h3>Error: Refused to connect</h3>
+### Error: Refused to connect
 
 <p><strong>Refused to connect</strong> errors come from privacy settings that block third-party cookies. To solve this issue, make sure the browser allows third-party cookies from Zendesk. Find instructions on how to <a href="https://support.google.com/chrome/answer/95647">Clear, enable, and manage cookies in Chrome</a> in Google Chrome Help.</p>
 
 <p>If your browser has ad-blockers, turn them off to see if this allows you to sign in. Some ad-blockers have their own list of exceptions. In this case, add <strong>datadog.zendesk.com</strong> to the allow list.</p>
 
-<h3>Ticket is no longer available</h3>
+### Ticket is no longer available
+
 <p>Datadog deletes closed tickets, including their attachments, 15 months after their last update.</p>
 
 <p>If you need help with a related issue, you can open a new ticket or search the Datadog documentation.</p>
 
-<h2>Further reading</h2>
+{{% /site-region %}}
 
-{{< partial name="whats-next/whats-next.html" >}}
+{{% site-region region="gov,gov2" %}}
 
-{{< /site-region >}}
-
-{{< site-region region="gov,gov2" >}}
-
-
-<h2>Register on the portal</h2>
+## Register on the portal
 
 <p>If you are a first-time user, follow these steps to register an account:</p>
 
@@ -112,7 +104,7 @@ further_reading:
 
 <p><strong>Note</strong>: To receive registration verification codes, password reset emails, and case notification emails, add the <code>ddog-gov.com</code> domain to your email allowlist. This includes <code>help@ddog-gov.com</code> and <code>support@ddog-gov.com</code>.</p>
 
-<h2>Create a new case</h2>
+## Create a new case
 
 <p>To create a new case:</p>
 
@@ -126,7 +118,7 @@ further_reading:
     <li>Click <strong>Submit</strong>.</li>
 </ol>
 
-<h2>Access existing cases</h2>
+## Access existing cases
 
 <p>If you have opened at least one Datadog case, follow this process to access your cases:</p>
 
@@ -138,25 +130,26 @@ further_reading:
 
 <p><strong>Note</strong>: Historical Zendesk cases are not migrated; legacy Zendesk is read-only.</p>
 
-<h2>Troubleshooting</h2>
+## Troubleshooting
 
-<h3>Cannot see new cases</h3>
+### Cannot see new cases
 
 <p>Change the filter from <strong>Recently Viewed</strong> to <strong>Cases</strong>.</p>
 
-<h3>Login issues</h3>
+### Login issues
 
 <p>Make sure your full username includes the <code>.ddgov.support</code> suffix.</p>
 
-<h3>Password reset not received</h3>
+### Password reset not received
 
 <p>Click <strong>Forgot Password</strong> and follow the process with your full username (with the <code>.ddgov.support</code> suffix). If you still do not receive the email, add <code>ddog-gov.com</code> to your email allowlist.</p>
 
-<h3>Registration error</h3>
+### Registration error
 
 <p>Your account may already exist. Click <strong>Forgot Password</strong> and enter your full username, including the <code>.ddgov.support</code> suffix (for example, <code>john@agency.gov.ddgov.support</code>). If you are still unable to access your account, contact <code>support@ddog-gov.com</code>.</p>
 
-<h2>Further reading</h2>
-{{< partial name="whats-next/whats-next.html" >}}
+{{% /site-region %}}
 
-{{< /site-region >}}
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fixes https://datadoghq.atlassian.net/browse/DOCS-14381

- switched site-region shortcodes from `{{< >}}` to `{{% %}}` syntax so Hugo processes inner content as Markdown, enabling heading anchors and the "On this page" sidebar
- converted `<h2>` and `<h3>` tags to Markdown headings
- moved Further Reading partial outside site-region blocks to avoid Markdown/HTML rendering conflicts

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Used Claude Sonnet 4.6 via Cursor to figure out why the headings weren't rendering + fix them.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
