### PR TITLE
[DOCS-14405, DOCS-14406, DOCS-14411] Add US1-FED/US2-FED unsupported banners

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  actions_catalog: [gov,gov2]
   adaptive_sampling: [gov,gov2]
   advanced_analysis: [gov,gov2]
   agent_builder: [gov,gov2]
@@ -332,6 +333,7 @@ unsupported_sites:
   fips-proxy: [us,us3,us5,eu,ap1,ap2,gov2]
   fleet_automation: [gov,gov2]
   forwarding_audit_events: [gov,gov2]
+  forms: [gov,gov2]
   gcp-private-service-connect: [us,us3,gov,gov2,ap1,ap2]
   getting_started_feature_flags: [gov,gov2]
   gitlab-source-code: [gov,gov2]

--- a/content/en/incident_response/incident_management/post_incident/follow-ups.md
+++ b/content/en/incident_response/incident_management/post_incident/follow-ups.md
@@ -30,6 +30,10 @@ By capturing these items as follow-ups, your team can stay focused on incident r
 
 ## AI-suggested follow-up tasks
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">AI-suggested follow-up tasks are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 After an incident is resolved, Incident AI scans the incident channel for follow-up tasks that responders mentioned during the incident. It then prompts you to review and create them with a single click. Tasks saved this way appear as Incident Follow-ups in Datadog Incident Management.
 
 To view AI-suggested follow-up tasks:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-14405](https://datadoghq.atlassian.net/browse/DOCS-14405), [DOCS-14406](https://datadoghq.atlassian.net/browse/DOCS-14406), [DOCS-14411](https://datadoghq.atlassian.net/browse/DOCS-14411)

Adds unsupported site banners for US1-FED and US2-FED across three pages:

- **Action Catalog**: Adds `actions_catalog: [gov,gov2]` to `unsupported_sites` in `params.yaml` to render the banner on the Action Catalog page for US1-FED and US2-FED.
- **Forms**: Adds `forms: [gov,gov2]` to `unsupported_sites` in `params.yaml` to mark the Actions Forms page as unsupported on US1-FED and US2-FED.
- **Incident follow-ups**: Manually inserts a `site-region` partial in the AI-suggested follow-up tasks section of the Incident follow-ups page to mark that feature as unsupported on US1-FED only.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14405]: https://datadoghq.atlassian.net/browse/DOCS-14405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14406]: https://datadoghq.atlassian.net/browse/DOCS-14406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14411]: https://datadoghq.atlassian.net/browse/DOCS-14411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ