### PR TITLE
Fix double space and stray quote in AWS integration CloudWatch FAQ

### DIFF
--- a/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
+++ b/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
@@ -51,7 +51,7 @@ Some important distinctions to be aware of:
 
 ### How do I adjust my data on Datadog to match the data displayed in CloudWatch?
 
-AWS CloudWatch reports metrics at one-minute granularity normalized to per-minute data. Datadog reports metrics at one-minute granularity normalized to per-second data. To adjust the data in Datadog, multiply by 60.  Also make sure the statistic of the metric is the same. For example, the metric `IntegrationLatency` fetches a number of different statistics": Average, Maximum, Minimum, as well as percentiles. In Datadog, these statistics are each represented as their own metrics:
+AWS CloudWatch reports metrics at one-minute granularity normalized to per-minute data. Datadog reports metrics at one-minute granularity normalized to per-second data. To adjust the data in Datadog, multiply by 60. Also make sure the statistic of the metric is the same. For example, the metric `IntegrationLatency` fetches a number of different statistics: Average, Maximum, Minimum, as well as percentiles. In Datadog, these statistics are each represented as their own metrics:
   ```
 aws.apigateway.integration_latency (average)
 aws.apigateway.integration_latency.maximum


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes two minor copy issues on a single line of `content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md`:

1. Replaces a double space (`multiply by 60.  Also`) with a single space — resolves a `Datadog.spaces` Vale error.
2. Removes a stray closing quote (`statistics":`) that has no matching opening quote.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes