### PR TITLE
Remove daily tool-call tier from Bits AI MCP Server fair-use limits

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -58,7 +58,6 @@ This demo shows the Datadog MCP Server being used in Cursor and Claude Code (unm
 
 The MCP Server comes with the following fair-use limits:
 - 50 requests/10 seconds tool call burst limits
-- 5000 daily tool calls
 - 50,000 monthly tool calls. 
 
 These limits are **subject to change** and can be adjusted if your use case requires more. Please contact [Datadog support][37] for requests or questions. 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the "5,000 daily tool calls" limit from the Bits AI MCP Server
fair-use limits documentation. The backend change removing this quota
tier has shipped to prod; only the 50 requests/10s burst limit and the
50,000 monthly limit remain.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes