### PR TITLE
[DOCS-14454] Add description front matter to top-level metrics pages

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+description: "Submit, query, visualize, and manage your metrics in Datadog."
 aliases:
   - /graphing/metrics/
   - /metrics/introduction/

--- a/content/en/metrics/derived-metrics.md
+++ b/content/en/metrics/derived-metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Derived Metrics 
+description: "Save a metrics query as a new metric you can reuse across dashboards, monitors, SLOs, and notebooks."
 further_reading:
 - link: "https://www.datadoghq.com/blog/auto-smoother-asap/"
   tag: "Blog"

--- a/content/en/metrics/metrics-without-limits.md
+++ b/content/en/metrics/metrics-without-limits.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics without Limits™
+description: "Decouple custom metric ingestion and indexing to control volumes and costs by selecting which tags remain queryable."
 aliases:
   - /metrics/faq/metrics-without-limits/
   - /metrics/guide/metrics-without-limits-getting-started/

--- a/content/en/metrics/nested_queries.md
+++ b/content/en/metrics/nested_queries.md
@@ -1,5 +1,6 @@
 ---
 title: Nested Queries
+description: "Apply additional layers of aggregation to metric queries for multilayer rollups, percentiles, and higher-resolution historical views."
 further_reading:
 - link: "/dashboards/querying/"
   tag: "Documentation"

--- a/content/en/metrics/overview.md
+++ b/content/en/metrics/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics Overview Page
+description: "Use the Metrics Overview page to explore your metric sources, generate metrics from Datadog products, and enable advanced platform features."
 further_reading:
   - link: "https://www.datadoghq.com/blog/metrics-without-limits"
     tag: "Blog"

--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics Types
+description: "Learn about Datadog metric submission types (count, rate, gauge, histogram, distribution) and how they map to in-app types."
 aliases:
     - /developers/metrics/counts/
     - /developers/metrics/distributions/

--- a/content/en/metrics/units.md
+++ b/content/en/metrics/units.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics Units
+description: "Set units on your metrics so values display at the right order of magnitude on graphs and widgets."
 aliases:
 - /developers/metrics/metrics_units
 - /developers/metrics/units/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14454

Adds the `description` field to YAML front matter on 7 top-level metrics pages that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

This PR covers top-level metrics pages only. Follow-up PRs will cover `metrics/guide/`, `metrics/custom_metrics/`, `metrics/faq/`, and `metrics/open_telemetry/`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes