### PR TITLE
[DOCS-14473] Add description front matter to AWS integration guide and FAQ pages

### DIFF
--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Elastic Container Service with Agent v5
+description: "Set up the Datadog Agent v5 to monitor Amazon ECS containers and workloads."
 
 private: true
 ---

--- a/content/en/integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do.md
+++ b/content/en/integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do.md
@@ -1,5 +1,6 @@
 ---
 title: Both my JMX and AWS integrations use "name" tags. What do I do?
+description: "Resolve name tag conflicts between the AWS integration and JMX-based integrations by renaming JMX bean tags."
 
 ---
 

--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -1,5 +1,6 @@
 ---
 title: How do I pull my EC2 tags without using the AWS integration?
+description: "Collect custom EC2 tags through the Datadog Agent using the EC2 Instance Metadata Service, without the AWS integration."
 
 ---
 

--- a/content/en/integrations/faq/integration-setup-ecs-fargate.md
+++ b/content/en/integrations/faq/integration-setup-ecs-fargate.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Setup for ECS Fargate
+description: "Add Datadog integrations to ECS Fargate clusters using Docker label annotations on task definitions."
 
 further_reading:
 - link: "/integrations/ecs_fargate/"

--- a/content/en/integrations/guide/amazon-eks-audit-logs.md
+++ b/content/en/integrations/guide/amazon-eks-audit-logs.md
@@ -1,5 +1,6 @@
 ---
 title: Log Collection for Amazon EKS Audit Logs
+description: "Enable log collection for Amazon EKS audit logs to monitor cluster actions with Datadog Cloud SIEM."
 
 ---
 

--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -1,5 +1,6 @@
 ---
 title: AWS CloudWatch Metric Streams with Amazon Data Firehose
+description: "Stream CloudWatch metrics to Datadog through Amazon Data Firehose for low-latency ingestion."
 
 further_reading:
 - link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html"

--- a/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
+++ b/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
@@ -1,5 +1,6 @@
 ---
 title: AWS Integration and CloudWatch FAQ
+description: "Frequently asked questions about the Datadog AWS integration and CloudWatch metric collection."
 
 aliases:
   - "/integrations/faq/do-you-believe-you-re-seeing-a-discrepancy-between-your-data-in-cloudwatch-and-datadog"

--- a/content/en/integrations/guide/aws-terraform-setup.md
+++ b/content/en/integrations/guide/aws-terraform-setup.md
@@ -1,5 +1,6 @@
 ---
 title: The AWS Integration with Terraform
+description: "Set up the Datadog-AWS integration with Terraform, including the IAM role and integration resource."
 aliases:
     - /integrations/faq/aws-integration-with-terraform/
 disable_toc: true

--- a/content/en/integrations/guide/cloud-metric-delay.md
+++ b/content/en/integrations/guide/cloud-metric-delay.md
@@ -1,5 +1,6 @@
 ---
 title: Cloud Metric Delay
+description: "Understand expected delays for AWS, Azure, Google Cloud, and other cloud integration metrics collected by API."
 
 aliases:
     - /integrations/faq/are-my-aws-cloudwatch-metrics-delayed/

--- a/content/en/integrations/guide/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/en/integrations/guide/error-datadog-not-authorized-sts-assume-role.md
@@ -1,5 +1,6 @@
 ---
 title: "Error: Datadog is not authorized to perform sts:AssumeRole"
+description: "Troubleshoot the sts:AssumeRole error in the Datadog AWS integration by checking the IAM role's trust relationship and policy."
 
 further_reading:
 - link: "/integrations/amazon_web_services/#installation"

--- a/content/en/integrations/guide/monitor-your-aws-billing-details.md
+++ b/content/en/integrations/guide/monitor-your-aws-billing-details.md
@@ -1,5 +1,6 @@
 ---
 title: Monitor your AWS billing details
+description: "Collect AWS billing metrics with Datadog by enabling the Billing namespace on the AWS integration."
 
 aliases:
   - /integrations/faq/how-do-i-monitor-my-aws-billing-details


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14473

Adds the `description` field to YAML front matter on 11 AWS-related pages under `content/en/integrations/guide/` and `content/en/integrations/faq/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

`guide/cloud-metric-delay.md` is included here because it covers AWS along with other cloud providers.

Companion to DOCS-14454 (metrics frontmatter). A follow-up PR will cover the Azure-related pages.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes