### PR TITLE
docs(mcp-server): Document omit_tools query parameter for filtering tool availability

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -92,6 +92,7 @@ The Datadog MCP Server is optimized to provide responses in a way that AI agents
 
 - Responses are truncated based on the estimated length of responses each tool provides. The tools respond to AI agents with instructions on how to request more information if the response was truncated.
 - Most tools have a `max_tokens` parameter that enables AI agents to request less or more information.
+- You can limit available tools at connection time with `toolsets` and `omit_tools`. See [Set Up the Datadog MCP Server][27].
 
 ## Track tool calls in Audit Trail
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -562,28 +562,24 @@ For example, based on your selected [Datadog site][17] ({{< region-param key="dd
 [17]: /getting_started/site/#navigate-the-datadog-documentation-by-site
 {{< /site-region >}}
 
-### Exclude specific tools with `omit_tools`
+### Omit specific tools
 
-Use the `omit_tools` query parameter to remove specific tools from the final tool list. This is useful when you want a broad toolset but need to exclude a few tools for tighter context control. Provide tool names as a comma-separated list.
+Use the `omit_tools` query parameter to remove specific tools from the final tool list.
 
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 Examples for your selected site ({{< region-param key="dd_site_name" >}}):
 
-- Exclude specific tools from the default set:
+- Omit tools from the default set:
   <pre><code>{{< region-param key="mcp_server_endpoint" >}}?omit_tools=search_datadog_logs,search_datadog_spans</code></pre>
 
-- Select toolsets, then exclude one tool:
+- Select toolsets, then omit one tool:
   <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=core,software-delivery&omit_tools=search_datadog_incidents</code></pre>
 
-- Start from all generally available toolsets, then exclude write tools:
+- Start from all generally available toolsets, then omit write tools:
   <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=all&omit_tools=create_datadog_notebook,edit_datadog_notebook</code></pre>
 {{< /site-region >}}
 
-When both parameters are present, the server resolves `toolsets` first and then removes any matching tools listed in `omit_tools`.
-
-If `omit_tools` includes unknown tool names, the server warns and continues instead of failing the connection.
-
-Use `toolsets` for broad scoping first, then use `omit_tools` for fine-grained exclusions.
+Provide tool names as a comma-separated list. When both parameters are present, the server resolves `toolsets` first and then removes matching tools in `omit_tools`. If `omit_tools` includes unknown tool names, the server warns and continues.
 
 ### Available toolsets
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -562,6 +562,29 @@ For example, based on your selected [Datadog site][17] ({{< region-param key="dd
 [17]: /getting_started/site/#navigate-the-datadog-documentation-by-site
 {{< /site-region >}}
 
+### Exclude specific tools with `omit_tools`
+
+Use the `omit_tools` query parameter to remove specific tools from the final tool list. This is useful when you want a broad toolset but need to exclude a few tools for tighter context control. Provide tool names as a comma-separated list.
+
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+Examples for your selected site ({{< region-param key="dd_site_name" >}}):
+
+- Exclude specific tools from the default set:
+  <pre><code>{{< region-param key="mcp_server_endpoint" >}}?omit_tools=search_datadog_logs,search_datadog_spans</code></pre>
+
+- Select toolsets, then exclude one tool:
+  <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=core,software-delivery&omit_tools=search_datadog_incidents</code></pre>
+
+- Start from all generally available toolsets, then exclude write tools:
+  <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=all&omit_tools=create_datadog_notebook,edit_datadog_notebook</code></pre>
+{{< /site-region >}}
+
+When both parameters are present, the server resolves `toolsets` first and then removes any matching tools listed in `omit_tools`.
+
+If `omit_tools` includes unknown tool names, the server warns and continues instead of failing the connection.
+
+Use `toolsets` for broad scoping first, then use `omit_tools` for fine-grained exclusions.
+
 ### Available toolsets
 
 These toolsets are generally available. See [Datadog MCP Server Tools][49] for a complete reference of available tools organized by toolset, with example prompts.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -20,6 +20,8 @@ To enable product-specific tools, include the `toolsets` query parameter at the 
 
    <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
 
+You can also exclude specific tools with the `omit_tools` query parameter. For usage details and precedence with `toolsets`, see [Set Up the Datadog MCP Server][1].
+
 [2]: /getting_started/site/
 {{< /site-region >}}
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -22,6 +22,8 @@ To enable product-specific tools, include the `toolsets` query parameter at the 
 
 You can also exclude specific tools with the `omit_tools` query parameter. For usage details and precedence with `toolsets`, see [Set Up the Datadog MCP Server][1].
 
+[1]: /bits_ai/mcp_server/setup#toolsets
+
 [2]: /getting_started/site/
 {{< /site-region >}}
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -20,14 +20,12 @@ To enable product-specific tools, include the `toolsets` query parameter at the 
 
    <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
 
-You can also exclude specific tools with the `omit_tools` query parameter. For usage details and precedence with `toolsets`, see [Set Up the Datadog MCP Server][1].
-
-[1]: /bits_ai/mcp_server/setup#toolsets
+You can also exclude specific tools with the `omit_tools` query parameter.
 
 [2]: /getting_started/site/
 {{< /site-region >}}
 
-See [Set Up the Datadog MCP Server][1] for more information on connecting to the MCP Server and enabling toolsets.
+See [Set Up the Datadog MCP Server][1] for more information on connecting to the MCP Server, enabling toolsets, and omitting specific tools.
 
 <div class="alert alert-info">Datadog MCP Server tools are under significant development and are subject to change. Use <a href="https://docs.google.com/forms/d/e/1FAIpQLSeorvIrML3F4v74Zm5IIaQ_DyCMGqquIp7hXcycnCafx4htcg/viewform">this feedback form</a> to share any feedback, use cases, or issues encountered with your prompts and queries.</div>
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0304465e-1163-4ea2-bca9-fd049f37a81a","source":"chat","resourceId":"e6e8994d-936d-49dc-82df-6f4b01706f0b","workflowId":"6e5c60d9-5d5f-475a-8ec1-79fb334f114a","codeChangeId":"6e5c60d9-5d5f-475a-8ec1-79fb334f114a","sourceType":"chat"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### Motivation

- In https://github.com/DataDog/dd-source/pull/422201 , I added an omit_tools param to let customers remove tools from products they don't subscribe to. This will improve tool selection for customers who may not use certain DD products yet, as the agent won't need to sift through unused tools that return poor results.
- For anyone other than the first org to request it to be able to benefit, we need to document the setting.
- https://datadoghq.atlassian.net/browse/GRAPHAI-833


### Changes

- Updated `content/en/bits_ai/mcp_server/setup.md` under **Toolsets** with an `omit_tools` section.
- Included examples for:
  - `omit_tools` by itself
  - `toolsets` combined with `omit_tools`
  - `toolsets=all` with selective exclusions
- Documented behavior:
  - precedence: server resolves `toolsets` first, then removes tools listed in `omit_tools`
  - unknown tool names in `omit_tools`: warn and continue
- Added a context-efficiency mention in `content/en/bits_ai/mcp_server/_index.md` pointing readers to setup guidance for `toolsets` and `omit_tools`.

# Testing

- No runtime testing needed, this is purely a writing PR

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

I used bits dev agent AI assistance to draft and refine documentation wording, examples, and crosslinks; content was reviewed and edited before finalizing.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e6e8994d-936d-49dc-82df-6f4b01706f0b)

Comment @datadog to request changes