### PR TITLE
Add GA security tools to MCP server docs

### DIFF
--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -1007,7 +1007,7 @@ Scans code for hardcoded secrets and credentials, detecting AWS keys, API keys, 
 - Scan my code for hardcoded secrets.
 - Check if there are any API keys or passwords committed in this file.
 
-### `datadog_security_signals_schema`
+### `get_datadog_security_signals_schema`
 *Toolset: **security***\
 *Permissions Required: `Security Signals Read`*\
 Returns the available fields and their types for security signals. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -998,7 +998,7 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 
 ## Security
 
-Tools for code security scanning and searching [security signals][53] and [security findings][54].
+Tools for code security scanning, searching and triaging [security signals][53], managing detection rules and suppressions, and analyzing [security findings][54].
 
 ### `datadog_secrets_scan`
 *Toolset: **security***\
@@ -1032,6 +1032,86 @@ Retrieves the full details of a single security signal by ID, including attribut
 
 - Get the full details of security signal `AwAAAZ27F1BUjY4rPQAAABhBWjI3RjFCVWpZNHJBQUFBSGFNQVZBQUFBR1Bu`.
 - Show me the rule, triage state, and linked cases for this signal.
+
+### `datadog_security_signals_schema`
+*Toolset: **security***\
+*Permissions Required: `Security Signals Read`*\
+Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+
+- What fields can I use to filter security signals?
+- Show me the available fields for Cloud SIEM signals.
+- What enum values are valid for the signal rule type field?
+
+### `update_datadog_security_signals_triage`
+*Toolset: **security***\
+*Permissions Required: `Security Signals Write`*\
+Updates the triage state and/or assignee of one or more security signals in bulk. Accepts either a list of signal IDs or a filter query. Valid states: `open`, `archived`, `under_review`. An archive reason is required when archiving. Call `analyze_datadog_security_signals` to count matching signals before bulk-updating.
+
+- Archive all signals from rule "Brute Force Login" in the last 24 hours.
+- Set all open signals for `service:checkout` to under review and assign them to me.
+- Mark signal `AwAAAZ27F1BUjY4rPQAAABhBWjI3RjFCVWpZNHJBQUFBSGFNQVZBQUFBR1Bu` as archived with reason "testing".
+
+### `list_datadog_security_detection_rules`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Read`*\
+Lists Cloud SIEM detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to fetch the full definition of a specific rule.
+
+- List all enabled Cloud SIEM detection rules.
+- Show me detection rules tagged with `source:cloudtrail`.
+- Which rules are configured for impossible travel detection?
+
+### `get_datadog_security_detection_rule`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Read`*\
+Retrieves the full definition of a single Cloud SIEM detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
+
+- Get the full definition of detection rule `abc-123-def`.
+- Show me the queries and cases for the rule generating this signal.
+- What thresholds and group-by fields does this detection rule use?
+
+### `get_datadog_security_detection_rules_schema`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Read`*\
+Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and valid search facets. Use this before authoring or querying detection rules. Returns static content with no network call.
+
+- What fields and options are available when creating a threshold detection rule?
+- Show me the schema for sequence detection rules.
+- What tag conventions and query syntax does the detection rules API use?
+
+### `get_datadog_security_suppressions`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Suppressions Read`*\
+Retrieves security monitoring suppressions. Supports three modes: list all suppressions, get a single suppression by ID, or get suppressions affecting a specific detection rule. Suppressions prevent detection rules from generating signals for matching conditions.
+
+- List all active suppressions.
+- Show me suppressions for detection rule `abc-123-def`.
+- Get the full details of suppression `sup-456-xyz`.
+
+### `create_datadog_security_suppression`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Suppressions Write`*\
+Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided. Call `get_datadog_security_detection_rule` first to inspect the target rule before writing the suppression query.
+
+- Suppress signals from the brute force rule for IP `10.0.0.1`.
+- Create a suppression for the anomaly detection rule that ignores the `staging` environment.
+- Suppress signals from rule `abc-123-def` where `@usr.email` matches our test accounts.
+
+### `update_datadog_security_suppression`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Suppressions Write`*\
+Updates an existing suppression rule. Only provided fields are changed. Call `get_datadog_security_suppressions` first to retrieve the current state and version before editing.
+
+- Update the suppression for the brute force rule to also exclude `10.0.0.2`.
+- Change the expiration date on suppression `sup-456-xyz` to next quarter.
+- Disable the suppression for the anomaly detection rule without deleting it.
+
+### `delete_datadog_security_suppression`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Suppressions Write`*\
+Deletes a suppression rule. This operation is irreversible and takes effect immediately. Call `get_datadog_security_suppressions` first to confirm the correct suppression will be deleted.
+
+- Delete suppression `sup-456-xyz`.
+- Remove the suppression that was silencing the brute force detection rule.
 
 ### `security_findings_schema`
 *Toolset: **security***\

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -998,7 +998,7 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 
 ## Security
 
-Tools for code security scanning, searching and triaging [security signals][53], managing [detection rules][60] and [suppressions][61], and analyzing [security findings][54].
+Tools for code security scanning, analyzing, searching and triaging [security signals][53], managing [detection rules][60] and [suppressions][61], and analyzing [security findings][54].
 
 ### `datadog_secrets_scan`
 *Toolset: **security***\
@@ -1420,7 +1420,7 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [54]: /security/misconfigurations/findings/
 [55]: /containers/monitoring/kubernetes_explorer/
 [60]: /security/detection_rules/
-[61]: /security/cloud_siem/detect_and_monitor/suppressions/
+[61]: /security/suppressions/
 [56]: /account_management/rbac/permissions/
 [57]: /notebooks/
 [58]: /real_user_monitoring/

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -1007,6 +1007,15 @@ Scans code for hardcoded secrets and credentials, detecting AWS keys, API keys, 
 - Scan my code for hardcoded secrets.
 - Check if there are any API keys or passwords committed in this file.
 
+### `datadog_security_signals_schema`
+*Toolset: **security***\
+*Permissions Required: `Security Signals Read`*\
+Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+
+- What fields can I use to filter security signals?
+- Show me the available fields for Cloud SIEM signals.
+- What enum values are valid for the signal rule type field?
+
 ### `search_datadog_security_signals`
 *Toolset: **security***\
 *Permissions Required: `Security Signals Read`*\
@@ -1033,15 +1042,6 @@ Retrieves the full details of a single security signal by ID, including attribut
 - Get the full details of security signal `AwAAAZ27F1BUjY4rPQAAABhBWjI3RjFCVWpZNHJBQUFBSGFNQVZBQUFBR1Bu`.
 - Show me the rule, triage state, and linked cases for this signal.
 
-### `datadog_security_signals_schema`
-*Toolset: **security***\
-*Permissions Required: `Security Signals Read`*\
-Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
-
-- What fields can I use to filter security signals?
-- Show me the available fields for Cloud SIEM signals.
-- What enum values are valid for the signal rule type field?
-
 ### `update_datadog_security_signals_triage`
 *Toolset: **security***\
 *Permissions Required: `Security Signals Write`*\
@@ -1050,6 +1050,15 @@ Updates the triage state and/or assignee of one or more security signals in bulk
 - Archive all signals from rule "Brute Force Login" in the last 24 hours.
 - Set all open signals for `service:checkout` to under review and assign them to me.
 - Mark signal `AwAAAZ27F1BUjY4rPQAAABhBWjI3RjFCVWpZNHJBQUFBSGFNQVZBQUFBR1Bu` as archived with reason "testing".
+
+### `get_datadog_security_detection_rules_schema`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Read`*\
+Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and valid search facets. Use this before authoring or querying detection rules. Returns static content with no network call.
+
+- What fields and options are available when creating a threshold detection rule?
+- Show me the schema for sequence detection rules.
+- What tag conventions and query syntax does the detection rules API use?
 
 ### `list_datadog_security_detection_rules`
 *Toolset: **security***\
@@ -1068,15 +1077,6 @@ Retrieves the full definition of a single Cloud SIEM detection rule by ID, inclu
 - Get the full definition of detection rule `abc-123-def`.
 - Show me the queries and cases for the rule generating this signal.
 - What thresholds and group-by fields does this detection rule use?
-
-### `get_datadog_security_detection_rules_schema`
-*Toolset: **security***\
-*Permissions Required: `Security Monitoring Rules Read`*\
-Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and valid search facets. Use this before authoring or querying detection rules. Returns static content with no network call.
-
-- What fields and options are available when creating a threshold detection rule?
-- Show me the schema for sequence detection rules.
-- What tag conventions and query syntax does the detection rules API use?
 
 ### `get_datadog_security_suppressions`
 *Toolset: **security***\

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -1010,7 +1010,7 @@ Scans code for hardcoded secrets and credentials, detecting AWS keys, API keys, 
 ### `datadog_security_signals_schema`
 *Toolset: **security***\
 *Permissions Required: `Security Signals Read`*\
-Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+Returns the available fields and their types for security signals. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
 
 - What fields can I use to filter security signals?
 - Show me the available fields for Cloud SIEM signals.
@@ -1045,7 +1045,7 @@ Retrieves the full details of a single security signal by ID, including attribut
 ### `update_datadog_security_signals_triage`
 *Toolset: **security***\
 *Permissions Required: `Security Signals Write`*\
-Updates the triage state and/or assignee of one or more security signals in bulk. Accepts either a list of signal IDs or a filter query. Valid states: `open`, `archived`, `under_review`. An archive reason is required when archiving. Call `analyze_datadog_security_signals` to count matching signals before bulk-updating.
+Updates the triage state or assignee of one or more security signals in bulk (up to 500 signals). Accepts either a list of signal IDs or a filter query matching all signals to update.
 
 - Archive all signals from rule "Brute Force Login" in the last 24 hours.
 - Set all open signals for `service:checkout` to under review and assign them to me.
@@ -1054,7 +1054,7 @@ Updates the triage state and/or assignee of one or more security signals in bulk
 ### `get_datadog_security_detection_rules_schema`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Read`*\
-Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and valid search facets. Use this before authoring or querying detection rules. Returns static content with no network call.
+Returns the authoring reference and schema for detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and valid search facets. Use this before authoring or querying detection rules. Currently supported rule types: log detection, API security, and AppSec.
 
 - What fields and options are available when creating a threshold detection rule?
 - Show me the schema for sequence detection rules.
@@ -1063,7 +1063,7 @@ Returns the authoring reference and schema for Cloud SIEM detection rules. Cover
 ### `list_datadog_security_detection_rules`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Read`*\
-Lists Cloud SIEM detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to fetch the full definition of a specific rule.
+Lists detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to fetch the full definition of a specific rule.
 
 - List all enabled Cloud SIEM detection rules.
 - Show me detection rules tagged with `source:cloudtrail`.
@@ -1072,7 +1072,7 @@ Lists Cloud SIEM detection rules for the organization. Detection rules define th
 ### `get_datadog_security_detection_rule`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Read`*\
-Retrieves the full definition of a single Cloud SIEM detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
+Retrieves the full definition of a single detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
 
 - Get the full definition of detection rule `abc-123-def`.
 - Show me the queries and cases for the rule generating this signal.
@@ -1090,7 +1090,7 @@ Retrieves security monitoring suppressions. Supports three modes: list all suppr
 ### `create_datadog_security_suppression`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Suppressions Write`*\
-Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided. Call `get_datadog_security_detection_rule` first to inspect the target rule before writing the suppression query.
+Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided.
 
 - Suppress signals from the brute force rule for IP `10.0.0.1`.
 - Create a suppression for the anomaly detection rule that ignores the `staging` environment.
@@ -1099,7 +1099,7 @@ Creates a new suppression rule that prevents a detection rule from generating si
 ### `update_datadog_security_suppression`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Suppressions Write`*\
-Updates an existing suppression rule. Only provided fields are changed. Call `get_datadog_security_suppressions` first to retrieve the current state and version before editing.
+Updates an existing suppression rule. Only provided fields are changed. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
 
 - Update the suppression for the brute force rule to also exclude `10.0.0.2`.
 - Change the expiration date on suppression `sup-456-xyz` to next quarter.
@@ -1108,7 +1108,7 @@ Updates an existing suppression rule. Only provided fields are changed. Call `ge
 ### `delete_datadog_security_suppression`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Suppressions Write`*\
-Deletes a suppression rule. This operation is irreversible and takes effect immediately. Call `get_datadog_security_suppressions` first to confirm the correct suppression will be deleted.
+Deletes a suppression rule.
 
 - Delete suppression `sup-456-xyz`.
 - Remove the suppression that was silencing the brute force detection rule.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -1099,7 +1099,7 @@ Creates a new suppression rule that prevents a detection rule from generating si
 ### `update_datadog_security_suppression`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Suppressions Write`*\
-Updates an existing suppression rule. Only provided fields are changed. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
+Updates an existing suppression rule. Only changes provided fields. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
 
 - Update the suppression for the brute force rule to also exclude `10.0.0.2`.
 - Change the expiration date on suppression `sup-456-xyz` to next quarter.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -998,7 +998,7 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 
 ## Security
 
-Tools for code security scanning, searching and triaging [security signals][53], managing detection rules and suppressions, and analyzing [security findings][54].
+Tools for code security scanning, searching and triaging [security signals][53], managing [detection rules][60] and [suppressions][61], and analyzing [security findings][54].
 
 ### `datadog_secrets_scan`
 *Toolset: **security***\
@@ -1419,6 +1419,8 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [53]: /security/threats/security_signals/
 [54]: /security/misconfigurations/findings/
 [55]: /containers/monitoring/kubernetes_explorer/
+[60]: /security/detection_rules/
+[61]: /security/cloud_siem/detect_and_monitor/suppressions/
 [56]: /account_management/rbac/permissions/
 [57]: /notebooks/
 [58]: /real_user_monitoring/

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -14,8 +14,14 @@ further_reading:
 - link: "security/guide/findings-schema/?tab=library_vulnerability"
   tag: "Documentation"
   text: "Security Findings"
+- link: "security/detection_rules/"
+  tag: "Documentation"
+  text: "Detection Rules"
+- link: "security/suppressions/"
+  tag: "Documentation"
+  text: "Suppressions"
 algolia:
-  tags: ["mcp", "mcp server", "security", "security signals", "security findings"]
+  tags: ["mcp", "mcp server", "security", "security signals", "security findings", "detection rules", "suppressions"]
 ---
 
 ## Overview
@@ -29,9 +35,12 @@ The [Datadog MCP Server][1] lets AI agents query your security data through the 
 You can use the `security` toolset to:
 
 - **Triage security signals**: Ask your AI agent to surface recent high-severity Cloud SIEM signals, App & API Protection alerts, or Workload Protection threats, and get a summary of patterns and affected resources.
+- **Triage and bulk-update signals**: Update triage state or assignee across a set of matching signals in bulk.
 - **Analyze your security posture**: Query findings across Cloud Security with SQL to understand the distribution of misconfigurations, vulnerabilities, and identity risks across your environment.
 - **Investigate specific findings**: Retrieve full details for a set of findings to understand scope, affected resources, and remediation context.
 - **Correlate signals and findings**: Cross-reference active security signals with open findings to determine whether an alert is tied to a known posture issue.
+- **Inspect and manage detection rules**: List and retrieve detection rule definitions to understand what logic is generating signals.
+- **Manage suppressions**: Create, update, and delete suppressions to silence noisy rules for specific conditions without disabling them entirely.
 - **Remediate vulnerabilities with an AI agent**: Pull library vulnerability findings, including code location and remediation guidance, and pass them to your AI agent to apply patches directly in your codebase.
 
 ## Quickstart
@@ -48,19 +57,63 @@ The `security` toolset is not enabled by default. You can enable it by adding a 
 
 ## Available tools
 
-The `security` toolset exposes the following tools to your AI client. Each tool performs a specific action on your security data, such as searching for signals or analyzing findings. When you ask a question in natural language, your AI client calls these tools on your behalf to retrieve the information it needs. For general information on how to use MCP tools, see the [Datadog MCP Server Overview][1].
+The `security` toolset exposes the following tools to your AI client. Each tool performs a specific action on your security data. When you ask a question in natural language, your AI client calls these tools on your behalf to retrieve the information it needs. For general information on how to use MCP tools, see the [Datadog MCP Server Overview][1].
+
+### Security Signals
 
 `search_datadog_security_signals`
 : Searches and retrieves security signals from Datadog, including Cloud SIEM signals, App & API Protection signals, and Workload Protection signals. Use this to surface and investigate suspicious activity.
 : *Permissions required: `Security Signals Read`*
 
 `analyze_datadog_security_signals`
-: Analyzes security signals using SQL for aggregations, grouping, and trend analysis. Use this for counts, top-N breakdowns, and time-based questions. To list signals or retrieve a single signal, use `search_datadog_security_signals` or `get_datadog_security_signal` instead.
+: Analyzes security signals using SQL for aggregations, grouping, and trend analysis. Use this for counts, top-N breakdowns, and time-based questions. To list signals or retrieve a single signal, use `search_datadog_security_signals` or `get_datadog_security_signal` instead. Call `datadog_security_signals_schema` first to discover queryable fields.
 : *Permissions required: `Security Signals Read`, `Timeseries`*
 
 `get_datadog_security_signal`
 : Retrieves the full details of a single security signal by ID, including attributes, rule information, triage state, tags, and case correlations. Use `search_datadog_security_signals` to find signal IDs first.
 : *Permissions required: `Security Signals Read`*
+
+`datadog_security_signals_schema`
+: Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+: *Permissions required: `Security Signals Read`*
+
+`update_datadog_security_signals_triage`
+: Updates the triage state and/or assignee of one or more security signals in bulk. Accepts either a list of signal IDs or a filter query. Valid states: `open`, `archived`, `under_review`. An archive reason is required when archiving. Call `analyze_datadog_security_signals` first to count matching signals before bulk-updating.
+: *Permissions required: `Security Signals Write`*
+
+### Detection Rules
+
+`list_datadog_security_detection_rules`
+: Lists Cloud SIEM detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to retrieve the full definition of a specific rule.
+: *Permissions required: `Security Monitoring Rules Read`*
+
+`get_datadog_security_detection_rule`
+: Retrieves the full definition of a single Cloud SIEM detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
+: *Permissions required: `Security Monitoring Rules Read`*
+
+`get_datadog_security_detection_rules_schema`
+: Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules.
+: *Permissions required: `Security Monitoring Rules Read`*
+
+### Suppressions
+
+`get_datadog_security_suppressions`
+: Retrieves security monitoring suppressions. Supports three modes: list all suppressions, get a single suppression by ID, or get suppressions affecting a specific detection rule. Suppressions prevent detection rules from generating signals for matching conditions.
+: *Permissions required: `Security Monitoring Suppressions Read`*
+
+`create_datadog_security_suppression`
+: Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided. Call `get_datadog_security_detection_rule` first to inspect the target rule before writing the suppression query.
+: *Permissions required: `Security Monitoring Suppressions Write`*
+
+`update_datadog_security_suppression`
+: Updates an existing suppression rule. Only provided fields are changed. Call `get_datadog_security_suppressions` first to retrieve the current state and version; providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
+: *Permissions required: `Security Monitoring Suppressions Write`*
+
+`delete_datadog_security_suppression`
+: Deletes a suppression rule. This operation is irreversible and takes effect immediately. Call `get_datadog_security_suppressions` first to confirm the correct suppression will be deleted.
+: *Permissions required: `Security Monitoring Suppressions Write`*
+
+### Security Findings
 
 `security_findings_schema`
 : Returns the available fields and their types for security findings. Call this before using `analyze_security_findings` to discover which fields you can filter and group by. Supports filtering by finding type.

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -61,7 +61,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 
 ### Security Signals
 
-`datadog_security_signals_schema`
+`get_datadog_security_signals_schema`
 : Returns the available fields and their types for security signals. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
 : *Permissions required: `Security Signals Read`*
 
@@ -70,7 +70,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Signals Read`*
 
 `analyze_datadog_security_signals`
-: Analyzes security signals using SQL for aggregations, grouping, and trend analysis. Use this for counts, top-N breakdowns, and time-based questions. To list signals or retrieve a single signal, use `search_datadog_security_signals` or `get_datadog_security_signal` instead. Call `datadog_security_signals_schema` first to discover queryable fields.
+: Analyzes security signals using SQL for aggregations, grouping, and trend analysis. Use this for counts, top-N breakdowns, and time-based questions. To list signals or retrieve a single signal, use `search_datadog_security_signals` or `get_datadog_security_signal` instead. Call `get_datadog_security_signals_schema` first to discover queryable fields.
 : *Permissions required: `Security Signals Read`, `Timeseries`*
 
 `get_datadog_security_signal`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -61,6 +61,10 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 
 ### Security Signals
 
+`datadog_security_signals_schema`
+: Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+: *Permissions required: `Security Signals Read`*
+
 `search_datadog_security_signals`
 : Searches and retrieves security signals from Datadog, including Cloud SIEM signals, App & API Protection signals, and Workload Protection signals. Use this to surface and investigate suspicious activity.
 : *Permissions required: `Security Signals Read`*
@@ -73,15 +77,15 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : Retrieves the full details of a single security signal by ID, including attributes, rule information, triage state, tags, and case correlations. Use `search_datadog_security_signals` to find signal IDs first.
 : *Permissions required: `Security Signals Read`*
 
-`datadog_security_signals_schema`
-: Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
-: *Permissions required: `Security Signals Read`*
-
 `update_datadog_security_signals_triage`
 : Updates the triage state and/or assignee of one or more security signals in bulk. Accepts either a list of signal IDs or a filter query. Valid states: `open`, `archived`, `under_review`. An archive reason is required when archiving. Call `analyze_datadog_security_signals` first to count matching signals before bulk-updating.
 : *Permissions required: `Security Signals Write`*
 
 ### Detection Rules
+
+`get_datadog_security_detection_rules_schema`
+: Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules.
+: *Permissions required: `Security Monitoring Rules Read`*
 
 `list_datadog_security_detection_rules`
 : Lists Cloud SIEM detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to retrieve the full definition of a specific rule.
@@ -89,10 +93,6 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 
 `get_datadog_security_detection_rule`
 : Retrieves the full definition of a single Cloud SIEM detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
-: *Permissions required: `Security Monitoring Rules Read`*
-
-`get_datadog_security_detection_rules_schema`
-: Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 ### Suppressions

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -120,7 +120,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 `update_datadog_security_suppression`
-: Updates an existing suppression rule. Only provided fields are changed. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
+: Updates an existing suppression rule. Only changes provided fields. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 `delete_datadog_security_suppression`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -62,7 +62,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 ### Security Signals
 
 `datadog_security_signals_schema`
-: Returns the available fields and their types for security signals. Call this before using `analyze_datadog_security_signals` to discover which fields you can filter and group by. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
+: Returns the available fields and their types for security signals. Signal types map to `@workflow.rule.type` values such as `Log Detection`, `Application Security`, and `Workload Security`.
 : *Permissions required: `Security Signals Read`*
 
 `search_datadog_security_signals`
@@ -78,21 +78,21 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Signals Read`*
 
 `update_datadog_security_signals_triage`
-: Updates the triage state and/or assignee of one or more security signals in bulk. Accepts either a list of signal IDs or a filter query. Valid states: `open`, `archived`, `under_review`. An archive reason is required when archiving. Call `analyze_datadog_security_signals` first to count matching signals before bulk-updating.
+: Updates the triage state or assignee of one or more security signals in bulk (up to 500 signals). Accepts either a list of signal IDs or a filter query matching all signals to update.
 : *Permissions required: `Security Signals Write`*
 
 ### Detection Rules
 
 `get_datadog_security_detection_rules_schema`
-: Returns the authoring reference and schema for Cloud SIEM detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules.
+: Returns the authoring reference and schema for detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules. Currently supported rule types: log detection, API security, and AppSec.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 `list_datadog_security_detection_rules`
-: Lists Cloud SIEM detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to retrieve the full definition of a specific rule.
+: Lists detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to retrieve the full definition of a specific rule.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 `get_datadog_security_detection_rule`
-: Retrieves the full definition of a single Cloud SIEM detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
+: Retrieves the full definition of a single detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 ### Suppressions
@@ -102,15 +102,15 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Suppressions Read`*
 
 `create_datadog_security_suppression`
-: Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided. Call `get_datadog_security_detection_rule` first to inspect the target rule before writing the suppression query.
+: Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided.
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 `update_datadog_security_suppression`
-: Updates an existing suppression rule. Only provided fields are changed. Call `get_datadog_security_suppressions` first to retrieve the current state and version; providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
+: Updates an existing suppression rule. Only provided fields are changed. Providing `version` enables optimistic concurrency control to prevent overwriting concurrent edits.
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 `delete_datadog_security_suppression`
-: Deletes a suppression rule. This operation is irreversible and takes effect immediately. Call `get_datadog_security_suppressions` first to confirm the correct suppression will be deleted.
+: Deletes a suppression rule.
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 ### Security Findings

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -34,8 +34,8 @@ The [Datadog MCP Server][1] lets AI agents query your security data through the 
 
 You can use the `security` toolset to:
 
-- **Triage security signals**: Ask your AI agent to surface recent high-severity Cloud SIEM signals, App & API Protection alerts, or Workload Protection threats, and get a summary of patterns and affected resources.
-- **Triage and bulk-update signals**: Update triage state or assignee across a set of matching signals in bulk.
+- **Analyze and understand security signals**: Ask your AI agent to surface recent high-severity Cloud SIEM signals, App & API Protection alerts, or Workload Protection threats, and get a summary of patterns and affected resources.
+- **Triage security signals**: Update triage state or assignee across a set of matching signals in bulk.
 - **Analyze your security posture**: Query findings across Cloud Security with SQL to understand the distribution of misconfigurations, vulnerabilities, and identity risks across your environment.
 - **Investigate specific findings**: Retrieve full details for a set of findings to understand scope, affected resources, and remediation context.
 - **Correlate signals and findings**: Cross-reference active security signals with open findings to determine whether an alert is tied to a known posture issue.
@@ -81,6 +81,20 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : Updates the triage state or assignee of one or more security signals in bulk (up to 500 signals). Accepts either a list of signal IDs or a filter query matching all signals to update.
 : *Permissions required: `Security Signals Write`*
 
+### Security Findings
+
+`security_findings_schema`
+: Returns the available fields and their types for security findings. Call this before using `analyze_security_findings` to discover which fields you can filter and group by. Supports filtering by finding type.
+: *Permissions required: `Security Monitoring Findings Read`*
+
+`analyze_security_findings`
+: Primary tool for analyzing security findings using SQL. Queries live data from the last 24 hours with support for aggregations, filtering, and grouping. Call `security_findings_schema` first to discover available fields.
+: *Permissions required: `Security Monitoring Findings Read`, `Timeseries`*
+
+`search_security_findings`
+: Retrieves full security finding objects. Use this when you need complete finding details or when SQL-based analysis is not sufficient. Prefer `analyze_security_findings` for most analysis tasks.
+: *Permissions required: `Security Monitoring Findings Read`*
+
 ### Detection Rules
 
 `get_datadog_security_detection_rules_schema`
@@ -112,20 +126,6 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 `delete_datadog_security_suppression`
 : Deletes a suppression rule.
 : *Permissions required: `Security Monitoring Suppressions Write`*
-
-### Security Findings
-
-`security_findings_schema`
-: Returns the available fields and their types for security findings. Call this before using `analyze_security_findings` to discover which fields you can filter and group by. Supports filtering by finding type.
-: *Permissions required: `Security Monitoring Findings Read`*
-
-`analyze_security_findings`
-: Primary tool for analyzing security findings using SQL. Queries live data from the last 24 hours with support for aggregations, filtering, and grouping. Call `security_findings_schema` first to discover available fields.
-: *Permissions required: `Security Monitoring Findings Read`, `Timeseries`*
-
-`search_security_findings`
-: Retrieves full security finding objects. Use this when you need complete finding details or when SQL-based analysis is not sufficient. Prefer `analyze_security_findings` for most analysis tasks.
-: *Permissions required: `Security Monitoring Findings Read`*
 
 ## Further reading
 

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -98,7 +98,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 ### Detection Rules
 
 `get_datadog_security_detection_rules_schema`
-: Returns the authoring reference and schema for detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules. Currently supported rule types: log detection, API security, and AppSec.
+: Returns the authoring reference and schema for detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules. Currently supported rule types: log detection and API security.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 `list_datadog_security_detection_rules`
@@ -116,7 +116,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Suppressions Read`*
 
 `create_datadog_security_suppression`
-: Creates a new suppression rule that prevents a detection rule from generating signals for specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided.
+: Creates a new suppression rule that prevents a detection rule from generating signals matching specific conditions. At least one of `suppression_query` or `data_exclusion_query` must be provided.
 : *Permissions required: `Security Monitoring Suppressions Write`*
 
 `update_datadog_security_suppression`


### PR DESCRIPTION
## Summary

- Adds 9 new GA security MCP tools (no org visibility gate) to both public docs pages
- Reorganizes `security/mcp_server.md` into named sub-groups: Security Signals, Detection Rules, Suppressions, Security Findings
- Expands use cases section to cover detection rule inspection and suppression management

**New tools documented:**

Security Signals:
- `datadog_security_signals_schema`
- `update_datadog_security_signals_triage`

Detection Rules (read-only):
- `list_datadog_security_detection_rules`
- `get_datadog_security_detection_rule`
- `get_datadog_security_detection_rules_schema`

Suppressions:
- `get_datadog_security_suppressions`
- `create_datadog_security_suppression`
- `update_datadog_security_suppression`
- `delete_datadog_security_suppression`

**Not included (preview, org-gated):** `add_datadog_security_signal_to_incidents`, `create/update/delete_datadog_security_detection_rule`, `get_datadog_security_filters`

## Test plan

- [ ] Review `security/mcp_server.md` renders correctly with four sub-sections under Available tools
- [ ] Review `bits_ai/mcp_server/tools.md` Security section has all 16 tools in correct order
- [ ] Verify anchor `https://docs.datadoghq.com/security/mcp_server/#available-tools` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)