### PR TITLE
(maint) Remove core.setFailed() from update-pr-status

### DIFF
--- a/.github/workflows/codeowner_review_status.yml
+++ b/.github/workflows/codeowner_review_status.yml
@@ -148,7 +148,7 @@ jobs:
 
             // Set final status
             if (isDocumentationTeamRequested && !hasDocumentationApproval) {
-              core.setFailed(`Team approval required from @${owner}/${DOCUMENTATION_TEAM} or @${owner}/${WEBOPSTEAM}`);
+              console.log(`Team approval still required from @${owner}/${DOCUMENTATION_TEAM} or @${owner}/${WEBOPSTEAM}`);
             } else if (!isDocumentationTeamRequested) {
               console.log('Documentation team review not required for this PR.');
             } else {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This failing check continues to cause confusion. It doesn't look like it actually has to be set to fail though cos `core.setOutput` on line 146 is doing that bit. 

### Merge instructions


Merge readiness:
- [ ] Ready for merge

### AI assistance

Got some troubleshooting help from Claude
