### PR TITLE
Document dd-otel-metric-config header fields for OSS Collector setup

### DIFF
--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -769,9 +769,9 @@ The `dd-otel-metric-config` header is a JSON payload sent with metrics requests 
 | `instrumentation_scope_metadata_as_tags` | Boolean | `false` | Propagates OTLP instrumentation scope metadata (scope name and version) as tags on emitted metrics. |
 | `trace_metrics.namespace` | String | `traces.span.metrics` | Namespace prefix applied to trace-derived metrics. |
 | `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes supported HTTP instrumentation metrics to power APM trace metrics. |
-| `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular Metrics destination after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
+| `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular metrics intake after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
 
-<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable this option alongside the <code>spanmetrics</code> connector unless directed by Datadog.</div>
+<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable this option alongside the <code>spanmetrics</code> connector.</div>
 
 ### Datadog extension
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -758,7 +758,44 @@ The `otlp_http` exporter sends telemetry data to Datadog's OTLP intake endpoints
 
 - **Endpoint**: `https://otlp.<YOUR_DD_SITE>` for traces and logs, `https://otlp.<YOUR_DD_SITE>/api/v2/otlpmetrics` for metrics.
 - **Compression**: `zstd` is recommended for reduced bandwidth usage. When using `zstd`, set `compression_params.level` explicitly, because the default uses the lowest compression level.
-- **Resource attributes as tags**: The `dd-otel-metric-config` header enables resource attributes and instrumentation scope metadata to be sent as metric tags.
+
+#### `dd-otel-metric-config` header {#dd-otel-metric-config-header}
+
+The `dd-otel-metric-config` header is a JSON payload sent with metrics requests that configures how Datadog processes OTLP metrics. Set it in the `headers` section of the `otlp_http` exporter.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `resource_attributes_as_tags` | Boolean | `false` | Propagates OTLP resource attributes as Datadog tags on emitted metrics. |
+| `instrumentation_scope_metadata_as_tags` | Boolean | `false` | Propagates OTLP instrumentation scope metadata (scope name and version) as tags on emitted metrics. |
+| `trace_metrics.namespace` | String | `traces.span.metrics` | Namespace prefix applied to trace-derived metrics. |
+| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | Routes standard HTTP instrumentation metrics to the TraceMetrics destination to power APM features. See [Use instrumentation metrics for APM](#use-instrumentation-metrics-for-apm). |
+| `raw_instrumentation_metrics_drop` | Boolean | `false` | Drops the raw HTTP instrumentation metrics from the regular Metrics destination. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
+
+### Use instrumentation metrics for APM
+
+By default, the [span metrics connector](#span-metrics-connector) generates the RED metrics that power APM features. As an alternative, you can configure the Datadog intake to derive trace metrics from standard HTTP instrumentation metrics that your OpenTelemetry SDK already produces.
+
+To enable this, set `trace_metrics.instrumentation_metrics_calc` to `true` in the `dd-otel-metric-config` header:
+
+```json
+{
+  "trace_metrics": {
+    "instrumentation_metrics_calc": true
+  },
+  "resource_attributes_as_tags": true,
+  "instrumentation_scope_metadata_as_tags": true
+}
+```
+
+When enabled, the following HTTP instrumentation metrics are routed to the TraceMetrics destination:
+- `http.server.request.duration`
+- `http.client.request.duration`
+- `http.server.request.calls`
+- `http.client.request.calls`
+
+By default, these metrics are also sent to the regular Metrics destination. To send them only to TraceMetrics, set `raw_instrumentation_metrics_drop` to `true`.
+
+To customize the namespace prefix applied to the trace-derived metrics, set `trace_metrics.namespace`. The default is `traces.span.metrics`.
 
 ### Datadog extension
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -768,12 +768,12 @@ The `dd-otel-metric-config` header is a JSON payload sent with metrics requests 
 | `resource_attributes_as_tags` | Boolean | `false` | Propagates OTLP resource attributes as Datadog tags on emitted metrics. |
 | `instrumentation_scope_metadata_as_tags` | Boolean | `false` | Propagates OTLP instrumentation scope metadata (scope name and version) as tags on emitted metrics. |
 | `trace_metrics.namespace` | String | `traces.span.metrics` | Namespace prefix applied to trace-derived metrics. |
-| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes standard HTTP instrumentation metrics to power APM trace metrics. See [Use HTTP instrumentation metrics for APM](#use-http-instrumentation-metrics-for-apm). |
+| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes supported HTTP instrumentation metrics to power APM trace metrics. See [Use HTTP instrumentation metrics for APM](#use-http-instrumentation-metrics-for-apm). |
 | `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular Metrics destination after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
 
 #### Use HTTP instrumentation metrics for APM
 
-The recommended configuration uses the `spanmetrics` connector to generate the RED metrics that power APM views. If your application already emits standard HTTP instrumentation metrics, you can use those metrics instead. Use this option only as an **alternative** to the `spanmetrics` connector, not alongside it.
+The recommended configuration uses the `spanmetrics` connector to generate the RED metrics that power APM views. If your application already emits the following HTTP instrumentation metrics, you can use those metrics instead. Use this option only as an **alternative** to the `spanmetrics` connector, not alongside it.
 
 To enable this, set `trace_metrics.instrumentation_metrics_calc` to `true` in the `dd-otel-metric-config` header:
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -768,34 +768,10 @@ The `dd-otel-metric-config` header is a JSON payload sent with metrics requests 
 | `resource_attributes_as_tags` | Boolean | `false` | Propagates OTLP resource attributes as Datadog tags on emitted metrics. |
 | `instrumentation_scope_metadata_as_tags` | Boolean | `false` | Propagates OTLP instrumentation scope metadata (scope name and version) as tags on emitted metrics. |
 | `trace_metrics.namespace` | String | `traces.span.metrics` | Namespace prefix applied to trace-derived metrics. |
-| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes supported HTTP instrumentation metrics to power APM trace metrics. See [Use HTTP instrumentation metrics for APM](#use-http-instrumentation-metrics-for-apm). |
+| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes supported HTTP instrumentation metrics to power APM trace metrics. |
 | `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular Metrics destination after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
 
-#### Use HTTP instrumentation metrics for APM
-
-The recommended configuration uses the `spanmetrics` connector to generate the RED metrics that power APM views. If your application already emits the following HTTP instrumentation metrics, you can use those metrics instead. Use this option only as an **alternative** to the `spanmetrics` connector, not alongside it.
-
-To enable this, set `trace_metrics.instrumentation_metrics_calc` to `true` in the `dd-otel-metric-config` header:
-
-```json
-{
-  "trace_metrics": {
-    "instrumentation_metrics_calc": true
-  },
-  "resource_attributes_as_tags": true,
-  "instrumentation_scope_metadata_as_tags": true
-}
-```
-
-When enabled, the following HTTP instrumentation metrics are routed to power APM features:
-- `http.server.request.duration`
-- `http.client.request.duration`
-- `http.server.request.calls`
-- `http.client.request.calls`
-
-By default, these metrics are also sent to the regular Metrics destination. To send them only for APM trace metrics, set `raw_instrumentation_metrics_drop` to `true`.
-
-To customize the namespace prefix applied to the trace-derived metrics, set `trace_metrics.namespace`. The default is `traces.span.metrics`.
+<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable this option alongside the <code>spanmetrics</code> connector unless directed by Datadog.</div>
 
 ### Datadog extension
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -768,12 +768,12 @@ The `dd-otel-metric-config` header is a JSON payload sent with metrics requests 
 | `resource_attributes_as_tags` | Boolean | `false` | Propagates OTLP resource attributes as Datadog tags on emitted metrics. |
 | `instrumentation_scope_metadata_as_tags` | Boolean | `false` | Propagates OTLP instrumentation scope metadata (scope name and version) as tags on emitted metrics. |
 | `trace_metrics.namespace` | String | `traces.span.metrics` | Namespace prefix applied to trace-derived metrics. |
-| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | Routes standard HTTP instrumentation metrics to the TraceMetrics destination to power APM features. See [Use instrumentation metrics for APM](#use-instrumentation-metrics-for-apm). |
-| `raw_instrumentation_metrics_drop` | Boolean | `false` | Drops the raw HTTP instrumentation metrics from the regular Metrics destination. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
+| `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes standard HTTP instrumentation metrics to power APM trace metrics. See [Use HTTP instrumentation metrics for APM](#use-http-instrumentation-metrics-for-apm). |
+| `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular Metrics destination after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
 
-### Use instrumentation metrics for APM
+#### Use HTTP instrumentation metrics for APM
 
-By default, the [span metrics connector](#span-metrics-connector) generates the RED metrics that power APM features. As an alternative, you can configure the Datadog intake to derive trace metrics from standard HTTP instrumentation metrics that your OpenTelemetry SDK already produces.
+The recommended configuration uses the `spanmetrics` connector to generate the RED metrics that power APM views. If your application already emits standard HTTP instrumentation metrics, you can use those metrics instead. Use this option only as an **alternative** to the `spanmetrics` connector, not alongside it.
 
 To enable this, set `trace_metrics.instrumentation_metrics_calc` to `true` in the `dd-otel-metric-config` header:
 
@@ -787,13 +787,13 @@ To enable this, set `trace_metrics.instrumentation_metrics_calc` to `true` in th
 }
 ```
 
-When enabled, the following HTTP instrumentation metrics are routed to the TraceMetrics destination:
+When enabled, the following HTTP instrumentation metrics are routed to power APM features:
 - `http.server.request.duration`
 - `http.client.request.duration`
 - `http.server.request.calls`
 - `http.client.request.calls`
 
-By default, these metrics are also sent to the regular Metrics destination. To send them only to TraceMetrics, set `raw_instrumentation_metrics_drop` to `true`.
+By default, these metrics are also sent to the regular Metrics destination. To send them only for APM trace metrics, set `raw_instrumentation_metrics_drop` to `true`.
 
 To customize the namespace prefix applied to the trace-derived metrics, set `trace_metrics.namespace`. The default is `traces.span.metrics`.
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -785,7 +785,7 @@ Example with instrumentation metrics enabled:
 }
 ```
 
-<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable this option alongside the <code>spanmetrics</code> connector.</div>
+<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable <code>instrumentation_metrics_calc</code> alongside the <code>spanmetrics</code> connector, as this computes trace metrics from both sources.</div>
 
 ### Datadog extension
 

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -771,6 +771,20 @@ The `dd-otel-metric-config` header is a JSON payload sent with metrics requests 
 | `trace_metrics.instrumentation_metrics_calc` | Boolean | `false` | When `true`, routes supported HTTP instrumentation metrics to power APM trace metrics. |
 | `raw_instrumentation_metrics_drop` | Boolean | `false` | When `true`, drops the raw HTTP instrumentation metrics from the regular metrics intake after routing them for APM trace metrics. Only applies when `trace_metrics.instrumentation_metrics_calc` is `true`. |
 
+Example with instrumentation metrics enabled:
+
+```json
+{
+  "trace_metrics": {
+    "namespace": "myapp.traces",
+    "instrumentation_metrics_calc": true
+  },
+  "raw_instrumentation_metrics_drop": false,
+  "resource_attributes_as_tags": true,
+  "instrumentation_scope_metadata_as_tags": false
+}
+```
+
 <div class="alert alert-info">The recommended OSS Collector configuration uses the <code>spanmetrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable this option alongside the <code>spanmetrics</code> connector.</div>
 
 ### Datadog extension


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a reference table for the `dd-otel-metric-config` header fields on the OSS Collector setup page, with an info note explaining that the `trace_metrics` fields support an optional alternative to the default `spanmetrics` connector for powering APM.

Changes:
- Replaces the brief `dd-otel-metric-config` one-liner with a reference table covering all five fields (`resource_attributes_as_tags`, `instrumentation_scope_metadata_as_tags`, `trace_metrics.namespace`, `trace_metrics.instrumentation_metrics_calc`, `raw_instrumentation_metrics_drop`)
- Adds an info callout clarifying the instrumentation metrics fields as an alternative to `spanmetrics`, not to be used alongside it

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The OSS setup page is still private/preview.