### PR TITLE
[DOCS-14430, DOCS-14432, DOCS-14435] Add US1-FED callouts for preview/disabled features

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -350,6 +350,7 @@ unsupported_sites:
   jetbrains-ides: [gov,gov2]
   jira-service-management-ops: [gov,gov2]
   jira_error_tracking: [gov,gov2]
+  key_management_v1: [gov,gov2] # V1 Key Management APIs are disabled on US1-FED
   launchdarkly: [gov,gov2]
   linear: [gov,gov2]
   live_debugger: [gov,gov2]

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -30,5 +30,9 @@ cascade:
     lang: en
   aliases:
     - /api/latest/service-scorecards
+- _target:
+    path: /api/latest/key-management
+    lang: en
+  site_support_id: key_management_v1
 
 ---

--- a/content/en/dashboards/annotations/_index.md
+++ b/content/en/dashboards/annotations/_index.md
@@ -3,6 +3,10 @@ title: Annotations
 description: Learn how to add, customize, and manage annotations on timeseries widgets in dashboards and notebooks to highlight important events.
 ---
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">Adding hyperlinks to annotation comments is not available on your <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Overview
 
 Annotations let you manually place markers with descriptions on timeseries widgets to highlight key events like deploys, incidents, or outages. Two annotation types are available:

--- a/content/en/incident_response/incident_management/setup_and_configuration/automations.md
+++ b/content/en/incident_response/incident_management/setup_and_configuration/automations.md
@@ -2,6 +2,7 @@
 title: Automations
 aliases:
 - /incident_response/incident_management/incident_settings/automations/
+site_support_id: workflow-automation
 further_reading:
 - link: "/actions/workflows/"
   tag: "Documentation"
@@ -18,6 +19,7 @@ further_reading:
 Automations enable you to customize and extend incident management to fit your organization's specific processes. Automatically trigger actions based on incident events such as severity changes, or state transitions.
 
 Automations are powered by [Datadog Workflow Automation][1] and are included in your Incident Management billing at no additional cost.
+
 
 ## Prerequisites
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Addresses three FED-related tickets with targeted `site-region` callouts:

- **DOCS-14430** (`automations.md`): Adds a warning after the Workflow Automation mention in the overview noting that Automations are in opt-in early preview on US1-FED/US2-FED and require contacting Datadog to enable.
- **DOCS-14432** (`annotations/_index.md`): Adds a warning after the mention of attaching links noting that hyperlinks in annotation comments are not yet available on US1-FED/US2-FED.
- **DOCS-14435** (`api/latest/key-management/_index.md`): Adds a warning on the Key Management API page noting that V1 APIs are disabled on US1-FED and to use V2 instead. Note: this file has only one manual commit and appears stable; if the API pipeline ever overwrites it, this change would need to move to a cascade in `content/en/api/_index.md`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes