### PR TITLE
Remove outdated AWS/GCP exception note from resource evaluation filters

### DIFF
--- a/content/en/security/cloud_security_management/guide/resource_evaluation_filters.md
+++ b/content/en/security/cloud_security_management/guide/resource_evaluation_filters.md
@@ -14,7 +14,7 @@ You can use resource tags to create filters that include or exclude resources fr
 **Notes**:
 
 - Resource evaluation filters can only be used with hosts that are scanned by cloud integrations.
-- Tags must be applied directly to the resource. The filters do not take into account user tags added in Datadog. The only exception is for tags added on the integration tiles for AWS and Google Cloud Platform.
+- Tags must be applied directly to the resource. The filters do not take into account user tags added in Datadog.
 
 | Format                       | Value        |
 |------------------------------|--------------|


### PR DESCRIPTION
## Summary
- Removes the sentence about AWS/GCP integration tile tags being an exception to the direct-tagging requirement, as this information is outdated

## Test plan
- [x] Verify the documentation still accurately describes resource evaluation filter behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)