### PR TITLE
[DOCS-14454] Add description front matter to metrics OpenTelemetry pages

### DIFF
--- a/content/en/metrics/open_telemetry/_index.md
+++ b/content/en/metrics/open_telemetry/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry Metrics
-description: "Send OpenTelemetry metrics to Datadog using the OpenTelemetry Collector, the Datadog Agent, or an agentless deployment."
+description: "Send OpenTelemetry metrics to Datadog using the OpenTelemetry Collector, the Datadog Agent, or an Agentless deployment."
 aliases:
   - /opentelemetry/otel_metrics
   - /opentelemetry/reference/otel_metrics

--- a/content/en/metrics/open_telemetry/_index.md
+++ b/content/en/metrics/open_telemetry/_index.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Metrics
+description: "Send OpenTelemetry metrics to Datadog using the OpenTelemetry Collector, the Datadog Agent, or an agentless deployment."
 aliases:
   - /opentelemetry/otel_metrics
   - /opentelemetry/reference/otel_metrics

--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -1,5 +1,6 @@
 ---
 title: OTLP Metrics Types
+description: "Understand how OTLP metric types (sums, gauges, histograms, summaries) map to Datadog metric types."
 further_reading:
     - link: 'metrics/distributions'
       tag: 'Documentation'

--- a/content/en/metrics/open_telemetry/query_metrics.md
+++ b/content/en/metrics/open_telemetry/query_metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Query Across Datadog and OpenTelemetry Metrics
+description: "Query equivalent Datadog and OpenTelemetry metrics together in hybrid environments using Semantic Mode."
 aliases:
 - metrics/open_telemetry/otlp_metrics/
 further_reading:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14454

Adds the `description` field to YAML front matter on 3 pages under `content/en/metrics/open_telemetry/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

Final companion PR to #36884 (top-level metrics), #36885 (metrics guides), #36886 (custom_metrics), and #36887 (metrics FAQ).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes