### PR TITLE
Profiling: clarify fork support in Python

### DIFF
--- a/layouts/shortcodes/mdoc/en/profiler/enabling/python.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/profiler/enabling/python.mdoc.md
@@ -58,10 +58,10 @@ To begin profiling applications:
 
 5. After a couple of minutes, your profiles appear on the [Datadog APM > Profiler page][8]. If they do not, see the [Troubleshooting][9] guide.
 
-### Caveats
+### Profiling across forks
 
 When your process forks using `os.fork`, the profiler is automatically restarted
-in the child process on supported Python versions. No manual restart is required.
+in the child process. No manual restart is required.
 
 ## Configuration
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR
- Updates the fork documentation to be titled in a more positive manner ("Caveats" sounds like there's a problem -- it's a feature that we're talking about here)
- Removes the phrasing about "supported Python versions" -- we do that in all Python versions in `ddtrace` today.
