### PR TITLE
Switch deployment gates setup script to v2 endpoint

### DIFF
--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -316,7 +316,7 @@ MAX_RETRIES=3
 DELAY_SECONDS=5
 POLL_INTERVAL_SECONDS=15
 MAX_POLL_TIME_SECONDS=10800 # 3 hours
-API_URL="https://api.<YOUR_DD_SITE>/api/unstable/deployments/gates/evaluation"
+API_URL="https://api.<YOUR_DD_SITE>/api/v2/deployments/gates/evaluation"
 API_KEY="<YOUR_API_KEY>"
 APP_KEY="<YOUR_APP_KEY>"
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `/api/v2/deployments/gates/evaluation` endpoint is now available, so the generic deployment gates setup script no longer needs to call the `/api/unstable/` version.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes