### PR TITLE
Fix ARN wildcard example in Cloud Authentication UI steps

### DIFF
--- a/content/en/account_management/cloud_provider_authentication.md
+++ b/content/en/account_management/cloud_provider_authentication.md
@@ -87,7 +87,7 @@ To create an identity mapping:
 
 1. Click {{< ui >}}+ New Mapping{{< /ui >}}.
 2. Select a **Cloud Provider**.
-3. Enter a **Source Pattern (ARN)**. Use `*` for wildcard patterns (for example, `role/terraform-*`).
+3. Enter a **Source Pattern (ARN)**. Use `/*` for wildcard patterns (for example, `assumed-role/terraform-runner/*`).
 4. Search for and select a **Target Identity**. This is the Datadog user or service account this cloud identity authenticates as.
 5. Click {{< ui >}}Create Mapping{{< /ui >}}.
 
@@ -276,7 +276,7 @@ To create an intake mapping:
 
 1. Click {{< ui >}}+ New Mapping{{< /ui >}}.
 2. Select a **Cloud Provider**.
-3. Enter a **Source Pattern (ARN)**. Use `*` for wildcard patterns (for example, `role/terraform-*`).
+3. Enter a **Source Pattern (ARN)**. Use `/*` for wildcard patterns (for example, `assumed-role/DatadogAgentRole/*`).
 4. Click {{< ui >}}Create Mapping{{< /ui >}}.
 
 {{< img src="account_management/cloud_provider_authentication/intake-mapping-create.png" alt="Create Intake Mapping dialog with fields for Cloud Provider and Source Pattern ARN" style="width:70%;" >}}


### PR DESCRIPTION
## What does this PR do?

Fixes an incorrect ARN wildcard example in the UI step-by-step instructions for creating identity and intake mappings (both occurrences).

## Problem

The docs currently show `role/terraform-*` as a valid wildcard example. This format is **rejected by the backend validator** — wildcards must be `/*` at the end of the resource path, not a suffix like `-*`.

Customers following this example hit: `invalid ARN pattern: wildcards must only be used as /* at the end of the resource`

The API examples and the "Using wildcards in ARN patterns" sections already use the correct `/*` format — only the UI step instructions were wrong.

## Changes

- Identity mapping step 3: `role/terraform-*` → `assumed-role/terraform-runner/*`
- Intake mapping step 3: `role/terraform-*` → `assumed-role/DatadogAgentRole/*`

## Additional context

Reported by a customer (Tracksuit) via ZD ticket 2900039. Confirmed by reading `dd-source/domains/aaa/external_authn/internal/libs/cloudconfig/arn_parser.go` and its test suite.