### PR TITLE
[DOCS-14473] Add description front matter to Azure integration guide pages

### DIFF
--- a/content/en/integrations/guide/azure-cloud-adoption-framework.md
+++ b/content/en/integrations/guide/azure-cloud-adoption-framework.md
@@ -1,5 +1,6 @@
 ---
 title: Azure Cloud Adoption Framework with Datadog
+description: "Use Datadog to plan, migrate, and monitor workloads through Azure's Cloud Adoption Framework."
 
 further_reading:
   - link: "/integrations/azure/"

--- a/content/en/integrations/guide/azure-graph-api-permissions.md
+++ b/content/en/integrations/guide/azure-graph-api-permissions.md
@@ -1,5 +1,6 @@
 ---
 title: Microsoft Graph API Permissions for Monitoring Azure
+description: "Grant Microsoft Graph API permissions to your Azure app registration so the Datadog-Azure integration can fetch tenant details."
 
 further_reading:
   - link: "/integrations/azure/"

--- a/content/en/integrations/guide/azure-native-integration.md
+++ b/content/en/integrations/guide/azure-native-integration.md
@@ -1,5 +1,6 @@
 ---
 title: Azure Native Integration Setup & Reference
+description: "Set up and manage the Datadog Azure native integration through the Azure portal Datadog Monitor resource."
 aliases:
 - /integrations/guide/azure-portal/
 - /integrations/guide/azure-native-programmatic-management/

--- a/content/en/integrations/guide/azure-resource-manager.md
+++ b/content/en/integrations/guide/azure-resource-manager.md
@@ -1,5 +1,6 @@
 ---
 title: Azure Resource Manager (ARM)
+description: "Set up the Datadog-Azure integration with Azure Resource Manager to configure data and log forwarding."
 private: true
 further_reading:
   - link: "/integrations/azure/"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14473

Adds the `description` field to YAML front matter on 4 Azure-related pages under `content/en/integrations/guide/` that lacked it. Per the Datadog docs front matter guidance, `description` is required on every page.

Companion to PR #36889 (AWS-related pages).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes