### PR TITLE
Add 5 missing tools to software delivery MCP tools docs

### DIFF
--- a/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -29,6 +29,8 @@ The Software Delivery MCP tools unlock AI-assisted workflows for:
 - **Analyzing CI performance**: Get aggregated statistics on pipeline durations, failure rates, and trends over time.
 - **Triaging test failures**: Understand which tests are failing, their ownership, and historical patterns.
 - **Reviewing code coverage**: Get coverage summaries for branches or commits, including patch coverage and breakdowns by service or code owner.
+- **Measuring DORA metrics**: Query deployment frequency, change lead time, change failure rate, and recovery time by service or team.
+- **Checking test optimization settings**: See which Test Optimization features are active for a service, including Test Impact Analysis, Early Flake Detection, and Auto Test Retries.
 
 ## Available tools
 
@@ -43,6 +45,9 @@ The `software-delivery` toolset includes the following tools:
 `get_datadog_flaky_tests`
 : Find flaky tests with triage details including failure rate, category, owners, and CI impact.
 
+`update_datadog_flaky_test_states`
+: Set the state of one or more flaky tests to `quarantined` (suppress failures), `disabled` (skip test), `fixed` (mark resolved), or `active` (restore). This is a write operation that requires `TestOptimizationWrite` permission and explicit user approval. All state changes are reversible.
+
 `aggregate_datadog_test_events`
 : Aggregate test events to analyze reliability and performance trends.
 
@@ -55,6 +60,18 @@ The `software-delivery` toolset includes the following tools:
 `get_datadog_code_coverage_commit_summary`
 : Fetch aggregated code coverage summary metrics for a repository commit, including total coverage, patch coverage, and service/codeowner breakdowns.
 
+`get_datadog_test_optimization_settings`
+: Retrieve which Test Optimization features are enabled for a service, including Test Impact Analysis (ITR), Early Flake Detection (EFD), Auto Test Retries (ATR), Failed Test Replay, Code Coverage collection, and PR Comments.
+
+`get_datadog_flaky_tests_management_policies`
+: Retrieve the Flaky Tests Management policies configured for a repository, including auto-quarantine windows, branch rules, failure rate thresholds, disable policies, and retry settings.
+
+`search_dora_deployments`
+: Search DORA deployment events with filters, or fetch full details for a single deployment by ID. For aggregated trends (deployment frequency, change lead time, failure rate), use `aggregate_dora_deployments` instead.
+
+`aggregate_dora_deployments`
+: Aggregate DORA metrics—deployment frequency, change lead time, change failure rate, and recovery time—as scalar values or timeseries. For a complete DORA summary, call this tool four times in parallel, once per metric.
+
 ## Example prompts
 
 After you are connected, try prompts like:
@@ -66,6 +83,9 @@ After you are connected, try prompts like:
 - Show me the 95th percentile of pipeline duration grouped by pipeline name.
 - What's the code coverage on the `main` branch for `github.com/my-org/my-repo`?
 - Show me coverage metrics for commit `abc123abc123abc123abc123abc123abc123abcd`.
+- What is the deployment frequency and change failure rate for the `checkout` service over the last 30 days?
+- Which test optimization features are enabled for the `auth-service`?
+- Quarantine all active flaky tests in the `checkout-service` repository.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds 5 missing tools to the Software Delivery MCP tools getting started page. The authoritative tool list in `dd-source` (`domains/mcp_services/libs/go/mcp/tools/skills/datadog/software-delivery.md`) registers 12 tools under the `software-delivery` toolset, but the docs page only listed 7.

**Tools added:**
- `update_datadog_flaky_test_states` — write operation to set flaky test states (quarantined, disabled, fixed, active)
- `get_datadog_test_optimization_settings` — retrieve enabled Test Optimization features per service
- `get_datadog_flaky_tests_management_policies` — retrieve FTM policies for a repository
- `search_dora_deployments` — search DORA deployment events
- `aggregate_dora_deployments` — aggregate DORA metrics (deployment frequency, change lead time, change failure rate, recovery time)

Also adds 2 use-case bullets and 3 example prompts to cover the new capabilities.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Related to dd-source PR #442187 which adds the DORA and test optimization tools to the source skill file.