### PR TITLE
[DOCS-14327] Network Path: clarify that manual and automatic config can be used simultaneously

### DIFF
--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-Setting up Network Path involves configuring your environment to monitor and trace the network routes between your services and endpoints. This helps identify bottlenecks, latency issues, and potential points of failure in your network infrastructure. Network Path allows you to manually configure individual network paths or automatically discover them, depending on your needs.
+Setting up Network Path involves configuring your environment to monitor and trace the network routes between your services and endpoints. This helps identify bottlenecks, latency issues, and potential points of failure in your network infrastructure. Network Path allows you to manually configure individual network paths, automatically discover them, or use both methods simultaneously, depending on your needs.
 
 **Note**: If your network configuration restricts outbound traffic, follow the setup instructions on the [Agent proxy configuration][2] documentation.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14327

Updates the Overview sentence in the Network Path setup page to clarify that manual path configuration and automatic discovery can be used simultaneously — not just one or the other.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes