### PR TITLE
[SYNTH-26796] Document JS assertion truncation in Privacy option

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -188,7 +188,12 @@ Use JavaScript assertions when standard response assertions don't meet your vali
 
 <div class="alert alert-info">JavaScript capabilities are not supported for API tests in Windows private locations.</div>
 
-**Note:** If a failed JavaScript assertion's error message might include sensitive data, enable **Do not save response body** under **Advanced Options** > **Privacy**. This truncates the assertion error message.
+<div class="alert alert-info">
+  <ul>
+    <li>JavaScript capabilities are not supported for API tests in Windows private locations.</li>
+    <li>If a failed JavaScript assertion's error message might include sensitive data, under <strong>Advanced Options</strong> > <strong>Privacy</strong>, enable <strong>Do not save response body</strong>. This truncates the assertion error message.</li>
+  </ul>
+</div>
 
 #### Using dd.assert()
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -125,7 +125,7 @@ You may create a test using one of the following options:
 
    {{% tab "Privacy" %}}
 
-   * **Do not save response body**: Select this option to prevent response body from being saved at runtime. This can be helpful to ensure no sensitive data gets featured in your test results. Use mindfully as it can make failures troubleshooting more difficult. For more security recommendations, see [Synthetic Monitoring Security][1].
+   * **Do not save response body**: Select this option to prevent the response body from being saved at runtime and to truncate the error message of failed JavaScript assertions. This helps ensure no sensitive data is displayed in your test results, but it can make failure troubleshooting more difficult. For full security recommendations, see [Synthetic Monitoring Data Security][1].
 
 
 [1]: /data_security/synthetics
@@ -187,6 +187,8 @@ Use JavaScript assertions when standard response assertions don't meet your vali
 {{< img src="synthetics/api_tests/JS_assertion.png" alt="JavaScript assertion for HTTP API test" style="width:90%;" >}}
 
 <div class="alert alert-info">JavaScript capabilities are not supported for API tests in Windows private locations.</div>
+
+**Note:** If a failed JavaScript assertion's error message might include sensitive data, enable **Do not save response body** under **Advanced Options** > **Privacy**. This truncates the assertion error message.
 
 #### Using dd.assert()
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -182,7 +182,7 @@ If a test contains an assertion on the response body and the timeout limit is re
 
 Use JavaScript assertions when standard response assertions don't meet your validation needs. Synthetic Monitoring uses the [Chai assertion library][20], which provides `dd.expect()`, `dd.should`, and `dd.assert()` for flexible assertion styles.
 
-**Note:** When working with JSON responses, use `JSON.parse(dd.response.body)` to parse the response body before accessing its properties. This is required for all assertion methods (`dd.assert()`, `dd.expect()`, and `dd.should`) when validating JSON data.
+When working with JSON responses, use `JSON.parse(dd.response.body)` to parse the response body before accessing its properties. This is required for all assertion methods (`dd.assert()`, `dd.expect()`, and `dd.should`) when validating JSON data.
 
 {{< img src="synthetics/api_tests/JS_assertion.png" alt="JavaScript assertion for HTTP API test" style="width:90%;" >}}
 


### PR DESCRIPTION
### What does this PR do?

Documents that the **Do not save response body** Privacy option on HTTP API tests also truncates the error message of failed JavaScript assertions, and brings the bullet's surrounding wording in line with the equivalent bullet on the browser and mobile test pages.

### Motivation

Companion to web-ui PR https://github.com/DataDog/web-ui/pull/308938, which updates the in-app tooltip for the same option. The current docs only mention the "don't save the body" half of the behavior; this PR adds the JS-assertion-truncation half so customers know how to opt into that protection. Tracked in [SYNTH-26796](https://datadoghq.atlassian.net/browse/SYNTH-26796).

### Additional notes

User-facing copy only — no code, schema, or layout changes.

[SYNTH-26796]: https://datadoghq.atlassian.net/browse/SYNTH-26796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ