### PR TITLE
Broaden Apple platform framing across iOS RUM docs

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/ios/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/_index.md
@@ -26,12 +26,12 @@ To get started with RUM for Apple platforms, create an application and configure
 {{< whatsnext desc="This section includes the following topics:">}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/setup">}}<u>Setup</u>: Learn how to set up the iOS SDK, track background events, and send data when devices are offline.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/error_tracking">}}<u>Crash Reporting</u>: Add crash reporting, get deobfuscated stack traces, then test your implementation.{{< /nextlink >}}
-   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/application_launch_monitoring">}}<u>Application Launch Monitoring</u>: Measure iOS mobile application launch performance, including the time to initial display and time to full display.{{< /nextlink >}}
+   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/application_launch_monitoring">}}<u>Application Launch Monitoring</u>: Measure application launch performance on Apple platforms, including the time to initial display and time to full display.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/monitoring_app_performance">}}<u>Monitoring App Performance</u>: Monitor view timings to understand your app's performance from a user's perspective. {{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/advanced_configuration">}}<u>Advanced Configuration</u>: Enrich user sessions, manage events and data, track custom global attributes, review initialization parameters, modify or drop RUM events, and more.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/mobile_vitals">}}<u>Data Collected</u>: Review data that the RUM iOS SDK collects.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/mobile_vitals">}}<u>Mobile Vitals</u>: View mobile vitals, which help compute insights about your mobile application.{{< /nextlink >}}
-  {{< nextlink href="/real_user_monitoring/application_monitoring/ios/frustration_signals">}}<u>Frustration Signals</u>: Identify the highest points of user friction in your iOS application.{{< /nextlink >}}
+  {{< nextlink href="/real_user_monitoring/application_monitoring/ios/frustration_signals">}}<u>Frustration Signals</u>: Identify the highest points of user friction in your Apple platform application.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/web_view_tracking/?tab=ios">}}<u>Web View Tracking</u>: Monitor web views and eliminate blind spots in your mobile applications.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/application_monitoring/ios/integrated_libraries">}}
   <u>Integrated Libraries</u>: Import integrated libraries you can use for your Apple platform applications.{{< /nextlink >}}

--- a/content/en/real_user_monitoring/application_monitoring/ios/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/advanced_configuration.mdoc.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Advanced Configuration
-description: "Configure advanced iOS RUM SDK settings to enrich user sessions, track custom events, and control data collection for better insights."
+title: Apple Platform Advanced Configuration
+description: "Configure advanced iOS SDK settings to enrich user sessions, track custom events, and control data collection on your Apple platform applications."
 aliases:
     - /real_user_monitoring/ios/advanced_configuration
     - /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios

--- a/content/en/real_user_monitoring/application_monitoring/ios/application_launch_monitoring.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/application_launch_monitoring.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Mobile App Launch Monitoring
-description: "Measure iOS mobile application launch performance, including the time to initial display and time to full display."
+title: Apple Platform App Launch Monitoring
+description: "Measure application launch performance on Apple platforms, including the time to initial display and time to full display."
 aliases:
 - /real_user_monitoring/ios/data_collected/
 - /real_user_monitoring/mobile_and_tv_monitoring/application_launch_monitoring/ios/
@@ -19,7 +19,7 @@ further_reading:
 
 ## Overview
 
-Application launch monitoring helps you understand how fast your iOS app becomes usable after a user taps the app icon. Use it to identify slow startup times, track performance regressions, and optimize the user’s first impression of your app.
+Application launch monitoring helps you understand how fast your app becomes usable after a user opens it on their Apple device. Use it to identify slow startup times, track performance regressions, and optimize the user's first impression of your app.
 
 With this feature, you can:
 - Measure time to initial display (TTID) and time to full display (TTFD) for cold and warm starts

--- a/content/en/real_user_monitoring/application_monitoring/ios/data_collected.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/data_collected.mdoc.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Data Collected
-description: "Understand RUM iOS SDK event types, attributes, and telemetry data including sessions, views, actions, resources, and errors."
+title: Apple Platform Data Collected
+description: "Understand the event types, attributes, and telemetry data collected by the iOS SDK across Apple platforms, including sessions, views, actions, resources, and errors."
 aliases:
 - /real_user_monitoring/ios/data_collected/
 - /real_user_monitoring/mobile_and_tv_monitoring/data_collected/ios/

--- a/content/en/real_user_monitoring/application_monitoring/ios/error_tracking.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/error_tracking.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Crash Reporting and Error Tracking
-description: "Enable comprehensive crash reporting and error tracking for iOS applications to monitor and resolve issues with detailed reports."
+title: Apple Platform Crash Reporting and Error Tracking
+description: "Enable crash reporting and error tracking for your Apple platform applications to monitor and resolve issues with detailed reports."
 aliases:
   - /real_user_monitoring/mobile_and_tv_monitoring/ios/error_tracking
 ---

--- a/content/en/real_user_monitoring/application_monitoring/ios/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your iOS app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your Apple platform app with RUM frustration signals, including rage taps and error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/ios/mobile_vitals.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/mobile_vitals.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Mobile Vitals
-description: "Monitor iOS mobile vitals including performance metrics, startup times, and resource usage to optimize app performance and user experience."
+title: Apple Platform Mobile Vitals
+description: "Monitor mobile vitals on Apple platforms, including performance metrics, startup times, and resource usage, to optimize app performance and user experience."
 aliases:
   - /real_user_monitoring/mobile_and_tv_monitoring/ios/mobile_vitals
 ---

--- a/content/en/real_user_monitoring/application_monitoring/ios/monitoring_app_performance.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/monitoring_app_performance.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Monitoring App Performance
-description: "Track iOS app performance with custom view timings, network metrics, and user interaction measurements for enhanced user experience."
+title: Apple Platform Monitoring App Performance
+description: "Track app performance on Apple platforms with custom view timings, network metrics, and user interaction measurements for enhanced user experience."
 aliases:
   - /real_user_monitoring/mobile_and_tv_monitoring/ios/monitoring_app_performance
 further_reading:
@@ -66,7 +66,7 @@ If you need more control over which interactions are considered "last interactio
 
 ### Notify the SDK that your view finished loading
 
-iOS RUM tracks the time it takes for your view to load. To notify the SDK that your view has finished loading, call the `addViewLoadingTime(override:)` method
+The iOS SDK tracks the time it takes for your view to load. To notify the SDK that your view has finished loading, call the `addViewLoadingTime(override:)` method
 through the `RUMMonitor` instance. Call this method when your view is fully loaded and displayed to the user:
 
 {{< tabs >}}

--- a/content/en/real_user_monitoring/application_monitoring/ios/sdk_performance_impact.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/sdk_performance_impact.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-When integrating any SDK into your iOS application, understanding its performance impact is crucial for maintaining a smooth user experience. The Datadog RUM SDK is designed with minimal performance overhead. Use these benchmarks to evaluate whether the SDK fits your app's performance budget and plan your integration accordingly.
+When integrating any SDK into your Apple platform application, understanding its performance impact is crucial for maintaining a smooth user experience. The Datadog RUM SDK is designed with minimal performance overhead. Use these benchmarks to evaluate whether the SDK fits your app's performance budget and plan your integration accordingly.
 
 ## Performance impact benchmarks
 

--- a/content/en/real_user_monitoring/application_monitoring/ios/supported_versions.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/supported_versions.md
@@ -23,6 +23,9 @@ further_reading:
    text: "Learn about instrumenting SwiftUI applications"
 ---
 
+## Overview
+
+The Datadog iOS SDK is the single SDK for instrumenting Real User Monitoring on all Apple platforms — iOS, iPadOS, tvOS, watchOS, and visionOS. Use this page to confirm the minimum OS version, dependency manager, and Datadog modules available for each platform.
 
 ## Supported versions
 

--- a/content/en/real_user_monitoring/application_monitoring/ios/web_view_tracking.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/web_view_tracking.md
@@ -1,6 +1,6 @@
 ---
-title: iOS Web View Tracking
-description: "Monitor web views within iOS applications to track performance and user interactions between native iOS and web content."
+title: Apple Platform Web View Tracking
+description: "Monitor web views within your Apple platform applications to track performance and user interactions between native and web content."
 aliases:
   - /real_user_monitoring/mobile_and_tv_monitoring/ios/web_view_tracking
 ---

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/ios.mdoc.md
@@ -3,7 +3,7 @@ This partial contains integrated libraries content for the iOS SDK.
 It can be included in the iOS SDK integrated libraries page or in the unified client_sdks view.
 -->
 
-This page lists integrated libraries you can use for iOS and tvOS applications.
+This page lists integrated libraries you can use for your Apple platform applications.
 
 ## Alamofire
 

--- a/layouts/shortcodes/mdoc/en/sdk/setup/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/setup/ios.mdoc.md
@@ -3,13 +3,13 @@ This partial contains setup instructions for the iOS SDK.
 It can be included directly in language-specific pages or wrapped in conditionals.
 -->
 
-This page describes how to instrument your iOS and tvOS applications for [Real User Monitoring (RUM)][1] with the iOS SDK. RUM includes Error Tracking by default, but if you have purchased Error Tracking as a standalone product, see the [Error Tracking setup guide][14] for specific steps.
+This page describes how to instrument your Apple platform applications for [Real User Monitoring (RUM)][1] with the iOS SDK. The iOS SDK supports iOS, iPadOS, tvOS, watchOS, and visionOS. For details on supported versions and module availability per platform, see [Supported Versions][18]. RUM includes Error Tracking by default, but if you have purchased Error Tracking as a standalone product, see the [Error Tracking setup guide][14] for specific steps.
 
 ## Prerequisites
 
 Before you begin, you need:
 - Xcode 12.0 or later
-- iOS 11.0+ or tvOS 11.0+ deployment target
+- A supported Apple platform deployment target (see [Supported Versions][18] for minimum OS versions per platform)
 - A Datadog account with RUM or Error Tracking enabled
 
 ## Setup
@@ -21,7 +21,7 @@ Before you begin, you need:
 
 ### Manual setup
 
-To send RUM data from your iOS or tvOS application to Datadog, complete the following steps.
+To send RUM data from your Apple platform application to Datadog, complete the following steps.
 
 {% stepper %}
 
@@ -652,4 +652,5 @@ See [Supported versions][9] for a list of operating system versions and platform
 [15]: /real_user_monitoring/application_monitoring/ios/advanced_configuration#custom-actions
 [16]: /real_user_monitoring/application_monitoring/agentic_onboarding/?tab=realusermonitoring
 [17]: /real_user_monitoring/application_monitoring/ios/advanced_configuration#custom-resources
+[18]: /real_user_monitoring/application_monitoring/ios/supported_versions/
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #36219, which marked watchOS and visionOS as officially supported.

That previous PR updated the section index and the setup page title, but several subpages, partials, and intro paragraphs still framed the iOS SDK as covering only iOS and tvOS. This PR sweeps the remaining mentions so the docs consistently reflect full Apple platform coverage (iOS, iPadOS, tvOS, watchOS, visionOS).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes