### PR TITLE
[DOCS-14552] Improve visibility of Dynamic tests in Network Path docs

### DIFF
--- a/content/en/network_monitoring/network_path/_index.md
+++ b/content/en/network_monitoring/network_path/_index.md
@@ -31,6 +31,15 @@ The following diagram depicts the typical flow of a network path from a source (
 
 {{< img src="network_performance_monitoring/network_path/network_path_diagram.png" alt="Diagram of how Network path works" >}}
 
+## Setup methods
+
+Network Path supports two Agent-based collection methods. You can use either method on its own or both together:
+
+- **[Scheduled tests][6]**: Monitor specific network paths by defining source-destination pairs in the Agent configuration file. Use scheduled tests to continuously monitor a known set of endpoints, such as critical APIs or partner services.
+- **[Dynamic tests][7]**: Automatically discover and monitor network paths based on actual network traffic observed by [Cloud Network Monitoring][8]. Use dynamic tests for broad visibility without manually listing every destination.
+
+To create Network Path tests in Synthetic Monitoring instead, see [Network Path Testing in Synthetic Monitoring][9].
+
 ## Next steps
 
 Use the following views and tools to set up Network Path and investigate network performance and connectivity issues:
@@ -49,3 +58,7 @@ Use the following views and tools to set up Network Path and investigate network
 [3]: /network_monitoring/network_path/path_view
 [4]: /network_monitoring/network_path/setup
 [5]: /network_monitoring/network_path/guide/traceroute_variants
+[6]: /network_monitoring/network_path/setup/#scheduled-tests
+[7]: /network_monitoring/network_path/setup/#dynamic-tests
+[8]: /network_monitoring/cloud_network_monitoring/
+[9]: /synthetics/network_path_tests/

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -29,8 +29,8 @@ Datadog provides two Agent-based collection methods. You can use either method o
 
 | Method | When to use |
 |--------|-------------|
-| **[Scheduled tests](#scheduled-tests)** | Monitor specific source-destination pairs that you define in the Agent configuration. Best for tracking a known set of endpoints, such as critical APIs or partner services. |
-| **[Dynamic tests](#dynamic-tests)** | Automatically discover and monitor paths based on traffic observed by [Cloud Network Monitoring][1]. Best for broad visibility without manually listing every destination. |
+| **[Scheduled&nbsp;tests](#scheduled-tests)** | Monitor specific source-destination pairs that you define in the Agent configuration. Best for tracking a known set of endpoints, such as critical APIs or partner services. |
+| **[Dynamic&nbsp;tests](#dynamic-tests)** | Automatically discover and monitor paths based on traffic observed by [Cloud Network Monitoring][1]. Best for broad visibility without manually listing every destination. |
 
 ### Scheduled tests
 

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -25,6 +25,13 @@ Setting up Network Path involves configuring your environment to monitor and tra
 
 <div class="alert alert-info">This page covers Network Path setup for Agent-based configuration in Network Monitoring. To create Network Path tests in Synthetic Monitoring, see <a href="/synthetics/network_path_tests/">Network Path Testing in Synthetic Monitoring</a>.</div>
 
+Datadog provides two Agent-based collection methods. You can use either method on its own or combine both:
+
+| Method | When to use |
+|--------|-------------|
+| **[Scheduled tests](#scheduled-tests)** | Monitor specific source-destination pairs that you define in the Agent configuration. Best for tracking a known set of endpoints, such as critical APIs or partner services. |
+| **[Dynamic tests](#dynamic-tests)** | Automatically discover and monitor paths based on traffic observed by [Cloud Network Monitoring][1]. Best for broad visibility without manually listing every destination. |
+
 ### Scheduled tests
 
 You can monitor specific network paths by defining them in the Agent configuration file located at `/etc/datadog-agent/conf.d/network_path.d/conf.yaml`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14552

The Network Path Setup page lists Dynamic tests at the bottom, after a long Scheduled tests section with multiple tabbed code blocks. Users often miss the Dynamic tests feature because it requires scrolling past the entire Scheduled tests setup.

This PR surfaces both collection methods earlier:

- On the Network Path overview page, adds a new **Setup methods** section that introduces Scheduled tests, Dynamic tests, and the Synthetic Monitoring alternative, with anchor links to each.
- On the Setup page, adds a short comparison table under the existing Synthetics callout so both options are visible without scrolling.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes