### PR TITLE
[DEBUG-5719] Add Debug with Bits page to Live Debugger docs

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4626,6 +4626,11 @@ menu:
       identifier: live_debugger
       parent: tracing
       weight: 12
+    - name: Debug with Bits
+      url: tracing/live_debugger/debug-with-bits/
+      identifier: live_debugger_debug_with_bits
+      parent: live_debugger
+      weight: 1
     - name: Error Tracking
       url: tracing/error_tracking/
       parent: tracing

--- a/content/en/tracing/live_debugger/_index.md
+++ b/content/en/tracing/live_debugger/_index.md
@@ -151,6 +151,10 @@ Live Debugger data might contain sensitive information, especially when using th
 1. Use the built-in [sensitive data scrubbing][1] mechanisms.
 2. Use [Sensitive Data Scanner][17] to identify and redact sensitive information based on regular expressions.
 
+### Debug with Bits
+
+Instead of creating and managing logpoints manually, you can investigate running services through a conversational interface. With [Debug with Bits][23], you describe what you want to investigate, and Bits AI Dev Agent places logpoints, retrieves variable snapshots, and helps interpret the results.
+
 ## Impact on performance and billing
 
 Enabling Live Debugger on a service does not trigger data capture or impact performance. Data capture only occurs when there are active Debug Sessions on that service.
@@ -194,3 +198,4 @@ The following constraints apply to Live Debugger usage and configuration:
 [20]: /tracing/code_origin
 [21]: /account_management/rbac/permissions#apm
 [22]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/go
+[23]: /tracing/live_debugger/debug-with-bits/

--- a/content/en/tracing/live_debugger/_index.md
+++ b/content/en/tracing/live_debugger/_index.md
@@ -153,7 +153,7 @@ Live Debugger data might contain sensitive information, especially when using th
 
 ### Debug with Bits
 
-Instead of creating and managing logpoints manually, you can investigate running services through a conversational interface. With [Debug with Bits][23], you describe what you want to investigate, and Bits Code places logpoints, retrieves variable snapshots, and helps interpret the results.
+[Debug with Bits][23] lets you investigate a running service by describing the issue in plain language. Bits Code handles logpoint placement, captures variable snapshots, and helps interpret the results.
 
 ## Impact on performance and billing
 

--- a/content/en/tracing/live_debugger/_index.md
+++ b/content/en/tracing/live_debugger/_index.md
@@ -153,7 +153,7 @@ Live Debugger data might contain sensitive information, especially when using th
 
 ### Debug with Bits
 
-Instead of creating and managing logpoints manually, you can investigate running services through a conversational interface. With [Debug with Bits][23], you describe what you want to investigate, and Bits AI Dev Agent places logpoints, retrieves variable snapshots, and helps interpret the results.
+Instead of creating and managing logpoints manually, you can investigate running services through a conversational interface. With [Debug with Bits][23], you describe what you want to investigate, and Bits Code places logpoints, retrieves variable snapshots, and helps interpret the results.
 
 ## Impact on performance and billing
 

--- a/content/en/tracing/live_debugger/debug-with-bits.md
+++ b/content/en/tracing/live_debugger/debug-with-bits.md
@@ -1,10 +1,10 @@
 ---
 title: Debug with Bits
-description: Use Bits AI Dev Agent to create and manage Live Debugger sessions through a conversational interface.
+description: Use Bits Code to create and manage Live Debugger sessions through a conversational interface.
 further_reading:
 - link: "/bits_ai/bits_ai_dev_agent/"
   tag: "Documentation"
-  text: "Bits AI Dev Agent"
+  text: "Bits Code"
 - link: "/tracing/live_debugger/"
   tag: "Documentation"
   text: "Live Debugger"
@@ -24,7 +24,7 @@ Debug with Bits brings a conversational interface to Live Debugger for investiga
 All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry behavior, and [sensitive data scrubbing][3] apply.
 
 <div class="alert alert-info">
-Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits AI Dev Agent</a>, which may impact billing.
+Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits Code</a>, which may impact billing.
 </div>
 
 ## Prerequisites
@@ -33,7 +33,7 @@ Before using Debug with Bits:
 
 - [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][1] for details.
 - Your account must have the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
-- [Bits AI Dev Agent][5] must be available in your organization.
+- [Bits Code][5] must be available in your organization.
 - [Source Code Integration][6] must be set up for the target service.
 
 

--- a/content/en/tracing/live_debugger/debug-with-bits.md
+++ b/content/en/tracing/live_debugger/debug-with-bits.md
@@ -19,20 +19,20 @@ Debug with Bits is in Preview. Request access to join the waiting list.
 
 ## Overview
 
-Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate and Bits does the work: placing logpoints, retrieving variable snapshots, and interpreting results. Once Bits identifies a root cause, it can also suggest code fixes based on its findings.
+Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate, and Bits places logpoints, retrieves variable snapshots, and interprets results. After Bits identifies a root cause, it can suggest code fixes based on its findings.
 
-All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry rules, and [sensitive data scrubbing][3] apply.
+All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry behavior, and [sensitive data scrubbing][3] apply.
 
 <div class="alert alert-info">
 Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits AI Dev Agent</a>, which may impact billing.
 </div>
 
-## Requirements
+## Prerequisites
 
 Before using Debug with Bits:
 
 - [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][1] for details.
-- Your account needs the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
+- Your account must have the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
 - [Bits AI Dev Agent][5] must be available in your organization.
 - [Source Code Integration][6] must be set up for the target service.
 
@@ -46,29 +46,33 @@ Bits can perform the following Live Debugger actions during a debugging session:
 | Discover services | Find and validate services available for debugging in a given environment. |
 | Create logpoints | Add logpoints to a running service at a specific code location. |
 | List session logpoints | Show the logpoints active in a Debug Session. |
-| Disable logpoints | Disable all logpoints in a session. |
+| Disable logpoints | Disable all logpoints in a Debug Session. |
 | Retrieve snapshot data | Fetch captured variable values and execution context from an active logpoint. |
 
-Logpoints created by Bits follow the same rules as manually created logpoints. They are read-only, non-blocking, and auto-expire after the configured time limit - between 10 minutes and 2 days (default: 60 minutes). Bits cannot modify application state or alter control flow.
+Logpoints created by Bits follow the same rules as manually created logpoints. They are read-only, non-blocking, and expire automatically after the configured time limit (10 minutes to 2 days; default: 60 minutes). Bits cannot modify application state or alter control flow.
 
-## Get started
+## Start a debugging session
 
-1. Navigate to the [Live Debugger page][4].
-1. In the Debug with Bits chatbox, describe the issue you want to investigate. Select the target service and environment before submitting the prompt.  
-1.  Bits analyzes relevant code paths in the connected source code repository and may ask follow up questions to form a hypothesis.
+1. Go to [Live Debugger][4] in Datadog.
+1. In the Debug with Bits chatbox, describe the issue you want to investigate. Select the target service and environment before submitting the prompt.
 
-1. Bits configures and activates up to 5 logpoints at relevant code locations to capture the specific data it needs.
-1. Bits retrieves and analyzes the logs and variable snapshots from the active logpoints to validate its hypothesis and formulate its response.
-1. Review the response from Bits and (optionally) explore the details of the logpoints, captured data, and any code fixes suggested. Reply to the chat to continue the investigation as needed.
-1. Bits typically disables the logpoints it creates as soon as it has retrieved the data it needs. Also, logpoints auto-expire after the session's set time period. Disable logpoints at any time by asking Bits or clicking the Disable button on an individual logpoint or the session.
+   Bits then works through the investigation automatically:
+   - It analyzes relevant code paths in the connected source code repository and may ask follow-up questions to form a hypothesis.
+   - It configures and activates up to 5 logpoints at relevant code locations to capture the specific data it needs.
+   - It retrieves and analyzes the logs and variable snapshots from the active logpoints to validate its hypothesis and formulate its response.
 
-## Notes
+1. Review the response from Bits and, optionally, explore the details of the logpoints, captured data, and any code fixes suggested. Reply to the chat to continue the investigation as needed.
+1. To disable logpoints at any time, ask Bits or click the **Disable** button on an individual logpoint or the session.
+
+**Note**: Bits typically disables the logpoints it creates as soon as it has retrieved the data it needs. Logpoints also expire automatically after the configured time limit.
+
+## Behavior and limitations
 
 **Multi-version environments**: When multiple code versions are deployed in the target environment, the target file may differ between versions. In that case, Bits asks you to confirm the target version before placing a logpoint. This prevents logpoints from landing at incorrect line numbers.
 
 **Language support**: Some features vary by language. For example, condition expressions are not supported for all runtimes. Bits notifies you when a requested feature is not available for the target service's language.
 
-**Sensitive data**: The same [sensitive data scrubbing][3] that applies to manually created logpoints applies to logpoints created by Bits. In production environments, non-numeric and non-Boolean captured values are redacted by default.
+**Sensitive data**: The [sensitive data scrubbing][3] behavior that applies to manually created logpoints also applies to logpoints created by Bits. In production environments, non-numeric and non-Boolean captured values are redacted by default.
 
 ## Further reading
 

--- a/content/en/tracing/live_debugger/debug-with-bits.md
+++ b/content/en/tracing/live_debugger/debug-with-bits.md
@@ -19,7 +19,7 @@ Debug with Bits is in Preview. Request access to join the waiting list.
 
 ## Overview
 
-Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate, and Bits places logpoints, retrieves variable snapshots, and interprets results. After Bits identifies a root cause, it can suggest code fixes based on its findings.
+Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate, and Bits places logpoints, retrieves variable snapshots, and interprets results. After Bits identifies a root cause, it can suggest code fixes.
 
 All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry behavior, and [sensitive data scrubbing][3] apply.
 
@@ -61,10 +61,10 @@ Logpoints created by Bits follow the same rules as manually created logpoints. T
    - It configures and activates up to 5 logpoints at relevant code locations to capture the specific data it needs.
    - It retrieves and analyzes the logs and variable snapshots from the active logpoints to validate its hypothesis and formulate its response.
 
-1. Review the response from Bits and, optionally, explore the details of the logpoints, captured data, and any code fixes suggested. Reply to the chat to continue the investigation as needed.
+1. Review the response from Bits and, optionally, explore the details of the logpoints, captured data, and any code fixes suggested. Reply in the chat to continue the investigation as needed.
 1. To disable logpoints at any time, ask Bits or click the **Disable** button on an individual logpoint or the session.
 
-**Note**: Bits typically disables the logpoints it creates as soon as it has retrieved the data it needs. Logpoints also expire automatically after the configured time limit.
+**Note**: Bits typically disables the logpoints it creates as soon as it retrieves the data it needs. Logpoints also expire automatically after the configured time limit.
 
 ## Behavior and limitations
 

--- a/content/en/tracing/live_debugger/debug-with-bits.md
+++ b/content/en/tracing/live_debugger/debug-with-bits.md
@@ -31,11 +31,10 @@ Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits Code</a>, which 
 
 Before using Debug with Bits:
 
-- [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][1] for details.
+- [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][7] for details.
 - Your account must have the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
 - [Bits Code][5] must be available in your organization.
 - [Source Code Integration][6] must be set up for the target service.
-
 
 ## Available actions
 
@@ -84,3 +83,4 @@ Logpoints created by Bits follow the same rules as manually created logpoints. T
 [4]: https://app.datadoghq.com/debugging/sessions
 [5]: /bits_ai/bits_ai_dev_agent/
 [6]: /source_code/source-code-management/
+[7]: /tracing/live_debugger/#requirements-and-setup

--- a/content/en/tracing/live_debugger/debug-with-bits.md
+++ b/content/en/tracing/live_debugger/debug-with-bits.md
@@ -1,0 +1,82 @@
+---
+title: Debug with Bits
+description: Use Bits AI Dev Agent to create and manage Live Debugger sessions through a conversational interface.
+further_reading:
+- link: "/bits_ai/bits_ai_dev_agent/"
+  tag: "Documentation"
+  text: "Bits AI Dev Agent"
+- link: "/tracing/live_debugger/"
+  tag: "Documentation"
+  text: "Live Debugger"
+- link: "/dynamic_instrumentation/sensitive-data-scrubbing/"
+  tag: "Documentation"
+  text: "Sensitive Data Scrubbing"
+---
+
+{{< beta-callout url="https://www.datadoghq.com/product-preview/debug-with-bits/" >}}
+Debug with Bits is in Preview. Request access to join the waiting list.
+{{< /beta-callout >}}
+
+## Overview
+
+Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate and Bits does the work: placing logpoints, retrieving variable snapshots, and interpreting results. Once Bits identifies a root cause, it can also suggest code fixes based on its findings.
+
+All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry rules, and [sensitive data scrubbing][3] apply.
+
+<div class="alert alert-info">
+Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits AI Dev Agent</a>, which may impact billing.
+</div>
+
+## Requirements
+
+Before using Debug with Bits:
+
+- [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][1] for details.
+- Your account needs the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
+- [Bits AI Dev Agent][5] must be available in your organization.
+- [Source Code Integration][6] must be set up for the target service.
+
+
+## Available actions
+
+Bits can perform the following Live Debugger actions during a debugging session:
+
+| Action | Description |
+|--------|-------------|
+| Discover services | Find and validate services available for debugging in a given environment. |
+| Create logpoints | Add logpoints to a running service at a specific code location. |
+| List session logpoints | Show the logpoints active in a Debug Session. |
+| Disable logpoints | Disable all logpoints in a session. |
+| Retrieve snapshot data | Fetch captured variable values and execution context from an active logpoint. |
+
+Logpoints created by Bits follow the same rules as manually created logpoints. They are read-only, non-blocking, and auto-expire after the configured time limit - between 10 minutes and 2 days (default: 60 minutes). Bits cannot modify application state or alter control flow.
+
+## Get started
+
+1. Navigate to the [Live Debugger page][4].
+1. In the Debug with Bits chatbox, describe the issue you want to investigate. Select the target service and environment before submitting the prompt.  
+1.  Bits analyzes relevant code paths in the connected source code repository and may ask follow up questions to form a hypothesis.
+
+1. Bits configures and activates up to 5 logpoints at relevant code locations to capture the specific data it needs.
+1. Bits retrieves and analyzes the logs and variable snapshots from the active logpoints to validate its hypothesis and formulate its response.
+1. Review the response from Bits and (optionally) explore the details of the logpoints, captured data, and any code fixes suggested. Reply to the chat to continue the investigation as needed.
+1. Bits typically disables the logpoints it creates as soon as it has retrieved the data it needs. Also, logpoints auto-expire after the session's set time period. Disable logpoints at any time by asking Bits or clicking the Disable button on an individual logpoint or the session.
+
+## Notes
+
+**Multi-version environments**: When multiple code versions are deployed in the target environment, the target file may differ between versions. In that case, Bits asks you to confirm the target version before placing a logpoint. This prevents logpoints from landing at incorrect line numbers.
+
+**Language support**: Some features vary by language. For example, condition expressions are not supported for all runtimes. Bits notifies you when a requested feature is not available for the target service's language.
+
+**Sensitive data**: The same [sensitive data scrubbing][3] that applies to manually created logpoints applies to logpoints created by Bits. In production environments, non-numeric and non-Boolean captured values are redacted by default.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/live_debugger/
+[2]: /tracing/live_debugger/#permissions
+[3]: /dynamic_instrumentation/sensitive-data-scrubbing/
+[4]: https://app.datadoghq.com/debugging/sessions
+[5]: /bits_ai/bits_ai_dev_agent/
+[6]: /source_code/source-code-management/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DEBUG-5719

Adds a new **Debug with Bits** sub-page under Live Debugger (`/tracing/live_debugger/debug-with-bits/`). The page is gated by a Preview callout with a Request Access link. It covers:

- What Debug with Bits is and how it relates to Live Debugger
- Prerequisites (Live Debugger setup, permissions, Bits AI Dev Agent access, Source Code Integration)
- A table of available actions Bits can take on your behalf
- A walkthrough of a debugging session, separating user actions from what Bits does automatically
- Behavior and limitations: multi-version environments, per-language feature gaps, and sensitive data handling

Permissions and sensitive data scrubbing details link out to existing Live Debugger and Dynamic Instrumentation pages rather than duplicating them here.

Also registers the page in the English nav menu as a child of the Live Debugger entry, and links to it from the Live Debugger overview page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
