### PR TITLE
docs(cloud-security): document runtime package tracking (Preview) for agent setup

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -48,12 +48,48 @@ docker run -d --name dd-agent \
   -e DD_SBOM_ENABLED=true
   -e DD_SBOM_CONTAINER_IMAGE_ENABLED=true
   -e DD_SBOM_HOST_ENABLED=true
+  -e DD_SBOM_ENRICHMENT_USAGE_ENABLED=true \
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
   registry.datadoghq.com/agent:7
 
 {{< /code-block >}}
 
+## Runtime Package Prioritization (Preview)
+
+Runtime package prioritization enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+
+Each vulnerability finding is enriched with the following signals:
+
+| Signal | Description |
+|--------|-------------|
+| Package is running | The package files are actively being accessed by running processes. |
+| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
+
+These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+
+**Requirements**:
+- Datadog Agent **7.78.0 or later**
+- Linux only (eBPF dependency)
+
+**Important**: Enabling runtime package prioritization activates [Workload Protection][4] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+
+Add `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` to your Docker run command:
+
+{{< code-block lang="shell" >}}
+docker run -d --name dd-agent \
+  [... other flags ...] \
+  -e DD_SBOM_ENABLED=true \
+  -e DD_SBOM_CONTAINER_IMAGE_ENABLED=true \
+  -e DD_SBOM_ENRICHMENT_USAGE_ENABLED=true \
+  -e DD_API_KEY=<API KEY> \
+  registry.datadoghq.com/agent:7
+{{< /code-block >}}
+
+**Note**: `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][4] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
+
 [1]: /security/cloud_security_management/misconfigurations/
 [2]: /security/threats
 [3]: /security/cloud_security_management/setup#supported-deployment-types-and-features
+[4]: /security/workload_protection/

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -99,16 +99,14 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
 
 {{< /tabs >}}
 
+**Note**: The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages. When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
+
 ### Supported application library package managers
-
-The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages.
-
-When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
 
 The `languages` analyzer covers the following package ecosystems:
 
 | Ecosystem | Package manager/format |
-|-----------|--------------------------|
+|-----------|------------------------|
 | Ruby | Bundler, GemSpec |
 | Rust | Cargo, Rust binary |
 | PHP | Composer |
@@ -123,6 +121,70 @@ The `languages` analyzer covers the following package ecosystems:
 | Elixir | Mix lock |
 | Julia | Julia |
 
+## Runtime Package Tracking (Preview)
+
+Runtime package tracking enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+
+Each vulnerability finding is enriched with the following signals:
+
+| Signal | Description |
+|--------|-------------|
+| Package is running | The package files are actively being accessed by running processes. |
+| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
+
+These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+
+**Requirements**:
+- Datadog Agent **7.78.0 or later**
+- Linux only (eBPF dependency)
+
+**Important**: Enabling runtime package tracking activates [Workload Protection][8] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+
+{{< tabs >}}
+
+{{% tab "Datadog Operator" %}}
+
+Add the `enrichment` block to the `sbom` section of your `datadog-agent.yaml` file:
+
+```yaml
+spec:
+  features:
+    sbom:
+      enabled: true
+      containerImage:
+        enabled: true
+      # Enables runtime package tracking (Preview, Agent 7.78+)
+      enrichment:
+        usage:
+          enabled: true
+```
+
+Apply the changes and restart the Agent.
+
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+
+Add the `enrichment` block to the `sbom` section of your `datadog-values.yaml` file:
+
+```yaml
+datadog:
+  sbom:
+    containerImage:
+      enabled: true
+    # Enables runtime package tracking (Preview, Agent 7.78+)
+    enrichment:
+      usage:
+        enabled: true
+```
+
+Restart the Agent.
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
 [1]: /security/cloud_security_management/misconfigurations/
 [2]: /security/threats
 [3]: /security/cloud_security_management/vulnerabilities
@@ -130,3 +192,4 @@ The `languages` analyzer covers the following package ecosystems:
 [5]: /getting_started/agent
 [6]: https://app.datadoghq.com/account/settings/agent/latest
 [7]: https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable
+[8]: /security/workload_protection/

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -56,6 +56,12 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
             enabled: true
             # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
             analyzers: ["os", "languages"]
+
+          # Enables runtime package prioritization (Preview, Agent 7.78+)
+          # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+          enrichment:
+            usage:
+              enabled: true
     ```
 
 2. Apply the changes and restart the Agent.
@@ -91,6 +97,12 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
           enabled: true
           # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
           analyzers: ["os", "languages"]
+
+        # Enables runtime package prioritization (Preview, Agent 7.78+)
+        # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+        enrichment:
+          usage:
+            enabled: true
     ```
 
 2. Restart the Agent.
@@ -98,6 +110,8 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
 {{% /tab %}}
 
 {{< /tabs >}}
+
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][8] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
 
 **Note**: The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages. When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
 
@@ -154,7 +168,7 @@ spec:
       enabled: true
       containerImage:
         enabled: true
-      # Enables runtime package tracking (Preview, Agent 7.78+)
+      # Enables runtime package prioritization (Preview, Agent 7.78+)
       enrichment:
         usage:
           enabled: true
@@ -173,7 +187,7 @@ datadog:
   sbom:
     containerImage:
       enabled: true
-    # Enables runtime package tracking (Preview, Agent 7.78+)
+    # Enables runtime package prioritization (Preview, Agent 7.78+)
     enrichment:
       usage:
         enabled: true

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -56,15 +56,13 @@ compliance_config:
     enabled: true
 {{< /code-block >}}
 
+**Note**: The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by package managers such as npm, pip, Maven/Gradle, NuGet, Go modules, Cargo, and Bundler, in addition to OS packages. When the `analyzers` field is omitted, only OS packages are scanned for container images. See [Supported application library package managers](#supported-application-library-package-managers) for the full list.
+
 ### Supported application library package managers
-
-The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages.
-
-When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
 
 The `languages` analyzer covers the following package ecosystems:
 
-| Ecosystem | Package manager/format |
+| Ecosystem | Package manager / format |
 |-----------|--------------------------|
 | Ruby | Bundler, GemSpec |
 | Rust | Cargo, Rust binary |
@@ -79,6 +77,41 @@ The `languages` analyzer covers the following package ecosystems:
 | Dart | PubSpec lock |
 | Elixir | Mix lock |
 | Julia | Julia |
+
+## Runtime Package Tracking (Preview)
+
+Runtime package tracking enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+
+Each vulnerability finding is enriched with the following signals:
+
+| Signal | Description |
+|--------|-------------|
+| Package is running | The package files are actively being accessed by running processes. |
+| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
+
+These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+
+**Requirements**:
+- Datadog Agent **7.78.0 or later**
+- Linux only (eBPF dependency)
+
+**Important**: Enabling runtime package tracking activates [Workload Protection][7] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+
+Add the `enrichment` block to the `sbom` section of your `datadog.yaml` file:
+
+{{< code-block lang="bash" filename="/etc/datadog-agent/datadog.yaml" disable_copy="false" collapsible="true" >}}
+sbom:
+  enabled: true
+  container_image:
+    enabled: true
+  # Enables runtime package tracking (Preview, Agent 7.78+)
+  enrichment:
+    usage:
+      enabled: true
+{{< /code-block >}}
+
+Restart the Agent after applying the changes.
 
 **Notes**:
 
@@ -102,3 +135,4 @@ sudo chgrp dd-agent /etc/datadog-agent/security-agent.yaml
 [4]: /security/cloud_security_management/setup#supported-deployment-types-and-features
 [5]: /getting_started/agent/#installation
 [6]: /agent/?tab=Linux
+[7]: /security/workload_protection/

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -44,7 +44,14 @@ sbom:
     enabled: true
     # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
     analyzers: ["os", "languages"]
+  # Enables runtime package prioritization (Preview, Agent 7.78+)
+  # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+  enrichment:
+    usage:
+      enabled: true
 {{< /code-block >}}
+
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][7] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
 
 {{< code-block lang="bash" filename="/etc/datadog-agent/security-agent.yaml" disable_copy="false" collapsible="true" >}}
 compliance_config:
@@ -105,7 +112,7 @@ sbom:
   enabled: true
   container_image:
     enabled: true
-  # Enables runtime package tracking (Preview, Agent 7.78+)
+  # Enables runtime package prioritization (Preview, Agent 7.78+)
   enrichment:
     usage:
       enabled: true


### PR DESCRIPTION
## What

Documents the new `sbom.enrichment.usage.enabled` flag introduced in Datadog Agent **7.78.0**, which enables runtime package tracking for prioritization in Cloud Security Vulnerability Management.

## Why

Agent 7.78.0 ships three new runtime enrichment signals that power vulnerability prioritization in Cloud Security:
- **Package is running** — whether the package's files are actively accessed by running processes
- **Accessed by root process** — whether a process running as root (UID 0) has accessed the package
- **SUID binary present** — whether the package contains a binary with the SUID bit set

These signals are not documented anywhere in the public docs today. Users cannot discover or enable them without this page. These are 3 core capabilities to empower advanced runtime prioritization for Cloud Security findings.

## Changes

### `setup/agent/kubernetes.md`
- Added `## Runtime Package Tracking (Preview)` section with Datadog Operator and Helm config snippets
- Minor: moved the languages analyzer note before `### Supported application library package managers` (it was placed after the header in the source, which is an odd structure)
- Added `[8]` link to `/security/workload_protection/`

### `setup/agent/linux.md`
- Added `## Runtime Package Tracking (Preview)` section with `datadog.yaml` code block
- Added `[7]` link to `/security/workload_protection/`

## Important notes for reviewers

- The feature is in **Preview** — made explicit in the section title and agent version requirement
- The **cost warning** is included: enabling this flag activates Workload Protection for eBPF-based file access monitoring, which may trigger Workload Protection usage and costs
- Config flag confirmed with agent team (Sylvain Baubeau, Paul Cacheux): `sbom.enrichment.usage.enabled: true`
- Operator syntax: `enrichment.usage.enabled: true` under `spec.features.sbom`
- Helm syntax: `enrichment.usage.enabled: true` under `datadog.sbom`
- Host syntax: `enrichment.usage.enabled: true` under `sbom` in `datadog.yaml`
- Agent 7.78.0 required, Linux only (eBPF)

## Testing

- [ ] Preview builds correctly on both pages
- [ ] Link to `/security/workload_protection/` resolves
- [ ] Code snippets render in tabs (Operator / Helm for Kubernetes page)
- [ ] Preview label visible in section title