### PR TITLE
docs(cloud-security): correct runtime package tracking version + remove WP cost warning

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -70,10 +70,10 @@ Each vulnerability finding is enriched with the following signals:
 These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
 
 **Requirements**:
-- Datadog Agent **7.78.0 or later**
+- Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Important**: Enabling runtime package prioritization activates [Workload Protection][4] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through Workload Protection, which can affect Workload Protection usage. From 7.79.0, runtime package prioritization runs independently and does not affect Workload Protection usage.
 
 Add `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` to your Docker run command:
 
@@ -87,7 +87,7 @@ docker run -d --name dd-agent \
   registry.datadoghq.com/agent:7
 {{< /code-block >}}
 
-**Note**: `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][4] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
+**Note**: `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package prioritization runs independently of [Workload Protection][4] and does not affect Workload Protection usage. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
 
 [1]: /security/cloud_security_management/misconfigurations/
 [2]: /security/threats

--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -73,7 +73,7 @@ These signals power vulnerability prioritization in Cloud Security, surfacing fi
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through Workload Protection, which can affect Workload Protection usage. From 7.79.0, runtime package prioritization runs independently and does not affect Workload Protection usage.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][4] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 
 Add `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` to your Docker run command:
 
@@ -87,7 +87,7 @@ docker run -d --name dd-agent \
   registry.datadoghq.com/agent:7
 {{< /code-block >}}
 
-**Note**: `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package prioritization runs independently of [Workload Protection][4] and does not affect Workload Protection usage. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
+**Note**: `DD_SBOM_ENRICHMENT_USAGE_ENABLED=true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package prioritization runs independently of [Workload Protection][4] and does not affect its usage.
 
 [1]: /security/cloud_security_management/misconfigurations/
 [2]: /security/threats

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -57,8 +57,8 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
             # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
             analyzers: ["os", "languages"]
 
-          # Enables runtime package prioritization (Preview, Agent 7.78+)
-          # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+          # Enables runtime package prioritization (Preview, Agent 7.79+)
+          # See Runtime Package Tracking section below.
           enrichment:
             usage:
               enabled: true
@@ -98,8 +98,8 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
           # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
           analyzers: ["os", "languages"]
 
-        # Enables runtime package prioritization (Preview, Agent 7.78+)
-        # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+        # Enables runtime package prioritization (Preview, Agent 7.79+)
+        # See Runtime Package Tracking section below.
         enrichment:
           usage:
             enabled: true
@@ -111,7 +111,7 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
 
 {{< /tabs >}}
 
-**Note**: `enrichment.usage.enabled: true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][8] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][8] and does not affect Workload Protection usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
 
 **Note**: The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages. When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
 
@@ -150,10 +150,10 @@ Each vulnerability finding is enriched with the following signals:
 These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
 
 **Requirements**:
-- Datadog Agent **7.78.0 or later**
+- Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Important**: Enabling runtime package tracking activates [Workload Protection][8] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8], which can affect Workload Protection usage. From 7.79.0, runtime package tracking runs independently and does not affect Workload Protection usage.
 
 {{< tabs >}}
 
@@ -168,7 +168,7 @@ spec:
       enabled: true
       containerImage:
         enabled: true
-      # Enables runtime package prioritization (Preview, Agent 7.78+)
+      # Enables runtime package prioritization (Preview, Agent 7.79+)
       enrichment:
         usage:
           enabled: true
@@ -187,7 +187,7 @@ datadog:
   sbom:
     containerImage:
       enabled: true
-    # Enables runtime package prioritization (Preview, Agent 7.78+)
+    # Enables runtime package prioritization (Preview, Agent 7.79+)
     enrichment:
       usage:
         enabled: true

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -111,7 +111,7 @@ Use the following instructions to enable Misconfigurations and Vulnerability Man
 
 {{< /tabs >}}
 
-**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][8] and does not affect Workload Protection usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][8] and does not affect its usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
 
 **Note**: The `languages` analyzer requires Datadog Agent **7.70 or later**. When enabled, it detects vulnerabilities in application libraries managed by the package managers below, in addition to OS packages. When the `analyzers` field is omitted, Datadog only scans OS packages for container images.
 
@@ -153,7 +153,7 @@ These signals power vulnerability prioritization in Cloud Security, surfacing fi
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8], which can affect Workload Protection usage. From 7.79.0, runtime package tracking runs independently and does not affect Workload Protection usage.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8] and can affect its usage. From 7.79.0, runtime package tracking runs independently and does not affect its usage.
 
 {{< tabs >}}
 

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -44,14 +44,14 @@ sbom:
     enabled: true
     # Enables scanning of application libraries in addition to OS packages (Agent 7.70+)
     analyzers: ["os", "languages"]
-  # Enables runtime package prioritization (Preview, Agent 7.78+)
-  # Note: activates Workload Protection — may incur additional costs. See Runtime Package Prioritization section below.
+  # Enables runtime package prioritization (Preview, Agent 7.79+)
+  # See Runtime Package Tracking section below.
   enrichment:
     usage:
       enabled: true
 {{< /code-block >}}
 
-**Note**: `enrichment.usage.enabled: true` is in Preview and requires Agent **7.78.0 or later**. It activates [Workload Protection][7] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs. See the [Runtime Package Prioritization](#runtime-package-prioritization-preview) section for more details.
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][7] and does not affect Workload Protection usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
 
 {{< code-block lang="bash" filename="/etc/datadog-agent/security-agent.yaml" disable_copy="false" collapsible="true" >}}
 compliance_config:
@@ -100,10 +100,10 @@ Each vulnerability finding is enriched with the following signals:
 These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
 
 **Requirements**:
-- Datadog Agent **7.78.0 or later**
+- Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Important**: Enabling runtime package tracking activates [Workload Protection][7] for runtime file access monitoring, which may trigger additional Workload Protection usage and costs.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][7], which can affect Workload Protection usage. From 7.79.0, runtime package tracking runs independently and does not affect Workload Protection usage.
 
 Add the `enrichment` block to the `sbom` section of your `datadog.yaml` file:
 
@@ -112,7 +112,7 @@ sbom:
   enabled: true
   container_image:
     enabled: true
-  # Enables runtime package prioritization (Preview, Agent 7.78+)
+  # Enables runtime package prioritization (Preview, Agent 7.79+)
   enrichment:
     usage:
       enabled: true

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -51,7 +51,7 @@ sbom:
       enabled: true
 {{< /code-block >}}
 
-**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][7] and does not affect Workload Protection usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
+**Note**: `enrichment.usage.enabled: true` is in Preview and requires Datadog Agent **7.79.0 or later**. From 7.79.0, runtime package tracking runs independently of [Workload Protection][7] and does not affect its usage. See the [Runtime Package Tracking](#runtime-package-tracking-preview) section for more details.
 
 {{< code-block lang="bash" filename="/etc/datadog-agent/security-agent.yaml" disable_copy="false" collapsible="true" >}}
 compliance_config:
@@ -103,7 +103,7 @@ These signals power vulnerability prioritization in Cloud Security, surfacing fi
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 
-**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][7], which can affect Workload Protection usage. From 7.79.0, runtime package tracking runs independently and does not affect Workload Protection usage.
+**Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][7] and can affect its usage. From 7.79.0, runtime package tracking runs independently and does not affect its usage.
 
 Add the `enrichment` block to the `sbom` section of your `datadog.yaml` file:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #36820.

The previous PR introduced a warning that enabling `sbom.enrichment.usage.enabled` triggers additional Workload Protection usage and costs. That is no longer accurate: from Datadog Agent **7.79.0**, runtime package tracking runs independently of Workload Protection and does not affect Workload Protection usage.

This PR:
- Removes the incorrect Workload Protection cost warning across all three setup pages
- Bumps the minimum Agent version from **7.78.0** to **7.79.0** for the Runtime Package Tracking (Preview) feature
- Replaces the warning with a positive note recommending 7.79.0+

Files updated:
- `content/en/security/cloud_security_management/setup/agent/docker.md`
- `content/en/security/cloud_security_management/setup/agent/kubernetes.md`
- `content/en/security/cloud_security_management/setup/agent/linux.md`

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes