### PR TITLE
[SVLS-9131] Address followup feedback on X-Ray docs

### DIFF
--- a/content/en/serverless/glossary/_index.md
+++ b/content/en/serverless/glossary/_index.md
@@ -98,7 +98,7 @@ AWS Step Functions is a serverless orchestration service from Amazon Web Service
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Step Functions monitoring][2]      | Datadog's offering for monitoring AWS Step Functions, including tracing, logs, and enhanced metrics.                            |
 | [Enhanced Step Functions metrics][3] | Metrics that go beyond the default CloudWatch metrics for Step Functions. Enhanced Step Functions metrics are in the `aws.states.enhanced.*` namespace. |
-| [Trace merging with Lambda][4] | Datadog merges AWS Step Functions traces with downstream AWS Lambda traces into a single, connected trace.                            |
+| [Trace merging with Lambda][4] | Datadog merges AWS Step Functions traces with upstream and downstream AWS Lambda traces into a single, connected trace.                            |
 | [Distributed Map tracing][5] | Tracing for large-scale parallel workloads run with Distributed Map states.                            |
 | [Redrive support][6] | Datadog supports tracing for redriven Step Function executions.                            |
 

--- a/content/en/serverless/guide/connect_invoking_resources.md
+++ b/content/en/serverless/guide/connect_invoking_resources.md
@@ -15,11 +15,10 @@ To instrument your Lambda functions for the first time, follow the [serverless i
 
 Managed resources are automatically connected to your AWS Lambda functions if all of the following are true:
 - Your functions are written in Node.js or Python Lambda runtimes.
-- [APM with Datadog SDKs (`dd-trace`)][2] is configured on your functions. (Existing X-Ray users can alternatively configure [APM with Datadog's X-Ray integration][2] and [enrich AWS X-Ray segments with Datadog's Lambda Library][3].)
+- [APM with Datadog SDKs (`dd-trace`)][2] is configured on your functions.
 - The managed resource invoking your function is one of the following: API Gateway, SQS, SNS, EventBridge, Kinesis, DynamoDB, S3.
 - Your functions are instrumented with a recent version of Datadog's Lambda Library (>= `v3.46.0` for Node, >= `v28` for Python).
 
 [1]: /serverless/installation
 [2]: /serverless/distributed_tracing#choose-your-tracing-library
-[3]: /integrations/amazon_xray/#enriching-xray-segments-with-datadog-libraries
 [4]: https://app.datadoghq.com/functions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Relates to SVLS-9131

Followup to [#36946](https://github.com/DataDog/documentation/pull/36946) to address two late review comments that did not make it into the merged change:

- [Glossary trace merging entry](https://github.com/DataDog/documentation/pull/36946#discussion_r3291026037): expand "downstream" to "upstream and downstream" so the entry matches the linked [Merge Step Functions and Lambda Traces](https://docs.datadoghq.com/serverless/step_functions/merge-step-functions-lambda/) page, which covers both directions.
- [`connect_invoking_resources.md` X-Ray fallback](https://github.com/DataDog/documentation/pull/36946#discussion_r3291038581): remove the X-Ray alternative parenthetical so the page consistently recommends the Datadog Lambda Extension (`dd-trace`).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes