### PR TITLE
[Auto] Site-support banners — 2026-05-27

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  bring_your_own_cloud: [gov]
   actions: [gov,gov2]
   adaptive_sampling: [gov,gov2]
   advanced_analysis: [gov,gov2]

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  ai_agents_console: [gov, gov2]
   bring_your_own_cloud: [gov]
   actions: [gov,gov2]
   adaptive_sampling: [gov,gov2]


### PR DESCRIPTION
## Site-Support Banner Changes

Automated by site-support-agent.

### Tickets processed
- **DOCS-14434**: Added `bring_your_own_cloud: [gov]` to params.yaml
- **DOCS-14427**: Added `ai_agents_console: [gov, gov2]` to params.yaml