### PR TITLE
[DOCS-12566] Update Flex Logs toggle description to match UI tooltip

### DIFF
--- a/content/en/dashboards/configure/_index.md
+++ b/content/en/dashboards/configure/_index.md
@@ -66,7 +66,7 @@ Click {{< ui >}}Configure{{< /ui >}} to open a menu of configuration options ava
 | ----------- | ----------- |
 | {{< ui >}}Clone dashboard{{< /ui >}} | Copy the entire dashboard to a new dashboard. You are prompted to name the clone. |
 | {{< ui >}}Display UTC time{{< /ui >}} | Toggle between UTC time and your default time zone. |
-| {{< ui >}}Include Flex Logs{{< /ui >}} | Toggle to include [Flex Logs][3] in all Flex-configured widgets. When off, widgets use [Standard Indexed][4] logs instead. |
+| {{< ui >}}Include Flex Logs{{< /ui >}} | Toggle to include [Flex Logs][3] in all Flex-configured widgets. When off, widgets use [Standard Indexed][4] logs instead. This is a user-level preference that persists across sessions for this dashboard. |
 | {{< ui >}}Increase density{{< /ui >}} | High-density mode displays group widgets in a dashboard side-by-side for increased widget density. This mode turns on by default on large screens for dashboards that use group widgets. |
 | {{< ui >}}Keyboard&nbsp;shortcuts{{< /ui >}} | View a list of available keyboard shortcuts. |
 | {{< ui >}}Pause Auto-Refresh{{< /ui >}} | Pause automatic refresh by default for dashboards with relative time ranges to optimize compute usage and reduce background activity. This setting applies to all users who view the dashboard. |

--- a/content/en/dashboards/configure/_index.md
+++ b/content/en/dashboards/configure/_index.md
@@ -66,7 +66,7 @@ Click {{< ui >}}Configure{{< /ui >}} to open a menu of configuration options ava
 | ----------- | ----------- |
 | {{< ui >}}Clone dashboard{{< /ui >}} | Copy the entire dashboard to a new dashboard. You are prompted to name the clone. |
 | {{< ui >}}Display UTC time{{< /ui >}} | Toggle between UTC time and your default time zone. |
-| {{< ui >}}Include Flex Logs{{< /ui >}} | Control whether widgets search [Flex Logs][3] or [Standard Indexed][4] logs. Switch between recent and historical data without editing individual widgets. This is a user-level preference that persists across sessions for this dashboard. |
+| {{< ui >}}Include Flex Logs{{< /ui >}} | Toggle to include [Flex Logs][3] in all Flex-configured widgets. When off, widgets use [Standard Indexed][4] logs instead. |
 | {{< ui >}}Increase density{{< /ui >}} | High-density mode displays group widgets in a dashboard side-by-side for increased widget density. This mode turns on by default on large screens for dashboards that use group widgets. |
 | {{< ui >}}Keyboard&nbsp;shortcuts{{< /ui >}} | View a list of available keyboard shortcuts. |
 | {{< ui >}}Pause Auto-Refresh{{< /ui >}} | Pause automatic refresh by default for dashboards with relative time ranges to optimize compute usage and reduce background activity. This setting applies to all users who view the dashboard. |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-12566](https://datadoghq.atlassian.net/browse/DOCS-12566)

Updates the description of the **Include Flex Logs** toggle in the dashboards configuration table to match the actual UI tooltip. The previous wording ("Switch between recent and historical data without editing individual widgets") was misleading — it implied any widget could switch between Flex and Standard logs, when in fact only Flex-configured widgets support Flex Logs.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes