### PR TITLE
Fix Kafka Monitoring callout UTM tracking (trailing slash)

### DIFF
--- a/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/content/en/tracing/guide/monitor-kafka-queues.md
@@ -17,7 +17,7 @@ further_reading:
 <div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
   <p style="margin:0;line-height:1.5;">
     <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
-    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try Kafka Monitoring &rarr;</a>
+    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka/?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try Kafka Monitoring &rarr;</a>
   </p>
 </div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes a UTM-tracking bug in the Kafka Monitoring callout that was previously merged. The current link points to `/data_streams/kafka?utm_*` (no trailing slash). That URL returns a 302 redirect to `/data_streams/kafka/` (with trailing slash) — and the redirect **strips the query string**, so all UTM tracking is lost before it reaches RUM.

### Verification

```
$ curl -I "https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_campaign=DocsCTA-DSMKafka-TracingGuide"
HTTP/2 302
location: /data_streams/kafka/      ← UTM query string dropped

$ curl -I "https://docs.datadoghq.com/data_streams/kafka/?utm_source=docs&utm_campaign=DocsCTA-DSMKafka-TracingGuide"
HTTP/2 200                          ← UTM preserved
```

Also verified empirically — the campaign tracking dashboard ([dz7-28r-bru](https://dd-corpsite.datadoghq.com/dashboard/dz7-28r-bru)) showed zero `utm_campaign:*DSMKafka*` views in RUM across the 4 days since the original PR merged.

### Fix

One-character change: add a trailing slash to the URL in the callout.

### Related PRs

Same fix landing in the sibling repos:
- DataDog/integrations-core (kafka README)
- DataDog/corp-hugo (kafka-dashboard page)

### Merge readiness
- [x] Ready for merge

### AI assistance
Drafted with Claude Code; root cause diagnosed via direct RUM query against the docs Documentation app.