### PR TITLE
[DOCS-13788] Clarify metric type descriptions in OP docs

### DIFF
--- a/content/en/observability_pipelines/configuration/_index.md
+++ b/content/en/observability_pipelines/configuration/_index.md
@@ -105,12 +105,12 @@ An example of a metric:
 
 The available metric types:
 
-| Metric type | Description | Example |
-| ----------- | ----------- | ------- |
-| COUNTER     | Represents the total number of event occurrences in one time interval. This value can be reset to zero, but cannot be decreased. | You want to count the number of logs with `status:error`. |
-| GAUGE       | Represents a snapshot of events in one time interval. | You want to measure the latest CPU utilization per host for all logs in the production environment. |
-| DISTRIBUTION | Represent the global statistical distribution of a set of values calculated across your entire distributed infrastructure in one time interval. | You want to measure the average time it takes for an API call to be made. |
-| HISTOGRAM   | Represents the statistical distribution of a set of values calculated in one time interval. | You want to measure response time distributions for a service or endpoint. |
+| Metric type  | Description                                                                                                                                                       | Example                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| COUNTER      | The total number of event occurrences in one time interval. Can be reset to zero, but cannot be decreased.                                                        | You want to count the number of logs with `status:error`.                                     |
+| GAUGE        | A snapshot of a value at the time it is reported.                                                                                                                 | You want to track the latest CPU utilization for each host.                                   |
+| HISTOGRAM    | Statistical aggregations (`avg`, `min`, `max`, `count`, `median`, percentiles) computed per host by the Datadog Agent in one time interval, then sent to Datadog. | You want per-host request latency aggregations from each web server.                          |
+| DISTRIBUTION | Raw values sent to Datadog so percentile aggregations are computed server-side, globally across every host reporting the metric in one time interval.             | You want the global p95 latency of an API endpoint, calculated across every host serving it.  |
 
 See [Metric Types][3] for more information.
 

--- a/content/en/observability_pipelines/configuration/explore_templates.md
+++ b/content/en/observability_pipelines/configuration/explore_templates.md
@@ -38,14 +38,14 @@ As your organization grows, your observability needs for different use cases, su
 
 ### Generate Log-based Metrics
 
-Some log sources, such as firewalls and network appliances, generate a large volume of log events that contain log data that don't need to be stored. Often, you just want to see a summary of the logs and compare it to historical data. Log-based metrics are also a cost-efficient way to summarize log data from your entire ingest stream. Use the Generate Metrics template to generate a count metric of logs that match a query or a distribution metric of a numeric value contained in the logs, such as a request duration.
+Some log sources, such as firewalls and network appliances, generate a large volume of log events that contain log data that don't need to be stored. Often, you only need a summary of the logs and a comparison to historical data. Log-based metrics are also a cost-efficient way to summarize log data from your entire ingest stream. Use the Generate Metrics template to generate count, gauge, or distribution metrics from logs that match a query.
 
 These are the available metric types:
-  | Metric type  | Description                                                                                                                                     | Example                                                                                             |
-  | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-  | COUNT        | Represents the total number of event occurrences in one time interval. This value can be reset to zero, but cannot be decreased.                | You want to count the number of logs with `status:error`.                                         |
-  | GAUGE        | Represents a snapshot of events in one time interval.                                                                                           | You want to measure the latest CPU utilization per host for all logs in the production environment. |
-  | DISTRIBUTION | Represent the global statistical distribution of a set of values calculated across your entire distributed infrastructure in one time interval. | You want to measure the average time it takes for an API call to be made.                           |
+  | Metric type  | Description                                                                                                                                         | Example                                                                                       |
+  | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+  | COUNT        | The total number of event occurrences in one time interval. Can be reset to zero, but cannot be decreased.                                          | You want to count the number of logs with `status:error`.                                     |
+  | GAUGE        | A snapshot of a value at the time it is reported.                                                                                                   | You want to track the latest CPU utilization per host.                                        |
+  | DISTRIBUTION | Raw values sent to Datadog so percentile aggregations (such as p95, p99) are computed server-side, globally across every host reporting the metric. | You want the global p95 of `response_time_seconds` across every host serving an API endpoint. |
 
 
 ### Log Enrichment

--- a/content/en/observability_pipelines/processors/generate_metrics.md
+++ b/content/en/observability_pipelines/processors/generate_metrics.md
@@ -11,7 +11,7 @@ products:
 
 ## Overview
 
-Many types of logs are meant to be used for telemetry to track trends, such as KPIs, over long periods of time. Generating metrics from your logs is a cost-effective way to summarize log data from high-volume logs, such as CDN logs, VPC flow logs, firewall logs, and networks logs. Use the generate metrics processor to generate either a count metric of logs that match a query or a distribution metric of a numeric value contained in the logs, such as a request duration.
+Many types of logs are meant to be used for telemetry to track trends, such as KPIs, over long periods of time. Generating metrics from your logs is a cost-effective way to summarize log data from high-volume logs, such as CDN logs, VPC flow logs, firewall logs, and network logs. Use the generate metrics processor to generate count, gauge, or distribution metrics from logs that match a query.
 
 **Note**: The metrics generated are [custom metrics][1] and billed accordingly. See [Custom Metrics Billing][2] for more information.
 
@@ -38,11 +38,11 @@ Click **Manage Metrics** to create new metrics or edit existing metrics. This op
 
 You can generate these types of metrics for your logs. See the [Metrics types][3] and [Distributions][4] documentation for more details.
 
-| Metric type  | Description                                                                                                                                     | Example                                                                                             |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| COUNT        | Represents the total number of event occurrences in one time interval. This value can be reset to zero, but cannot be decreased.                | You want to count the number of logs with `status:error`.                                         |
-| GAUGE        | Represents a snapshot of events in one time interval.                                                                                           | You want to measure the latest CPU utilization per host for all logs in the production environment. |
-| DISTRIBUTION | Represent the global statistical distribution of a set of values calculated across your entire distributed infrastructure in one time interval. | You want to measure the average time it takes for an API call to be made.                           |
+| Metric type  | Description                                                                                                                                         | Example                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| COUNT        | The total number of event occurrences in one time interval. Can be reset to zero, but cannot be decreased.                                          | You want to count the number of logs with `status:error`.                                     |
+| GAUGE        | A snapshot of a value at the time it is reported.                                                                                                   | You want to track the latest CPU utilization per host.                                        |
+| DISTRIBUTION | Raw values sent to Datadog so percentile aggregations (such as p95, p99) are computed server-side, globally across every host reporting the metric. | You want the global p95 of `response_time_seconds` across every host serving an API endpoint. |
 
 ##### Count metric example
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13788

Clarifies the difference between the HISTOGRAM and DISTRIBUTION metric types in the Observability Pipelines docs. The metric-type table descriptions in `configuration/_index.md`, `processors/generate_metrics.md`, and `configuration/explore_templates.md` are reframed around where aggregation happens (Agent-side per host vs. server-side globally) so the two types are visibly differentiated. The intro sentences for the Generate Log-based Metrics processor and template are aligned with the tables (count, gauge, and distribution). Includes minor copy fixes flagged by Vale ("networks logs" → "network logs", removal of "just").

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes