### PR TITLE
Restore actions site support banner with single catch-all key

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,10 +280,9 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
-  actions_catalog: [gov,gov2]
+  actions: [gov,gov2]
   adaptive_sampling: [gov,gov2]
   advanced_analysis: [gov,gov2]
-  agent_builder: [gov,gov2]
   agent_flare: [gov,gov2]
   agentic_onboarding: [gov,gov2]
   agentless-scanning: [gov,gov2] # api page
@@ -294,7 +293,6 @@ unsupported_sites:
   amazon-event-bridge: [gov,gov2]
   apm_processing_pipelines: [gov,gov2]
   apm_recommendations: [gov,gov2]
-  app_builder: [gov,gov2]
   application_security: [gov,gov2]
   autocomplete_search: [gov,gov2]
   azure-private-link: [us,us5,eu,gov,gov2,ap1,ap2]
@@ -334,7 +332,6 @@ unsupported_sites:
   fips-proxy: [us,us3,us5,eu,ap1,ap2,gov2]
   fleet_automation: [gov,gov2]
   forwarding_audit_events: [gov,gov2]
-  forms: [gov,gov2]
   gcp-private-service-connect: [us,us3,gov,gov2,ap1,ap2]
   getting_started_feature_flags: [gov,gov2]
   gitlab-source-code: [gov,gov2]

--- a/content/en/actions/agents/_index.md
+++ b/content/en/actions/agents/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Agent Builder
 description: Build and deploy custom AI agents that automate operational tasks using Datadog's tools and integrations.
-site_support_id: agent_builder
 further_reading:
 - link: "/actions/actions_catalog/"
   tag: "Documentation"

--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -1,7 +1,6 @@
 ---
 title: Apps
 description: Build and deploy custom Apps locally using a code-based development workflow with React, backend functions, and a CLI.
-site_support_id: app_builder #Site support banner for US1-FED and US2-FED
 further_reading:
 - link: "/actions/app_builder/"
   tag: "Documentation"

--- a/content/en/dashboards/annotations/_index.md
+++ b/content/en/dashboards/annotations/_index.md
@@ -10,8 +10,6 @@ Annotations let you manually place markers with descriptions on timeseries widge
 - **Point annotation**: Marks a single moment in time with a vertical line.
 - **Timerange annotation**: Highlights a span of time across the widget.
 
-You can also attach a link to any annotation to reference related resources, such as a runbook or incident ticket.
-
 {{< img src="dashboards/annotations-12-2025.png" alt="Timeseries showing a drop-off in availability with a vertical annotation line at the end of the drop-off and a comment that says 'Rollback completed — service availability restored.'" style="width:100%;" >}}
 
 Annotations are available in both dashboards and notebooks. If you export a widget from a dashboard to a notebook, any annotations you've added to the widget persist.

--- a/content/en/incident_response/incident_management/setup_and_configuration/automations.md
+++ b/content/en/incident_response/incident_management/setup_and_configuration/automations.md
@@ -1,5 +1,7 @@
 ---
 title: Automations
+description: Automatically trigger actions based on incident events such as severity changes or state transitions using Datadog Workflow Automation.
+site_support_id: workflow-automation
 aliases:
 - /incident_response/incident_management/incident_settings/automations/
 further_reading:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Restores the `actions: [gov,gov2]` catch-all key in `params.yaml` that was removed in a direct-to-master test commit in Nov 2025 and never restored. Since then, coverage was added back piecemeal (app_builder, workflows, forms, etc.) but left gaps — the top-level `actions/_index.md`, datastores, connections, and private_actions pages had no banner.

A single `actions` key covers all pages under `/actions/` via Hugo's path segment matching, making the individual sub-keys redundant. This PR:
- Adds `actions: [gov,gov2]` to `params.yaml`
- Removes dead `actions_catalog`, `agent_builder`, `app_builder`, and `forms` keys (all covered by `actions` now; `workflows` and `workflow-automation` are kept since they also cover non-actions pages)
- Removes now-redundant `site_support_id` frontmatter from `actions/agents/_index.md` and `actions/datadog_apps.md`

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes