### PR TITLE
[DOCS-14454] Add description front matter to metrics custom_metrics pages

### DIFF
--- a/content/en/metrics/custom_metrics/_index.md
+++ b/content/en/metrics/custom_metrics/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Metrics
+description: "Learn what custom metrics are, how they're identified by name and tags, and how they're billed in Datadog."
 aliases:
   - /guides/metrics/
   - /metrictypes/

--- a/content/en/metrics/custom_metrics/agent_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/agent_metrics_submission.md
@@ -1,5 +1,6 @@
 ---
 title: "Metric Submission: Custom Agent Check"
+description: "Submit custom metrics from a custom Agent check using count, gauge, histogram, and rate functions."
 aliases:
   - /developers/metrics/agent_metrics_submission/
   - /metrics/agent_metrics_submission

--- a/content/en/metrics/custom_metrics/historical_metrics.md
+++ b/content/en/metrics/custom_metrics/historical_metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Historical Metrics Ingestion
+description: "Ingest custom metric values with timestamps older than one hour, up to your metric retention period."
 further_reading:
 - link: "https://www.datadoghq.com/blog/historical-metrics/"
   tag: "Blog"

--- a/content/en/metrics/custom_metrics/powershell_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/powershell_metrics_submission.md
@@ -1,5 +1,6 @@
 ---
 title: "Metric submission: PowerShell"
+description: "Submit custom metrics to Datadog from PowerShell using the API or the Datadog Agent."
 aliases:
   - /developers/faq/powershell-api-examples
   - /developers/faq/submitting-metrics-via-powershell

--- a/content/en/metrics/custom_metrics/type_modifiers.md
+++ b/content/en/metrics/custom_metrics/type_modifiers.md
@@ -1,5 +1,6 @@
 ---
 title: Metric Type Modifiers
+description: "Use the as_count and as_rate in-app modifiers to switch metrics between count and rate representations."
 aliases:
  - /developers/metrics/metric_type_modifiers
  - /graphing/faq/as_count_validation


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14454

Adds the `description` field to YAML front matter on 5 pages under `content/en/metrics/custom_metrics/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

Companion PR to #36884 (top-level metrics) and #36885 (metrics guides). Two more PRs to follow for `metrics/faq/` and `metrics/open_telemetry/`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes