### PR TITLE
[CCM] Document the new ccm_forecast_write permission

### DIFF
--- a/content/en/cloud_cost_management/planning/budgets.md
+++ b/content/en/cloud_cost_management/planning/budgets.md
@@ -145,6 +145,7 @@ Learn more about how [forecasting][3] works and data requirements.
 |--------|---------------------|
 | View budgets | `cloud_cost_management_read` |
 | Create, edit, or delete a budget | `ccm_budget_write` |
+| Edit custom forecast values | `ccm_forecast_write` |
 
 For the full list of CCM permissions, see the [Permissions documentation][4].
 

--- a/content/en/cloud_cost_management/setup/permissions.md
+++ b/content/en/cloud_cost_management/setup/permissions.md
@@ -16,7 +16,7 @@ further_reading:
 
 Permissions control what actions a user can take in Datadog. Users are assigned to roles, and each role has a set of permissions that determines what that user can see and do.
 
-Cloud Cost Management (CCM) uses two main permissions, `cloud_cost_management_read` and `cloud_cost_management_write`, to control access to cost data and most CCM configurations. Additional product-level permissions are available for specific features, such as editing budgets (`ccm_budget_write`) and managing report schedules (`generate_ccm_report_schedules`, `manage_ccm_report_schedules`). Assign these permissions to roles through [Role Based Access Control (RBAC)][1].
+Cloud Cost Management (CCM) uses two main permissions, `cloud_cost_management_read` and `cloud_cost_management_write`, to control access to cost data and most CCM configurations. Additional product-level permissions are available for specific features, such as editing budgets (`ccm_budget_write`), customizing forecast in the budgets (`ccm_forecast_write`), and managing report schedules (`generate_ccm_report_schedules`, `manage_ccm_report_schedules`). Assign these permissions to roles through [Role Based Access Control (RBAC)][1].
 
 CCM also supports [Data Access Control](#data-access-control) to further restrict cost data by tags.
 
@@ -27,6 +27,7 @@ CCM also supports [Data Access Control](#data-access-control) to further restric
 | `cloud_cost_management_read` | Grants read-only access to view cost data, budgets, recommendations, and settings across CCM pages and external integrations. |
 | `cloud_cost_management_write` | Grants access to modify CCM configurations, including uploading custom costs and managing cloud accounts. Does not grant access to create, edit, or delete budgets; see `ccm_budget_write`. |
 | `ccm_budget_write` | Grants access to create, update, and delete Cloud Cost Management budgets, including budget metadata and budgeted amounts per entry. Requires the read permission to access pages. |
+| `ccm_forecast_write` | Grants access to edit custom forecast values on Cloud Cost Management budgets. Requires the read permission to access pages. |
 | `generate_ccm_report_schedules` | Grants access to view all report schedules and manage only the ones the user has created. |
 | `manage_ccm_report_schedules` | Grants access to view, create, and fully manage all report schedules across the organization. |
 


### PR DESCRIPTION
## Context

Cloud Cost Management is introducing a new product-level permission `ccm_forecast_write` that controls who can edit custom forecast values on budgets. This is the forecast-write equivalent of `ccm_budget_write` (introduced in #36393).

This PR updates the public CCM documentation to reflect the new permission.

Jira: [CCT-1332](https://datadoghq.atlassian.net/browse/CCT-1332)

## Changes

### Preview

- [CCM permissions](https://docs-staging.datadoghq.com/dmytro.kliagin/ccm-forecast-write-permissions/cloud_cost_management/setup/permissions/) => Updated intro sentence. New `ccm_forecast_write` row in 'Available permissions' table.
- [CCM Budgets](https://docs-staging.datadoghq.com/dmytro.kliagin/ccm-forecast-write-permissions/cloud_cost_management/planning/budgets/) => New `ccm_forecast_write` row in the 'Permissions' section.

### In details

- `content/en/cloud_cost_management/setup/permissions.md`
  - Updated the Overview sentence to mention `ccm_forecast_write` alongside `ccm_budget_write`.
  - Added `ccm_forecast_write` row to the Available permissions table.
- `content/en/cloud_cost_management/planning/budgets.md`
  - Added `ccm_forecast_write` row to the Permissions table.

The auto-generated `account_management/rbac/permissions/` page is intentionally not modified; new permissions are picked up automatically.

[CCT-1332]: https://datadoghq.atlassian.net/browse/CCT-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ