### PR TITLE
Editorial review: Agent Console overview and setup pages

### DIFF
--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="Preview">}}
-Agent Console is in Preview.
+Agent Console is in Preview and available to all Datadog customers.
 {{< /callout >}}
 
 The [Agent Console][1] provides centralized monitoring for AI agents across your organization. It collects logs and metrics from coding agents and Datadog's own Bits AI agents, surfacing them in real time to give you visibility into usage, cost, latency, productivity impact, and emerging problem patterns.
@@ -115,6 +115,10 @@ The {{< ui >}}Bits AI Agents{{< /ui >}} tab shows usage of Datadog's built-in AI
 Individual cards summarize activity for each Bits AI agent, including [Bits AI SRE][11], [Bits AI Dev Agent][12], and [Agent Builder][13]. Select {{< ui >}}View Details{{< /ui >}} on a card to examine that agent.
 
 {{< img src="ai_agents_console/bits-ai-agents.png" alt="Bits AI Agents tab with a combined agent activity chart over time and individual cards for Bits AI SRE, Bits AI Dev, and Agent Builder showing recent investigations, sessions, and executions" style="width:100%;" >}}
+
+## Set up
+
+To start sending data to Agent Console, see [Set Up Agent Console][14].
 
 ## Further reading
 

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -1,6 +1,10 @@
 ---
 title: Agent Console
+description: Monitor coding agent and Bits AI agent usage, cost, and performance across your organization in Datadog Agent Console.
 further_reading:
+  - link: '/ai_agents_console/setup/'
+    tag: 'Documentation'
+    text: 'Set Up Agent Console'
   - link: '/integrations/anthropic-usage-and-costs/'
     tag: 'Documentation'
     text: 'Anthropic Usage and Costs integration'
@@ -13,7 +17,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="Preview">}}
-Agent Console is available to all Datadog customers in Preview.
+Agent Console is in Preview.
 {{< /callout >}}
 
 The [Agent Console][1] provides centralized monitoring for AI agents across your organization. It collects logs and metrics from coding agents and Datadog's own Bits AI agents, surfacing them in real time to give you visibility into usage, cost, latency, productivity impact, and emerging problem patterns.
@@ -28,7 +32,7 @@ Agent Console supports the following coding agents:
 
 In addition, Agent Console includes a dedicated tab for [Bits AI agents](#bits-ai-agents), Datadog's built-in AI agents.
 
-## Coding Agents
+## Coding agents
 
 The {{< ui >}}Coding Agents{{< /ui >}} tab gives you a top-level view of coding agent activity across your organization. By default, the view aggregates all coding agents and can be filtered to a single agent.
 
@@ -50,7 +54,7 @@ The {{< ui >}}Impact Metrics{{< /ui >}} panel measures the effect of AI-assisted
 
 ### Detected problems
 
-The {{< ui >}}Detected Problems{{< /ui >}} panel highlights common problem patterns that your team is hitting and recommends fixes. The Sankey diagram shows how problem patterns (such as skipped checks, retry loops, and file rereads) flow from individual agents into specific repositories, with an estimated monthly cost for each pattern.
+The {{< ui >}}Detected Problems{{< /ui >}} panel highlights common problem patterns your team is encountering and recommends fixes. The Sankey diagram shows how problem patterns (such as skipped checks, retry loops, and file rereads) flow from individual agents into specific repositories, with an estimated monthly cost for each pattern.
 
 {{< img src="ai_agents_console/detected-problems.png" alt="Detected Problems Sankey diagram mapping Claude Code, Cursor, and GitHub Copilot sessions to problem patterns such as Skipped checks, Retry loops, and File rereads, then to affected repositories, with a side panel showing cost breakdowns per repository" style="width:100%;" >}}
 
@@ -60,25 +64,25 @@ Select a pattern to open a detail view that includes the pattern definition, est
 
 ### Individual agent dashboards
 
-Click an agent tile to open a dedicated dashboard for that coding agent. Each dashboard includes summary tiles for total spend, sessions, commits, and lines added, along with performance charts covering request volume, latency, model usage patterns, lines added vs. removed, and tool accepts vs. rejects.
+Select an agent tile to open a dedicated dashboard for that coding agent. Each dashboard includes summary tiles for total spend, sessions, commits, and lines added, along with performance charts covering request volume, latency, model usage patterns, lines added vs. removed, and tool accepts vs. rejects.
 
 Filter each dashboard by team, user, repository, and time range.
 
 {{< img src="ai_agents_console/coding-agent-dashboard.png" alt="Claude Code dashboard in the Coding Agents tab with Teams, Users, and Repository filters; summary tiles for Total Spend, Sessions, Commits, and Lines Added; and Performance charts for Commits Over Time, Pull Requests Over Time, Lines Added vs Removed, and Tool Accepts vs Rejects" style="width:100%;" >}}
 
-## Analytics
+## Analyze agent usage
 
 The {{< ui >}}Analytics{{< /ui >}} tab provides granular details for individuals and teams, helping you identify power users, outliers, and team-level adoption patterns.
 
 ### Team comparison
 
-The {{< ui >}}Comparison{{< /ui >}} panel compares your team to other teams and the broader organization across spend, cost per line, and model usage. The line chart trends the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right surface notable trends, such as teams that are running well above or below the organization average.
+The {{< ui >}}Comparison{{< /ui >}} panel shows how your team stacks up against other teams and the broader organization across spend, cost per line, and model usage. The line chart shows the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right highlight notable trends, such as teams that are running well above or below the organization average.
 
 Select {{< ui >}}Team Details{{< /ui >}} on a row to open that team's view.
 
 {{< img src="ai_agents_console/team-comparison.png" alt="Comparison panel with a line chart of spend per engineer across teams over time, insight callouts on the right, and a table comparing spend per engineer, cost per PR, time to merge, and sessions for each team" style="width:100%;" >}}
 
-### User Analytics
+### User analytics
 
 The {{< ui >}}User Analytics{{< /ui >}} panel breaks down activity by individual user.
 
@@ -100,21 +104,17 @@ The {{< ui >}}User Cost Across Agents{{< /ui >}} table lists every user, the age
 
 {{< img src="ai_agents_console/user-cost-across-agents.png" alt="User Cost Across Agents table showing per-user model cost, agents used, lines of code generated, and sessions for 98 users" style="width:100%;" >}}
 
-Select a user to open a detail view that includes their user spend, lines generated, pull requests, AI adoption percentage, model mix, and recent pull requests. Switch to the {{< ui >}}Github Pull Requests{{< /ui >}} tab to see the user's full PR history.
+Select a user to open a detail view that includes their spend, lines generated, pull requests, AI adoption percentage, model mix, and recent pull requests. Switch to the {{< ui >}}Github Pull Requests{{< /ui >}} tab to see the user's full PR history.
 
 {{< img src="ai_agents_console/user-detail.png" alt="User detail view for an individual user, showing summary tiles for User Spend, Lines Generated, and Pull Requests; an AI Adoption and Model Mix breakdown; and a Recent Pull Requests table" style="width:100%;" >}}
 
-## Bits AI Agents
+## Bits AI agents
 
 The {{< ui >}}Bits AI Agents{{< /ui >}} tab shows usage of Datadog's built-in AI agents alongside your coding agents. The combined view of investigations, sessions, and executions across all Datadog agents lets you correlate Bits AI activity with the rest of your organization.
 
 Individual cards summarize activity for each Bits AI agent, including [Bits AI SRE][11], [Bits AI Dev Agent][12], and [Agent Builder][13]. Select {{< ui >}}View Details{{< /ui >}} on a card to examine that agent.
 
 {{< img src="ai_agents_console/bits-ai-agents.png" alt="Bits AI Agents tab with a combined agent activity chart over time and individual cards for Bits AI SRE, Bits AI Dev, and Agent Builder showing recent investigations, sessions, and executions" style="width:100%;" >}}
-
-## Set up
-
-To start sending data to Agent Console, see [Set Up Agent Console][14].
 
 ## Further reading
 

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -76,7 +76,7 @@ The {{< ui >}}Analytics{{< /ui >}} tab provides granular details for individuals
 
 ### Team comparison
 
-The {{< ui >}}Comparison{{< /ui >}} panel compares your team to other teams and the broader organization across spend, cost per line, and model usage. The line chart shows the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right highlight notable trends, such as teams that are running well above or below the organization average.
+The {{< ui >}}Comparison{{< /ui >}} panel shows your team's spend, cost per line, and model usage relative to other teams and the broader organization. The line chart shows the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right highlight notable trends, such as teams that are running well above or below the organization average.
 
 Select {{< ui >}}Team Details{{< /ui >}} on a row to open that team's view.
 

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -76,7 +76,7 @@ The {{< ui >}}Analytics{{< /ui >}} tab provides granular details for individuals
 
 ### Team comparison
 
-The {{< ui >}}Comparison{{< /ui >}} panel shows how your team stacks up against other teams and the broader organization across spend, cost per line, and model usage. The line chart shows the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right highlight notable trends, such as teams that are running well above or below the organization average.
+The {{< ui >}}Comparison{{< /ui >}} panel compares your team to other teams and the broader organization across spend, cost per line, and model usage. The line chart shows the selected metric per engineer over time, and the table breaks down spend per engineer, cost per PR, time to merge, and sessions for each team. Insights on the right highlight notable trends, such as teams that are running well above or below the organization average.
 
 Select {{< ui >}}Team Details{{< /ui >}} on a row to open that team's view.
 

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -104,7 +104,7 @@ The {{< ui >}}User Cost Across Agents{{< /ui >}} table lists every user, the age
 
 {{< img src="ai_agents_console/user-cost-across-agents.png" alt="User Cost Across Agents table showing per-user model cost, agents used, lines of code generated, and sessions for 98 users" style="width:100%;" >}}
 
-Select a user to open a detail view that includes their spend, lines generated, pull requests, AI adoption percentage, model mix, and recent pull requests. Switch to the {{< ui >}}Github Pull Requests{{< /ui >}} tab to see the user's full PR history.
+Select a user to open a detail view that includes their spend, lines generated, pull requests, AI adoption percentage, model mix, and recent pull requests. Switch to the {{< ui >}}GitHub Pull Requests{{< /ui >}} tab to see the user's full PR history.
 
 {{< img src="ai_agents_console/user-detail.png" alt="User detail view for an individual user, showing summary tiles for User Spend, Lines Generated, and Pull Requests; an AI Adoption and Model Mix breakdown; and a Recent Pull Requests table" style="width:100%;" >}}
 

--- a/content/en/ai_agents_console/setup.md
+++ b/content/en/ai_agents_console/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set Up Agent Console
+description: Set up integrations for Claude Code, Cursor, and GitHub Copilot to monitor coding agent activity in Datadog Agent Console.
 further_reading:
   - link: '/ai_agents_console/'
     tag: 'Documentation'
@@ -54,7 +55,7 @@ The following procedure configures Claude Code to send telemetry directly to Dat
    <div class="alert alert-info">To set up Agent Console for Claude Code across your organization, your IT team can use a Mobile Device Management (MDM) system or <a href="https://code.claude.com/docs/en/server-managed-settings">server-managed settings</a> to distribute the Claude Code settings file across all managed devices.</div>
 4. Restart Claude Code.
 
-After you restart Claude Code, navigate to the [Agent Console][1] and click on the {{< ui >}}Claude Code{{< /ui >}} tile. Metrics (usage, cost, latency, errors) should appear within a few minutes.
+After you restart Claude Code, navigate to the [Agent Console][1] and click the {{< ui >}}Claude Code{{< /ui >}} tile. Metrics (usage, cost, latency, errors) should appear within a few minutes.
 
 ### Option 3: Forward data through the Datadog Agent
 
@@ -89,7 +90,7 @@ After you restart Claude Code, navigate to the [Agent Console][1] and click on t
    <div class="alert alert-info">To set up Agent Console for Claude Code across your organization, your IT team can use a Mobile Device Management (MDM) system or <a href="https://code.claude.com/docs/en/server-managed-settings">server-managed settings</a> to distribute the Claude Code settings file across all managed devices.</div>
 5. Restart Claude Code.
 
-After you restart Claude Code, navigate to the [Agent Console][1] and click on the {{< ui >}}Claude Code{{< /ui >}} tile. Metrics (usage, cost, latency, errors) should appear within a few minutes.
+After you restart Claude Code, navigate to the [Agent Console][1] and click the {{< ui >}}Claude Code{{< /ui >}} tile. Metrics (usage, cost, latency, errors) should appear within a few minutes.
 
 ## Cursor
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Editorial pass on the Agent Console overview and new setup pages from #36862.

Changes:
- Add `description` frontmatter to `_index.md` and `setup.md` for AI/LLM discoverability per AI-friendly docs guidelines
- Rename `## Analytics` → `## Analyze agent usage` for specificity (avoids a generic heading in RAG retrieval context)
- Remove thin `## Set up` pointer section; covered by `further_reading` links
- Standardize heading casing to sentence case throughout
- Replace "is hitting" → "is encountering", "Click" → "Select"
- Remove redundant "their user spend" → "their spend"
- Add Set Up Agent Console link to `further_reading` in `_index.md`

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Depends on / intended to accompany #36862.