### PR TITLE
[DOCS-14454] Add description front matter to metrics FAQ pages

### DIFF
--- a/content/en/metrics/faq/_index.md
+++ b/content/en/metrics/faq/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics FAQ
+description: "Frequently asked questions about Datadog metrics."
 cascade:
   - private: true
 ---

--- a/content/en/metrics/faq/rollup-for-distributions-with-percentiles.md
+++ b/content/en/metrics/faq/rollup-for-distributions-with-percentiles.md
@@ -1,5 +1,6 @@
 ---
 title: Rollup Update for Distribution Metrics with Percentiles?
+description: "Understand how the rollup function works with distribution metrics that include percentile aggregations."
 is_beta: false
 ---
 **This FAQ is useful for users who query percentiles on distributions over a given timeframe, or users who want to query percentiles for specific intervals within a given timeframe.**

--- a/content/en/metrics/faq/updating-to-distribution-metrics-faq.md
+++ b/content/en/metrics/faq/updating-to-distribution-metrics-faq.md
@@ -1,5 +1,6 @@
 ---
 title: Update to Distribution Metrics Workflow FAQ
+description: "Learn about the new pipeline for globally accurate percentiles on distribution metrics and the updated tag configuration workflow."
 is_beta: true
 further_reading:
 - link: "/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers/"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14454

Adds the `description` field to YAML front matter on 3 pages under `content/en/metrics/faq/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

Companion PR to #36884 (top-level metrics), #36885 (metrics guides), and #36886 (custom_metrics). One more PR to follow for `metrics/open_telemetry/`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes