### PR TITLE
Add missing permission for pipeline scanner.

### DIFF
--- a/content/en/logs/log_configuration/pipeline_scanner.md
+++ b/content/en/logs/log_configuration/pipeline_scanner.md
@@ -39,9 +39,9 @@ The Pipeline Scanner samples and annotates logs matching the search query with t
 1. Navigate to [Log Explorer][1].
 1. Click on a log where you want to find out which pipelines and processors are modifying it.
 1. Click the Pipeline Scanner icon in the upper right corner of the panel. If you hover over the icon, it says {{< ui >}}View pipelines for similar logs{{< /ui >}}.
-    Alternatively, click on an attribute in the log panel and select {{< ui >}}Scan pipelines for{{< /ui >}}. 
+    Alternatively, click on an attribute in the log panel and select {{< ui >}}Scan pipelines for{{< /ui >}}.
 1. You can further refine your query in the [Pipeline Scanner][2] page. This query cannot be changed after a session is started.
-1. Click {{< ui >}}Launch this session{{< /ui >}}.   
+1. Click {{< ui >}}Launch this session{{< /ui >}}.
     For the next 15 minutes, logs matching your query are tagged with information about which pipelines and processors are modifying those logs. The Live Tail in the scanner shows which pipelines and how many pipelines match each of the logs.
 1. Click a log to see the list of pipelines and processors matched to that log. Live Tail is paused at this point.
 
@@ -49,13 +49,13 @@ You can modify the pipelines and processors in the right side panel. The modific
 
 You can also access Pipeline Scanner from the Log Pipelines page:
 
-1. Navigate to [Log Pipelines][3]. 
+1. Navigate to [Log Pipelines][3].
 2. Click {{< ui >}}Pipeline Scanner{{< /ui >}}.
 3. Define the query for the logs you want to inspect.
 
 ### Limitations
 
-The `logs_write_pipelines` permission is required to use the Pipeline Scanner. See [Log Management RBAC permissions][4] for more information.
+The `logs_read_config` and `logs_write_pipelines` permissions are required to use the Pipeline Scanner. See [Log Management RBAC permissions][4] for more information.
 
 The number of sessions you can launch is limited to:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
A customer raised an issue with pipeline scanner and after discussion with engineering we discovered they were missing a permission that isn't mentioned in the docs.

### Merge instructions



Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance



### Additional notes

