### PR TITLE
Add Lapdog Uninstall section and sidebar nav entry

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5303,11 +5303,16 @@ menu:
       parent: llm_obs_instrumentation
       identifier: llm_obs_instrumentation_trace_proxy_services
       weight: 205
+    - name: Lapdog
+      url: llm_observability/lapdog
+      parent: llm_obs
+      identifier: llm_obs_lapdog
+      weight: 3
     - name: Monitoring
       url: llm_observability/monitoring
       parent: llm_obs
       identifier: llm_obs_monitoring
-      weight: 3
+      weight: 4
     - name: Querying spans and traces
       url: llm_observability/monitoring/querying
       parent: llm_obs_monitoring
@@ -5356,7 +5361,7 @@ menu:
       url: llm_observability/evaluations/
       parent: llm_obs
       identifier: llm_obs_evaluations
-      weight: 4
+      weight: 5
     - name: Custom LLM-as-a-Judge
       url: llm_observability/evaluations/custom_llm_as_a_judge_evaluations
       parent: llm_obs_evaluations
@@ -5436,7 +5441,7 @@ menu:
       url: llm_observability/experiments
       parent: llm_obs
       identifier: llm_obs_experiments
-      weight: 5
+      weight: 6
     - name: Setup and Usage
       url: llm_observability/experiments/setup
       parent: llm_obs_experiments
@@ -5476,22 +5481,22 @@ menu:
       url: llm_observability/mcp_server
       parent: llm_obs
       identifier: llm_obs_mcp_server
-      weight: 6
+      weight: 7
     - name: Data Security and RBAC
       url: llm_observability/data_security_and_rbac
       parent: llm_obs
       identifier: llm_obs_data_security_and_rbac
-      weight: 7
+      weight: 8
     - name: Terms and Concepts
       url: llm_observability/terms/
       parent: llm_obs
       identifier: llm_obs_terms
-      weight: 8
+      weight: 9
     - name: Guides
       url: llm_observability/guide/
       parent: llm_obs
       identifier: llm_obs_guide
-      weight: 9
+      weight: 10
     - name: GPU Monitoring
       url: gpu_monitoring/
       pre: gpu-monitoring-wui

--- a/content/en/llm_observability/lapdog.md
+++ b/content/en/llm_observability/lapdog.md
@@ -54,7 +54,7 @@ Lapdog instruments coding agents end-to-end. Each prompt, tool call, and permiss
 ```shell
 lapdog claude
 ```
-Starts the local agent, installs the Claude Code lapdog plugin, and launches Claude Code with hooks wired up.
+Starts the local agent, installs the Claude Code lapdog plugin, and launches Claude Code.
 {{% /tab %}}
 {{% tab "Codex" %}}
 ```shell
@@ -154,11 +154,8 @@ Follow these steps to remove Lapdog and the state it writes to your home directo
    {{% /tab %}}
    {{< /tabs >}}
 
-If you used `lapdog --hooks claude` to write hook entries into `~/.claude/settings.json`, see the [Lapdog uninstall guide][2] for the `jq` recipe that strips them cleanly.
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-apm-test-agent/blob/master/lapdog/README.md
-[2]: https://github.com/DataDog/dd-apm-test-agent/blob/master/lapdog/README.md#uninstallation

--- a/content/en/llm_observability/lapdog.md
+++ b/content/en/llm_observability/lapdog.md
@@ -4,7 +4,7 @@ description: "Run an LLM Observability dashboard locally to inspect coding-agent
 further_reading:
     - link: 'https://github.com/DataDog/dd-apm-test-agent/blob/master/lapdog/README.md'
       tag: 'GitHub'
-      text: 'Lapdog install and usage guide'
+      text: 'Lapdog README on GitHub'
     - link: '/llm_observability/instrumentation/sdk'
       tag: 'Documentation'
       text: 'Instrument your application with the LLM Observability SDK'
@@ -108,8 +108,57 @@ Forwarded spans are tagged `source:lapdog` so you can distinguish development se
 
 For the full list of options, run `lapdog --help`.
 
+## Uninstall
+
+Follow these steps to remove Lapdog and the state it writes to your home directory. Your package manager (Homebrew, pip, or pipx) cleans up only what it installed; it does not touch `~/.lapdog/`, the Claude Code plugin, or the pi extension.
+
+### 1. Stop the local agent
+
+```shell
+lapdog stop
+```
+
+### 2. Remove the Claude Code plugin (if installed)
+
+```shell
+claude plugin uninstall lapdog@lapdog
+claude plugin marketplace remove lapdog
+```
+
+### 3. Remove the pi extension (only if you ran `lapdog pi`)
+
+```shell
+rm -f ~/.pi/agent/extensions/lapdog.ts
+```
+
+### 4. Remove the Lapdog working directory
+
+```shell
+rm -rf ~/.lapdog
+```
+
+### 5. Uninstall the package
+
+{{< tabs >}}
+{{% tab "Homebrew (macOS)" %}}
+```shell
+brew uninstall lapdog
+brew untap datadog/lapdog
+```
+{{% /tab %}}
+{{% tab "pip / pipx" %}}
+```shell
+pipx uninstall ddapm-test-agent
+# or: pip uninstall ddapm-test-agent
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+If you used `lapdog --hooks claude` to write hook entries into `~/.claude/settings.json`, see the [Lapdog uninstall guide][2] for the `jq` recipe that strips them cleanly.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-apm-test-agent/blob/master/lapdog/README.md
+[2]: https://github.com/DataDog/dd-apm-test-agent/blob/master/lapdog/README.md#uninstallation

--- a/content/en/llm_observability/lapdog.md
+++ b/content/en/llm_observability/lapdog.md
@@ -112,47 +112,47 @@ For the full list of options, run `lapdog --help`.
 
 Follow these steps to remove Lapdog and the state it writes to your home directory. Your package manager (Homebrew, pip, or pipx) cleans up only what it installed; it does not touch `~/.lapdog/`, the Claude Code plugin, or the pi extension.
 
-### 1. Stop the local agent
+1. Stop the local agent:
 
-```shell
-lapdog stop
-```
+   ```shell
+   lapdog stop
+   ```
 
-### 2. Remove the Claude Code plugin (if installed)
+2. Remove the Claude Code plugin (if installed):
 
-```shell
-claude plugin uninstall lapdog@lapdog
-claude plugin marketplace remove lapdog
-```
+   ```shell
+   claude plugin uninstall lapdog@lapdog
+   claude plugin marketplace remove lapdog
+   ```
 
-### 3. Remove the pi extension (only if you ran `lapdog pi`)
+3. Remove the pi extension (only if you ran `lapdog pi`):
 
-```shell
-rm -f ~/.pi/agent/extensions/lapdog.ts
-```
+   ```shell
+   rm -f ~/.pi/agent/extensions/lapdog.ts
+   ```
 
-### 4. Remove the Lapdog working directory
+4. Remove the Lapdog working directory:
 
-```shell
-rm -rf ~/.lapdog
-```
+   ```shell
+   rm -rf ~/.lapdog
+   ```
 
-### 5. Uninstall the package
+5. Uninstall the package:
 
-{{< tabs >}}
-{{% tab "Homebrew (macOS)" %}}
-```shell
-brew uninstall lapdog
-brew untap datadog/lapdog
-```
-{{% /tab %}}
-{{% tab "pip / pipx" %}}
-```shell
-pipx uninstall ddapm-test-agent
-# or: pip uninstall ddapm-test-agent
-```
-{{% /tab %}}
-{{< /tabs >}}
+   {{< tabs >}}
+   {{% tab "Homebrew (macOS)" %}}
+   ```shell
+   brew uninstall lapdog
+   brew untap datadog/lapdog
+   ```
+   {{% /tab %}}
+   {{% tab "pip / pipx" %}}
+   ```shell
+   pipx uninstall ddapm-test-agent
+   # or: pip uninstall ddapm-test-agent
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
 If you used `lapdog --hooks claude` to write hook entries into `~/.claude/settings.json`, see the [Lapdog uninstall guide][2] for the `jq` recipe that strips them cleanly.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Lapdog page shipped without a sidebar nav entry, so it was only reachable by search or direct link. It also had no on-page uninstall procedure, sending users to the GitHub README for teardown steps.

This PR:

- Adds an **Uninstall** section to \`content/en/llm_observability/lapdog.md\` so the procedure (stop the agent, remove the Claude Code plugin and pi extension, delete \`~/.lapdog\`, then uninstall the package) lives on the docs page. The static dashboard's "Collecting sessions" popover deep-links to the new \`#uninstall\` anchor.
- Adds a **Lapdog** entry to the LLM Observability sidebar in \`config/_default/menus/main.en.yaml\`, placed between Instrumentation and Monitoring. The following top-level entries (Monitoring, Evaluations, Experiments, MCP Server, Data Security and RBAC, Terms and Concepts, Guides) get their \`weight\` bumped by 1 to make room. Sub-entry weights are unchanged (they sort relative to their parent).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Vale was not run locally (binary not installed in my dev environment). Will rely on CI's Vale check.

Claude session: \`1e26db38-e2e5-41d5-b214-b4a8c11b8ddb\`
Resume: \`claude --resume 1e26db38-e2e5-41d5-b214-b4a8c11b8ddb\`