### PR TITLE
byoc-logs: limit supported object storage to S3, GCS, Azure Blob

### DIFF
--- a/content/en/byoc-logs/install/_index.md
+++ b/content/en/byoc-logs/install/_index.md
@@ -37,9 +37,6 @@ BYOC Logs supports the following object storage types:
 - Amazon S3
 - Google Cloud Storage (GCS)
 - Azure Blob Storage
-- MinIO
-- Ceph Object Storage
-- Any S3-compatible storage
 
 ## Cloud-managed Kubernetes
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes MinIO, Ceph Object Storage, and the generic "Any S3-compatible storage" entries from the object storage prerequisites on the BYOC Logs install page. Only the three cloud-managed storage backends (Amazon S3, Google Cloud Storage, Azure Blob Storage) are supported.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)