### PR TITLE
[DOCS-14454] Add description front matter to metrics guide pages

### DIFF
--- a/content/en/metrics/guide/agent-filtering-for-custom-metrics.md
+++ b/content/en/metrics/guide/agent-filtering-for-custom-metrics.md
@@ -1,6 +1,7 @@
 
 ---
 title: Agent-Side Filtering for Custom Metrics
+description: "Filter out unused custom metrics at the Datadog Agent to reduce ingested and indexed metric volume."
 aliases:
 - /metrics/guide/agent-filtering-for-dogstatsd-custom-metrics/
 further_reading:

--- a/content/en/metrics/guide/calculating-the-system-mem-used-metric.md
+++ b/content/en/metrics/guide/calculating-the-system-mem-used-metric.md
@@ -1,5 +1,6 @@
 ---
 title: Calculating the 'system.mem.used' metric
+description: "Understand how Datadog calculates the system.mem.used metric and why values can differ from other system tools."
 aliases:
   - /agent/faq/how-is-the-system-mem-used-metric-calculated/
 further_reading:

--- a/content/en/metrics/guide/custom_metrics_governance.md
+++ b/content/en/metrics/guide/custom_metrics_governance.md
@@ -1,5 +1,6 @@
 ---
 title: Best Practices for Custom Metrics Governance
+description: "Apply best practices for visibility, attribution, and prevention to manage custom metric volumes and costs."
 further_reading:
 - link: "/metrics/custom_metrics/"
   tag: "Documentation"

--- a/content/en/metrics/guide/different-aggregators-look-same.md
+++ b/content/en/metrics/guide/different-aggregators-look-same.md
@@ -1,5 +1,6 @@
 ---
 title: Switching between the sum/min/max/avg aggregators doesn't change the value
+description: "Understand why switching between sum, min, max, and avg can return the same value when a query is already at its most granular level."
 aliases:
     - /graphing/faq/i-m-switching-between-the-sum-min-max-avg-aggregators-but-the-values-look-the-same
     - /dashboards/faq/i-m-switching-between-the-sum-min-max-avg-aggregators-but-the-values-look-the-same

--- a/content/en/metrics/guide/dynamic_quotas.md
+++ b/content/en/metrics/guide/dynamic_quotas.md
@@ -1,5 +1,6 @@
 ---
 title: Dynamic Metric Quotas
+description: "Automate custom metric quotas with Workflow Automation to control account, team, and metric-level usage."
 further_reading:
 - link: "/account_management/billing/custom_metrics/?tab=countrate"
   tag: "Documentation"

--- a/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
+++ b/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
@@ -1,6 +1,6 @@
 ---
 title: Interpolation and the Fill Modifier
-description: "Understand how interpolation and the fill modifier align metric series so you can aggregate across sources."
+description: "Understand how interpolation and the fill modifier help you aggregate across sources by aligning metric series."
 aliases:
     - /graphing/faq/interpolation-the-fill-modifier-explained
     - /dashboards/faq/interpolation-the-fill-modifier-explained

--- a/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
+++ b/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
@@ -1,5 +1,6 @@
 ---
 title: Interpolation and the Fill Modifier
+description: "Understand how interpolation and the fill modifier align metric series so you can aggregate across sources."
 aliases:
     - /graphing/faq/interpolation-the-fill-modifier-explained
     - /dashboards/faq/interpolation-the-fill-modifier-explained

--- a/content/en/metrics/guide/micrometer.md
+++ b/content/en/metrics/guide/micrometer.md
@@ -1,5 +1,6 @@
 ---
 title: Send metrics with Micrometer
+description: "Send application metrics from Micrometer to Datadog using OpenTelemetry, Prometheus, or OpenMetrics."
 further_reading:
 - link: "https://docs.micrometer.io/micrometer/reference/implementations/otlp.html"
   tag: "External Site"

--- a/content/en/metrics/guide/rate-limit.md
+++ b/content/en/metrics/guide/rate-limit.md
@@ -1,5 +1,6 @@
 ---
 title: Events Generated from Rate Limited Metrics
+description: "Identify rate-limited metrics and address the high-cardinality tags that trigger metric rate limits."
 private: true
 further_reading:
 - link: "/metrics/custom_metrics/"

--- a/content/en/metrics/guide/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph.md
+++ b/content/en/metrics/guide/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph.md
@@ -1,5 +1,6 @@
 ---
 title: What is the granularity of my graphs? Am I seeing raw data or aggregates on my graph?
+description: "Understand how Datadog rolls up metric data into aggregated buckets to render graphs across long time windows."
 aliases:
     - /graphing/faq/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph
     - /dashboards/faq/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph

--- a/content/en/metrics/guide/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
+++ b/content/en/metrics/guide/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
@@ -1,5 +1,6 @@
 ---
 title: Why does zooming out a timeframe also smooth out my graphs?
+description: "Understand why graphs lose granularity and appear smoother as you increase the timeframe."
 further_reading:
 - link: "/metrics/types/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14454

Adds the `description` field to YAML front matter on 10 pages under `content/en/metrics/guide/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

Companion PR to #36884 (top-level metrics pages). Three more PRs to follow for `metrics/custom_metrics/`, `metrics/faq/`, and `metrics/open_telemetry/`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes