### PR TITLE
llmobs: document gen_ai.conversation.id for multi-root grouping

### DIFF
--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -407,7 +407,7 @@ example, an HTTP handler that invokes several LLMs in parallel), LLM
 Observability produces a separate LLM Observability trace for each
 top-level gen_ai span in that APM trace. To keep these split traces
 grouped together in the UI, set `gen_ai.conversation.id` to the same
-value on every gen_ai span within the APM trace — LLM Observability
+value on each gen_ai span within the APM trace — LLM Observability
 groups by `session_id`, so the resulting traces appear together even
 though they have distinct LLM Observability trace IDs. This is the same
 attribute used for cross-request conversation grouping.

--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -402,15 +402,7 @@ All `gen_ai.request.*` parameters map to `meta.metadata.*` with the prefix strip
 |----------------|--------------|-------|
 | `gen_ai.conversation.id` | `session_id` | Also added to `metadata.conversation_id` and tags |
 
-**Tip:** When an APM trace's top-most span is not a gen_ai span (for
-example, an HTTP handler that invokes several LLMs in parallel), LLM
-Observability produces a separate LLM Observability trace for each
-top-level gen_ai span in that APM trace. To keep these split traces
-grouped together in the UI, set `gen_ai.conversation.id` to the same
-value on each gen_ai span within the APM trace — LLM Observability
-groups by `session_id`, so the resulting traces appear together even
-though they have distinct LLM Observability trace IDs. This is the same
-attribute used for cross-request conversation grouping.
+When an APM trace's top-most span is not a gen_ai span (for example, an HTTP handler that invokes several LLMs in parallel), LLM Observability produces a separate LLM Observability trace for each top-level gen_ai span in that APM trace. To keep these split traces grouped together in the UI, set `gen_ai.conversation.id` to the same value on each gen_ai span within the APM trace: LLM Observability groups by `session_id`, so the resulting traces appear together even though they have distinct LLM Observability trace IDs. This is the same attribute used for cross-request conversation grouping.
 
 #### Response attributes
 

--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -402,13 +402,15 @@ All `gen_ai.request.*` parameters map to `meta.metadata.*` with the prefix strip
 |----------------|--------------|-------|
 | `gen_ai.conversation.id` | `session_id` | Also added to `metadata.conversation_id` and tags |
 
-**Recommended for traces with multiple top-level gen_ai spans.** When an
-APM trace contains multiple sibling gen_ai LLM calls under a non-gen_ai
-parent (for example, an HTTP handler that invokes several LLMs in
-parallel), LLM Observability renders each subtree as its own LLM
-Observability trace. Setting `gen_ai.conversation.id` to the same value
-on every gen_ai span keeps the resulting traces grouped together by
-`session_id` in the UI, even though they have distinct trace IDs.
+**Tip:** When an APM trace's top-most span is not a gen_ai span (for
+example, an HTTP handler that invokes several LLMs in parallel), LLM
+Observability produces a separate LLM Observability trace for each
+top-level gen_ai span in that APM trace. To keep these split traces
+grouped together in the UI, set `gen_ai.conversation.id` to the same
+value on every gen_ai span within the APM trace — LLM Observability
+groups by `session_id`, so the resulting traces appear together even
+though they have distinct LLM Observability trace IDs. This is the same
+attribute used for cross-request conversation grouping.
 
 #### Response attributes
 

--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -402,6 +402,14 @@ All `gen_ai.request.*` parameters map to `meta.metadata.*` with the prefix strip
 |----------------|--------------|-------|
 | `gen_ai.conversation.id` | `session_id` | Also added to `metadata.conversation_id` and tags |
 
+**Recommended for traces with multiple top-level gen_ai spans.** When an
+APM trace contains multiple sibling gen_ai LLM calls under a non-gen_ai
+parent (for example, an HTTP handler that invokes several LLMs in
+parallel), LLM Observability renders each subtree as its own LLM
+Observability trace. Setting `gen_ai.conversation.id` to the same value
+on every gen_ai span keeps the resulting traces grouped together by
+`session_id` in the UI, even though they have distinct trace IDs.
+
 #### Response attributes
 
 | OTel Attribute | LLM Observability Field |


### PR DESCRIPTION
## Summary

Adds a recommendation paragraph in the OpenTelemetry instrumentation reference's "Session and conversation" subsection. After the trace-indexer change in [DataDog/dd-go#239022](https://github.com/DataDog/dd-go/pull/239022), APM traces with multiple sibling gen_ai LLM calls under a non-gen_ai parent produce multiple independent LLM Observability traces (each with its own trace ID). Customers who want the resulting traces grouped together in the UI should set `gen_ai.conversation.id` to the same value on every gen_ai span; that flows through to LLMObs `session_id`.

The attribute mapping itself is already documented (one-line entry in the table). This adds a short paragraph below it explaining when and why to set it.

## Test plan
- [ ] Hugo preview renders the new paragraph in the existing "Session and conversation" subsection of [OpenTelemetry Instrumentation](https://docs.datadoghq.com/llm_observability/instrumentation/otel_instrumentation/)
- [ ] No layout or link regressions

## Related
- Backend change: https://github.com/DataDog/dd-go/pull/239022

Claude session: \`3d39dd2d-18eb-4730-9671-8c93804e3657\`
Resume: \`claude --resume 3d39dd2d-18eb-4730-9671-8c93804e3657\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)