### PR TITLE
Document comments.disabled YAML field for Code Coverage

### DIFF
--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -295,23 +295,15 @@ gates:
 
 ## PR Comments
 
-By default, Datadog posts a code coverage summary on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
+By default, Datadog posts a code coverage summary comment on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
 
 PR Gate checks are not affected by this setting.
 
-### Example
-
-{{% collapse-content title="Enforce gates without posting comments" level="h4" %}}
 {{< code-block lang="yaml" filename="code-coverage.datadog.yml" >}}
 schema-version: v1
-gates:
-  - type: patch_coverage_percentage
-    config:
-      threshold: 90
 comments:
   disabled: true
 {{< /code-block >}}
-{{% /collapse-content %}}
 
 ## Carryforward
 

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -302,7 +302,7 @@ comments:
   disabled: true
 ```
 
-When `comments.disabled` is set to `true`, Datadog stops adding the Code Coverage section to the pull request summary comment. PR Gate checks are not affected: any gates configured in this file or in the Datadog UI continue to evaluate and report their status as commit checks.
+When `comments.disabled` is set to `true`, Datadog stops adding the Code Coverage section to the pull request summary comment. PR Gate checks are not affected.
 
 The `comments` block accepts the following fields:
 

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -293,20 +293,11 @@ gates:
 {{< /code-block >}}
 {{% /collapse-content %}}
 
-## Pull request comments
+## PR Comments
 
 By default, Datadog posts a code coverage summary on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
 
-```yaml
-comments:
-  disabled: true
-```
-
-When `comments.disabled` is set to `true`, Datadog stops adding the Code Coverage section to the pull request summary comment. PR Gate checks are not affected.
-
-The `comments` block accepts the following fields:
-
-- `disabled` (optional, defaults to `false`): A Boolean that suppresses the Code Coverage section of the pull request summary comment when set to `true`.
+PR Gate checks are not affected by this setting.
 
 ### Example
 

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -295,7 +295,7 @@ gates:
 
 ## PR comments
 
-By default, Datadog posts a pull request comment with code coverage results after each coverage upload. You can suppress this comment on a per-repository basis with the `comments.disabled` field.
+By default, Datadog posts a code coverage summary on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
 
 ```yaml
 comments:

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -43,6 +43,8 @@ gates:
   - type: patch_coverage_percentage
     config:
       threshold: 95
+comments:
+  disabled: false
 ```
 
 ## Services configuration
@@ -288,6 +290,35 @@ gates:
       flags:
         - "*"
         - "!nightly-*"
+{{< /code-block >}}
+{{% /collapse-content %}}
+
+## PR comments
+
+By default, Datadog posts a pull request comment with code coverage results after each coverage upload. You can suppress this comment on a per-repository basis with the `comments.disabled` field.
+
+```yaml
+comments:
+  disabled: true
+```
+
+When `comments.disabled` is set to `true`, Datadog stops adding the Code Coverage section to the pull request summary comment. PR Gate checks are not affected: any gates configured in this file or in the Datadog UI continue to evaluate and report their status as commit checks.
+
+The `comments` block accepts the following fields:
+
+- `disabled` (optional, defaults to `false`): A Boolean that suppresses the Code Coverage section of the pull request summary comment when set to `true`.
+
+### Example
+
+{{% collapse-content title="Enforce gates without posting comments" level="h4" %}}
+{{< code-block lang="yaml" filename="code-coverage.datadog.yml" >}}
+schema-version: v1
+gates:
+  - type: patch_coverage_percentage
+    config:
+      threshold: 90
+comments:
+  disabled: true
 {{< /code-block >}}
 {{% /collapse-content %}}
 

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -293,7 +293,7 @@ gates:
 {{< /code-block >}}
 {{% /collapse-content %}}
 
-## PR comments
+## Pull request comments
 
 By default, Datadog posts a code coverage summary on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
 

--- a/content/en/code_coverage/configuration.md
+++ b/content/en/code_coverage/configuration.md
@@ -44,7 +44,7 @@ gates:
     config:
       threshold: 95
 comments:
-  disabled: false
+  enabled: true
 ```
 
 ## Services configuration
@@ -295,14 +295,14 @@ gates:
 
 ## PR Comments
 
-By default, Datadog posts a code coverage summary comment on every pull request. You can suppress it on a per-repository basis with the `comments.disabled` field.
+By default, Datadog posts a code coverage summary comment on every pull request. You can suppress it on a per-repository basis with the `comments.enabled` field.
 
 PR Gate checks are not affected by this setting.
 
 {{< code-block lang="yaml" filename="code-coverage.datadog.yml" >}}
 schema-version: v1
 comments:
-  disabled: true
+  enabled: false
 {{< /code-block >}}
 
 ## Carryforward


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a \"PR comments\" section to the [Code Coverage Configuration](https://docs.datadoghq.com/code_coverage/configuration/) page documenting the new \`comments.disabled\` YAML field. When set to \`true\`, Datadog stops adding the Code Coverage section to the pull request summary comment; PR Gate checks continue to evaluate and report as commit checks.

Also updates the top-level example configuration on the page to surface the new field for discoverability (with the explicit default value \`false\`).

The backing implementation lives in DataDog/dd-source#449253.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Page preview: the new section appears between \"PR Gates\" and \"Carryforward\".