### PR TITLE
[DOCS-XXXXX] Rename Bits Assistant to Bits AI Assistant and update page

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1554,7 +1554,7 @@ menu:
       identifier: bits_ai_bits_ai_security_analyst
       parent: bits_ai
       weight: 3
-    - name: Bits Assistant
+    - name: Bits AI Assistant
       url: bits_ai/bits_assistant
       identifier: bits_ai_bits_assistant
       parent: bits_ai

--- a/content/en/bits_ai/_index.md
+++ b/content/en/bits_ai/_index.md
@@ -34,7 +34,7 @@ Bits AI is your agentic teammate in Datadog, built to automate development, secu
    {{< nextlink href="bits_ai/bits_ai_sre" >}}Investigate alerts with Bits AI SRE{{< /nextlink >}}
    {{< nextlink href="bits_ai/bits_ai_dev_agent" >}}Automate code fixes with Bits AI Dev Agent{{< /nextlink >}}
    {{< nextlink href="bits_ai/bits_ai_security_analyst" >}}Triage security threat signals with Bits AI Security Analyst{{< /nextlink >}}
-   {{< nextlink href="bits_ai/bits_assistant" >}}Explore your observability data with Bits Assistant{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_assistant" >}}Explore your observability data with Bits AI Assistant{{< /nextlink >}}
    {{< nextlink href="bits_ai/mcp_server" >}}Get observability insights from AI agents with the Datadog MCP server{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -29,7 +29,7 @@ After [completing setup][6], do one of the following to start a code session:
 - Enter a freeform prompt at [**Code Sessions**][7]: enter a custom prompt or generate one by clicking a **Suggestions** or **Proactive Fixes** card
 - Invoke Bits AI Dev Agent in a [supported Datadog product][9]
 
-A code session can also be created when another Bits AI agent (like [Bits Assistant][16] or [Bits AI SRE][17]) hands off a coding task to the Dev Agent.
+A code session can also be created when another Bits AI agent (like [Bits AI Assistant][16] or [Bits AI SRE][17]) hands off a coding task to the Dev Agent.
 
 ### View and manage code sessions
 On **[Code Sessions][7]**, view your past sessions in the **My Sessions** panel. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR.
@@ -44,7 +44,7 @@ Bits AI Dev Agent can suggest code improvements in the following Datadog product
 |---------------------------|--------------------------------------------------------------------|
 | [APM][20]                 | Proposes code changes for relevant [APM Recommendations][21]|
 | [Bits AI SRE][17]         | Generates code remediations based on Bits AI SRE investigations |
-| [Bits Assistant][16]      | Suggests code changes arising from Bits Assistant conversations |
+| [Bits AI Assistant][16]   | Suggests code changes arising from Bits AI Assistant conversations |
 | [Cloud Cost][22]          | Generates code changes for [Cloud Cost Recommendations][23] |
 | [Error Tracking][1]       | Diagnoses issues and generates code fixes on-demand or autonomously |
 | [Code Security][2]        | Remediates code vulnerabilities individually or in bulk  |

--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -1,6 +1,6 @@
 ---
-title: Bits Assistant
-description: "Use Bits Assistant in Datadog to explore and act on your observability data using natural language."
+title: Bits AI Assistant
+description: "Use Bits AI Assistant in Datadog to explore and act on your observability data using natural language."
 further_reading:
 - link: "bits_ai/"
   tag: "Documentation"
@@ -10,37 +10,62 @@ further_reading:
   text: "Coordinate incidents with Incident AI"
 - link: "/cloud_cost_management/cloud_cost_skill/"
   tag: "Documentation"
-  text: "Cloud Cost Skill in Bits Assistant"
+  text: "Cloud Cost Skill in Bits AI Assistant"
+- link: "/bits_ai/ai_credits/"
+  tag: "Documentation"
+  text: "AI Credits"
 aliases:
 - /bits_ai/getting_started/
 - /bits_ai/chat_with_bits_ai
 ---
 
-{{< callout url="#" btn_hidden="true" header="Bits Assistant is in Preview" >}}
-Fill out the [Preview form](https://www.datadoghq.com/product-preview/bits-assistant/) to get access to Bits Assistant.
-{{< /callout >}}
-
-
 ## Overview
-Bits Assistant is an AI-powered companion in Datadog that helps you search and act across Datadog using natural language. Bits Assistant is available across the web application, mobile app, and Slack.
-Ask Bits Assistant questions like:
-- `Summarize high severity incidents that have occurred in the last day`
-- `Which services have the most errors right now?`
-- `Show me what changed in alerts for the checkout service in the last 24 hours.`
-- `What's causing 400 errors on the checkout endpoint in the last hour?`
-- `How do I configure log collection for the Datadog Agent?`
-- `Do we already have monitors for high latency on the payments service?`
-- `Summarize the key findings from Kubernetes overview dashboard.`
+Bits AI Assistant is an AI-powered companion in Datadog that helps you search and act across Datadog using natural language. Bits AI Assistant is available across the web application, mobile app, and Slack.
 
-{{< img src="bits_ai/getting_started/bits_assistant_full_page.png" alt="Full-page Bits Assistant interface showing conversation history and prompt suggestions" style="width:100%;">}}
+Ask Bits AI Assistant questions across these categories:
+
+#### Investigate issues and remediate
+- `Summarize high severity incidents that have occurred in the last day`
+- `What's causing 400 errors on the checkout endpoint in the last hour?`
+- `Why is the error rate spiking on the web-store service?`
+- `What is the root cause of this error? How did it propagate and what is the impact on users?`
+- `What could cause 500 errors on this API endpoint?`
+
+#### Explore and analyze telemetry
+- `Which services have the most errors right now?`
+- `Summarize the key findings from the Kubernetes overview dashboard`
+- `What's the success rate for my top API endpoints over the past week?`
+- `Show me error rates for the checkout service over the last 24 hours`
+- `Are there any incidents related to Kafka lag?`
+
+#### Learn Datadog concepts and how-to
+- `How do I configure log collection for the Datadog Agent?`
+- `What is the difference between a metric monitor and an anomaly monitor?`
+- `What permission do I need to create a new connection?`
+- `Can I set the timepicker on a notebook to read-only?`
+
+#### Set up and optimize observability
+- `Do we already have monitors for high latency on the payments service?`
+- `Build me a dashboard to show latency, errors, and request rates for my service`
+- `How can I put a team tag on this monitor?`
+- `Add a timeseries widget for request count over time to this notebook`
+
+{{< img src="bits_ai/getting_started/bits_assistant_full_page.png" alt="Full-page Bits AI Assistant interface showing conversation history and prompt suggestions" style="width:100%;">}}
 
 ### Permissions
-To use Bits Assistant, your role must have the **Bits Assistant Access** permission.
 
-Bits Assistant uses your Datadog role to fetch data, so it can only access the resources you have permission to view or modify. For example, if you do not have permission to edit a dashboard, Bits Assistant cannot edit that dashboard on your behalf.
+#### Access to Bits AI Assistant
+
+To use Bits AI Assistant, your role must have the **Bits Assistant Access** permission. This permission is enabled by default for all three standard Datadog roles: Datadog Admin, Datadog Standard, and Datadog Read Only.
+
+To manage this permission for custom roles, go to **Organization Settings** > **Roles**, select a role, and toggle **Bits Assistant Access** under **General Permissions**.
+
+#### Data access through Bits AI Assistant
+
+Bits AI Assistant uses your Datadog role to fetch data, so it can only access the resources you have permission to view or modify. For example, if your role restricts access to a specific set of logs indexes, Bits AI Assistant can only query logs from those indexes. Similarly, if you do not have permission to edit a dashboard, Bits AI Assistant cannot edit that dashboard on your behalf.
 
 ### Skills
-Bits Assistant has skills that help with specialized tasks.
+Bits AI Assistant has access to 50+ specialized skills that help with tasks across Datadog. Below are some of the most commonly used skills.
 
 #### Dashboards
 Build [dashboards][5] and widgets from natural language descriptions.
@@ -73,37 +98,47 @@ Example prompts:
 - `What's the latency bottleneck for this service?`
 
 #### Cloud Cost Management
-Investigate [cloud cost][4] changes and identify the teams or resources responsible. See [Cloud Cost Skill in Bits Assistant][9].
+Investigate [cloud cost][4] changes and identify the teams or resources responsible. See [Cloud Cost Skill in Bits AI Assistant][9].
 
 Example prompts:
 - `Investigate why EC2 costs changed between January and February`
 - `Which teams are responsible for the highest S3 storage costs this month?`
 
 #### DDSQL
-Generate and run [DDSQL][7] queries against Datadog [telemetry data][8] using natural language. 
+Generate and run [DDSQL][7] queries against Datadog [telemetry data][8] using natural language.
 
 Example prompts:
 - `Write a DDSQL query that shows the top 10 services by error count in the last hour`
 - `Query average request latency for the payments service broken down by status code`
 - `Show me a DDSQL query for the number of RUM sessions by country over the past day`
 
+### Reports
+
+The Bits AI Assistant Reports page provides visibility into how your organization uses Bits AI Assistant. Go to [**Bits AI** > **Assistant** > **Reports**][10] to view:
+
+- **Top users**: See which team members use Bits AI Assistant the most, ranked by conversation count.
+- **Usage trends**: Track conversation volume over time to understand adoption and identify usage patterns.
+- **Conversation intent distribution**: See how conversations break down by intent category, such as investigating issues, exploring telemetry, learning Datadog concepts, and configuring observability.
+
+Use these insights to understand adoption patterns, identify power users for best-practice sharing, and assess which use cases deliver the most value for your organization.
+
 ### Web application
-There are multiple ways to open Bits Assistant in the Datadog web application:
+There are multiple ways to open Bits AI Assistant in the Datadog web application:
 - In the top-right of the navigation bar, click {{< ui >}}Ask Bits{{< /ui >}}
-- In a Datadog product integrated with Bits Assistant, click {{< ui >}}Ask Bits{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon)
+- In a Datadog product integrated with Bits AI Assistant, click {{< ui >}}Ask Bits{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon)
 - Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>I</kbd>
 - In the left-side navigation panel, click {{< ui >}}Bits AI{{< /ui >}}
 
-{{< img src="bits_ai/getting_started/bits_assistant_side_panel.png" alt="Bits Assistant side panel showing example prompts" style="width:40%;">}}
+{{< img src="bits_ai/getting_started/bits_assistant_side_panel.png" alt="Bits AI Assistant side panel showing example prompts" style="width:40%;">}}
 
 ### Mobile application
 <div class="alert alert-info">
-Bits Assistant is available on iOS v5.8.4+.
+Bits AI Assistant is available on iOS v5.8.4+ and Android v3.15+.
 </div>
 
 1. [Download the mobile app and log in][2].
-2. On the home screen, tap {{< ui >}}Bits Assistant{{< /ui >}}.
-3. Start chatting with Bits Assistant in chat or voice mode.
+2. On the home screen, tap {{< ui >}}Bits AI Assistant{{< /ui >}}.
+3. Start chatting with Bits AI Assistant in chat or voice mode.
 {{< img src="bits_ai/getting_started/bitsai_mobile_app.PNG" alt="View of the Mobile App Home dashboard with Bits AI" style="width:40%;" >}}
 
 ### Slack
@@ -120,7 +155,7 @@ After setup is completed, you can send queries to `@Datadog` in natural language
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /integrations/slack/?tab=applicationforslack
-[2]: /mobile/?tab=ios#installing
+[2]: /mobile/#installing
 [3]: /tracing/trace_explorer/
 [4]: /cloud_cost_management/
 [5]: /dashboards/
@@ -128,3 +163,4 @@ After setup is completed, you can send queries to `@Datadog` in natural language
 [7]: /ddsql_editor/
 [8]: /ddsql_reference/data_directory/
 [9]: /cloud_cost_management/cloud_cost_skill/
+[10]: https://app.datadoghq.com/bits-ai/assistant/reports

--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -11,9 +11,6 @@ further_reading:
 - link: "/cloud_cost_management/cloud_cost_skill/"
   tag: "Documentation"
   text: "Cloud Cost Skill in Bits AI Assistant"
-- link: "/bits_ai/ai_credits/"
-  tag: "Documentation"
-  text: "AI Credits"
 aliases:
 - /bits_ai/getting_started/
 - /bits_ai/chat_with_bits_ai
@@ -24,27 +21,27 @@ Bits AI Assistant is an AI-powered companion in Datadog that helps you search an
 
 Ask Bits AI Assistant questions across these categories:
 
-#### Investigate issues and remediate
+### Investigate issues and remediate
 - `Summarize high severity incidents that have occurred in the last day`
 - `What's causing 400 errors on the checkout endpoint in the last hour?`
 - `Why is the error rate spiking on the web-store service?`
 - `What is the root cause of this error? How did it propagate and what is the impact on users?`
 - `What could cause 500 errors on this API endpoint?`
 
-#### Explore and analyze telemetry
+### Explore and analyze telemetry
 - `Which services have the most errors right now?`
 - `Summarize the key findings from the Kubernetes overview dashboard`
 - `What's the success rate for my top API endpoints over the past week?`
 - `Show me error rates for the checkout service over the last 24 hours`
 - `Are there any incidents related to Kafka lag?`
 
-#### Learn Datadog concepts and how-to
+### Learn Datadog concepts and how-to
 - `How do I configure log collection for the Datadog Agent?`
 - `What is the difference between a metric monitor and an anomaly monitor?`
 - `What permission do I need to create a new connection?`
 - `Can I set the timepicker on a notebook to read-only?`
 
-#### Set up and optimize observability
+### Set up and optimize observability
 - `Do we already have monitors for high latency on the payments service?`
 - `Build me a dashboard to show latency, errors, and request rates for my service`
 - `How can I put a team tag on this monitor?`
@@ -65,7 +62,7 @@ To manage this permission for custom roles, go to **Organization Settings** > **
 Bits AI Assistant uses your Datadog role to fetch data, so it can only access the resources you have permission to view or modify. For example, if your role restricts access to a specific set of logs indexes, Bits AI Assistant can only query logs from those indexes. Similarly, if you do not have permission to edit a dashboard, Bits AI Assistant cannot edit that dashboard on your behalf.
 
 ### Skills
-Bits AI Assistant has access to 50+ specialized skills that help with tasks across Datadog. Below are some of the most commonly used skills.
+Bits AI Assistant has a range of specialized skills for tasks across Datadog. The most commonly used skills are described below.
 
 #### Dashboards
 Build [dashboards][5] and widgets from natural language descriptions.

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -12,7 +12,7 @@ further_reading:
     text: "Learn about Tags in Cloud Cost Management"
   - link: "/cloud_cost_management/cloud_cost_skill/"
     tag: "Documentation"
-    text: "Use Cloud Cost skill in Bits Assistant"
+    text: "Use Cloud Cost skill in Bits AI Assistant"
   - link: "https://www.datadoghq.com/blog/control-your-cloud-spend-with-datadog-cloud-cost-management/"
     tag: "Blog"
     text: "Gain visibility and control of your cloud spend with Datadog Cloud Cost Management"
@@ -136,9 +136,9 @@ Use this page to troubleshoot data delays or confirm that recent tag pipelines a
 
 ## Use AI for cost analysis
 
-Use the [Cloud Cost Skill in Bits Assistant][10] to investigate cost changes, identify likely owners, compare spend against budgets, correlate cost with observability metrics, and create handoff notebooks for engineering teams.
+Use the [Cloud Cost Skill in Bits AI Assistant][10] to investigate cost changes, identify likely owners, compare spend against budgets, correlate cost with observability metrics, and create handoff notebooks for engineering teams.
 
-{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
+{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits AI Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
 
 ## Further reading
 

--- a/content/en/cloud_cost_management/cloud_cost_skill.md
+++ b/content/en/cloud_cost_management/cloud_cost_skill.md
@@ -1,13 +1,13 @@
 ---
-title: Cloud Cost Skill in Bits Assistant
-description: Use the Cloud Cost skill in Bits Assistant to investigate, explain, and share cloud cost findings.
+title: Cloud Cost Skill in Bits AI Assistant
+description: Use the Cloud Cost skill in Bits AI Assistant to investigate, explain, and share cloud cost findings.
 algolia:
-  tags: ["cloud cost", "cloud cost management", "ccm", "finops", "cloud cost skill", "bits assistant", "mcp"]
+  tags: ["cloud cost", "cloud cost management", "ccm", "finops", "cloud cost skill", "bits ai assistant", "bits assistant", "mcp"]
   rank: 75
 further_reading:
 - link: "/bits_ai/bits_assistant/"
   tag: "Documentation"
-  text: "Bits Assistant"
+  text: "Bits AI Assistant"
 - link: "/bits_ai/mcp_server/"
   tag: "Documentation"
   text: "Datadog MCP Server"
@@ -20,12 +20,12 @@ further_reading:
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/bits-assistant/" btn_hidden="false" header="Cloud Cost skill is in Preview" >}}
-The Cloud Cost skill runs in Bits Assistant. Fill out the Bits Assistant Preview form to request access.
+The Cloud Cost skill runs in Bits AI Assistant. Fill out the Bits AI Assistant Preview form to request access.
 {{< /callout >}}
 
 ## Overview
 
-The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits Assistant][1]. It is designed for root cause analysis, budget tracking, and general cost questions. For example, you can ask Bits Assistant to:
+The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits AI Assistant][1]. It is designed for root cause analysis, budget tracking, and general cost questions. For example, you can ask Bits AI Assistant to:
 
 - Investigate [cost monitor alerts][2], [cost anomalies][3], and [cost changes][4]
 - Identify teams, services, accounts, regions, or resources driving spend
@@ -36,7 +36,7 @@ The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits Ass
 
 ## Prerequisites
 
-To use the Cloud Cost skill in Bits Assistant, you must:
+To use the Cloud Cost skill in Bits AI Assistant, you must:
 
 - [Set up Cloud Cost Management][6] for the cost sources you want to analyze
 - Have these permissions:
@@ -50,7 +50,7 @@ To use the Cloud Cost skill in Bits Assistant, you must:
 
 When you want to start an investigation, such as for a [cost anomaly][3], click {{< ui >}}Investigate{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon) to open the Cloud Cost skill.
 
-Alternatively, you can click {{< ui >}}Ask Bits{{< /ui >}} on the top right of the navigation bar on any Datadog page to open the Bits Assistant and ask a cost question.
+Alternatively, you can click {{< ui >}}Ask Bits{{< /ui >}} on the top right of the navigation bar on any Datadog page to open Bits AI Assistant and ask a cost question.
 
 Example prompts:
 
@@ -62,16 +62,16 @@ Example prompts:
 
 ### Cost change investigations
 
-When you investigate a cost change with the Cloud Cost skill, Bits Assistant provides a concise summary, then asks what you want to explore next. The initial analysis typically includes:
+When you investigate a cost change with the Cloud Cost skill, Bits AI Assistant provides a concise summary, then asks what you want to explore next. The initial analysis typically includes:
 
 - A daily cost chart for the baseline and investigation periods
 - The baseline period, investigation period, total dollar amount and percentage change, and projected annual impact when applicable
 - Rate-versus-usage context to help distinguish price changes from consumption changes
 - Owner or team attribution based on your cost tags
 
-{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
+{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits AI Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
 
-After the initial summary, Bits Assistant can:
+After the initial summary, Bits AI Assistant can:
 
 - Find the top services, accounts, regions, resources, or tags driving the change
 - Correlate the cost change with metrics such as CPU requests, memory requests, request count, bucket size, or database usage
@@ -81,14 +81,14 @@ After the initial summary, Bits Assistant can:
 
 ### Budgets and forecasting
 
-After setting up [Budgets][5], use the Cloud Cost skill in Bits Assistant to explain budget status and spending. Bits Assistant can help summarize:
+After setting up [Budgets][5], use the Cloud Cost skill in Bits AI Assistant to explain budget status and spending. Bits AI Assistant can help summarize:
 
 - Actual spend versus budgeted amount
 - Forecasted spend versus budgeted amount
 - Which cost scope a budget covers, based on the budget's filters
 - Which budget entries, teams, services, or providers are contributing to an overage
 
-After the initial summary, Bits Assistant can:
+After the initial summary, Bits AI Assistant can:
 
 - Find the top services, accounts, regions, resources, or tags driving spending
 - Identify the teams that own the resources contributing to the cost change

--- a/content/en/mobile/_index.md
+++ b/content/en/mobile/_index.md
@@ -287,7 +287,7 @@ On the Services page, you can view, search and filter all services that you have
 {{% /tab %}}
 {{< /tabs >}}
 
-On the Bits AI home page, you can ask questions about your organization's system health. Bits AI supports natural language querying for logs and APM traces. For more information, see [Bits Assistant][27].
+On the Bits AI home page, you can ask questions about your organization's system health. Bits AI supports natural language querying for logs and APM traces. For more information, see [Bits AI Assistant][27].
 
 ### Bits AI SRE
 {{< tabs >}}


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Updates the Bits AI Assistant documentation page with the following changes:

- **Rename**: "Bits Assistant" → "Bits AI Assistant" across all documentation pages (7 files), keeping the RBAC permission name "Bits Assistant Access" unchanged
- **Remove Preview callout**: The product is out of Preview
- **Categorized example prompts**: Organized prompts into 4 usage categories: Investigate issues and remediate, Explore and analyze telemetry, Learn Datadog concepts and how-to, Set up and optimize observability
- **Permissions restructured**: Split into "Access to Bits AI Assistant" (with note that permission is enabled by default for standard roles) and "Data access through Bits AI Assistant" (with logs index scoping example)
- **50+ skills**: Updated Skills section intro to mention 50+ specialized skills
- **Reports section**: New section covering top users, usage trends, and conversation intent distribution
- **Android support**: Updated mobile section to include Android v3.15+ alongside iOS v5.8.4+

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- The blog post title on `bits_ai/_index.md` line 23 ("Search and act across Datadog to resolve issues faster with Bits Assistant") is intentionally unchanged since it references a published blog post.
- The algolia tag in `cloud_cost_skill.md` keeps "bits assistant" for backward search compatibility and adds "bits ai assistant".

🤖 Generated with [Claude Code](https://claude.com/claude-code)