### PR TITLE
(WEB-9180)(maint) Don't index site support banner

### DIFF
--- a/layouts/partials/site_support_banner/site_support_banner.html
+++ b/layouts/partials/site_support_banner/site_support_banner.html
@@ -16,7 +16,7 @@
     {{/*  "Remove the trailing comma"  */}}
     {{ $unsupported_regions = substr $unsupported_regions 0 -1 }}
 
-    <div class="d-none site-region-container" data-region="{{ $unsupported_regions }}">
+    <div data-nosnippet class="d-none site-region-container" data-region="{{ $unsupported_regions }}">
         <div class="alert alert-danger">{{ $text }} ({{ partial "region-param" (dict "key" "dd_site_name") }}).</div>
     </div>
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds `data-nosnippet` to the site support div to prevent it from being indexed. 

<img width="604" height="183" alt="Screenshot 2026-05-20 at 12 36 40 PM" src="https://github.com/user-attachments/assets/970d432f-6f17-4154-bd51-4a6a05c78904" />