### PR TITLE
[SDS] Clarify that keywords match attribute names in structured events

### DIFF
--- a/content/en/security/sensitive_data_scanner/setup/telemetry_data.md
+++ b/content/en/security/sensitive_data_scanner/setup/telemetry_data.md
@@ -117,6 +117,7 @@ The [recommended keywords][15] are used by default when library rules are added.
     - To add keywords, enter a keyword and click the plus icon to add the keyword to the list.
     - To remove keywords, click the **X** next to the keyword you want to remove.
     - You can also require that these keywords be within a specified number of characters of a match. By default, keywords must be within 30 characters before a matched value.
+    - For structured events, keywords are also matched against attribute names in the event path. Separators such as `-`, `_`, and `.` in attribute names count as word boundaries, so the keyword `card` matches an attribute named `card_number` or `card-type`. The character limit does not apply to attribute name matching.
     - **Note**: You cannot have more than 20 keywords for a rule.
 1. In the **Type or paste event data to test the rule** section, add event data to evaluate your rule and add keywords to refine match conditions.
 1. Click **Update**.
@@ -149,6 +150,7 @@ You can create custom scanning rules using regex patterns to scan for sensitive 
     - To add keywords, enter a keyword and click the plus icon to add the keyword to the list.
     - To remove keywords, click the **X** next to the keyword you want to remove.
     - You can also require that these keywords be within a specified number of characters of a match. By default, keywords must be within 30 characters before a matched value.
+    - For structured events, keywords are also matched against attribute names in the event path. Separators such as `-`, `_`, and `.` in attribute names count as word boundaries, so the keyword `card` matches an attribute named `card_number` or `card-type`. The character limit does not apply to attribute name matching.
       **Note**: You cannot have more than 20 keywords for a rule.
 {{% sds-suppressions %}}
 1. In the **Type or paste event data to test the rule** section, add event data to evaluate your rule and add keywords to refine match conditions.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a clarification note in both the library rules and custom rules sections of the SDS keyword documentation.

Currently, the docs only describe the character proximity limit for keyword matching — suggesting keywords work exclusively on content near the matched value. This omits an important behavior: for structured events (JSON logs, APM traces, RUM events), keywords are also matched against attribute names in the event path. Separators like `-`, `_`, and `.` within attribute names are treated as word boundaries, so a keyword like `card` matches an attribute named `card_number` or `card-type`.

This gap caused confusion in a customer support thread where it was unclear whether an out-of-the-box credit card rule should have caught data in a `card_number` attribute (it should have).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Two places updated: the "Add custom keywords" section (library rules) and the "Add a custom rule" section (custom rules).