### PR TITLE
document the 2.9 macros backport

### DIFF
--- a/content/en/data_observability/jobs_monitoring/airflow.md
+++ b/content/en/data_observability/jobs_monitoring/airflow.md
@@ -392,6 +392,8 @@ dbt_run = BashOperator(
 )
 ```
 
+**Note**: On Airflow 2.9.2 with `apache-airflow-providers-openlineage` 2.2.0 - the latest provider enabled for this Airflow version - the `lineage_root_*` macros required for root-parent linking are not available. To use them anyway, see [Backport OpenLineage lineage macros for older provider versions](#backport-openlineage-lineage-macros-for-older-provider-versions).
+
 ### Link your Spark jobs with Airflow tasks
 
 OpenLineage integration can automatically inject Airflow's parent job information (namespace, job name, run id) into Spark application properties. This creates a parent-child relationship between Airflow tasks and Spark jobs, enabling you to troubleshoot both systems in one place.
@@ -409,6 +411,143 @@ AIRFLOW__OPENLINEAGE__SPARK_INJECT_PARENT_JOB_INFO=true
 ```
 
 This automatically injects parent job properties for all supported Spark Operators. To disable for specific operators, set `openlineage_inject_parent_job_info=False` on the operator.
+
+#### Manually inject parent job information for unsupported operators
+
+For operators that do not support automatic injection (for example, a `BashOperator` running the AWS CLI to start an Amazon EMR Serverless job), use the [OpenLineage Airflow lineage macros][4] to pass parent and root-parent identifiers as Spark configuration properties:
+
+```python
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+with DAG(
+    dag_id="emr_serverless_with_openlineage_parent",
+    start_date=datetime(2026, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+) as dag:
+
+    submit = BashOperator(
+        task_id="start_emr_serverless_job",
+        bash_command=r"""
+set -euo pipefail
+
+aws emr-serverless start-job-run \
+  --application-id <APPLICATION_ID> \
+  --execution-role-arn <EXECUTION_ROLE_ARN> \
+  --name <JOB_NAME> \
+  --region <AWS_REGION> \
+  --mode STREAMING \
+  --job-driver '{"sparkSubmit": {
+    "entryPoint": "<JAR_URL>",
+    "entryPointArguments": ["--config-key", "<CONFIG_KEY>", "--stage", "<STAGE>"],
+    "sparkSubmitParameters": "\
+--conf spark.app.name=<APP_NAME> \
+--conf spark.openlineage.parentJobNamespace={{ lineage_job_namespace() }} \
+--conf spark.openlineage.parentJobName={{ lineage_job_name(task_instance) }} \
+--conf spark.openlineage.parentRunId={{ lineage_run_id(task_instance) }} \
+--conf spark.openlineage.rootParentJobNamespace={{ lineage_root_job_namespace(task_instance) }} \
+--conf spark.openlineage.rootParentJobName={{ lineage_root_job_name(task_instance) }} \
+--conf spark.openlineage.rootParentRunId={{ lineage_root_run_id(task_instance) }}\
+"
+  }}'
+""",
+    )
+```
+
+The `lineage_root_*` macros require `apache-airflow-providers-openlineage` 2.3.0 or later. On older provider versions (for example, Airflow 2.9.2 with provider 2.2.0), see [Backport OpenLineage lineage macros for older provider versions](#backport-openlineage-lineage-macros-for-older-provider-versions).
+
+### Backport OpenLineage lineage macros for older provider versions
+
+The `lineage_root_job_namespace`, `lineage_root_job_name`, and `lineage_root_run_id` macros that emit the outermost DAG identifiers for root-parent linking were added in `apache-airflow-providers-openlineage` 2.3.0. If you cannot upgrade the provider (for example, Amazon MWAA on Airflow 2.9.2 pins provider 2.2.0), define the missing macros as `user_defined_macros` on the DAG:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.providers.openlineage import conf as ol_conf
+from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
+
+
+def _logical_date(ti):
+    return getattr(ti, "logical_date", None) or ti.execution_date
+
+
+def _clear_number(ti) -> int:
+    return ti.get_dagrun().clear_number
+
+
+def _root_from_conf(ti, key):
+    ol = (ti.get_dagrun().conf or {}).get("openlineage") or {}
+    return ol.get(key) or None
+
+
+def lineage_job_namespace():
+    return ol_conf.namespace()
+
+
+def lineage_job_name(ti):
+    return f"{ti.dag_id}.{ti.task_id}"
+
+
+def lineage_run_id(ti):
+    return OpenLineageAdapter.build_task_instance_run_id(
+        dag_id=ti.dag_id,
+        task_id=ti.task_id,
+        try_number=ti.try_number,
+        logical_date=_logical_date(ti),
+        map_index=ti.map_index,
+    )
+
+
+def lineage_root_job_namespace(ti):
+    return _root_from_conf(ti, "rootParentJobNamespace") or ol_conf.namespace()
+
+
+def lineage_root_job_name(ti):
+    return _root_from_conf(ti, "rootParentJobName") or ti.dag_id
+
+
+def lineage_root_run_id(ti):
+    forwarded = _root_from_conf(ti, "rootParentRunId")
+    if forwarded:
+        return forwarded
+    return OpenLineageAdapter.build_dag_run_id(
+        dag_id=ti.dag_id,
+        logical_date=_logical_date(ti),
+        clear_number=_clear_number(ti),
+    )
+
+
+OL_MACROS = {
+    "lineage_job_namespace": lineage_job_namespace,
+    "lineage_job_name": lineage_job_name,
+    "lineage_run_id": lineage_run_id,
+    "lineage_root_job_namespace": lineage_root_job_namespace,
+    "lineage_root_job_name": lineage_root_job_name,
+    "lineage_root_run_id": lineage_root_run_id,
+}
+
+
+with DAG(
+    dag_id="<YOUR_DAG_ID>",
+    start_date=datetime(2026, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    user_defined_macros=OL_MACROS,
+) as dag:
+    submit = BashOperator(
+        task_id="<YOUR_TASK_ID>",
+        bash_command="...",
+    )
+```
+
+With `user_defined_macros` set on the DAG, the `{{ lineage_*() }}` and `{{ lineage_root_*() }}` calls in your task templates resolve to values that match the built-in macros shipped with provider 2.3.0+, so downstream Spark or dbt jobs can link to the Airflow root parent in Datadog.
 
 
 ## Further Reading

--- a/content/en/data_observability/jobs_monitoring/airflow.md
+++ b/content/en/data_observability/jobs_monitoring/airflow.md
@@ -360,6 +360,8 @@ To run an automated check of your OpenLineage setup, see [Troubleshoot Airflow S
 
 ### Link your dbt jobs with Airflow tasks
 
+<div class="alert alert-info">On Airflow 2.9.2 with <code>apache-airflow-providers-openlineage</code> 2.2.0 - the latest provider enabled for this Airflow version - the <code>lineage_root_*</code> macros required for root-parent linking are not available. To use them anyway, see <a href="#backport-openlineage-lineage-macros-for-older-provider-versions">Backport OpenLineage lineage macros for older provider versions</a>.</div>
+
 You can monitor your dbt jobs that are running in Airflow by connecting the dbt telemetry with respective Airflow tasks, using [OpenLineage dbt integration][6].
 
 To see the link between Airflow tasks and dbt jobs, follow those steps:
@@ -392,9 +394,9 @@ dbt_run = BashOperator(
 )
 ```
 
-**Note**: On Airflow 2.9.2 with `apache-airflow-providers-openlineage` 2.2.0 - the latest provider enabled for this Airflow version - the `lineage_root_*` macros required for root-parent linking are not available. To use them anyway, see [Backport OpenLineage lineage macros for older provider versions](#backport-openlineage-lineage-macros-for-older-provider-versions).
-
 ### Link your Spark jobs with Airflow tasks
+
+<div class="alert alert-info">The <code>lineage_root_*</code> macros require <code>apache-airflow-providers-openlineage</code> 2.3.0 or later. On older provider versions (for example, Airflow 2.9.2 with provider 2.2.0), see <a href="#backport-openlineage-lineage-macros-for-older-provider-versions">Backport OpenLineage lineage macros for older provider versions</a>.</div>
 
 OpenLineage integration can automatically inject Airflow's parent job information (namespace, job name, run id) into Spark application properties. This creates a parent-child relationship between Airflow tasks and Spark jobs, enabling you to troubleshoot both systems in one place.
 
@@ -456,8 +458,6 @@ aws emr-serverless start-job-run \
 """,
     )
 ```
-
-The `lineage_root_*` macros require `apache-airflow-providers-openlineage` 2.3.0 or later. On older provider versions (for example, Airflow 2.9.2 with provider 2.2.0), see [Backport OpenLineage lineage macros for older provider versions](#backport-openlineage-lineage-macros-for-older-provider-versions).
 
 ### Backport OpenLineage lineage macros for older provider versions
 

--- a/content/en/data_observability/jobs_monitoring/airflow.md
+++ b/content/en/data_observability/jobs_monitoring/airflow.md
@@ -360,7 +360,7 @@ To run an automated check of your OpenLineage setup, see [Troubleshoot Airflow S
 
 ### Link your dbt jobs with Airflow tasks
 
-<div class="alert alert-info">On Airflow 2.9.2 with <code>apache-airflow-providers-openlineage</code> 2.2.0 - the latest provider enabled for this Airflow version - the <code>lineage_root_*</code> macros required for root-parent linking are not available. To use them anyway, see <a href="#backport-openlineage-lineage-macros-for-older-provider-versions">Backport OpenLineage lineage macros for older provider versions</a>.</div>
+<div class="alert alert-info">The <code>lineage_root_*</code> macros used below require <code>apache-airflow-providers-openlineage</code> 2.3.0 or later. On older provider versions (for example, Airflow 2.9.2 with provider 2.2.0), see <a href="#backport-openlineage-lineage-macros-for-older-provider-versions">Backport OpenLineage lineage macros for older provider versions</a>.</div>
 
 You can monitor your dbt jobs that are running in Airflow by connecting the dbt telemetry with respective Airflow tasks, using [OpenLineage dbt integration][6].
 
@@ -380,7 +380,7 @@ Also, add the --consume-structured-logs flag to view dbt jobs while the command 
 dbt-ol run --consume-structured-logs --project-dir=$TEMP_DIR --profiles-dir=$PROFILES_DIR
 ```
 
-3. In your DAG file, add the OPENLINEAGE_PARENT_ID variable to the environment of the Airflow task that runs the dbt process:
+3. In your DAG file, set the OpenLineage parent and root-parent environment variables on the Airflow task that runs the dbt process so dbt jobs link to both the immediate parent task and the outermost DAG run in Datadog:
 
 ```python
 dbt_run = BashOperator(
@@ -389,7 +389,12 @@ dbt_run = BashOperator(
     bash_command=f"dbt-ol run --consume-structured-logs --project-dir=$TEMP_DIR --profiles-dir=$PROFILES_DIR",
     append_env=True,
     env={
-        "OPENLINEAGE_PARENT_ID": "{{ macros.OpenLineageProviderPlugin.lineage_parent_id(task_instance) }}",
+        "OPENLINEAGE_PARENT_JOB_NAMESPACE": "{{ lineage_job_namespace() }}",
+        "OPENLINEAGE_PARENT_JOB_NAME": "{{ lineage_job_name(task_instance) }}",
+        "OPENLINEAGE_PARENT_RUN_ID": "{{ lineage_run_id(task_instance) }}",
+        "OPENLINEAGE_ROOT_PARENT_JOB_NAMESPACE": "{{ lineage_root_job_namespace(task_instance) }}",
+        "OPENLINEAGE_ROOT_PARENT_JOB_NAME": "{{ lineage_root_job_name(task_instance) }}",
+        "OPENLINEAGE_ROOT_PARENT_RUN_ID": "{{ lineage_root_run_id(task_instance) }}",
     },
 )
 ```


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds instructions for customers on how to proceed with enabling Airflow linkage with subsequent jobs when on Airflow 2.9.2 with  `apache-airflow-providers-openlineage==2.2.0`.

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude to draft the initial change.