### PR TITLE
Document browser profiling quota API endpoint and proxy/CSP setup

### DIFF
--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -156,7 +156,7 @@ All Datadog SDKs traffic is transmitted over SSL (default 443) to the following 
 
 ### Additional endpoints for Browser Profiling
 
-When [Browser Profiling][18] is enabled, the SDK also contacts a quota API to determine whether profiling is permitted for the current session. This uses a `quota.` subdomain of the standard intake origin:
+When [Browser Profiling][19] is enabled, the SDK also contacts a quota API to determine whether profiling is permitted for the current session. This uses a `quota.` subdomain of the standard intake origin:
 
 | Site | Quota API URL                                             |
 |------|-----------------------------------------------------------|

--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -154,6 +154,23 @@ All Datadog SDKs traffic is transmitted over SSL (default 443) to the following 
 | AP1  | `https://browser-intake-ap1-datadoghq.com`    |
 | AP2  | `https://browser-intake-ap2-datadoghq.com`    |
 
+### Additional endpoints for Browser Profiling
+
+When [Browser Profiling][18] is enabled, the SDK also contacts a quota API to determine whether profiling is permitted for the current session. This uses a `quota.` subdomain of the standard intake origin:
+
+| Site | Quota API URL                                             |
+|------|-----------------------------------------------------------|
+| US1  | `https://quota.browser-intake-datadoghq.com`             |
+| US3  | `https://quota.browser-intake-us3-datadoghq.com`         |
+| US5  | `https://quota.browser-intake-us5-datadoghq.com`         |
+| EU1  | `https://quota.browser-intake-datadoghq.eu`              |
+| US1-FED  | `https://quota.browser-intake-ddog-gov.com`          |
+| US2-FED  | `https://quota.browser-intake-us2-ddog-gov.com`      |
+| AP1  | `https://quota.browser-intake-ap1-datadoghq.com`         |
+| AP2  | `https://quota.browser-intake-ap2-datadoghq.com`         |
+
+If you use a [proxy][20] or have a [Content Security Policy (CSP)][21], ensure these `quota.` domains are also allowed. See the [Browser Profiling setup][19] page for details.
+
 ## Explore Datadog RUM
 
 Access RUM by navigating to [**Digital Experience > Performance Summary**][1].
@@ -270,3 +287,6 @@ You must have edit access to restore general access to a restricted application.
 [16]: /real_user_monitoring/application_monitoring/
 [17]: https://app.datadoghq.com/rum/optimization/inspect
 [18]: /account_management/rbac/
+[19]: /real_user_monitoring/correlate_with_other_telemetry/profiling
+[20]: /real_user_monitoring/guide/proxy-rum-data
+[21]: /integrations/content_security_policy_logs

--- a/content/en/real_user_monitoring/correlate_with_other_telemetry/profiling/_index.mdoc.md
+++ b/content/en/real_user_monitoring/correlate_with_other_telemetry/profiling/_index.mdoc.md
@@ -83,7 +83,7 @@ To start collecting data, set up [RUM Browser Monitoring][2].
         });
     ```
 
-3. **Quota check**: Before starting a profiled session, the SDK makes a request to a quota API to determine whether the current RUM session will receive profiling data. No additional setup is required for this unless you use a proxy or have Content Security Policy (CSP) restrictions.
+3. **Quota check**: Before starting a profiled session, the SDK makes a request to a quota API to determine whether the current RUM session will receive profiling data.
 
     If you use a [proxy][13] or [CSP][14], you must also allow the `quota.` subdomain of your site's standard intake origin (for example, `https://quota.browser-intake-datadoghq.com` for US1, serving the `/api/v2/profiling/quota` endpoint). See the full list of quota endpoints per site in the [Supported endpoints][15] section, and refer to the [proxy setup documentation][13] for details on routing subdomain-specific requests.
 
@@ -105,7 +105,7 @@ To start collecting data, set up [RUM Browser Monitoring][2].
        });
        ```
 
-{% collapse-content title="Browser profiling and CORS" %}
+{% collapse-content title="Browser profiling and CORS" id="cors"%}
 
 #### Requirements for Cross-Origin Scripts (CORS)
 

--- a/content/en/real_user_monitoring/correlate_with_other_telemetry/profiling/_index.mdoc.md
+++ b/content/en/real_user_monitoring/correlate_with_other_telemetry/profiling/_index.mdoc.md
@@ -83,7 +83,11 @@ To start collecting data, set up [RUM Browser Monitoring][2].
         });
     ```
 
-3. Set up Cross-Origin Resource Sharing (CORS) if needed.
+3. **Quota check**: Before starting a profiled session, the SDK makes a request to a quota API to determine whether the current RUM session will receive profiling data. No additional setup is required for this unless you use a proxy or have Content Security Policy (CSP) restrictions.
+
+    If you use a [proxy][13] or [CSP][14], you must also allow the `quota.` subdomain of your site's standard intake origin (for example, `https://quota.browser-intake-datadoghq.com` for US1, serving the `/api/v2/profiling/quota` endpoint). See the full list of quota endpoints per site in the [Supported endpoints][15] section, and refer to the [proxy setup documentation][13] for details on routing subdomain-specific requests.
+
+4. Set up Cross-Origin Resource Sharing (CORS) if needed.
 
       This step is required only if your JavaScript files are served from a different origin than your HTML. For example, if your HTML is served from `cdn.com` and JavaScript files from `static.cdn.com`, you must enable CORS to make JavaScript files visible to the profiler. For more information, see the [Browser profiling and CORS](#cors) section.
     
@@ -350,3 +354,6 @@ Use the **flame graph** to identify which functions consume the most Wall time d
 [10]: /real_user_monitoring/rum_without_limits/ 
 [11]: /real_user_monitoring/application_monitoring/ios
 [12]: /real_user_monitoring/application_monitoring/ios/application_launch_monitoring?tab=swift
+[13]: /real_user_monitoring/guide/proxy-rum-data
+[14]: /integrations/content_security_policy_logs
+[15]: /real_user_monitoring/#supported-endpoints-for-sdk-domains

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.mdoc.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.mdoc.md
@@ -148,6 +148,8 @@ The RUM Browser SDK adds a `ddforward` query parameter to all requests to your p
 
 For example, with a `site` set to `datadoghq.eu` and a `proxy` set to `https://example.org/datadog-intake-proxy`, the RUM Browser SDK sends requests to a URL like this: `https://example.org/datadog-intake-proxy?ddforward=%2Fapi%2Fv2%2Frum%3Fddsource%3Dbrowser`. The proxy forwards the request to `https://browser-intake-datadoghq.eu/api/v2/rum?ddsource=browser`.
 
+When [Browser Profiling][3] is enabled, the SDK also sends requests to the quota API using a `quota.` subdomain of the standard intake origin. For these requests, a `ddforwardSubdomain=quota` query parameter is added alongside `ddforward`, so your proxy can construct the correct target URL: `https://quota.browser-intake-datadoghq.eu/api/v2/profiling/quota?...`.
+
 <!-- SDK version >=5.4.0 -->
 {% if equals($rum_browser_sdk_version, "gte_5_4_0") %}
 ### Passing a function to the `proxy` initialization parameter
@@ -158,6 +160,7 @@ This function receives an object with the following properties:
 
 - `path`: the path for the Datadog requests (example: `/api/v2/rum`)
 - `parameters`: the parameters of the Datadog requests (example: `ddsource=browser&...`)
+- `subdomain` _(optional)_: the intake subdomain to target, when the request should go to a subdomain-specific endpoint rather than the standard intake origin. For example, when [Browser Profiling][3] is enabled, the SDK passes `subdomain: 'quota'` so your proxy can route the request to `https://quota.browser-intake-datadoghq.eu/api/v2/profiling/quota?...` instead of the standard intake.
 
 <!-- NPM -->
 {% if equals($lib_src, "npm") %}
@@ -226,3 +229,4 @@ The Datadog intake origin needs to be defined in your proxy implementation to en
 
 [1]: /real_user_monitoring/application_monitoring/browser/setup/client/?tab=rum#initialization-parameters
 [2]: https://github.com/easylist/easylist/blob/997fb6533c719a015c21723b34e0cedefcc0d83d/easyprivacy/easyprivacy_general.txt#L3840
+[3]: /real_user_monitoring/correlate_with_other_telemetry/profiling

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.mdoc.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.mdoc.md
@@ -148,7 +148,7 @@ The RUM Browser SDK adds a `ddforward` query parameter to all requests to your p
 
 For example, with a `site` set to `datadoghq.eu` and a `proxy` set to `https://example.org/datadog-intake-proxy`, the RUM Browser SDK sends requests to a URL like this: `https://example.org/datadog-intake-proxy?ddforward=%2Fapi%2Fv2%2Frum%3Fddsource%3Dbrowser`. The proxy forwards the request to `https://browser-intake-datadoghq.eu/api/v2/rum?ddsource=browser`.
 
-When [Browser Profiling][3] is enabled, the SDK also sends requests to the quota API using a `quota.` subdomain of the standard intake origin. For these requests, a `ddforwardSubdomain=quota` query parameter is added alongside `ddforward`, so your proxy can construct the correct target URL: `https://quota.browser-intake-datadoghq.eu/api/v2/profiling/quota?...`.
+When [Browser Profiling][3] is enabled, the SDK also sends requests to the quota API using a `quota.` subdomain of the standard intake origin. For these requests, the SDK adds a `ddforwardSubdomain=quota` query parameter alongside `ddforward`, so your proxy can construct the correct target URL: `https://quota.browser-intake-datadoghq.eu/api/v2/profiling/quota?...`.
 
 <!-- SDK version >=5.4.0 -->
 {% if equals($rum_browser_sdk_version, "gte_5_4_0") %}


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the quota check API call made by the Browser SDK when Browser Profiling is enabled.

## Changes

### `content/en/real_user_monitoring/_index.md`
- Adds a new **"Additional endpoints for Browser Profiling"** subsection under "Supported endpoints for SDK domains", listing the `quota.` subdomain URLs for all 8 Datadog sites (e.g. `https://quota.browser-intake-datadoghq.com`).
- Includes a note that proxy and CSP users must allow these domains.

### `content/en/real_user_monitoring/correlate_with_other_telemetry/profiling/_index.mdoc.md`
- Adds a new **Step 3 "Quota check"** in the browser setup section, explaining:
  - The SDK calls `/api/v2/profiling/quota` before starting a profiling session
  - The call goes to a `quota.` subdomain of the standard RUM intake
  - Proxy and CSP users must explicitly allow this domain

### `content/en/real_user_monitoring/guide/proxy-rum-data.mdoc.md`
- Documents the **`ddforwardSubdomain` query parameter** sent when using a string proxy, which tells the proxy which intake subdomain to target (`quota` for profiling quota requests).
- Documents the **`subdomain` property** in the function proxy options object (alongside existing `path` and `parameters`), used for the same purpose.

## Motivation

The Browser SDK's profiling quota check reaches a new `quota.` subdomain that wasn't previously documented. Customers using a proxy or CSP restrictions would silently fail to collect profiling data without this information.