### PR TITLE
Add ClickHouse destination docs

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6785,106 +6785,111 @@ menu:
       url: observability_pipelines/destinations/azure_storage/
       parent: observability_pipelines_destinations
       weight: 404
+    - name: ClickHouse
+      identifier: observability_pipelines_clickhouse
+      url: observability_pipelines/destinations/clickhouse/
+      parent: observability_pipelines_destinations
+      weight: 405
     - name: CrowdStrike NG-SIEM
       identifier: observability_pipelines_crowdstrike_ng_siem
       url: observability_pipelines/destinations/crowdstrike_ng_siem/
       parent: observability_pipelines_destinations
-      weight: 405
+      weight: 406
     - name: Databricks (Zerobus)
       identifier: observability_pipelines_databricks
       url: observability_pipelines/destinations/databricks/
       parent: observability_pipelines_destinations
-      weight: 406
+      weight: 407
     - name: Datadog Archives
       identifier: observability_pipelines_destinations_datadog_archives
       url: observability_pipelines/destinations/datadog_archives/
       parent: observability_pipelines_destinations
-      weight: 407
+      weight: 408
     - name: Datadog BYOC Logs
       url: observability_pipelines/destinations/datadog_byoc_logs/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_datadog_byoc_logs
-      weight: 408
+      weight: 409
     - name: Datadog Logs
       url: observability_pipelines/destinations/datadog_logs/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_datadog_logs
-      weight: 409
+      weight: 410
     - name: Datadog Metrics
       url: observability_pipelines/destinations/datadog_metrics/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_datadog_metrics
-      weight: 410
+      weight: 411
     - name: Elasticsearch
       url: observability_pipelines/destinations/elasticsearch/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_elasticsearch
-      weight: 411
+      weight: 412
     - name: Google Cloud Storage
       identifier: observability_pipelines_google_cloud_storage
       url: /observability_pipelines/destinations/google_cloud_storage/
       parent: observability_pipelines_destinations
-      weight: 412
+      weight: 413
     - name: Google Pub/Sub
       identifier: observability_pipelines_google_pubsub
       url: /observability_pipelines/destinations/google_pubsub/
       parent: observability_pipelines_destinations
-      weight: 413
+      weight: 414
     - name: Google SecOps
       url: observability_pipelines/destinations/google_secops/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_google_secops
-      weight: 414
+      weight: 415
     - name: HTTP Client
       url: observability_pipelines/destinations/http_client/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_http_client
-      weight: 415
+      weight: 416
     - name: Kafka
       url: observability_pipelines/destinations/kafka/
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_kafka
-      weight: 416
+      weight: 417
     - name: Microsoft Sentinel
       identifier: observability_pipelines_microsoft_sentinel
       url: /observability_pipelines/destinations/microsoft_sentinel/
       parent: observability_pipelines_destinations
-      weight: 417
+      weight: 418
     - name: New Relic
       identifier: observability_pipelines_new_relic
       url: /observability_pipelines/destinations/new_relic/
       parent: observability_pipelines_destinations
-      weight: 418
+      weight: 419
     - name: OpenSearch
       url: observability_pipelines/destinations/opensearch
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_opensearch
-      weight: 419
+      weight: 420
     - name: SentinelOne
       url: observability_pipelines/destinations/sentinelone
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_sentinelone
-      weight: 420
+      weight: 421
     - name: Socket
       url: observability_pipelines/destinations/socket
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_socket
-      weight: 421
+      weight: 422
     - name: Splunk HEC
       url: observability_pipelines/destinations/splunk_hec
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_splunk_hec
-      weight: 422
+      weight: 423
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/destinations/sumo_logic_hosted_collector
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_sumo_logic_hosted_collector
-      weight: 423
+      weight: 424
     - name: Syslog
       url: observability_pipelines/destinations/syslog
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_syslog
-      weight: 424
+      weight: 425
     - name: Packs
       url: observability_pipelines/packs/
       parent: observability_pipelines

--- a/content/en/observability_pipelines/configuration/update_existing_pipelines.md
+++ b/content/en/observability_pipelines/configuration/update_existing_pipelines.md
@@ -117,6 +117,11 @@ On the Worker installation page:
 {{% observability_pipelines/configure_existing_pipelines/destination_env_vars/amazon_security_lake %}}
 
 {{% /tab %}}
+{{% tab "ClickHouse" %}}
+
+{{% observability_pipelines/configure_existing_pipelines/destination_env_vars/clickhouse %}}
+
+{{% /tab %}}
 {{% tab "CrowdStrike NG-SIEM" %}}
 
 {{% observability_pipelines/configure_existing_pipelines/destination_env_vars/crowdstrike_ng_siem %}}

--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -24,6 +24,7 @@ These are the available destinations:
 - [Amazon S3][22]
 - [Amazon Security Lake][3]
 - [Azure Storage][4]
+- [ClickHouse][24]
 - [CrowdStrike Next-Gen SIEM][6]
 - [Databricks (Zerobus)][23]
 - [Datadog Archives][2]
@@ -67,6 +68,7 @@ These are the available destinations:
 [21]: /observability_pipelines/destinations/syslog/
 [22]: /observability_pipelines/destinations/amazon_s3/
 [23]: /observability_pipelines/destinations/databricks/
+[24]: /observability_pipelines/destinations/clickhouse/
 
 {{% /tab %}}
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -1,0 +1,144 @@
+---
+title: ClickHouse Destination
+disable_toc: false
+products:
+- name: Logs
+  icon: logs
+  url: /observability_pipelines/configuration/?tab=logs#pipeline-types
+further_reading:
+- link: "/observability_pipelines/"
+  tag: "Documentation"
+  text: "Observability Pipelines"
+---
+
+{{< product-availability >}}
+
+## Overview
+
+Use Observability Pipelines' ClickHouse destination to send logs to a [ClickHouse][1] server over the HTTP interface. The destination supports JSON insert formats for mapping events to columns by name or storing raw payloads, and Apache Arrow IPC streaming for higher-throughput inserts.
+
+## Prerequisites
+
+Before you configure the ClickHouse destination, you must have:
+
+- A running ClickHouse server reachable from the Observability Pipelines Worker over the [HTTP interface][2].
+- A database and target table where events are inserted. The destination does not create the database or table for you.
+- (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The destination authenticates with HTTP Basic auth.
+- (Optional) TLS material if your ClickHouse server requires HTTPS with client certificates.
+
+## Setup
+
+Configure the ClickHouse destination when you [set up a pipeline][3]. You can set up a pipeline in the [UI][4], using the [API][5], or with [Terraform][6]. The steps in this section are configured in the UI.
+
+<div class="alert alert-danger">Only enter the identifiers for the ClickHouse endpoint URL and, if applicable, the username, password, and TLS key pass. Do <b>not</b> enter the actual values.</div>
+
+After you select the ClickHouse destination in the pipeline UI:
+
+1. Enter the identifier for your ClickHouse HTTP endpoint URL. If you leave it blank, the [default](#secret-defaults) is used.
+1. In the **Table** field, enter the name of the ClickHouse table to insert events into. This field is required.
+1. (Optional) In the **Database** field, enter the name of the ClickHouse database that contains the table. If you leave it blank, the ClickHouse user's default database is used.
+1. In the **Format** dropdown menu, select the insert format for events:
+    - `json_each_row` (default): Inserts each event as a JSON object on its own line. Event fields are mapped to columns of the same name. This maps to ClickHouse's [`JSONEachRow`][7] format.
+    - `json_as_object`: Inserts each event into a single `JSON`-typed column. This maps to ClickHouse's [`JSONAsObject`][8] format.
+    - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
+    - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Batch encoding](#batch-encoding).
+
+### Optional settings
+
+#### Skip unknown fields
+
+Toggle the **Skip unknown fields** switch to drop event fields that are not present in the target table schema instead of returning an insert error. When this setting is left unset, the ClickHouse server's [`input_format_skip_unknown_fields`][10] setting applies.
+
+#### Date time best effort
+
+Toggle the **Date time best effort** switch to enable flexible `DateTime` parsing on the ClickHouse server. When enabled, the server accepts a wider range of date and time string formats. See ClickHouse's [`date_time_input_format`][11] setting for more information.
+
+#### Compression
+
+In the **Compression** dropdown menu, select the algorithm used to compress outbound HTTP requests:
+- `gzip` (default): Compresses requests with gzip.
+- `none`: Sends requests uncompressed.
+
+When you select `gzip`, you can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the algorithm's default level is used.
+
+#### Enable basic authentication
+
+Toggle the **Enable Basic Auth** switch to authenticate to ClickHouse with HTTP Basic auth.
+
+1. Enter the identifier for your ClickHouse username. If you leave it blank, the [default](#secret-defaults) is used.
+1. Enter the identifier for your ClickHouse password. If you leave it blank, the [default](#secret-defaults) is used.
+
+#### Enable TLS
+
+{{% observability_pipelines/tls_settings %}}
+
+#### Batch encoding
+
+Batch encoding is required when **Format** is set to `arrow_stream`. It is not used with the JSON formats.
+
+1. In the **Codec** dropdown menu, select `arrow_stream`.
+1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns cause encoding errors.
+
+**Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline starts because the target table's schema is read from the server to build the Arrow encoder.
+
+#### Batching
+
+Use the **Batching** settings to control how events are grouped into HTTP inserts:
+
+1. (Optional) In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
+1. (Optional) In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
+
+See [Event batching](#event-batching) for more information.
+
+## Secret defaults
+
+{{% observability_pipelines/set_secrets_intro %}}
+
+{{< tabs >}}
+{{% tab "Secrets Management" %}}
+
+- ClickHouse HTTP endpoint URL identifier:
+    - References the HTTP interface endpoint of your ClickHouse server.
+    - The default identifier is `DESTINATION_CLICKHOUSE_ENDPOINT_URL`.
+- ClickHouse username identifier (when basic auth is enabled):
+    - The default identifier is `DESTINATION_CLICKHOUSE_USERNAME`.
+- ClickHouse password identifier (when basic auth is enabled):
+    - The default identifier is `DESTINATION_CLICKHOUSE_PASSWORD`.
+- ClickHouse TLS passphrase identifier (when TLS is enabled with an encrypted private key):
+    - The default identifier is `DESTINATION_CLICKHOUSE_KEY_PASS`.
+
+{{% /tab %}}
+
+{{% tab "Environment Variables" %}}
+
+{{% observability_pipelines/configure_existing_pipelines/destination_env_vars/clickhouse %}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## How the destination works
+
+### Event batching
+
+A batch of events is flushed when one of the configured parameters is met. See [event batching][12] for more information.
+
+| Maximum Events | Timeout (seconds) |
+|----------------|-------------------|
+| Configurable   | Configurable      |
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://clickhouse.com/docs
+[2]: https://clickhouse.com/docs/interfaces/http
+[3]: /observability_pipelines/configuration/set_up_pipelines/
+[4]: https://app.datadoghq.com/observability-pipelines
+[5]: /api/latest/observability-pipelines/
+[6]: https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/observability_pipeline
+[7]: https://clickhouse.com/docs/interfaces/formats/JSONEachRow
+[8]: https://clickhouse.com/docs/interfaces/formats/JSONAsObject
+[9]: https://clickhouse.com/docs/interfaces/formats/JSONAsString
+[10]: https://clickhouse.com/docs/operations/settings/formats#input_format_skip_unknown_fields
+[11]: https://clickhouse.com/docs/operations/settings/formats#date_time_input_format
+[12]: /observability_pipelines/destinations/#event-batching

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -110,11 +110,11 @@ See [Event batching](#event-batching) for more information.
 
 ### Event batching
 
-A batch of events is flushed when one of the configured parameters is met. See [event batching][12] for more information.
+A batch of events is flushed when one of these parameters is met. Batching is also configurable for this destination. See [event batching][12] for more information.
 
 | Maximum Events | Timeout (seconds) |
 |----------------|-------------------|
-| Configurable   | Configurable      |
+| None           | 1                 |
 
 ## Further reading
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -72,9 +72,9 @@ Batch encoding is required when **Format** is set to `arrow_stream` and is optio
 
 Toggle **Enable batching** for batch encoding.
 
+1. Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 1. In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
 1. In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
-1. Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 
 See [Event batching](#event-batching) for more information.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -108,9 +108,9 @@ See [Event batching](#event-batching) for more information.
 
 A batch of events is flushed when one of these parameters is met. Batching is also configurable for this destination. See [event batching][12] for more information.
 
-| Maximum Events | Timeout (seconds) |
-|----------------|-------------------|
-| No limit       | 1                 |
+| Maximum Events | Maximum Bytes | Timeout (seconds) |
+|----------------|---------------|-------------------|
+| No limit       | 10 MB         | 1                 |
 
 ## Further reading
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -72,7 +72,6 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 
 Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
 
-1. In the **Codec** dropdown menu, select `arrow_stream`.
 1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns cause encoding errors.
 
 **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline starts because the target table's schema is read from the server to build the Arrow encoder.

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -52,7 +52,7 @@ After you select the ClickHouse destination in the pipeline UI:
 
 #### Skip unknown fields
 
-Toggle the **Skip unknown fields** switch to either **Drop Unknown Fields** or **Fail On Unknown Fields** for fields that are not present in the target table schema instead of returning an insert error. The default is **Use ClickHouse Server**, which uses the [`input_format_skip_unknown_fields`][10] setting.
+Toggle the **Skip unknown fields** switch to either **Drop Unknown Fields** or **Fail On Unknown Fields**  that are not present in the target table schema instead of returning an insert error. The default is **Use ClickHouse Server**, which uses the [`input_format_skip_unknown_fields`][10] setting.
 
 #### Date time best effort
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -25,7 +25,7 @@ Before you configure the ClickHouse destination, you must have:
 - A running ClickHouse server that the Observability Pipelines Worker can access using the [HTTP interface][2].
 - A ClickHouse database and target table to which the Worker sends events.
 - (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The Worker authenticates with HTTP basic authentication.
-- (Optional) TLS material if your ClickHouse server requires HTTPS with client certificates.
+- (Optional) TLS certificates if your ClickHouse server requires HTTPS with client certificates.
 
 ## Setup
 
@@ -52,11 +52,11 @@ After you select the ClickHouse destination in the pipeline UI:
 
 #### Skip unknown fields
 
-Toggle the **Skip unknown fields** switch to either **Drop Unknown Fields** or **Fail On Unknown Fields**  that are not present in the target table schema instead of returning an insert error. The default is **Use ClickHouse Server**, which uses the [`input_format_skip_unknown_fields`][10] setting.
+In the **Skip unknown fields** dropdown menu, select either **Drop Unknown Fields** or **Fail On Unknown Fields** for fields that are not present in the target table schema instead of returning an insert error. The default is **Use ClickHouse Server**, which uses the [`input_format_skip_unknown_fields`][10] setting.
 
 #### Date time best effort
 
-Toggle the **Date time best effort** switch to enable flexible `DateTime` parsing on the ClickHouse server. When enabled, the server accepts a wider range of date and time string formats. See ClickHouse's [`date_time_input_format`][11] setting for more information.
+Toggle **Date time best effort** to enable flexible `DateTime` parsing on the ClickHouse server. When enabled, the server accepts a wider range of date and time string formats. See ClickHouse's [`date_time_input_format`][11] setting for more information.
 
 #### Compression
 
@@ -68,11 +68,13 @@ Toggle **Enable Compression** to compress outbound HTTP requests with gzip. You 
 
 #### Enable batching
 
-Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
+Batch encoding is required when **Format** is set to `arrow_stream` and is optional for JSON formats.
+
+Toggle **Enable batching** for batch encoding.
 
 1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
-1. (Optional) In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
-1. (Optional) In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
+1. In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
+1. In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
 
 See [Event batching](#event-batching) for more information.
 
@@ -110,7 +112,7 @@ A batch of events is flushed when one of these parameters is met. Batching is al
 
 | Maximum Events | Maximum Bytes | Timeout (seconds) |
 |----------------|---------------|-------------------|
-| No limit       | 10 MB         | 1                 |
+| None           | 10 MB         | 1                 |
 
 ## Further reading
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -64,13 +64,6 @@ In the **Compression** dropdown menu, select the algorithm used to compress outb
 
 When you select `gzip`, you can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the default is `6`.
 
-#### Enable basic authentication
-
-Toggle the **Enable Basic Auth** switch to authenticate to ClickHouse with HTTP Basic auth.
-
-1. Enter the identifier for your ClickHouse username. If you leave it blank, the [default](#secret-defaults) is used.
-1. Enter the identifier for your ClickHouse password. If you leave it blank, the [default](#secret-defaults) is used.
-
 #### Enable TLS
 
 {{% observability_pipelines/tls_settings %}}

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -24,7 +24,7 @@ Before you configure the ClickHouse destination, you must have:
 
 - A running ClickHouse server that the Observability Pipelines Worker can access using the [HTTP interface][2].
 - A ClickHouse database and target table to which the Worker sends events.
-- (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The destination authenticates with HTTP Basic auth.
+- (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The Worker authenticates with HTTP basic authentication.
 - (Optional) TLS material if your ClickHouse server requires HTTPS with client certificates.
 
 ## Setup

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -70,7 +70,7 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 
 #### Enable batching
 
-Batch encoding is required when **Format** is set to `arrow_stream`. It is not used with the JSON formats.
+Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
 
 1. In the **Codec** dropdown menu, select `arrow_stream`.
 1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns cause encoding errors.

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -46,7 +46,7 @@ After you select the ClickHouse destination in the pipeline UI:
     - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
     - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Enable batching](#enable-batching).
 
-    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline is created because the target table's schema is read from the server to build the Arrow encoder.
+    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable when the Worker starts because the target table's schema is fetched at startup to build the Arrow encoder.
 
 ### Optional settings
 
@@ -60,11 +60,7 @@ Toggle the **Date time best effort** switch to enable flexible `DateTime` parsin
 
 #### Compression
 
-In the **Compression** dropdown menu, select the algorithm used to compress outbound HTTP requests:
-- `gzip` (default): Compresses requests with gzip.
-- `none`: Sends requests uncompressed.
-
-When you select `gzip`, you can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the default is `6`.
+Toggle **Enable Compression** to compress outbound HTTP requests with gzip. You can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the default is `6`.
 
 #### Enable TLS
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -44,7 +44,7 @@ After you select the ClickHouse destination in the pipeline UI:
     - `json_each_row` (default): Inserts each event as a JSON object on its own line. Event fields are mapped to columns of the same name. This maps to ClickHouse's [`JSONEachRow`][7] format.
     - `json_as_object`: Inserts each event into a single `JSON`-typed column. This maps to ClickHouse's [`JSONAsObject`][8] format.
     - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
-    - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Batch encoding](#batch-encoding).
+    - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Enable batching](#enable-batching).
 
 ### Optional settings
 
@@ -68,7 +68,7 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 
 {{% observability_pipelines/tls_settings %}}
 
-#### Batch encoding
+#### Enable batching
 
 Batch encoding is required when **Format** is set to `arrow_stream`. It is not used with the JSON formats.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -72,9 +72,9 @@ Batch encoding is required when **Format** is set to `arrow_stream` and is optio
 
 Toggle **Enable batching** for batch encoding.
 
-1. Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 1. In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
 1. In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
+1. Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 
 See [Event batching](#event-batching) for more information.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -114,7 +114,7 @@ A batch of events is flushed when one of these parameters is met. Batching is al
 
 | Maximum Events | Timeout (seconds) |
 |----------------|-------------------|
-| None           | 1                 |
+| No limit       | 1                 |
 
 ## Further reading
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -46,7 +46,7 @@ After you select the ClickHouse destination in the pipeline UI:
     - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
     - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Enable batching](#enable-batching).
 
-    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable when a pipeline configuration loads in the Worker and on restart because the target table's schema is fetched at that time to build the Arrow encoder.
+    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable when your worker loads the pipeline configuration from the remote configuration backend, or upon worker restart. The Clickhouse table schema is not persisted between restarts.
 
 ### Optional settings
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -72,7 +72,7 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 
 Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
 
-1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns cause encoding errors.
+1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 
 **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline starts because the target table's schema is read from the server to build the Arrow encoder.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -36,8 +36,10 @@ Configure the ClickHouse destination when you [set up a pipeline][3]. You can se
 After you select the ClickHouse destination in the pipeline UI:
 
 1. Enter the identifier for your ClickHouse HTTP endpoint URL. If you leave it blank, the [default](#secret-defaults) is used.
-1. In the **Table** field, enter the name of the ClickHouse table to insert events into. This field is required.
+1. (Optional) Enter the identifier for your ClickHouse username. If you leave it blank, the [default](#secret-defaults) is used.
+1. (Optional) Enter the identifier for your ClickHouse password. If you leave it blank, the [default](#secret-defaults) is used.
 1. (Optional) In the **Database** field, enter the name of the ClickHouse database that contains the table. If you leave it blank, the ClickHouse user's default database is used.
+1. In the **Table** field, enter the name of the ClickHouse table to insert events into.
 1. In the **Format** dropdown menu, select the insert format for events:
     - `json_each_row` (default): Inserts each event as a JSON object on its own line. Event fields are mapped to columns of the same name. This maps to ClickHouse's [`JSONEachRow`][7] format.
     - `json_as_object`: Inserts each event into a single `JSON`-typed column. This maps to ClickHouse's [`JSONAsObject`][8] format.

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -72,7 +72,7 @@ Batch encoding is required when **Format** is set to `arrow_stream` and is optio
 
 Toggle **Enable batching** for batch encoding.
 
-1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
+1. Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
 1. In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
 1. In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -46,7 +46,7 @@ After you select the ClickHouse destination in the pipeline UI:
     - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
     - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Enable batching](#enable-batching).
 
-    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable when the Worker starts because the target table's schema is fetched at startup to build the Arrow encoder.
+    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable when a pipeline configuration loads in the Worker and on restart because the target table's schema is fetched at that time to build the Arrow encoder.
 
 ### Optional settings
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -46,6 +46,8 @@ After you select the ClickHouse destination in the pipeline UI:
     - `json_as_string`: Inserts each event into a single `String`-typed column, storing the raw JSON. This maps to ClickHouse's [`JSONAsString`][9] format.
     - `arrow_stream`: Batches events using the Apache Arrow IPC streaming format. When you select this format, you must also configure [Enable batching](#enable-batching).
 
+    **Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline is created because the target table's schema is read from the server to build the Arrow encoder.
+
 ### Optional settings
 
 #### Skip unknown fields
@@ -73,8 +75,6 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
 
 1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
-
-**Note**: When you use `arrow_stream`, your ClickHouse server must be reachable at the time the pipeline starts because the target table's schema is read from the server to build the Arrow encoder.
 
 #### Batching
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -62,7 +62,7 @@ In the **Compression** dropdown menu, select the algorithm used to compress outb
 - `gzip` (default): Compresses requests with gzip.
 - `none`: Sends requests uncompressed.
 
-When you select `gzip`, you can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the algorithm's default level is used.
+When you select `gzip`, you can optionally set the **Compression level** to an integer from `1` (fastest) to `9` (best compression). If left unset, the default is `6`.
 
 #### Enable basic authentication
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -75,11 +75,6 @@ When you select `gzip`, you can optionally set the **Compression level** to an i
 Batch encoding is required when **Format** is set to `arrow_stream` and optional for JSON formats.
 
 1. (Optional) Toggle **Allow nullable fields** to allow `null` values for non-nullable columns in the target table. When this setting is off (default), missing values for non-nullable columns results in encoding errors.
-
-#### Batching
-
-Use the **Batching** settings to control how events are grouped into HTTP inserts:
-
 1. (Optional) In the **Max events** field, enter the maximum number of events per batch. Must be `1` or greater.
 1. (Optional) In the **Timeout (secs)** field, enter the maximum time, in seconds, before a partial batch is flushed. Must be between `1` and `65535`. If left unset, the default is 1 second.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -1,5 +1,6 @@
 ---
 title: ClickHouse Destination
+description: Learn how to configure the ClickHouse destination.
 disable_toc: false
 products:
 - name: Logs

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -23,7 +23,7 @@ Use Observability Pipelines' ClickHouse destination to send logs to a [ClickHous
 Before you configure the ClickHouse destination, you must have:
 
 - A running ClickHouse server that the Observability Pipelines Worker can access using the [HTTP interface][2].
-- A database and target table where events are inserted. The destination does not create the database or table for you.
+- A ClickHouse database and target table to which the Worker sends events.
 - (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The destination authenticates with HTTP Basic auth.
 - (Optional) TLS material if your ClickHouse server requires HTTPS with client certificates.
 

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -22,7 +22,7 @@ Use Observability Pipelines' ClickHouse destination to send logs to a [ClickHous
 
 Before you configure the ClickHouse destination, you must have:
 
-- A running ClickHouse server reachable from the Observability Pipelines Worker over the [HTTP interface][2].
+- A running ClickHouse server that the Observability Pipelines Worker can access using the [HTTP interface][2].
 - A database and target table where events are inserted. The destination does not create the database or table for you.
 - (Optional) Credentials for a ClickHouse user that has `INSERT` permission on the target table. The destination authenticates with HTTP Basic auth.
 - (Optional) TLS material if your ClickHouse server requires HTTPS with client certificates.

--- a/content/en/observability_pipelines/destinations/clickhouse.md
+++ b/content/en/observability_pipelines/destinations/clickhouse.md
@@ -50,7 +50,7 @@ After you select the ClickHouse destination in the pipeline UI:
 
 #### Skip unknown fields
 
-Toggle the **Skip unknown fields** switch to drop event fields that are not present in the target table schema instead of returning an insert error. When this setting is left unset, the ClickHouse server's [`input_format_skip_unknown_fields`][10] setting applies.
+Toggle the **Skip unknown fields** switch to either **Drop Unknown Fields** or **Fail On Unknown Fields** for fields that are not present in the target table schema instead of returning an insert error. The default is **Use ClickHouse Server**, which uses the [`input_format_skip_unknown_fields`][10] setting.
 
 #### Date time best effort
 

--- a/layouts/shortcodes/observability_pipelines/configure_existing_pipelines/destination_env_vars/clickhouse.en.md
+++ b/layouts/shortcodes/observability_pipelines/configure_existing_pipelines/destination_env_vars/clickhouse.en.md
@@ -1,0 +1,9 @@
+- ClickHouse HTTP endpoint URL:
+   - The HTTP interface endpoint your Observability Pipelines Worker sends events to. For example, `https://clickhouse.example.com:8443`.
+   - The default environment variable is `DD_OP_DESTINATION_CLICKHOUSE_ENDPOINT_URL`.
+- ClickHouse authentication username (when basic auth is enabled):
+   - The default environment variable is `DD_OP_DESTINATION_CLICKHOUSE_USERNAME`.
+- ClickHouse authentication password (when basic auth is enabled):
+   - The default environment variable is `DD_OP_DESTINATION_CLICKHOUSE_PASSWORD`.
+- ClickHouse TLS passphrase (when TLS is enabled with an encrypted private key):
+   - The default environment variable is `DD_OP_DESTINATION_CLICKHOUSE_KEY_PASS`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a public documentation page for the new Observability Pipelines ClickHouse destination, which sends logs to a ClickHouse server over the HTTP interface.

The page documents the v1 field surface:
- HTTP endpoint URL identifier
- `database` (optional) and `table` (required)
- Insert formats: `json_each_row`, `json_as_object`, `json_as_string`, `arrow_stream`
- `skip_unknown_fields`, `date_time_best_effort`
- Compression (`gzip` with optional level 1-9, or `none`)
- Basic authentication
- TLS settings
- Batching (`max_events`, `timeout_secs`)
- `batch_encoding` for `arrow_stream` (`allow_nullable_fields`)

Also adds:
- A new environment-variables partial at `layouts/shortcodes/observability_pipelines/configure_existing_pipelines/destination_env_vars/clickhouse.en.md`.
- An entry under the **Logs** tab on the destinations index page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Initial draft generated with Claude Code from the destination schema; then manually reviewed for Vale style compliance and to confirm no internal implementation details leak into the public docs.

### Additional notes

Draft until the in-product UI strings and field labels are confirmed against the released UI.