### PR TITLE
[WP]Updating pull_config and pull_config_preview glob paths for workload-security 

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -377,8 +377,8 @@
         - action: security-rules
           branch: main
           globs:
-            - "workload-security/backend-rules/*.yaml"
-            - "workload-security/backend-rules/*.md"
+            - "workload-security/backend-rules/**/*.yaml"
+            - "workload-security/backend-rules/**/*.md"
             - "cloud-siem/**/*.json"
             - "cloud-siem/**/*.md"
             - "posture-management/**/*.json"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -378,8 +378,8 @@
         - action: security-rules
           branch: main
           globs:
-            - "workload-security/backend-rules/*.yaml"
-            - "workload-security/backend-rules/*.md"
+            - "workload-security/backend-rules/**/*.yaml"
+            - "workload-security/backend-rules/**/*.md"
             - "cloud-siem/**/*.json"
             - "cloud-siem/**/*.md"
             - "posture-management/**/*.json"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updating pull_config and pull_config_preview glob paths for workload-security to account for a recent structure change to back-end rules from [PR #7676](https://github.com/DataDog/security-monitoring/pull/7676) 
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

