### PR TITLE
[DOCS-XXXXX] Add AI Credits documentation page

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1585,6 +1585,11 @@ menu:
       identifier: bits_ai_agent_builder
       parent: bits_ai
       weight: 6
+    - name: AI Credits
+      identifier: bits_ai_ai_credits
+      url: bits_ai/ai_credits/
+      parent: bits_ai
+      weight: 7
     - name: Dashboards
       url: dashboards/
       pre: dashboard

--- a/content/en/actions/agents/_index.md
+++ b/content/en/actions/agents/_index.md
@@ -11,6 +11,9 @@ further_reading:
 - link: "https://www.datadoghq.com/knowledge-center/aiops/ai-agents/"
   tag: "Knowledge Center"
   text: "What are AI agents and how do they work?"
+- link: "/bits_ai/ai_credits/"
+  tag: "Documentation"
+  text: "AI Credits"
 ---
 
 {{< callout url="#" btn_hidden="true" header="Preview" >}}

--- a/content/en/bits_ai/_index.md
+++ b/content/en/bits_ai/_index.md
@@ -24,6 +24,9 @@ further_reading:
     - link: "https://www.datadoghq.com/blog/how-to-use-ai-more-effectively/"
       tag: "Blog"
       text: "How to use AI tools more effectively: Tips from Datadog Engineers"
+    - link: "/bits_ai/ai_credits/"
+      tag: "Documentation"
+      text: "AI Credits"
 ---
 
 Bits AI is your agentic teammate in Datadog, built to automate development, security, and operational workflows. You can chat and collaborate with Bits in real time, or delegate full tasks—like alert investigations, code fixes, or security triage—and let it take care of the details.

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -28,10 +28,10 @@ The following products consume AI Credits:
 
 | Product | What it does |
 |---|---|
-| [Bits AI Assistant][1] | Conversational assistant for searching telemetry, exploring data, and generating dashboards across the Datadog platform. |
-| [Bits AI Dev][2] | AI-assisted code fixes for application code, infrastructure-as-code, and Datadog configuration. |
-| [Bits AI SRE][3] | Autonomous investigations triggered by monitors, incidents, and other signals. |
-| [Agent Builder][4] | Custom agents built on Datadog telemetry and tools. |
+| [Bits AI Assistant][1] | Search, explore, and take action across Datadog using natural language from the web app, mobile, and Slack. |
+| [Bits AI SRE][3] | Resolve issues faster with autonomous alert investigations built for complex environments. |
+| [Bits AI Dev][2] | Generate, review, and refine code in-app to speed up implementation and bug fixing. |
+| [Agent Builder][4] | Build custom AI agents inside Datadog to automate workflows like incident response, report generation, and standards enforcement. |
 
 ## Pricing
 
@@ -61,33 +61,22 @@ These are average credit costs per feature. Actual consumption for any single re
 
 | Feature | Avg. credits per use |
 |---|---|
-| Bits AI Assistant — search and explore telemetry | 0.5 |
-| Bits AI Assistant — dashboard generation | 3 |
-| Bits AI Assistant — cloud cost investigation | 2.1 |
+| Bits AI Assistant — search and explore telemetry | 0.6 |
+| Bits AI Assistant — setup and optimize observability | 0.4 |
+| Bits AI Assistant — root cause analysis | 0.8 |
 | Bits AI SRE — investigation | 6.5 |
 | Bits AI Dev — code fix | 5 |
 | Agent Builder — message | 0.3 |
 
-<div class="alert alert-info">These are the credit consumption rates as of June 1, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
+<div class="alert alert-info">These are the credit consumption rates as of May 26, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
 
 ## Admin controls
 
-### Enable or disable billable AI products
+All AI Credit management lives in **Plan & Usage > AI Credits**. From there, admins can:
 
-Admins can disable all billable AI products with a single org-level toggle. When billable AI products are disabled, users in your organization can still see the product surfaces in Datadog and view past results (for example, previous Bits AI SRE investigations or Bits AI Assistant conversations). New requests are blocked, and users see a message directing them to ask an admin to enable AI.
-
-### Manage AI Credits in Plan & Usage
-
-All AI Credit configuration lives in **Plan & Usage > AI Credits**. From there, admins can:
-
-- View the current month's credit consumption, broken down by AI product.
-- Turn billable AI products on or off (single org-level toggle covering all billable AI products).
-- Receive notifications as your organization approaches its monthly AI Credit limit, with time to add capacity before usage is impacted.
+- **View usage**: See the current month's credit consumption, broken down by AI product.
+- **Enable or disable billable AI products**: A single org-level toggle controls all billable AI products. When disabled, users can still see product surfaces and view past results (for example, previous Bits AI SRE investigations or Bits AI Assistant conversations), but new requests are blocked.
 - **Coming soon**: Set a monthly AI Credit spend cap to block new requests after a configured threshold is reached.
-
-### Track usage
-
-Admins can view AI Credit consumption at any time in **Plan & Usage > AI Credits**, broken down by AI product.
 
 ## Availability
 
@@ -117,10 +106,6 @@ Not exactly. Because the model decides which steps it needs to take to complete 
 ### Can I disable AI Credits billing entirely?
 
 Yes. An admin can disable all billable AI products from **Plan & Usage > AI Credits**. With billable AI products disabled, your organization is not billed for AI Credit consumption.
-
-### What is the difference between AI Credits and other usage-based SKUs?
-
-AI Credits unify billing across Datadog's billable AI products under a single, predictable unit. Instead of separate SKUs and pricing models per AI product, you purchase one currency (credits) that works across [Bits AI Assistant][1], [Bits AI Dev][2], [Bits AI SRE][3], and [Agent Builder][4].
 
 ## Further reading
 

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -28,10 +28,10 @@ The following products consume AI Credits:
 
 | Product | What it does |
 |---|---|
-| [Bits Chat][1] | Search, explore, and act across Datadog using natural language. |
-| [Bits Investigation][3] | Investigate production issues end to end to help on-call engineers pinpoint root causes. |
-| [Bits Code][2] | Diagnose issues and generate code fixes using Datadog observability data. |
-| [Bits Agent Builder][4] | Build custom AI agents that automate operational tasks using Datadog tools and integrations. |
+| [Bits Chat][1] | Search and analyze telemetry, create dashboards and notebooks, and inspect monitors with natural language. |
+| [Bits Investigation][3] | Automatically investigate alerts, correlate telemetry, identify root causes, summarize impact, and apply remediations. |
+| [Bits Code][2] | Turn Datadog context into faster fixes with AI-assisted code generation, review, and debugging. |
+| [Bits Agent Builder][4] | Build custom AI agents that automate high-value workflows like incident response and custom reporting. |
 
 ## Pricing
 
@@ -49,25 +49,23 @@ AI Credits reset on the first day of each calendar month. Unused Commit credits 
 
 ### Overages
 
-If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing tiers or top up manually. Any task already in flight is allowed to complete (for example, a Bits Investigation that is already running finishes its work).
+If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate.
 
 ## Credit consumption by feature
 
-These are average credit costs per feature. Actual consumption for any single request varies with task complexity and the amount of context the model processes, so use these as planning estimates rather than exact-per-call quotes.
-
 | Feature | Avg. credits per use |
 |---|---|
-| Bits Chat — search and explore telemetry | 0.6 |
-| Bits Chat — setup and optimize observability | 0.4 |
-| Bits Chat — root cause analysis | 0.8 |
-| Bits Chat — monitor creation | 0.5 |
-| Bits Chat — dashboard creation | 0.6 |
-| Bits Chat — notebook creation | 0.7 |
-| Bits Investigation — autonomous investigation | 6.5 |
-| Bits Code — code fix | 5 |
-| Bits Agent Builder — message | 0.3 |
+| Bits Agent Builder — message | 0.3 credits |
+| Bits Chat — monitor creation / modification* | 0.5 credits |
+| Bits Chat — search and explore telemetry* | 0.6 credits |
+| Bits Chat — dashboard creation / modification* | 0.6 credits |
+| Bits Chat — notebook creation / modification* | 0.7 credits |
+| Bits Code — code fix | 5 credits |
+| Bits Investigation — autonomous investigation | 6.5 credits |
 
-<div class="alert alert-info">These are the credit consumption rates as of May 27, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
+\* Estimates are per message.
+
+Average credit consumption for each feature set out above is provided only for reference. Actual consumption for any single request may vary with task complexity and the amount of context the model processes.
 
 ## Admin controls
 
@@ -82,10 +80,10 @@ All AI Credits products are enabled by default with the Datadog Standard Role. T
 
 | Product | Permission |
 |---|---|
-| [Bits Chat][1] | Bits Assistant Access |
-| [Bits Investigation][3] | Bits SRE Investigations Write |
-| [Bits Code][2] | Bits Dev Write |
-| [Bits Agent Builder][4] | Agent Builder Write, Agent Builder Run |
+| [Bits Chat][1] | Bits Chat Access |
+| [Bits Investigation][3] | Bits Investigations Write |
+| [Bits Code][2] | Bits Code Write |
+| [Bits Agent Builder][4] | Bits Agent Builder Write, Bits Agent Builder Run |
 
 To manage permissions, go to **Organization Settings > Roles**, select a role, and toggle the relevant permission.
 

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product—for example, a [Bits Chat][1] query, a [Bits Code][2] code fix, or a [Bits Investigation][3] investigation.
+AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product.
 
 Use this page to understand which products consume AI Credits, how pricing works, how to track usage, and how to control access for your organization.
 
@@ -65,14 +65,14 @@ If your usage exceeds your monthly Commit, additional credits are billed automat
 
 \* Estimates are per message.
 
-Average credit consumption for each feature set out above is provided only for reference. Actual consumption for any single request may vary with task complexity and the amount of context the model processes.
+<div class="alert alert-info">Average credit consumption for each feature set out above is provided only for reference. Actual consumption for any single request may vary with task complexity and the amount of context the model processes.</div>
 
 ## Admin controls
 
 All AI Credit management lives in **Plan & Usage > AI Credits**. From there, admins can:
 
 - **View usage**: See the current month's credit consumption, broken down by AI product.
-- **Enable or disable billable AI products**: A single org-level toggle controls all billable AI products. When disabled, users can still see product surfaces and view past results (for example, previous Bits Investigation reports or Bits Chat conversations), but new requests are blocked.
+- **Enable or disable AI products powered by AI Credits**: A single org-level toggle controls all AI products powered by AI Credits. When disabled, users can still see product surfaces and view past results, but new requests are blocked.
 
 ### Disable specific products
 
@@ -102,4 +102,4 @@ AI Credits are available to all Datadog customers except:
 [2]: /bits_ai/bits_ai_dev_agent/
 [3]: /bits_ai/bits_ai_sre/
 [4]: /actions/agents/
-[5]: https://www.datadoghq.com/pricing/
+[5]: https://www.datadoghq.com/pricing/?site=us&product=ai-credits#products

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -4,21 +4,21 @@ description: "Understand how AI Credits work, which products consume them, prici
 further_reading:
 - link: "/bits_ai/bits_assistant/"
   tag: "Documentation"
-  text: "Bits AI Assistant"
+  text: "Bits Chat"
 - link: "/bits_ai/bits_ai_dev_agent/"
   tag: "Documentation"
-  text: "Bits AI Dev Agent"
+  text: "Bits Code"
 - link: "/bits_ai/bits_ai_sre/"
   tag: "Documentation"
-  text: "Bits AI SRE"
+  text: "Bits Investigation"
 - link: "/actions/agents/"
   tag: "Documentation"
-  text: "Agent Builder"
+  text: "Bits Agent Builder"
 ---
 
 ## Overview
 
-AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product—for example, a [Bits AI Assistant][1] query, a [Bits AI Dev][2] code fix, or a [Bits AI SRE][3] investigation.
+AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product—for example, a [Bits Chat][1] query, a [Bits Code][2] code fix, or a [Bits Investigation][3] investigation.
 
 Use this page to understand which products consume AI Credits, how pricing works, how to track usage, and how to control access for your organization.
 
@@ -28,10 +28,10 @@ The following products consume AI Credits:
 
 | Product | What it does |
 |---|---|
-| [Bits AI Assistant][1] | Search, explore, and act across Datadog using natural language. |
-| [Bits AI SRE][3] | Investigate production issues end to end to help on-call engineers pinpoint root causes. |
-| [Bits AI Dev][2] | Diagnose issues and generate code fixes using Datadog observability data. |
-| [Agent Builder][4] | Build custom AI agents that automate operational tasks using Datadog tools and integrations. |
+| [Bits Chat][1] | Search, explore, and act across Datadog using natural language. |
+| [Bits Investigation][3] | Investigate production issues end to end to help on-call engineers pinpoint root causes. |
+| [Bits Code][2] | Diagnose issues and generate code fixes using Datadog observability data. |
+| [Bits Agent Builder][4] | Build custom AI agents that automate operational tasks using Datadog tools and integrations. |
 
 ## Pricing
 
@@ -49,7 +49,7 @@ AI Credits reset on the first day of each calendar month. Unused Commit credits 
 
 ### Overages
 
-If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing tiers or top up manually. Any task already in flight is allowed to complete (for example, a Bits AI SRE investigation that is already running finishes its work).
+If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing tiers or top up manually. Any task already in flight is allowed to complete (for example, a Bits Investigation that is already running finishes its work).
 
 ## Credit consumption by feature
 
@@ -57,15 +57,15 @@ These are average credit costs per feature. Actual consumption for any single re
 
 | Feature | Avg. credits per use |
 |---|---|
-| Bits AI Assistant — search and explore telemetry | 0.6 |
-| Bits AI Assistant — setup and optimize observability | 0.4 |
-| Bits AI Assistant — root cause analysis | 0.8 |
-| Bits AI Assistant — monitor creation | 0.5 |
-| Bits AI Assistant — dashboard creation | 0.6 |
-| Bits AI Assistant — notebook creation | 0.7 |
-| Bits AI SRE — autonomous investigation | 6.5 |
-| Bits AI Dev — code fix | 5 |
-| Agent Builder — message | 0.3 |
+| Bits Chat — search and explore telemetry | 0.6 |
+| Bits Chat — setup and optimize observability | 0.4 |
+| Bits Chat — root cause analysis | 0.8 |
+| Bits Chat — monitor creation | 0.5 |
+| Bits Chat — dashboard creation | 0.6 |
+| Bits Chat — notebook creation | 0.7 |
+| Bits Investigation — autonomous investigation | 6.5 |
+| Bits Code — code fix | 5 |
+| Bits Agent Builder — message | 0.3 |
 
 <div class="alert alert-info">These are the credit consumption rates as of May 27, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
 
@@ -74,7 +74,7 @@ These are average credit costs per feature. Actual consumption for any single re
 All AI Credit management lives in **Plan & Usage > AI Credits**. From there, admins can:
 
 - **View usage**: See the current month's credit consumption, broken down by AI product.
-- **Enable or disable billable AI products**: A single org-level toggle controls all billable AI products. When disabled, users can still see product surfaces and view past results (for example, previous Bits AI SRE investigations or Bits AI Assistant conversations), but new requests are blocked.
+- **Enable or disable billable AI products**: A single org-level toggle controls all billable AI products. When disabled, users can still see product surfaces and view past results (for example, previous Bits Investigation reports or Bits Chat conversations), but new requests are blocked.
 
 ### Disable specific products
 
@@ -82,10 +82,10 @@ All AI Credits products are enabled by default with the Datadog Standard Role. T
 
 | Product | Permission |
 |---|---|
-| [Bits AI Assistant][1] | Bits Assistant Access |
-| [Bits AI SRE][3] | Bits SRE Investigations Write |
-| [Bits AI Dev][2] | Bits Dev Write |
-| [Agent Builder][4] | Agent Builder Write, Agent Builder Run |
+| [Bits Chat][1] | Bits Assistant Access |
+| [Bits Investigation][3] | Bits SRE Investigations Write |
+| [Bits Code][2] | Bits Dev Write |
+| [Bits Agent Builder][4] | Agent Builder Write, Agent Builder Run |
 
 To manage permissions, go to **Organization Settings > Roles**, select a role, and toggle the relevant permission.
 

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -28,10 +28,10 @@ The following products consume AI Credits:
 
 | Product | What it does |
 |---|---|
-| [Bits AI Assistant][1] | Search, explore, and take action across Datadog using natural language from the web app, mobile, and Slack. |
-| [Bits AI SRE][3] | Resolve issues faster with autonomous alert investigations built for complex environments. |
-| [Bits AI Dev][2] | Generate, review, and refine code in-app to speed up implementation and bug fixing. |
-| [Agent Builder][4] | Build custom AI agents inside Datadog to automate workflows like incident response, report generation, and standards enforcement. |
+| [Bits AI Assistant][1] | AI-powered assistant that helps you search, explore, and act across Datadog using natural language. |
+| [Bits AI SRE][3] | Autonomous AI agent that investigates production issues end to end to help on-call engineers pinpoint root causes. |
+| [Bits AI Dev][2] | AI coding assistant that uses Datadog observability data to diagnose issues and generate code fixes. |
+| [Agent Builder][4] | Build custom AI agents that use Datadog tools and integrations to automate operational tasks. |
 
 ## Pricing
 
@@ -64,7 +64,7 @@ These are average credit costs per feature. Actual consumption for any single re
 | Bits AI Assistant — search and explore telemetry | 0.6 |
 | Bits AI Assistant — setup and optimize observability | 0.4 |
 | Bits AI Assistant — root cause analysis | 0.8 |
-| Bits AI SRE — investigation | 6.5 |
+| Bits AI SRE — autonomous investigation | 6.5 |
 | Bits AI Dev — code fix | 5 |
 | Agent Builder — message | 0.3 |
 
@@ -82,7 +82,7 @@ All AI Credit management lives in **Plan & Usage > AI Credits**. From there, adm
 
 AI Credits are available to all Datadog customers except:
 
-- **FedRAMP / Datadog for Government** customers, where AI Credit products are not supported.
+- **FedRAMP** customers, where AI Credit products are not supported.
 - Customers who have explicitly opted out of AI features through their account team.
 
 ## Frequently asked questions
@@ -93,7 +93,7 @@ No. Unused Commit credits expire at the end of each monthly billing period. On-D
 
 ### What happens if I run out of Commit credits mid-month?
 
-Usage automatically continues at the On-Demand rate ($1.30 per credit). You do not need to take any action.
+Usage automatically continues at the On-Demand rate. You do not need to take any action.
 
 ### What happens if I run out of credits while an AI product is mid-task?
 
@@ -101,7 +101,7 @@ Any task already in flight is allowed to complete—for example, a Bits AI SRE i
 
 ### Can I see what a request costs before I run it?
 
-Not exactly. Because the model decides which steps it needs to take to complete a task, the final credit cost is determined after the request completes. AI Credit consumption is visible in Plan & Usage at the AI product level, and the per-feature averages on this page are a reliable planning estimate.
+No. The final credit cost is determined after the request completes, because the model decides which steps to take. AI Credit consumption is visible in Plan & Usage at the AI product level, and the per-feature averages on this page are a reliable planning estimate.
 
 ### Can I disable AI Credits billing entirely?
 

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -35,7 +35,7 @@ The following products consume AI Credits:
 
 ## Pricing
 
-AI Credits are available in three pricing tiers. You can use any combination.
+See the [Datadog pricing page][5] for current rates. AI Credits are available in three pricing tiers, and you can use any combination.
 
 | Pricing tier | How it works |
 |---|---|
@@ -43,13 +43,9 @@ AI Credits are available in three pricing tiers. You can use any combination.
 | Monthly Commit | Month-to-month, no annual commitment. Credits are purchased in bundles of 500 per month. |
 | On-Demand | No commitment. Billed monthly based on actual usage. |
 
-Most customers purchase multiple Commit bundles to match their forecasted usage. For example, a team that expects to use 2,000 credits per month would purchase four Annual Commit bundles.
-
-See the [Datadog pricing page][5] for current rates.
-
 ### Billing cycle
 
-AI Credits reset on the first day of each calendar month. Unused Commit credits do not roll over.
+AI Credits reset on the first day of each calendar month. Unused Commit credits do not roll over to the next month.
 
 ### Overages
 
@@ -71,7 +67,7 @@ These are average credit costs per feature. Actual consumption for any single re
 | Bits AI Dev — code fix | 5 |
 | Agent Builder — message | 0.3 |
 
-<div class="alert alert-info">These are the credit consumption rates as of May 26, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
+<div class="alert alert-info">These are the credit consumption rates as of May 27, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
 
 ## Admin controls
 

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -20,7 +20,7 @@ further_reading:
 
 AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product—for example, a [Bits AI Assistant][1] query, a [Bits AI Dev][2] code fix, or a [Bits AI SRE][3] investigation.
 
-Use this page to understand what AI Credits cost, which products consume them, how to track usage, and how to control access for your organization.
+Use this page to understand which products consume AI Credits, how pricing works, how to track usage, and how to control access for your organization.
 
 ## AI products billed in AI Credits
 
@@ -28,24 +28,24 @@ The following products consume AI Credits:
 
 | Product | What it does |
 |---|---|
-| [Bits AI Assistant][1] | AI-powered assistant that helps you search, explore, and act across Datadog using natural language. |
-| [Bits AI SRE][3] | Autonomous AI agent that investigates production issues end to end to help on-call engineers pinpoint root causes. |
-| [Bits AI Dev][2] | AI coding assistant that uses Datadog observability data to diagnose issues and generate code fixes. |
-| [Agent Builder][4] | Build custom AI agents that use Datadog tools and integrations to automate operational tasks. |
+| [Bits AI Assistant][1] | Search, explore, and act across Datadog using natural language. |
+| [Bits AI SRE][3] | Investigate production issues end to end to help on-call engineers pinpoint root causes. |
+| [Bits AI Dev][2] | Diagnose issues and generate code fixes using Datadog observability data. |
+| [Agent Builder][4] | Build custom AI agents that automate operational tasks using Datadog tools and integrations. |
 
 ## Pricing
 
-Pick the model that matches how you want to consume AI Credits. You can use any combination.
+AI Credits are available in three pricing tiers. You can use any combination.
 
-| Pricing model | Per credit | Per 500-credit bundle | Commitment |
-|---|---|---|---|
-| Annual Commit | $1.00 | $500 / month | 12-month commitment, billed monthly |
-| Monthly Commit | $1.15 | $575 / month | Month-to-month, no annual commitment |
-| On-Demand | $1.30 | — | None. Billed monthly on actual usage |
+| Pricing tier | How it works |
+|---|---|
+| Annual Commit | 12-month commitment, billed monthly. Credits are purchased in bundles of 500 per month. |
+| Monthly Commit | Month-to-month, no annual commitment. Credits are purchased in bundles of 500 per month. |
+| On-Demand | No commitment. Billed monthly based on actual usage. |
 
-### How Commit purchases work
+Most customers purchase multiple Commit bundles to match their forecasted usage. For example, a team that expects to use 2,000 credits per month would purchase four Annual Commit bundles.
 
-Commit Bundles are purchased in increments of 500 credits per month, and most customers purchase multiple bundles to match their forecasted usage. For example, a team that expects to use 2,000 credits per month on the Annual Commit would purchase four bundles, for a total of $2,000 per month.
+See the [Datadog pricing page][5] for current rates.
 
 ### Billing cycle
 
@@ -53,7 +53,7 @@ AI Credits reset on the first day of each calendar month. Unused Commit credits 
 
 ### Overages
 
-If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing models or top up manually.
+If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing tiers or top up manually. Any task already in flight is allowed to complete (for example, a Bits AI SRE investigation that is already running finishes its work).
 
 ## Credit consumption by feature
 
@@ -64,6 +64,9 @@ These are average credit costs per feature. Actual consumption for any single re
 | Bits AI Assistant — search and explore telemetry | 0.6 |
 | Bits AI Assistant — setup and optimize observability | 0.4 |
 | Bits AI Assistant — root cause analysis | 0.8 |
+| Bits AI Assistant — monitor creation | 0.5 |
+| Bits AI Assistant — dashboard creation | 0.6 |
+| Bits AI Assistant — notebook creation | 0.7 |
 | Bits AI SRE — autonomous investigation | 6.5 |
 | Bits AI Dev — code fix | 5 |
 | Agent Builder — message | 0.3 |
@@ -76,7 +79,19 @@ All AI Credit management lives in **Plan & Usage > AI Credits**. From there, adm
 
 - **View usage**: See the current month's credit consumption, broken down by AI product.
 - **Enable or disable billable AI products**: A single org-level toggle controls all billable AI products. When disabled, users can still see product surfaces and view past results (for example, previous Bits AI SRE investigations or Bits AI Assistant conversations), but new requests are blocked.
-- **Coming soon**: Set a monthly AI Credit spend cap to block new requests after a configured threshold is reached.
+
+### Disable specific products
+
+All AI Credits products are enabled by default with the Datadog Standard Role. To disable specific products, remove the following permissions per user or role:
+
+| Product | Permission |
+|---|---|
+| [Bits AI Assistant][1] | Bits Assistant Access |
+| [Bits AI SRE][3] | Bits SRE Investigations Write |
+| [Bits AI Dev][2] | Bits Dev Write |
+| [Agent Builder][4] | Agent Builder Write, Agent Builder Run |
+
+To manage permissions, go to **Organization Settings > Roles**, select a role, and toggle the relevant permission.
 
 ## Availability
 
@@ -84,28 +99,6 @@ AI Credits are available to all Datadog customers except:
 
 - **FedRAMP** customers, where AI Credit products are not supported.
 - Customers who have explicitly opted out of AI features through their account team.
-
-## Frequently asked questions
-
-### Do AI Credits roll over month to month?
-
-No. Unused Commit credits expire at the end of each monthly billing period. On-Demand credits are billed only when consumed, so there is nothing to roll over.
-
-### What happens if I run out of Commit credits mid-month?
-
-Usage automatically continues at the On-Demand rate. You do not need to take any action.
-
-### What happens if I run out of credits while an AI product is mid-task?
-
-Any task already in flight is allowed to complete—for example, a Bits AI SRE investigation that is already running finishes its work. New tasks are blocked until your credit capacity is increased, additional credits are added, or your next monthly cycle resets.
-
-### Can I see what a request costs before I run it?
-
-No. The final credit cost is determined after the request completes, because the model decides which steps to take. AI Credit consumption is visible in Plan & Usage at the AI product level, and the per-feature averages on this page are a reliable planning estimate.
-
-### Can I disable AI Credits billing entirely?
-
-Yes. An admin can disable all billable AI products from **Plan & Usage > AI Credits**. With billable AI products disabled, your organization is not billed for AI Credit consumption.
 
 ## Further reading
 
@@ -115,3 +108,4 @@ Yes. An admin can disable all billable AI products from **Plan & Usage > AI Cred
 [2]: /bits_ai/bits_ai_dev_agent/
 [3]: /bits_ai/bits_ai_sre/
 [4]: /actions/agents/
+[5]: https://www.datadoghq.com/pricing/

--- a/content/en/bits_ai/ai_credits.md
+++ b/content/en/bits_ai/ai_credits.md
@@ -1,0 +1,132 @@
+---
+title: AI Credits
+description: "Understand how AI Credits work, which products consume them, pricing models, and how to manage usage for your organization."
+further_reading:
+- link: "/bits_ai/bits_assistant/"
+  tag: "Documentation"
+  text: "Bits AI Assistant"
+- link: "/bits_ai/bits_ai_dev_agent/"
+  tag: "Documentation"
+  text: "Bits AI Dev Agent"
+- link: "/bits_ai/bits_ai_sre/"
+  tag: "Documentation"
+  text: "Bits AI SRE"
+- link: "/actions/agents/"
+  tag: "Documentation"
+  text: "Agent Builder"
+---
+
+## Overview
+
+AI Credits are how Datadog meters and bills usage of its AI products. One AI Credit represents a unit of intelligent work performed by a Datadog AI product—for example, a [Bits AI Assistant][1] query, a [Bits AI Dev][2] code fix, or a [Bits AI SRE][3] investigation.
+
+Use this page to understand what AI Credits cost, which products consume them, how to track usage, and how to control access for your organization.
+
+## AI products billed in AI Credits
+
+The following products consume AI Credits:
+
+| Product | What it does |
+|---|---|
+| [Bits AI Assistant][1] | Conversational assistant for searching telemetry, exploring data, and generating dashboards across the Datadog platform. |
+| [Bits AI Dev][2] | AI-assisted code fixes for application code, infrastructure-as-code, and Datadog configuration. |
+| [Bits AI SRE][3] | Autonomous investigations triggered by monitors, incidents, and other signals. |
+| [Agent Builder][4] | Custom agents built on Datadog telemetry and tools. |
+
+## Pricing
+
+Pick the model that matches how you want to consume AI Credits. You can use any combination.
+
+| Pricing model | Per credit | Per 500-credit bundle | Commitment |
+|---|---|---|---|
+| Annual Commit | $1.00 | $500 / month | 12-month commitment, billed monthly |
+| Monthly Commit | $1.15 | $575 / month | Month-to-month, no annual commitment |
+| On-Demand | $1.30 | — | None. Billed monthly on actual usage |
+
+### How Commit purchases work
+
+Commit Bundles are purchased in increments of 500 credits per month, and most customers purchase multiple bundles to match their forecasted usage. For example, a team that expects to use 2,000 credits per month on the Annual Commit would purchase four bundles, for a total of $2,000 per month.
+
+### Billing cycle
+
+AI Credits reset on the first day of each calendar month. Unused Commit credits do not roll over.
+
+### Overages
+
+If your usage exceeds your monthly Commit, additional credits are billed automatically at the On-Demand rate—you do not need to switch pricing models or top up manually.
+
+## Credit consumption by feature
+
+These are average credit costs per feature. Actual consumption for any single request varies with task complexity and the amount of context the model processes, so use these as planning estimates rather than exact-per-call quotes.
+
+| Feature | Avg. credits per use |
+|---|---|
+| Bits AI Assistant — search and explore telemetry | 0.5 |
+| Bits AI Assistant — dashboard generation | 3 |
+| Bits AI Assistant — cloud cost investigation | 2.1 |
+| Bits AI SRE — investigation | 6.5 |
+| Bits AI Dev — code fix | 5 |
+| Agent Builder — message | 0.3 |
+
+<div class="alert alert-info">These are the credit consumption rates as of June 1, 2026. Costs for each feature may change as models are optimized or new models become available.</div>
+
+## Admin controls
+
+### Enable or disable billable AI products
+
+Admins can disable all billable AI products with a single org-level toggle. When billable AI products are disabled, users in your organization can still see the product surfaces in Datadog and view past results (for example, previous Bits AI SRE investigations or Bits AI Assistant conversations). New requests are blocked, and users see a message directing them to ask an admin to enable AI.
+
+### Manage AI Credits in Plan & Usage
+
+All AI Credit configuration lives in **Plan & Usage > AI Credits**. From there, admins can:
+
+- View the current month's credit consumption, broken down by AI product.
+- Turn billable AI products on or off (single org-level toggle covering all billable AI products).
+- Receive notifications as your organization approaches its monthly AI Credit limit, with time to add capacity before usage is impacted.
+- **Coming soon**: Set a monthly AI Credit spend cap to block new requests after a configured threshold is reached.
+
+### Track usage
+
+Admins can view AI Credit consumption at any time in **Plan & Usage > AI Credits**, broken down by AI product.
+
+## Availability
+
+AI Credits are available to all Datadog customers except:
+
+- **FedRAMP / Datadog for Government** customers, where AI Credit products are not supported.
+- Customers who have explicitly opted out of AI features through their account team.
+
+## Frequently asked questions
+
+### Do AI Credits roll over month to month?
+
+No. Unused Commit credits expire at the end of each monthly billing period. On-Demand credits are billed only when consumed, so there is nothing to roll over.
+
+### What happens if I run out of Commit credits mid-month?
+
+Usage automatically continues at the On-Demand rate ($1.30 per credit). You do not need to take any action.
+
+### What happens if I run out of credits while an AI product is mid-task?
+
+Any task already in flight is allowed to complete—for example, a Bits AI SRE investigation that is already running finishes its work. New tasks are blocked until your credit capacity is increased, additional credits are added, or your next monthly cycle resets.
+
+### Can I see what a request costs before I run it?
+
+Not exactly. Because the model decides which steps it needs to take to complete a task, the final credit cost is determined after the request completes. AI Credit consumption is visible in Plan & Usage at the AI product level, and the per-feature averages on this page are a reliable planning estimate.
+
+### Can I disable AI Credits billing entirely?
+
+Yes. An admin can disable all billable AI products from **Plan & Usage > AI Credits**. With billable AI products disabled, your organization is not billed for AI Credit consumption.
+
+### What is the difference between AI Credits and other usage-based SKUs?
+
+AI Credits unify billing across Datadog's billable AI products under a single, predictable unit. Instead of separate SKUs and pricing models per AI product, you purchase one currency (credits) that works across [Bits AI Assistant][1], [Bits AI Dev][2], [Bits AI SRE][3], and [Agent Builder][4].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /bits_ai/bits_assistant/
+[2]: /bits_ai/bits_ai_dev_agent/
+[3]: /bits_ai/bits_ai_sre/
+[4]: /actions/agents/

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -7,6 +7,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/bitsai-dev-agent-code-security"
     tag: "Blog"
     text: "Introducing Bits Code for Code Security"
+  - link: "/bits_ai/ai_credits/"
+    tag: "Documentation"
+    text: "AI Credits"
 ---
 
 ## Overview

--- a/content/en/bits_ai/bits_ai_sre/_index.md
+++ b/content/en/bits_ai/bits_ai_sre/_index.md
@@ -8,6 +8,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/bits-ai-sre-deeper-reasoning"
     tag: "Blog"
     text: "Meet the new Bits Investigation: Deeper reasoning, twice as fast"
+  - link: "/bits_ai/ai_credits/"
+    tag: "Documentation"
+    text: "AI Credits"
 cascade:
     site_support_id: bits_ai_sre
 ---

--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -11,6 +11,9 @@ further_reading:
 - link: "/cloud_cost_management/cloud_cost_skill/"
   tag: "Documentation"
   text: "Cloud Cost Skill in Bits Chat"
+- link: "/bits_ai/ai_credits/"
+  tag: "Documentation"
+  text: "AI Credits"
 aliases:
 - /bits_ai/getting_started/
 - /bits_ai/chat_with_bits_ai


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Add a new AI Credits documentation page under the Bits AI section (`/bits_ai/ai_credits/`). This page explains how AI Credits work as the unified billing unit for Datadog's AI products, covering pricing models, credit consumption rates by feature, admin controls, availability, and FAQs.

**Files added:**
- `content/en/bits_ai/ai_credits.md` — New AI Credits documentation page

**Files changed (cross-links):**
- `config/_default/menus/main.en.yaml` — Added AI Credits nav entry under Bits AI (weight 7)
- `content/en/bits_ai/_index.md` — Added further_reading link to AI Credits
- `content/en/bits_ai/bits_assistant.md` — Added further_reading link to AI Credits
- `content/en/bits_ai/bits_ai_dev_agent/_index.md` — Added further_reading link to AI Credits
- `content/en/bits_ai/bits_ai_sre/_index.md` — Added further_reading link to AI Credits
- `content/en/actions/agents/_index.md` — Added further_reading link to AI Credits

### Reviewer notes

- The DOCS ticket number is a placeholder (`DOCS-XXXXX`) — update before merge.
- Page is placed under `/bits_ai/ai_credits/` (Bits AI section) rather than under `/account_management/billing/` per author's request.
- Pricing page (`/account_management/billing/`) was intentionally not modified — it will be updated separately.
- No screenshots/images included in the initial version.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.ai/code)