### PR TITLE
add ingestion mechanism documentation for rust

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -282,6 +282,23 @@ C++ does not provide integrations for automatic instrumentation, but it's used b
 [1]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.1.0
 [2]: /tracing/trace_collection/proxy_setup
 {{% /tab %}}
+{{% tab "Rust" %}}
+**Local configuration**
+
+For Rust applications, set by-service sampling rates with the `DD_TRACE_SAMPLING_RULES` environment variable.
+
+For example, to send 50% of the traces for the service named `my-service` and 10% for the rest of the traces:
+
+```
+export DD_TRACE_SAMPLING_RULES='[{"service": "my-service", "sample_rate": 0.5},{"sample_rate": 0.1}]'
+```
+
+Configure a rate limit by setting the `DD_TRACE_RATE_LIMIT` environment variable to the maximum traces per second per service instance. If no `DD_TRACE_RATE_LIMIT` value is set, a limit of 100 traces per second is applied.
+
+Read more about sampling controls in the [Rust SDK documentation][1].
+
+[1]: /tracing/trace_collection/dd_libraries/rust
+{{% /tab %}}
 {{% tab ".NET" %}}
 For .NET applications, set a global sampling rate for the library using the `DD_TRACE_SAMPLE_RATE` environment variable. Set by-service sampling rates with the `DD_TRACE_SAMPLING_RULES` environment variable.
 
@@ -400,7 +417,7 @@ The head-based sampling mechanism can be overridden at the SDK level. For exampl
 
 - Set Manual Drop on a span to make sure that **no** child span is ingested. The [error and rare samplers](#error-and-rare-traces) are ignored in the Agent.
 
-{{< programming-lang-wrapper langs="java,python,ruby,go,nodejs,.NET,php,cpp" >}}
+{{< programming-lang-wrapper langs="java,python,ruby,go,nodejs,.NET,php,cpp,rust" >}}
 {{< programming-lang lang="java" >}}
 
 Manually keep a trace:
@@ -686,6 +703,11 @@ span.trace_segment().override_sampling_priority(int(dd::SamplingPriority::USER_D
 ```
 
 {{< /programming-lang >}}
+{{< programming-lang lang="rust" >}}
+
+<div class="alert alert-info">The Rust SDK uses the OpenTelemetry API and does not support the Datadog <code>ManualKeep</code>/<code>ManualDrop</code> tags. To force keep or drop a trace in Rust, set the OpenTelemetry <code>sampling.priority</code> attribute on the root span using <a href="/tracing/trace_collection/custom_instrumentation/rust">custom instrumentation</a>.</div>
+
+{{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
 Set Manual Keep before context propagation. If set after context propagation, the entire trace may not be kept across services. Because this decision is set at the tracing client, the trace can still be dropped by the Agent or server based on sampling rules.
@@ -804,6 +826,15 @@ For example, to collect `100%` of the spans from the service named `my-service`,
 ```
 
 [1]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.1.0
+{{% /tab %}}
+{{% tab "Rust" %}}
+For Rust applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.
+
+For example, to collect `100%` of the spans from the service named `my-service`, for the operation `http.request`, up to `50` spans per second:
+
+```
+@env DD_SPAN_SAMPLING_RULES=[{"service": "my-service", "name": "http.request", "sample_rate":1.0, "max_per_second": 50}]
+```
 {{% /tab %}}
 {{% tab ".NET" %}}
 Starting from version [v2.18.0][1], for .NET applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This adds APM ingestion mechanism documentation for the `rust` language.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
