### PR TITLE
gpu: clarify that system-probe.yaml is required for non-containerized Linux setup

### DIFF
--- a/content/en/gpu_monitoring/setup.md
+++ b/content/en/gpu_monitoring/setup.md
@@ -228,32 +228,35 @@ services:
 {{% /tab %}}
 {{% tab "Linux (non-containerized)" %}}
 
-Modify your `/etc/datadog-agent/datadog.yaml` file to enable GPU monitoring
+GPU monitoring requires configuration in **both** `datadog.yaml` and `system-probe.yaml`. Configuring only `datadog.yaml` does not load the eBPF module and results in no metrics being collected.
 
-```yaml
-gpu:
-  enabled: true
-```
+1. Add the following to `/etc/datadog-agent/datadog.yaml`:
 
-Additionally, to enable advanced eBPF-based metrics such as GPU core utilization (`gpu.process.core.usage`), follow these steps:
+    ```yaml
+    gpu:
+      enabled: true
+    collect_gpu_tags: true
+    enable_nvml_detection: true
+    ```
 
-1. If `/etc/datadog-agent/system-probe.yaml` does not exist, create it from `system-probe.yaml.example`:
+2. If `/etc/datadog-agent/system-probe.yaml` does not exist, create it from the example:
 
     ```shell
     sudo -u dd-agent install -m 0640 /etc/datadog-agent/system-probe.yaml.example /etc/datadog-agent/system-probe.yaml
     ```
 
-2. Edit `/etc/datadog-agent/system-probe.yaml` and enable GPU monitoring in system-probe:
+3. Add the following to `/etc/datadog-agent/system-probe.yaml`:
 
     ```yaml
     gpu_monitoring:
       enabled: true
     ```
 
-3. Restart the Datadog Agent
+4. Restart both the Agent and system-probe:
 
     ```shell
     sudo systemctl restart datadog-agent
+    sudo systemctl restart datadog-agent-sysprobe
     ```
 
 {{% /tab %}}


### PR DESCRIPTION
## Summary

- Restructures the **Linux (non-containerized)** tab in `gpu_monitoring/setup.md` into four numbered steps
- Adds an explicit note at the top of the tab that **both** `datadog.yaml` and `system-probe.yaml` must be configured — the previous wording framed the `system-probe.yaml` step as optional ("Additionally, to enable advanced eBPF-based metrics")
- Adds `collect_gpu_tags: true` and `enable_nvml_detection: true` to the `datadog.yaml` block to match what the integrations-core README documents
- Adds a step to restart `datadog-agent-sysprobe` alongside `datadog-agent`

## Motivation

Tracked in AGENT-16266. The previous tab wording implied `system-probe.yaml` was only needed for "advanced eBPF metrics". In practice, `gpu_monitoring.enabled: true` in `system-probe.yaml` is what loads the eBPF module — without it, the core-agent GPU check has no data source and never runs. A customer following the previous instructions ended up with system-probe healthy but `Last Check from Core Agent: 1969-12-31` (epoch 0, check never ran).

## Test plan

- [ ] Verify the Linux (non-containerized) tab renders as four numbered steps
- [ ] Confirm the note about both files being required appears at the top of the tab
- [ ] Confirm `system-probe.yaml` step is no longer framed as optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)