### PR TITLE
[DOCS-14488] Add missing Microsoft Graph API permissions

### DIFF
--- a/content/en/integrations/guide/azure-graph-api-permissions.md
+++ b/content/en/integrations/guide/azure-graph-api-permissions.md
@@ -19,10 +19,16 @@ To fetch Azure app registration details, the [Datadog-Azure integration][1] requ
 3. Click **+ Add a permission**.
 4. In the panel that opens, select **Microsoft Graph**.
 5. On the next page, select **Application permissions**. Then, under _Select permissions_, search for and enable each of the following permissions. 
+   - `AdministrativeUnit.Read.All`
    - `Application.Read.All`
+   - `AuditLog.Read.All`
    - `Directory.Read.All`
+   - `Domain.Read.All`
    - `Group.Read.All`
    - `Policy.Read.All`
+   - `PrivilegedAssignmentSchedule.Read.AzureADGroup`
+   - `PrivilegedEligibilitySchedule.Read.AzureADGroup`
+   - `RoleManagement.Read.All`
    - `User.Read.All`
      
    Click the checkbox on the left, and click the **Add permissions** button at the bottom to add each permission.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14488

Adds six missing Microsoft Graph API permissions to the Azure Graph API permissions guide. The existing page listed only five permissions, but the full set required for the Datadog-Azure integration is eleven.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes