### PR TITLE
Add Claude OTEL resource attributes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repo.owner=DataDog,repo.name=documentation"
+  },
   "extraKnownMarketplaces": {
     "datadog-claude-plugins": {
       "source": {
@@ -9,6 +12,7 @@
   },
   "enabledPlugins": {
     "marketplace-auto-update@datadog-claude-plugins": true,
-    "documentation@datadog-claude-plugins": true
+    "documentation@datadog-claude-plugins": true,
+    "dd@datadog-claude-plugins": true
   }
 }


### PR DESCRIPTION
## Problem

Claude sessions in this repository do not declare repo-level OpenTelemetry resource attributes, so telemetry cannot reliably attribute activity to `DataDog/documentation`.

## Changes

- Add `OTEL_RESOURCE_ATTRIBUTES=repo.owner=DataDog,repo.name=documentation` to `.claude/settings.json`.
- Preserve the existing documentation Claude plugin configuration.
- Enable the shared Datadog Claude plugin alongside marketplace auto-update.

## Validation

- Verified the settings payload is valid JSON.
- No runtime tests were run; this is a Claude settings-only change.