### PR TITLE
[DOCS-14475] Document ~24h delay before new Agent versions appear in Fleet

### DIFF
--- a/content/en/agent/fleet_automation/upgrade_agents.md
+++ b/content/en/agent/fleet_automation/upgrade_agents.md
@@ -94,6 +94,10 @@ Datadog recommends managing upgrades from one source at a time. Use either Fleet
 
 ## Troubleshooting
 
+### Newly released Agent version is not yet available for upgrade
+
+After a new Agent version is released, it can take up to 24 hours before it appears as an upgrade target in Fleet Automation. If a recently released version is missing from the upgrade picker, wait up to 24 hours and retry.
+
 ### Datadog Installer incompatible with Agent (pre-7.66)
 
 If you were a Preview customer and set up remote Agent Management before Agent version 7.66, your Datadog Installer might be incompatible with the Agent.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14475

Adds a Troubleshooting entry to the Upgrade Agents page noting that a newly released Agent version can take up to 24 hours before it appears as an upgrade target in Fleet Automation. Customers occasionally report the latest version is missing from the upgrade picker shortly after release; this entry lets them self-serve before contacting support.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes