### PR TITLE
Update Datadog apps documentation for pre-release

### DIFF
--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -18,14 +18,14 @@ further_reading:
 
 With Apps, you build applications locally as code with React and TypeScript (or JavaScript), using your standard development workflow.
 
-Apps use the same [permissions model][1] as App Builder apps and can also be embedded in other Datadog products such as [dashboards and the Internal Developer Portal][2].
+Apps use the same [permissions model][1] as [App Builder apps][2]. You can also embed them in other Datadog products, such as [dashboards and the Internal Developer Portal][3].
 
 Choose Apps when you need:
 
 - **Team collaboration**: Multiple engineers contributing to the same app, with code review and version history through your existing source control.
 - **Source control and CI/CD**: Store your app in GitHub and deploy automatically on merge.
 - **AI-assisted development**: Use your preferred local tooling (such as Cursor, GitHub Copilot, or Claude) to generate and refine code.
-- **Custom cloud providers and APIs**: Integrate with services beyond the [Action Catalog][3] using your own backend code.
+- **Custom cloud providers and APIs**: Integrate with services beyond the [Action Catalog][4] using your own backend code.
 - **Complex UI and logic**: Full React and TypeScript control over components, state, and rendering.
 
 ## Prerequisites
@@ -34,25 +34,21 @@ Choose Apps when you need:
   ```shell
   node --version
   ```
-- A Datadog **API key** and an **application key** with Actions API Access enabled. For instructions on creating keys, see [API and Application Keys][4].
+- A Datadog **API key** and an **application key** with [Actions API Access][5] enabled. For instructions on creating keys, see [API and Application Keys][6].
 
   To enable Actions API Access on an application key:
 
-  1. Navigate to [**Organization Settings > Application Keys**][5].
+  1. Navigate to [**Organization Settings > Application Keys**][7].
   1. Select your application key.
   1. Enable **Actions API Access**.
 
 ## Scaffold an app
 
-1. Run the scaffolding command to create a new app:
+1. Run the scaffolding command to create an app:
    ```shell
-   npm create @datadog/apps
+   npm create @datadog/apps@latest
    ```
 2. Follow the interactive prompts to configure your app name and template.
-3. (Optional) Set up [Datadog RUM][6] for the app. This automatically sets up the Browser SDK for:
-   - Real User Monitoring (RUM)
-   - Error Tracking
-   - Build metrics
 
 ### Generated app structure
 
@@ -61,9 +57,9 @@ The scaffolded project includes:
 | File or directory | Description |
 |---|---|
 | `src/App.tsx` | Root UI component (React) |
-| `src/**/*.backend.ts` | Backend functions that run server-side with access to API keys |
-| `vite.config.ts` | Build configuration with [`@datadog/vite-plugin`][7] pre-configured |
-| `package.json` | Dependencies and scripts (`dev`, `build`) |
+| `src/**/*.backend.ts` | Backend functions that run server-side with access to [Datadog connections][8] |
+| `vite.config.ts` | Build configuration with [`@datadog/vite-plugin`][9] pre-configured |
+| `package.json` | Dependencies and scripts (`dev`, `build`, `upload`) |
 
 ## Develop your app locally
 
@@ -80,13 +76,13 @@ The scaffolded project includes:
    npm run dev
    ```
 
-3. Open the URL shown in the terminal (`http://localhost:5173/`) to preview your app.
+3. Open the URL shown in the terminal (for example, `http://localhost:5173/`) to preview your app.
 
 ### Backend functions
 
-Files matching `*.backend.ts` or `*.js` contain backend functions. Backend functions run server-side with access to your API keys and are never shipped to the browser. The frontend imports and calls them like standard ES modules.
+Files matching `*.backend.ts` or `*.backend.js` contain backend functions. Backend functions run server-side with access to your [connections][8]. The frontend imports and calls them like standard ES modules.
 
-Backend functions can call any action in Datadog's [Action Catalog][3] through the [`@datadog/action-catalog`][8] library. The Action Catalog provides reusable, pre-built actions for interacting with cloud providers, SaaS tools, and the Datadog API, so you can build functionality on top of existing integrations instead of writing API clients from scratch.
+Backend functions can call any action in Datadog's [Action Catalog][4] through the [`@datadog/action-catalog`][10] library. The Action Catalog provides reusable, prebuilt actions for interacting with cloud providers, SaaS tools, and the Datadog API. You can build on top of existing integrations instead of writing API clients from scratch.
 
 The library is a fully typed TypeScript client that wraps integrations, including AWS, Azure, GCP, the Datadog API, GitHub, GitLab, Slack, Jira, PagerDuty, ServiceNow, OpenAI, Anthropic, and generic HTTP. Importing actions from `@datadog/action-catalog` gives you typed inputs and responses for each action.
 
@@ -138,43 +134,37 @@ export default App;
 ```
 {{% /collapse-content %}}
 
-## Upload your app
+## Build and upload your app
 
-Run a production build to upload your app to Datadog:
+Use `npm run build` to build the app locally without uploading it. This is the recommended default for local development, where you typically don't want to upload every build.
+
+Use `npm run upload` to build and upload the app to Datadog. This runs `vite build` with `DD_APPS_UPLOAD_ASSETS=1`.
 
 ```shell
-npm run build
+npm run upload
 ```
 
-The following environment variables are available with `npm run build`:
+The following environment variables are available:
 
 | Variable | Description |
 |---|---|
 | `DD_API_KEY` | Datadog API key. |
 | `DD_APP_KEY` | Datadog application key. |
 | `DD_APPS_VERSION_NAME` | Optional. The version name for the uploaded app version. Must be a unique string per app. If unset, Datadog assigns a version name. |
-| `DD_APPS_UPLOAD_ASSETS` | If set and `dryRun` is `false`, uploads built assets to Datadog when you run `npm run build`. |
+| `DD_APPS_UPLOAD_ASSETS` | If set, uploads built assets to Datadog. Set automatically by `npm run upload`. |
 
-By default, `npm run build` runs in dry run mode, which builds the app without uploading it to Datadog. Dry run mode is the recommended default for local development, where you typically don't want to upload every local build.
-
-For production deployments, [set up CI/CD with GitHub Actions](#set-up-cicd-with-github-actions). [`DataDog/apps-github-action`][9] handles the upload step for you, so you don't need to change `dryRun` for this workflow.
-
-To upload from your local environment as an end-to-end test (for example, to verify that the build pipeline works before a release), set `DD_APPS_UPLOAD_ASSETS`:
-
-```shell
-DD_APPS_UPLOAD_ASSETS=1 npm run build
-```
+For production deployments, [set up CI/CD with GitHub Actions](#set-up-cicd-with-github-actions). [`DataDog/apps-github-action`][11] handles the upload step for you.
 
 After a successful upload, the build output displays a URL where your app is accessible in Datadog.
 
 ## Publish and manage your apps
 
-After you upload an app, it appears in your [App Builder][10] app list. From App Builder, you can:
+After you upload an app, it appears in your [App Builder][12] app list. From App Builder, you can:
 
-- [Publish your app][11]
-- [Edit the app name and description][11]
-- Manage [permissions][12]
-- [Embed the app][2] in dashboards, notebooks, and the Internal Developer Portal
+- [Publish your app][13]
+- [Edit the app name and description][13]
+- Manage [permissions][14]
+- [Embed the app][3] in dashboards, notebooks, and the Internal Developer Portal
 
 <div class="alert alert-danger">
 The following App Builder features are not available for locally-built apps:
@@ -182,14 +172,14 @@ The following App Builder features are not available for locally-built apps:
 <li>UI editing with drag-and-drop components</li>
 <li>Variables, events, and expressions managed in the App Builder UI</li>
 </ul>
-To change an app's UI or logic, update the code in your local project and redeploy.
+To change an app's UI or logic, update the code in your local project and re-upload.
 </div>
 
 ## Set up CI/CD with GitHub Actions
 
-To automatically deploy your app on every push to the `main` branch, use the [`DataDog/apps-github-action`][9] GitHub Action. This action builds your app and deploys it to Datadog.
+To automatically upload your app on every push to the `main` branch, use the [`DataDog/apps-github-action`][11] GitHub Action. This action builds your app and uploads it to Datadog.
 
-If your organization is not on US1 (`datadoghq.com`), set `auth.site` in `vite.config.ts` to your [Datadog site][13]. The build reads this configuration when uploading the app, so the same setting also applies to local development. Your Datadog site is `{{< region-param key="dd_site" >}}`.
+If your organization is not on US1 (`datadoghq.com`), set `auth.site` in `vite.config.ts` to your [Datadog site][15]. The build reads this configuration when uploading the app, so the same setting also applies to local development. Your Datadog site is `{{< region-param key="dd_site" >}}`.
 
 {{< site-region region="us3,us5,eu,ap1,ap2" >}}
 
@@ -230,7 +220,7 @@ jobs:
         uses: actions/setup-node@v6
 
       - name: Deploy
-        uses: DataDog/apps-github-action@v0.0.1
+        uses: DataDog/apps-github-action@v0.0.2
         with:
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
           datadog-app-key: ${{ secrets.DATADOG_APP_KEY }}
@@ -241,34 +231,36 @@ jobs:
 
 ### Authentication errors
 
-For authentication errors (such as 401 or `Missing authentication token`), or backend function call failures, verify that `DD_API_KEY` and `DD_APP_KEY` are set and that the application key has Actions API Access enabled.
+Authentication errors (such as 401 or `Missing authentication token`) and backend function call failures usually point to missing or invalid credentials. Verify that `DD_API_KEY` and `DD_APP_KEY` are set, and that the application key has [Actions API Access][5] enabled.
 
 ### Build succeeds but nothing uploads
 
-The build defaults to dry run mode. Set `DD_APPS_UPLOAD_ASSETS=1` or configure `dryRun: false` in `vite.config.ts`.
+Make sure you ran `npm run upload` (not `npm run build`), and that `dryRun` in `vite.config.ts` is not set to `true`.
 
 ### Node.js version errors during scaffolding
 
-The scaffolding tool requires Node.js v20.12.0 or later. If you still encounter version errors on a supported version, try upgrading to v22. Use a version manager such as [nvm][14], [Volta][15], or [fnm][16], or download from [nodejs.org][17].
+The scaffolding tool requires Node.js 20.12.0 or later. If you see errors even on a supported version, upgrade to v22. Use a version manager such as [nvm][16], [Volta][17], or [fnm][18], or download from [nodejs.org][19].
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /actions/app_builder/access_and_auth/
-[2]: /actions/app_builder/embedded_apps/
-[3]: /actions/actions_catalog/
-[4]: /account_management/api-app-keys/
-[5]: https://app.datadoghq.com/organization-settings/application-keys
-[6]: /real_user_monitoring/
-[7]: https://github.com/DataDog/build-plugin
-[8]: https://www.npmjs.com/package/@datadog/action-catalog
-[9]: https://github.com/DataDog/apps-github-action
-[10]: https://app.datadoghq.com/app-builder/apps/list
-[11]: /actions/app_builder/build/#customize-your-app
-[12]: /actions/app_builder/access_and_auth/#app-permissions
-[13]: /getting_started/site/
-[14]: https://github.com/nvm-sh/nvm
-[15]: https://volta.sh
-[16]: https://github.com/Schniz/fnm
-[17]: https://nodejs.org
+[2]: /actions/app_builder/
+[3]: /actions/app_builder/embedded_apps/
+[4]: /actions/actions_catalog/
+[5]: /account_management/api-app-keys/#actions-api-access
+[6]: /account_management/api-app-keys/
+[7]: https://app.datadoghq.com/organization-settings/application-keys
+[8]: /actions/connections/
+[9]: https://github.com/DataDog/build-plugin
+[10]: https://www.npmjs.com/package/@datadog/action-catalog
+[11]: https://github.com/DataDog/apps-github-action
+[12]: https://app.datadoghq.com/app-builder/apps/list
+[13]: /actions/app_builder/build/#customize-your-app
+[14]: /actions/app_builder/access_and_auth/#app-permissions
+[15]: /getting_started/site/
+[16]: https://github.com/nvm-sh/nvm
+[17]: https://volta.sh
+[18]: https://github.com/Schniz/fnm
+[19]: https://nodejs.org


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Datadog Apps documentation to reflect changes in the pre-release scaffolded template and align the page with editorial standards.

**Build/upload workflow:**
- Documents that `npm run build` now builds locally without uploading, and `npm run upload` builds and uploads to Datadog (sets `DD_APPS_UPLOAD_ASSETS=1` and runs `vite build`).
- Renames the "Upload your app" section to "Build and upload your app".
- Removes stale references to dry-run mode and the manual `DD_APPS_UPLOAD_ASSETS=1 npm run build` workaround.
- Bumps the documented `DataDog/apps-github-action` to `v0.0.2`.

**Content accuracy:**
- Replaces "access to your API keys" with a link to Datadog connections, since backend functions authenticate through connections.
- Fixes the backend file glob from `*.backend.ts` or `*.js` to `*.backend.ts` or `*.backend.js`.
- Updates `npm create @datadog/apps` to `npm create @datadog/apps@latest`.
- Removes the optional RUM setup step from scaffolding (no longer surfaced by the scaffolder).
- Adds a link to the Actions API Access docs in Prerequisites and in the authentication troubleshooting entry.
- Rewrites the "Build succeeds but nothing uploads" troubleshooting entry to point users at the new `npm run upload` command.

**Editorial cleanup (Vale):**
- "create a new app" → "create an app"
- "pre-built" → "prebuilt"
- Removes "Under the hood"
- Tightens long sentences in Overview, Backend functions, and Troubleshooting.
- Removes an unused link reference and renumbers all link references sequentially in order of first appearance.
- Drops the trailing `v` from `Node.js v20.12.0` for consistency with the prereqs section.
- Replaces "redeploy" / "deploys" with "re-upload" / "uploads" for consistency with the new command naming.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Used Claude Code to draft revisions, run Vale, and renumber link references; manually reviewed and accepted each change.

### Additional notes