### PR TITLE
docs(llmobs): document MultiEvaluatorResult for experiment evaluators

### DIFF
--- a/content/en/llm_observability/evaluations/evaluation_developer_guide.md
+++ b/content/en/llm_observability/evaluations/evaluation_developer_guide.md
@@ -509,13 +509,6 @@ By default, sub-metric labels are prefixed with the evaluator's name: `confusion
 return MultiEvaluatorResult({"precision": 0.9, "recall": 0.8}, prefix=False)
 {{< /code-block >}}
 
-#### `MultiEvaluatorResult` parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `values` | `dict[str, Union[str, float, int, bool, dict, EvaluatorResult]]` | — | Mapping of sub-metric name to value or `EvaluatorResult`. Keys must follow evaluation [label naming conventions](#naming-conventions). |
-| `prefix` | `bool` | `True` | If `True`, labels are emitted as `"<evaluator_name>-<key>"`. If `False`, labels are the raw keys. |
-
 <div class="alert alert-warning">If two evaluators in the same row emit the same metric label (for example, both use <code>prefix=False</code> with the same key), the second value overwrites the first and a warning is logged.</div>
 
 `MultiEvaluatorResult` is also supported in class-based evaluators and summary evaluators:
@@ -536,7 +529,8 @@ class ConfusionMatrixEvaluator(BaseEvaluator):
                 "correct": correct,
                 "false_positive": predicted and not expected,
                 "false_negative": not predicted and expected,
-            }
+            },
+            prefix=False
         )
         # Emitted labels: confusion_matrix-correct, confusion_matrix-false_positive, ...
 {{< /code-block >}}

--- a/content/en/llm_observability/evaluations/evaluation_developer_guide.md
+++ b/content/en/llm_observability/evaluations/evaluation_developer_guide.md
@@ -41,7 +41,7 @@ The evaluation system has four main components:
 
 - **[EvaluatorContext](#evaluatorcontext)**: The input to an evaluator. Contains the LLM's input, output, expected output, and span identifiers. In Experiments, the SDK builds this automatically from each dataset record. In production, you construct the EvaluatorContext yourself.
 - **[EvaluatorResult](#evaluatorresult)**: The output of an evaluator. Contains a typed value, optional reasoning, a pass/fail assessment, metadata, and tags. You can also return a plain value (`str`, `float`, `int`, `bool`, `dict`) instead.
-- **[MultiEvaluatorResult](#multievaluatorresult)**: An optional container for returning **multiple named metrics** from a single evaluator. Each sub-value can be a plain value or its own `EvaluatorResult`. Useful when one evaluator pass produces several related metrics (for example, precision, recall, and F1).
+- **[MultiEvaluatorResult](#multievaluatorresult)**: An optional container for returning multiple named metrics from a single evaluator. Each sub-value can be a plain value or its own `EvaluatorResult`. Useful when one evaluator pass produces several related metrics (for example, precision, recall, and F1).
 - **[Metric type](#metric-types)**: Determines how the evaluation value is interpreted and displayed: `categorical` (string labels), `score` (numeric), `boolean` (pass/fail), or `json` (structured data).
 - **[SummaryEvaluatorContext](#summaryevaluatorcontext)** — Experiments only. After all dataset records are evaluated, summary evaluators receive the aggregated results to compute statistics like averages or pass rates.
 
@@ -464,7 +464,7 @@ def evaluator_function(
     ...
 {{< /code-block >}}
 
-You can return either:
+You can return:
 - A plain value (`str`, `float`, `int`, `bool`, `dict`), or
 - An `EvaluatorResult` for rich results with reasoning and metadata, or
 - A `MultiEvaluatorResult` to emit multiple named metrics from one evaluator call
@@ -509,7 +509,7 @@ By default, sub-metric labels are prefixed with the evaluator's name: `confusion
 return MultiEvaluatorResult({"precision": 0.9, "recall": 0.8}, prefix=False)
 {{< /code-block >}}
 
-<div class="alert alert-warning">If two evaluators in the same row emit the same metric label (for example, both use <code>prefix=False</code> with the same key), the second value overwrites the first and a warning is logged.</div>
+<div class="alert alert-warning">If two evaluators emit the same metric label for the same dataset record (for example, both use <code>prefix=False</code> with the same key), the second value overwrites the first and a warning is logged.</div>
 
 `MultiEvaluatorResult` is also supported in class-based evaluators and summary evaluators:
 
@@ -524,6 +524,7 @@ class ConfusionMatrixEvaluator(BaseEvaluator):
         predicted = bool(context.output_data)
         expected = bool(context.expected_output)
         correct = predicted == expected
+        # Emitted labels: correct, false_positive, false_negative (prefix=False)
         return MultiEvaluatorResult(
             {
                 "correct": correct,
@@ -532,7 +533,6 @@ class ConfusionMatrixEvaluator(BaseEvaluator):
             },
             prefix=False
         )
-        # Emitted labels: confusion_matrix-correct, confusion_matrix-false_positive, ...
 {{< /code-block >}}
 
 ## Using evaluators in experiments
@@ -720,7 +720,7 @@ A container for emitting multiple named evaluation metrics from a single evaluat
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `values` | `dict[str, Union[str, float, int, bool, dict, EvaluatorResult]]` | — | Mapping of sub-metric name to a plain value or an `EvaluatorResult`. Must be non-empty; keys must follow evaluation [label naming conventions](#naming-conventions). |
+| `values` | `Dict[str, Union[str, float, int, bool, dict, EvaluatorResult]]` | — | Mapping of sub-metric name to a plain value or an `EvaluatorResult`. Must be non-empty; keys must follow evaluation [label naming conventions](#naming-conventions). |
 | `prefix` | `bool` | `True` | Controls label generation. `True` → `"<evaluator_name>-<key>"`. `False` → raw key. |
 
 Supported in function-based evaluators, class-based evaluators (`BaseEvaluator`), and summary evaluators (`BaseSummaryEvaluator`).

--- a/content/en/llm_observability/evaluations/evaluation_developer_guide.md
+++ b/content/en/llm_observability/evaluations/evaluation_developer_guide.md
@@ -41,12 +41,13 @@ The evaluation system has four main components:
 
 - **[EvaluatorContext](#evaluatorcontext)**: The input to an evaluator. Contains the LLM's input, output, expected output, and span identifiers. In Experiments, the SDK builds this automatically from each dataset record. In production, you construct the EvaluatorContext yourself.
 - **[EvaluatorResult](#evaluatorresult)**: The output of an evaluator. Contains a typed value, optional reasoning, a pass/fail assessment, metadata, and tags. You can also return a plain value (`str`, `float`, `int`, `bool`, `dict`) instead.
+- **[MultiEvaluatorResult](#multievaluatorresult)**: An optional container for returning **multiple named metrics** from a single evaluator. Each sub-value can be a plain value or its own `EvaluatorResult`. Useful when one evaluator pass produces several related metrics (for example, precision, recall, and F1).
 - **[Metric type](#metric-types)**: Determines how the evaluation value is interpreted and displayed: `categorical` (string labels), `score` (numeric), `boolean` (pass/fail), or `json` (structured data).
 - **[SummaryEvaluatorContext](#summaryevaluatorcontext)** — Experiments only. After all dataset records are evaluated, summary evaluators receive the aggregated results to compute statistics like averages or pass rates.
 
 The typical flow:
 
-- **Experiments**: Dataset record → `EvaluatorContext` → Evaluator → `EvaluatorResult` → (after all records) `SummaryEvaluatorContext` → Summary evaluator → summary result
+- **Experiments**: Dataset record → `EvaluatorContext` → Evaluator → `EvaluatorResult` (or `MultiEvaluatorResult`) → (after all records) `SummaryEvaluatorContext` → Summary evaluator → summary result
 - **Production**: Span data → `EvaluatorContext` (built manually) → Evaluator → `EvaluatorResult` → `LLMObs.submit_evaluation()` or HTTP API
 
 ## Building evaluators
@@ -459,13 +460,86 @@ def evaluator_function(
     input_data: Any,
     output_data: Any,
     expected_output: Any
-) -> Union[JSONType, EvaluatorResult]:
+) -> Union[JSONType, EvaluatorResult, MultiEvaluatorResult]:
     ...
 {{< /code-block >}}
 
 You can return either:
 - A plain value (`str`, `float`, `int`, `bool`, `dict`), or
-- An `EvaluatorResult` for rich results with reasoning and metadata
+- An `EvaluatorResult` for rich results with reasoning and metadata, or
+- A `MultiEvaluatorResult` to emit multiple named metrics from one evaluator call
+
+### Returning multiple values with MultiEvaluatorResult
+
+When a single evaluator produces several related metrics—for example, precision, recall, and a confusion-matrix category from one LLM judge call—return a `MultiEvaluatorResult` instead of a single value. Each entry is emitted as its own metric in Datadog.
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import EvaluatorResult, MultiEvaluatorResult
+
+def confusion_matrix_evaluator(input_data, output_data, expected_output):
+    predicted = bool(output_data)
+    expected = bool(expected_output)
+    correct = predicted == expected
+
+    if predicted and expected:
+        category = "true_positive"
+    elif predicted and not expected:
+        category = "false_positive"
+    elif not predicted and expected:
+        category = "false_negative"
+    else:
+        category = "true_negative"
+
+    return MultiEvaluatorResult(
+        {
+            "correct": EvaluatorResult(
+                value=correct,
+                assessment="pass" if correct else "fail",
+                reasoning=f"predicted={predicted}, expected={expected}",
+            ),
+            "category": category,
+            "false_positive": category == "false_positive",
+        }
+    )
+{{< /code-block >}}
+
+By default, sub-metric labels are prefixed with the evaluator's name: `confusion_matrix_evaluator-correct`, `confusion_matrix_evaluator-category`, and so on. To emit raw keys without a prefix, pass `prefix=False`:
+
+{{< code-block lang="python" >}}
+return MultiEvaluatorResult({"precision": 0.9, "recall": 0.8}, prefix=False)
+{{< /code-block >}}
+
+#### `MultiEvaluatorResult` parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `values` | `dict[str, Union[str, float, int, bool, dict, EvaluatorResult]]` | — | Mapping of sub-metric name to value or `EvaluatorResult`. Keys must follow evaluation [label naming conventions](#naming-conventions). |
+| `prefix` | `bool` | `True` | If `True`, labels are emitted as `"<evaluator_name>-<key>"`. If `False`, labels are the raw keys. |
+
+<div class="alert alert-warning">If two evaluators in the same row emit the same metric label (for example, both use <code>prefix=False</code> with the same key), the second value overwrites the first and a warning is logged.</div>
+
+`MultiEvaluatorResult` is also supported in class-based evaluators and summary evaluators:
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import BaseEvaluator, EvaluatorContext, MultiEvaluatorResult
+
+class ConfusionMatrixEvaluator(BaseEvaluator):
+    def __init__(self):
+        super().__init__(name="confusion_matrix")
+
+    def evaluate(self, context: EvaluatorContext) -> MultiEvaluatorResult:
+        predicted = bool(context.output_data)
+        expected = bool(context.expected_output)
+        correct = predicted == expected
+        return MultiEvaluatorResult(
+            {
+                "correct": correct,
+                "false_positive": predicted and not expected,
+                "false_negative": not predicted and expected,
+            }
+        )
+        # Emitted labels: confusion_matrix-correct, confusion_matrix-false_positive, ...
+{{< /code-block >}}
 
 ## Using evaluators in experiments
 
@@ -645,6 +719,17 @@ Allows you to return rich evaluation results with additional context. Used in bo
 | `assessment` | `Optional[str]` | An assessment of this evaluation. Accepted values are `pass` and `fail`. |
 | `metadata` | `Optional[Dict[str, Any]]` | Additional metadata about the evaluation. |
 | `tags` | `Optional[Dict[str, str]]` | Tags to apply to the evaluation metric. |
+
+### MultiEvaluatorResult
+
+A container for emitting multiple named evaluation metrics from a single evaluator. Import from `ddtrace.llmobs`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `values` | `dict[str, Union[str, float, int, bool, dict, EvaluatorResult]]` | — | Mapping of sub-metric name to a plain value or an `EvaluatorResult`. Must be non-empty; keys must follow evaluation [label naming conventions](#naming-conventions). |
+| `prefix` | `bool` | `True` | Controls label generation. `True` → `"<evaluator_name>-<key>"`. `False` → raw key. |
+
+Supported in function-based evaluators, class-based evaluators (`BaseEvaluator`), and summary evaluators (`BaseSummaryEvaluator`).
 
 ### SummaryEvaluatorContext
 

--- a/content/en/llm_observability/experiments/setup.md
+++ b/content/en/llm_observability/experiments/setup.md
@@ -190,7 +190,7 @@ To create an experiment:
 
    You can also return:
    - An `EvaluatorResult` to capture richer evaluation data, such as `reasoning`, `assessment` (`"pass"` or `"fail"`), `metadata`, and `tags`.
-   - A `MultiEvaluatorResult` to emit multiple named metrics from a single evaluator call. Each sub-value can be a plain value or its own `EvaluatorResult`. Labels default to `"<evaluator_name>-<key>"`; pass `prefix=False` for raw keys. For details and examples, see the [Evaluation Developer Guide][4].
+   - A `MultiEvaluatorResult` to emit multiple named metrics from a single evaluator call. For details and examples, see the [Evaluation Developer Guide][4].
 
    #### Function-based evaluators
 

--- a/content/en/llm_observability/experiments/setup.md
+++ b/content/en/llm_observability/experiments/setup.md
@@ -188,7 +188,9 @@ To create an experiment:
    - **categorical**: returns a labeled category (string)
    - **json**: returns structured data (dict)
 
-   You can also return an `EvaluatorResult` to capture richer evaluation data, such as `reasoning`, `assessment` (`"pass"` or `"fail"`), `metadata`, and `tags`.
+   You can also return:
+   - An `EvaluatorResult` to capture richer evaluation data, such as `reasoning`, `assessment` (`"pass"` or `"fail"`), `metadata`, and `tags`.
+   - A `MultiEvaluatorResult` to emit multiple named metrics from a single evaluator call. Each sub-value can be a plain value or its own `EvaluatorResult`. Labels default to `"<evaluator_name>-<key>"`; pass `prefix=False` for raw keys. For details and examples, see the [Evaluation Developer Guide][4].
 
    #### Function-based evaluators
 
@@ -213,6 +215,19 @@ To create an experiment:
            assessment="pass", # or fail
            tags={"task": "judge_llm_call"},
        )
+
+   # Return multiple metrics from one evaluator call
+   from ddtrace.llmobs import MultiEvaluatorResult
+
+   def multi_metric_evaluator(input_data, output_data, expected_output):
+       correct = output_data == expected_output
+       return MultiEvaluatorResult(
+           {
+               "correct": EvaluatorResult(value=correct, assessment="pass" if correct else "fail"),
+               "length": len(str(output_data)),
+           }
+       )
+       # Emitted as: multi_metric_evaluator-correct, multi_metric_evaluator-length
    ```
 
    #### Class-based evaluators


### PR DESCRIPTION
## What does this PR do?

Documents the new `MultiEvaluatorResult` class added in [dd-trace-py#18203](https://github.com/DataDog/dd-trace-py/pull/18203), which allows experiment evaluators to return multiple named metrics from a single evaluator call.

## Changes

- **`evaluation_developer_guide.md`**:
  - Added `MultiEvaluatorResult` to the "Evaluation components" list
  - Updated typical flow description
  - Added "Returning multiple values with MultiEvaluatorResult" section with function-based and class-based examples, parameter table, prefix/no-prefix usage, and collision warning
  - Updated function-based evaluator return type signature
  - Added `MultiEvaluatorResult` entry in "Data model reference"

- **`experiments/setup.md`**:
  - Added `MultiEvaluatorResult` to the supported evaluator return types list in step 3
  - Added `multi_metric_evaluator` code example

## Motivation

`MultiEvaluatorResult` lets users emit several metrics (e.g. precision, recall, false-positive rate) from one LLM judge pass without writing multiple separate evaluator functions. Labels default to `"<evaluator_name>-<key>"` with `prefix=False` available for raw keys.

## Additional notes

Companion SDK PR: https://github.com/DataDog/dd-trace-py/pull/18203