### PR TITLE
Rename Overview to Prerequisites in SCA runtime setup

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/_index.md
@@ -4,14 +4,14 @@ disable_toc: false
 aliases:
 - /security/application_security/enabling/tracing_libraries/sca/
 ---
-## Overview
+## Prerequisites
 SCA can detect vulnerabilities that affect open source libraries running in your services based on Datadog's application telemetry.
 
 Before setting up runtime detection, ensure the following prerequisites are met:
 
 1. **Datadog Agent Installation:** The Datadog Agent is installed and configured for your application's operating system or container, cloud, or virtual environment.
 2. **Datadog APM Configuration:** Datadog APM is configured for your application or service, and web traces (`type:web`) are being received by Datadog.
-3. **Supported SDK:** The Datadog SDK used by your application or service supports Software Composition Analysis capabilities for the language of your application or service. For more details, refer to the [Library Compatibility][2] page for each AAP product.
+3. **Supported SDK:** The Datadog SDK used by your application or service supports Software Composition Analysis capabilities for the language of your application or service. For more details, refer to the [Library Compatibility][2] page.
 
 ## Software Composition Analysis enablement types
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Two small edits to the SCA runtime setup page (`setup_runtime/_index.md`):

1. Renames the **Overview** section heading to **Prerequisites** — the section is entirely prerequisite content, so the heading now matches what it describes.
2. Removes the trailing "for each AAP product" qualifier from the Library Compatibility reference in item 3 of the prerequisites list.

No other pages in `/security/code_security/` link to the `#overview` anchor on this page, so no redirects or cross-reference updates are needed.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes