### PR TITLE
Rename Bits AI products (Chat, Investigation, Code, Agent Builder)

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1515,7 +1515,7 @@ menu:
       identifier: bits_ai
       parent: platform_heading
       weight: 100000
-    - name: Bits AI SRE
+    - name: Bits Investigation
       url: bits_ai/bits_ai_sre
       identifier: bits_ai_sre
       parent: bits_ai
@@ -1530,7 +1530,7 @@ menu:
       identifier: bits_ai_sre_take_action
       parent: bits_ai_sre
       weight: 200
-    - name: Bits AI SRE Integrations and Settings
+    - name: Bits Investigation Integrations and Settings
       url: bits_ai/bits_ai_sre/configure
       identifier: bits_ai_sre_configure
       parent: bits_ai_sre
@@ -1540,12 +1540,12 @@ menu:
       identifier: bits_ai_sre_knowledge_sources
       parent: bits_ai_sre
       weight: 400
-    - name: Chat with Bits AI SRE
+    - name: Chat with Bits Investigation
       url: bits_ai/bits_ai_sre/chat_bits_ai_sre
       identifier: bits_ai_sre_chat
       parent: bits_ai_sre
       weight: 500
-    - name: Bits AI Dev Agent
+    - name: Bits Code
       url: bits_ai/bits_ai_dev_agent
       parent: bits_ai
       identifier: bits_ai_dev_agent
@@ -1560,7 +1560,7 @@ menu:
       identifier: bits_ai_bits_ai_security_analyst
       parent: bits_ai
       weight: 3
-    - name: Bits AI Assistant
+    - name: Bits Chat
       url: bits_ai/bits_assistant
       identifier: bits_ai_bits_assistant
       parent: bits_ai
@@ -1580,7 +1580,7 @@ menu:
       identifier: bits_ai_mcp_server_tools
       parent: bits_ai_mcp_server
       weight: 502
-    - name: Agent Builder
+    - name: Bits Agent Builder
       url: actions/agents/
       identifier: bits_ai_agent_builder
       parent: bits_ai
@@ -2314,7 +2314,7 @@ menu:
       parent: error_tracking
       identifier: error_tracking_error_grouping
       weight: 4
-    - name: Bits AI Dev Agent
+    - name: Bits Code
       url: bits_ai/bits_ai_dev_agent
       parent: error_tracking
       identifier: error_tracking_bits_ai_dev_agent
@@ -2847,7 +2847,7 @@ menu:
       weight: 9
     - name: Agents
       weight: 7
-    - name: Agent Builder
+    - name: Bits Agent Builder
       url: actions/agents/
       pre: robot-wui
       identifier: agents

--- a/content/en/actions/agents/_index.md
+++ b/content/en/actions/agents/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Builder
+title: Bits Agent Builder
 description: Build and deploy custom AI agents that automate operational tasks using Datadog's tools and integrations.
 further_reading:
 - link: "/actions/actions_catalog/"
@@ -14,26 +14,26 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="Preview" >}}
-Agent Builder is in Preview.
+Bits Agent Builder is in Preview.
 {{< /callout >}}
 
 ## Overview
 
-Agent Builder lets you create custom AI agents that use Datadog's tools and integrations to automate operational tasks. Agents can search logs, query metrics, create cases, send messages, or perform any action from the [Action Catalog][7].
+Bits Agent Builder lets you create custom AI agents that use Datadog's tools and integrations to automate operational tasks. Agents can search logs, query metrics, create cases, send messages, or perform any action from the [Action Catalog][7].
 
 Use agents to handle work that's too complex for static automation but too repetitive for humans. For example, triaging errors, responding to incidents, analyzing trends, and escalating issues.
 
-{{< img src="/actions/agents/agent-builder-interface.png" alt="The Agent Builder editor showing instructions, model, tools, and automation configuration" style="width:100%;" >}}
+{{< img src="/actions/agents/agent-builder-interface.png" alt="The Bits Agent Builder editor showing instructions, model, tools, and automation configuration" style="width:100%;" >}}
 
 ## Create an agent
 
-From the [Agent Builder page][1], click **New Agent**. From there, you can create an agent in three ways:
+From the [Bits Agent Builder page][1], click **New Agent**. From there, you can create an agent in three ways:
 
-- **Build with AI**: Describe what you want the agent to do in plain language. Agent Builder generates the instructions, selects relevant tools, and configures the agent for you.
+- **Build with AI**: Describe what you want the agent to do in plain language. Bits Agent Builder generates the instructions, selects relevant tools, and configures the agent for you.
 - **Start from a blueprint**: Choose a prebuilt template for common use cases such as error triage, incident response, security analysis, or DevOps assistance. Blueprints come preconfigured with instructions, tools, and automations, and are customizable.
 - **Start from scratch**: Configure the agent manually—write instructions, pick a model, and add tools.
 
-{{< img src="/actions/agents/empty-state.png" alt="The Agent Builder new agent interface showing a text field and blueprint options" style="width:100%;" >}}
+{{< img src="/actions/agents/empty-state.png" alt="The Bits Agent Builder new agent interface showing a text field and blueprint options" style="width:100%;" >}}
 
 ## Configure your agent
 

--- a/content/en/actions/workflows/_index.md
+++ b/content/en/actions/workflows/_index.md
@@ -40,7 +40,7 @@ further_reading:
   text: "How we created a single app to automate repetitive tasks with Datadog Workflow Automation, Datastore, and App Builder"
 - link: "https://www.datadoghq.com/blog/datadog-agent-builder/"
   tag: "Blog"
-  text: "Introducing Datadog Agent Builder: Build agentic workflows for alert response and remediation"
+  text: "Introducing Bits Agent Builder: Build agentic workflows for alert response and remediation"
 ---
 
 {{< vimeo url="https://player.vimeo.com/progressive_redirect/playback/852419580/rendition/1080p/file.mp4?loc=external&signature=fb7ae8df018e24c9f90954f62ff3217bc1b904b92e600f3d3eb3f5a9d143213e" poster="/images/poster/workflow_automation.png" >}}

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -111,9 +111,9 @@ Select a user to open a detail view that includes their spend, lines generated, 
 
 The {{< ui >}}Bits AI Agents{{< /ui >}} tab shows usage of Datadog's built-in AI agents alongside your coding agents. The combined view of investigations, sessions, and executions across all Datadog agents lets you correlate Bits AI activity with the rest of your organization.
 
-Individual cards summarize activity for each Bits AI agent, including [Bits AI SRE][11], [Bits AI Dev Agent][12], and [Agent Builder][13]. Select {{< ui >}}View Details{{< /ui >}} on a card to examine that agent.
+Individual cards summarize activity for each Bits AI agent, including [Bits Investigation][11], [Bits Code][12], and [Bits Agent Builder][13]. Select {{< ui >}}View Details{{< /ui >}} on a card to examine that agent.
 
-{{< img src="ai_agents_console/bits-ai-agents.png" alt="Bits AI Agents tab with a combined agent activity chart over time and individual cards for Bits AI SRE, Bits AI Dev, and Agent Builder showing recent investigations, sessions, and executions" style="width:100%;" >}}
+{{< img src="ai_agents_console/bits-ai-agents.png" alt="Bits AI Agents tab with a combined agent activity chart over time and individual cards for Bits Investigation, Bits Code, and Bits Agent Builder showing recent investigations, sessions, and executions" style="width:100%;" >}}
 
 ## Set up
 

--- a/content/en/bits_ai/_index.md
+++ b/content/en/bits_ai/_index.md
@@ -11,16 +11,16 @@ further_reading:
       text: "Bits AI Agents"
     - link: "https://www.datadoghq.com/blog/bits-ai-sre/"
       tag: "Blog"
-      text: "Introducing Bits AI SRE, your AI on-call teammate"
+      text: "Introducing Bits Investigation, your AI on-call teammate"
     - link: "https://www.datadoghq.com/blog/bits-ai-dev-agent/"
       tag: "Blog"
-      text: "Automatically identify issues and generate fixes with Bits AI Dev"
+      text: "Automatically identify issues and generate fixes with Bits Code"
     - link: "https://www.datadoghq.com/blog/bits-ai-security-analyst/"
       tag: "Blog"
       text: "Automate Cloud SIEM investigations with Bits AI Security Analyst"
     - link: "https://www.datadoghq.com/blog/introducing-bits-assistant/"
       tag: "Blog"
-      text: "Search and act across Datadog to resolve issues faster with Bits Assistant"
+      text: "Search and act across Datadog to resolve issues faster with Bits Chat"
     - link: "https://www.datadoghq.com/blog/how-to-use-ai-more-effectively/"
       tag: "Blog"
       text: "How to use AI tools more effectively: Tips from Datadog Engineers"
@@ -31,10 +31,10 @@ Bits AI is your agentic teammate in Datadog, built to automate development, secu
 ## Features
 
 {{< whatsnext desc="Learn about how you can use Bits AI:" >}}
-   {{< nextlink href="bits_ai/bits_ai_sre" >}}Investigate alerts with Bits AI SRE{{< /nextlink >}}
-   {{< nextlink href="bits_ai/bits_ai_dev_agent" >}}Automate code fixes with Bits AI Dev Agent{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_ai_sre" >}}Investigate alerts with Bits Investigation{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_ai_dev_agent" >}}Automate code fixes with Bits Code{{< /nextlink >}}
    {{< nextlink href="bits_ai/bits_ai_security_analyst" >}}Triage security threat signals with Bits AI Security Analyst{{< /nextlink >}}
-   {{< nextlink href="bits_ai/bits_assistant" >}}Explore your observability data with Bits AI Assistant{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_assistant" >}}Explore your observability data with Bits Chat{{< /nextlink >}}
    {{< nextlink href="bits_ai/mcp_server" >}}Get observability insights from AI agents with the Datadog MCP server{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -1,50 +1,50 @@
 ---
-title: Bits AI Dev Agent
+title: Bits Code
 further_reading:
   - link: "https://www.datadoghq.com/blog/bits-ai-dev-agent/"
     tag: "Blog"
-    text: "Automatically identify issues and generate fixes with the Bits AI Dev Agent"
+    text: "Automatically identify issues and generate fixes with Bits Code"
   - link: "https://www.datadoghq.com/blog/bitsai-dev-agent-code-security"
     tag: "Blog"
-    text: "Introducing Bits AI Dev Agent for Code Security"
+    text: "Introducing Bits Code for Code Security"
 ---
 
 ## Overview
 
-Bits AI Dev Agent is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with GitHub to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
+Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with GitHub to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
 
 {{< img src="bits_ai/dev_agent/code_sessions_overview.png" alt="A tab titled 'Code Sessions' shows a text field with suggestions underneath" style="width:100%;" >}}
 
-Each time the Dev Agent investigates an issue or generates a fix, it creates a [code session][19], which captures the agent's analysis, actions, and any resulting code changes across supported Datadog products.
+Each time Bits Code investigates an issue or generates a fix, it creates a [code session][19], which captures the agent's analysis, actions, and any resulting code changes across supported Datadog products.
 
-To get started with Bits AI Dev Agent, [set up the GitHub integration][6] and complete any additional configuration. Then, [start your first code session][18].
+To get started with Bits Code, [set up the GitHub integration][6] and complete any additional configuration. Then, [start your first code session][18].
 
 ## Code sessions
-A code session captures a segment of work with the Bits AI Dev Agent, including its analysis and code changes. Start, view, and manage your sessions at **Bits AI** > **Dev Agent** > [**Code Sessions**][7].
+A code session captures a segment of work with Bits Code, including its analysis and code changes. Start, view, and manage your sessions at **Bits AI** > **Code** > [**Code Sessions**][7].
 
 {{< img src="bits_ai/dev_agent/code_fix.png" alt="A code session showing a Bits AI summary and task list on the left and a code diff on the right" style="width:100%;" >}}
 
 ### Start a code session
 After [completing setup][6], do one of the following to start a code session:
 - Enter a freeform prompt at [**Code Sessions**][7]: enter a custom prompt or generate one by clicking a **Suggestions** or **Proactive Fixes** card
-- Invoke Bits AI Dev Agent in a [supported Datadog product][9]
+- Invoke Bits Code in a [supported Datadog product][9]
 
-A code session can also be created when another Bits AI agent (like [Bits AI Assistant][16] or [Bits AI SRE][17]) hands off a coding task to the Dev Agent.
+A code session can also be created when another Bits AI agent (like [Bits Chat][16] or [Bits Investigation][17]) hands off a coding task to Bits Code.
 
 ### View and manage code sessions
 On **[Code Sessions][7]**, view your past sessions in the **My Sessions** panel. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR.
 
-Click a session to view its details and continue working with the Dev Agent. To remove a session from your **My Sessions** list, click <i class="icon-archive-wui"></i> (**Archive for everyone**) or <i class="icon-eye-slashed-wui"></i> (**Unwatch session**).
+Click a session to view its details and continue working with Bits Code. To remove a session from your **My Sessions** list, click <i class="icon-archive-wui"></i> (**Archive for everyone**) or <i class="icon-eye-slashed-wui"></i> (**Unwatch session**).
 
 ## Supported Datadog products
 
-Bits AI Dev Agent can suggest code improvements in the following Datadog products:
+Bits Code can suggest code improvements in the following Datadog products:
 
 | Product                   | Capabilities                                                       |
 |---------------------------|--------------------------------------------------------------------|
 | [APM][20]                 | Proposes code changes for relevant [APM Recommendations][21]|
-| [Bits AI SRE][17]         | Generates code remediations based on Bits AI SRE investigations |
-| [Bits AI Assistant][16]   | Suggests code changes arising from Bits AI Assistant conversations |
+| [Bits Investigation][17]         | Generates code remediations based on Bits Investigations |
+| [Bits Chat][16]   | Suggests code changes arising from Bits Chat conversations |
 | [Cloud Cost][22]          | Generates code changes for [Cloud Cost Recommendations][23] |
 | [Error Tracking][1]       | Diagnoses issues and generates code fixes on-demand or autonomously |
 | [Code Security][2]        | Remediates code vulnerabilities individually or in bulk  |
@@ -52,27 +52,27 @@ Bits AI Dev Agent can suggest code improvements in the following Datadog product
 | [Continuous Profiler][3]  | Provides code changes for [Automated Analysis][10] insights   |
 | [Containers][12]          | Provides code changes for [Kubernetes Remediations][13]  |
 
-**Note**: Enabling Bits AI Dev Agent is product-specific. Even if it's active for one Datadog product, it must be separately enabled for each additional product you use.
+**Note**: Enabling Bits Code is product-specific. Even if it's active for one Datadog product, it must be separately enabled for each additional product you use.
 
 ## Key capabilities 
 
-The following sections detail how Bits AI Dev Agent integrates with Datadog products to generate contextual code fixes.
+The following sections detail how Bits Code integrates with Datadog products to generate contextual code fixes.
 
 ### Pull request assistance
 
-Bits AI Dev Agent integrates with GitHub to create pull requests, respond to comments, update commits, and fix CI failures. 
+Bits Code integrates with GitHub to create pull requests, respond to comments, update commits, and fix CI failures. 
 
 - Generates PR titles and descriptions based on your PR template.
 - Opens PRs as drafts, iterates using CI logs, and marks the PRs as ready for review when checks pass.
 - Continues iterating in response to chat messages and review feedback.
   
-  **Note**: Comment `@Datadog` to prompt Bits for updates to the PR. Bits Dev never auto-merges PRs.
+  **Note**: Comment `@Datadog` to prompt Bits for updates to the PR. Bits Code never auto-merges PRs.
 
-See all PRs the Dev Agent is working on in **Bits AI** > **Dev Agent** > **[Code Sessions][7]**.
+See all PRs Bits Code is working on in **Bits AI** > **Code** > **[Code Sessions][7]**.
 
 ### Auto-push
 
-Auto-push allows the Dev Agent to create branches, push code, and open PRs when it detects something it can help you with. For example, the Dev Agent can:
+Auto-push allows Bits Code to create branches, push code, and open PRs when it detects something it can help you with. For example, Bits Code can:
 - Auto-create PRs for high-impact errors (such as 500s or crashes).
 - Update PRs in response to your comments in GitHub.
 - Update PRs to address CI failures.
@@ -83,13 +83,13 @@ Auto-push is available for Error Tracking and Test Optimization.
 
 #### Security considerations
 
-Allowing any AI-based tool to read untrusted data can let attackers influence its output. Auto-push behavior depends on the type of data the Dev Agent works with: code-only workflows operate on source code the Agent can inspect directly, while telemetry-based workflows (such as errors or traces) may include untrusted runtime inputs.
+Allowing any AI-based tool to read untrusted data can let attackers influence its output. Auto-push behavior depends on the type of data Bits Code works with: code-only workflows operate on source code the Agent can inspect directly, while telemetry-based workflows (such as errors or traces) may include untrusted runtime inputs.
 
 To balance safety and automation, you can configure auto-push behavior in [Datadog][14] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
 
 ### Error tracking
 
-In [Error Tracking][1], Bits AI Dev Agent diagnoses and remediates code issues with context and unit-tested fixes:
+In [Error Tracking][1], Bits Code diagnoses and remediates code issues with context and unit-tested fixes:
 - Determines whether an error can be fixed through code and generates a fix with unit tests.
 - Provides links within the chat to relevant files and methods for streamlined navigation.
 - Analyzes errors asynchronously as they arrive.
@@ -99,26 +99,26 @@ In [Error Tracking][1], Bits AI Dev Agent diagnoses and remediates code issues w
 
 ### Flaky test management 
 
-Bits AI Dev Agent fixes flaky tests that are detected through Flaky Test Management in [Test Optimization][4] and attempts to verify that tests remain stable.
+Bits Code fixes flaky tests that are detected through Flaky Test Management in [Test Optimization][4] and attempts to verify that tests remain stable.
 
 [Auto-push](#auto-push) is available for this feature. 
 
 ### In-product recommendations
 
-Bits AI Dev Agent suggests code improvements and fixes in various Datadog products, such as CCM Recommendations, [APM Recommendations][21], and Profiling Insights. See [Supported Datadog products][9] for a full list.
+Bits Code suggests code improvements and fixes in various Datadog products, such as CCM Recommendations, [APM Recommendations][21], and Profiling Insights. See [Supported Datadog products][9] for a full list.
 
 ### Code security
 
-Bits AI Dev Agent remediates vulnerabilities at scale, from single issues to large backlogs. You can:
+Bits Code remediates vulnerabilities at scale, from single issues to large backlogs. You can:
 - Create PR batches to fix multiple vulnerabilities at once.
 - Use the Campaign tool to push PRs incrementally and manage review workload across teams.
 
-Datadog Code Security uses Bits AI to enhance static analysis and generate remediation suggestions, which can be reviewed and applied through the Bits AI Dev Agent. Learn more about [AI-Enhanced Static Code Analysis][15].
+Datadog Code Security uses Bits AI to enhance static analysis and generate remediation suggestions, which can be reviewed and applied through Bits Code. Learn more about [AI-Enhanced Static Code Analysis][15].
 
 ## Limitations
 
-- Bits Dev is an AI product, which means it can make mistakes. Use best practices when reviewing and testing agent-generated code.  
-- Bits AI Dev Agent does not support multi-repository investigations.
+- Bits Code is an AI product, which means it can make mistakes. Use best practices when reviewing and testing agent-generated code.  
+- Bits Code does not support multi-repository investigations.
 
 ## Further reading
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -1,15 +1,15 @@
 ---
-title: Bits AI Dev Agent Setup
+title: Bits Code Setup
 disable_toc: false
 ---
 
 ## Overview
 
-[Bits AI Dev Agent][8] integrates with GitHub to open, update, and iterate on pull requests based on issues detected in Datadog. After completing setup, you can [start using the Dev Agent][7].
+[Bits Code][8] integrates with GitHub to open, update, and iterate on pull requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
 
 ## Prerequisites
 
-To set up Bits AI Dev Agent, you need the **Bits Dev Agent Write** (`bits_dev_write`) permission. This permission is included in managed Datadog roles such as the Datadog Standard Role.
+To set up Bits Code, you need the **Bits Code Write** (`bits_dev_write`) permission. This permission is included in managed Datadog roles such as the Datadog Standard Role.
 
 If your organization uses custom roles, an admin must add this permission manually. For details, see [Access Control][1].
 
@@ -19,7 +19,7 @@ If your organization uses custom roles, an admin must add this permission manual
 
 1. In your GitHub account, navigate to {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Apps{{< /ui >}} > {{< ui >}}Datadog{{< /ui >}} to configure GitHub permissions.
 
-   1. To enable basic Dev Agent functionality, set the following permissions:
+   1. To enable basic Bits Code functionality, set the following permissions:
 
       - {{< ui >}}Repository permissions{{< /ui >}}
         - Repository contents: Read & write
@@ -27,7 +27,7 @@ If your organization uses custom roles, an admin must add this permission manual
       - {{< ui >}}Subscribe to events{{< /ui >}}
         - Push
 
-   1. (Optional) To allow the Dev Agent to use CI logs when iterating on pull requests, you must send CI logs to Datadog and enable the [auto-push](#enable-auto-push) feature. This requires additional permissions:  
+   1. (Optional) To allow Bits Code to use CI logs when iterating on pull requests, you must send CI logs to Datadog and enable the [auto-push](#enable-auto-push) feature. This requires additional permissions:  
 
        - {{< ui >}}Repository permissions{{< /ui >}}
          - Checks: Read  
@@ -40,24 +40,24 @@ If your organization uses custom roles, an admin must add this permission manual
 
 ## Additional configuration  
 
-These optional configurations help you get the most out of Bits AI Dev Agent.
+These optional configurations help you get the most out of Bits Code.
 
 ### Configure telemetry tagging
 
-Bits AI Dev Agent uses the `service` and `version` telemetry tags to match detected issues (such as errors or vulnerabilities) to the version of code that was running at the time.  
+Bits Code uses the `service` and `version` telemetry tags to match detected issues (such as errors or vulnerabilities) to the version of code that was running at the time.  
 
 To configure telemetry tagging, see [Tag your APM telemetry with Git information][4]. 
 
-You can also configure service-to-repository mapping manually in the Bits AI Dev Agent settings under [{{< ui >}}Repositories{{< /ui >}}][5] > {{< ui >}}Service Repository Mapping{{< /ui >}}.
+You can also configure service-to-repository mapping manually in Bits Code settings under [{{< ui >}}Repositories{{< /ui >}}][5] > {{< ui >}}Service Repository Mapping{{< /ui >}}.
 
 ### Enable auto-push
-To enable auto-push, so the Dev Agent can push commits directly to a branch, navigate to **Bits AI Dev** > **Settings** > [**General**][6] , and set the toggle to **Enable**.
+To enable auto-push, so Bits Code can push commits directly to a branch, navigate to **Bits Code** > **Settings** > [**General**][6] , and set the toggle to **Enable**.
 
-**Note**: If auto-push is disabled, you must review and approve code in Datadog before the Dev Agent can push it.
+**Note**: If auto-push is disabled, you must review and approve code in Datadog before Bits Code can push it.
 
 ### Configure custom instructions
 
-The Dev Agent ingests custom instruction files from your repository, including:
+Bits Code ingests custom instruction files from your repository, including:
 
 - `.cursorrules`
 - `.windsurfrules`
@@ -67,15 +67,15 @@ The Dev Agent ingests custom instruction files from your repository, including:
 - `agent.md`
 
 
-You can also define global custom instructions, which apply to all Dev Agent sessions, in **Bits AI Dev** > **Settings** > [**General**][6], in the **Global Agent Instructions** section.
+You can also define global custom instructions, which apply to all Bits Code sessions, in **Bits Code** > **Settings** > [**General**][6], in the **Global Agent Instructions** section.
 
 ## Environment setup
 
-Configure the Dev Agent's runtime environment, including network access policies and repository-specific tooling.
+Configure Bits Code's runtime environment, including network access policies and repository-specific tooling.
 
 ### Configure internet access
 
-By default, the Dev Agent has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to **Bits AI Dev** > **Settings** > [**General**][6], and find the **Internet Access** section. Choose from the following access policies: **No Internet Access**, **Default Allowlist**, **Custom + Default Allowlist**, or **Custom Allowlist**.
+By default, Bits Code has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to **Bits Code** > **Settings** > [**General**][6], and find the **Internet Access** section. Choose from the following access policies: **No Internet Access**, **Default Allowlist**, **Custom + Default Allowlist**, or **Custom Allowlist**.
 
 The default allowlist includes the following domains. This list will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
 
@@ -93,20 +93,20 @@ The default allowlist includes the following domains. This list will evolve over
 
 ### Configure repository environment
 
-Configure a custom environment for the Dev Agent to install dependencies, formatters, linters, and build tools that are needed for your codebase. Each repository runs in its own isolated sandbox, and the environment defines the settings for that sandbox. 
+Configure a custom environment for Bits Code to install dependencies, formatters, linters, and build tools that are needed for your codebase. Each repository runs in its own isolated sandbox, and the environment defines the settings for that sandbox. 
 
 To configure a repository environment:
 
-1. Go to {{< ui >}}Bits AI Dev{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}Repositories{{< /ui >}}][5], and find the {{< ui >}}Environments{{< /ui >}} section.
+1. Go to {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}Repositories{{< /ui >}}][5], and find the {{< ui >}}Environments{{< /ui >}} section.
 1. Click {{< ui >}}Add Environment{{< /ui >}} to create a repository configuration:
    1. Select a repository from the dropdown.
    1. (Optional) Under {{< ui >}}Pre-installed Languages{{< /ui >}}, click {{< ui >}}Select Versions{{< /ui >}} to specify the language versions the sandbox should use.
-   1. (Optional) Define environment variables and secrets. Environment variables are available during both environment setup and Dev Agent execution. Secrets are available as environment variables only during environment setup.
+   1. (Optional) Define environment variables and secrets. Environment variables are available during both environment setup and Bits Code execution. Secrets are available as environment variables only during environment setup.
    1. (Optional) Add a shell script with setup commands to execute (for example: `pip install -r requirements.txt`).
 1. Run the setup command to ensure it runs successfully.
 1. Save the configuration.
 
-The Dev Agent runs the setup command at startup and can use any tools installed in your environment. The setup command runs with network access enabled to download dependencies. After setup is complete, your [internet access](#configure-internet-access) policy controls outbound network access during agent execution. Because setup commands execute against code in your repository, enable them only if you trust the repository's code.
+Bits Code runs the setup command at startup and can use any tools installed in your environment. The setup command runs with network access enabled to download dependencies. After setup is complete, your [internet access](#configure-internet-access) policy controls outbound network access during agent execution. Because setup commands execute against code in your repository, enable them only if you trust the repository's code.
 
 **Note**: For best results, add a [custom instructions file](#configure-custom-instructions) (like `claude.md`) to your repository with instructions on how to build and test your code.
 

--- a/content/en/bits_ai/bits_ai_sre/_index.md
+++ b/content/en/bits_ai/bits_ai_sre/_index.md
@@ -1,31 +1,31 @@
 ---
-title: Bits AI SRE
-description: "Learn how Bits AI SRE autonomously investigates alerts to improve on-call operations."
+title: Bits Investigation
+description: "Learn how Bits Investigation autonomously investigates alerts to improve on-call operations."
 further_reading:
   - link: "https://www.datadoghq.com/blog/bits-ai-sre/"
     tag: "Blog"
-    text: "Introducing Bits AI SRE, your AI on-call teammate"
+    text: "Introducing Bits Investigation, your AI on-call teammate"
   - link: "https://www.datadoghq.com/blog/bits-ai-sre-deeper-reasoning"
     tag: "Blog"
-    text: "Meet the new Bits AI SRE: Deeper reasoning, twice as fast"
+    text: "Meet the new Bits Investigation: Deeper reasoning, twice as fast"
 cascade:
     site_support_id: bits_ai_sre
 ---
 
 ## Overview
 
-Bits AI SRE is an autonomous AI agent that investigates production issues end to end. It iteratively forms hypotheses, gathers relevant telemetry, and uses data-based reasoning to help on-call engineers pinpoint root causes. By reducing manual effort and cognitive load, Bits AI SRE makes on-call operations smoother and more efficient.
+Bits Investigation is an autonomous AI agent that investigates production issues end to end. It iteratively forms hypotheses, gathers relevant telemetry, and uses data-based reasoning to help on-call engineers pinpoint root causes. By reducing manual effort and cognitive load, Bits Investigation makes on-call operations smoother and more efficient.
 
 {{< img src="bits_ai/overview_2.png" alt="Bits AI analysis on a monitor alert" style="width:100%;" >}}
 
 ## Features
 
-{{< whatsnext desc="Learn about how you can use Bits AI SRE:" >}}
+{{< whatsnext desc="Learn about how you can use Bits Investigation:" >}}
    {{< nextlink href="bits_ai/bits_ai_sre/investigate_issues" >}}Investigate issues{{< /nextlink >}}
    {{< nextlink href="bits_ai/bits_ai_sre/take_action" >}}Take action{{< /nextlink >}}
-   {{< nextlink href="bits_ai/bits_ai_sre/configure" >}}Bits AI SRE integrations and settings{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_ai_sre/configure" >}}Bits Investigation integrations and settings{{< /nextlink >}}
    {{< nextlink href="bits_ai/bits_ai_sre/knowledge_sources" >}}Knowledge sources{{< /nextlink >}}
-   {{< nextlink href="bits_ai/bits_ai_sre/chat_bits_ai_sre" >}}Chat with Bits AI SRE{{< /nextlink >}}
+   {{< nextlink href="bits_ai/bits_ai_sre/chat_bits_ai_sre" >}}Chat with Bits Investigation{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further reading

--- a/content/en/bits_ai/bits_ai_sre/chat_bits_ai_sre.md
+++ b/content/en/bits_ai/bits_ai_sre/chat_bits_ai_sre.md
@@ -1,14 +1,14 @@
 ---
-title: Chat with Bits AI SRE
+title: Chat with Bits Investigation
 ---
 
-Within an investigation, you can chat with Bits AI SRE to gather additional information about the investigation, related telemetry, and more.
+Within an investigation, you can chat with Bits Investigation to gather additional information about the investigation, related telemetry, and more.
 
 {{< img src="bits_ai/bits_ai_sre_chat_example.png" alt="Example chat where a user asks Bits AI about related ongoing incidents, and Bits AI responds with a list of related incidents and an explanation on what makes them related" style="width:100%;" >}}
 
 ## Data sources
 
-The Bits AI SRE chatbot has access to:
+The Bits Investigation chatbot has access to:
 - **Investigation details**: Details on the monitor alert, exploratory queries that were run, hypotheses and their assessments, and the root cause conclusion
 - **Telemetry**: Details on metrics, logs, traces, events, monitors, RUM events, dashboards, notebooks, and hosts
 - **Incidents**: Details on incidents and their status, severity, and more
@@ -20,13 +20,13 @@ The Bits AI SRE chatbot has access to:
 
 | Functionality                                  | Example prompt                                                    | Data source                       |
 |------------------------------------------------|-------------------------------------------------------------------|-----------------------------------|
-| Ask for clarification on investigation details | `Why do you think there's database query slowness?`               | Bits AI SRE Investigation details |
-| Ask for elaborations on investigation findings | `Tell me more about the increased 500s on <web-store>.`           | Bits AI SRE Investigation details |
-| Learn how to make Bits work better             | `How can I make the investigation more effective next time?`      | Bits AI SRE Investigation details |
+| Ask for clarification on investigation details | `Why do you think there's database query slowness?`               | Bits Investigation details |
+| Ask for elaborations on investigation findings | `Tell me more about the increased 500s on <web-store>.`           | Bits Investigation details |
+| Learn how to make Bits work better             | `How can I make the investigation more effective next time?`      | Bits Investigation details |
 | Look up information about a service            | `Are there any ongoing incidents for <web-store>?`                | Catalog and Incidents    |
 | Find recent changes for a service              | `Were there any recent changes on <web-store>?`                   | Change Tracking                   |
 | Query APM request, error, and duration metrics | `What's the current error rate for <web-store>?`                  | APM                               |
-| Ask about Datadog products                     | `Does Bits AI SRE connect to Datadog Case Management?`            | Datadog Documentation             |
+| Ask about Datadog products                     | `Does Bits Investigation connect to Datadog Case Management?`            | Datadog Documentation             |
 | Create a Notebook                              | `Can you create a notebook with a summary of this investigation?` | Notebooks                         |
 
 [1]: bits_ai/bits_ai_sre/configure#confluence

--- a/content/en/bits_ai/bits_ai_sre/configure.md
+++ b/content/en/bits_ai/bits_ai_sre/configure.md
@@ -2,14 +2,14 @@
 title: Configure Integrations and Settings
 ---
 
-Set up integrations to extend Bits AI SRE’s capabilities:
+Set up integrations to extend Bits Investigation’s capabilities:
 - [Integrate with third-party observability and SCM platforms](#integrate-with-third-party-observability-and-scm-platforms) to enrich investigations with external telemetry and code context.
 - [Send investigation findings to ITSM and collaboration platforms](#send-investigation-findings-to-itsm-and-collaboration-platforms) to streamline incident response.
 - [Pull context from knowledge bases](#pull-context-from-knowledge-bases) to incorporate runbooks and documentation into investigations.
 
 ## Integrate with third-party observability and SCM platforms
 
-Bits AI SRE integrates with GitHub, Grafana, Dynatrace, Splunk, Sentry, and ServiceNow to incorporate observability data and source code into investigations. Source code access is also required for the Bits Dev Agent to generate a code fix when Bits AI SRE identifies an issue that can be resolved in code.
+Bits Investigation integrates with GitHub, Grafana, Dynatrace, Splunk, Sentry, and ServiceNow to incorporate observability data and source code into investigations. Source code access is also required for Bits Code to generate a code fix when Bits Investigation identifies an issue that can be resolved in code.
 
 ### GitHub
 To configure GitHub:
@@ -27,7 +27,7 @@ For monitor alert investigations, a summary of the findings is available on the 
 
 1. Ensure the [Datadog Slack app][3] is installed in your Slack workspace.
 1. In your monitor, go to {{< ui >}}Configure notifications and automations{{< /ui >}} and add the `@slack-{channel-name}` handle. This sends monitor notifications to your chosen Slack channel.
-1. Lastly, go to [{{< ui >}}Bits AI SRE{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Integrations{{< /ui >}}][4] and connect your Slack workspace. This allows Bits to write its findings directly under the monitor notification in Slack.
+1. Lastly, go to [{{< ui >}}Bits Investigation{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Integrations{{< /ui >}}][4] and connect your Slack workspace. This allows Bits to write its findings directly under the monitor notification in Slack.
 
 <div class="alert alert-info">Each Slack workspace can only be connected to one Datadog organization.</div>
 
@@ -37,11 +37,11 @@ For monitor alert investigations, a summary of the findings is available on the 
 1. In your monitor, go to {{< ui >}}Configure notifications and automations{{< /ui >}} and add the `@teams-{handle-name}` handle. This sends monitor notifications to your chosen MS Teams channel. Bits will append its findings to these notifications.
 
 <div class="alert alert-info">
-The Microsoft Teams integration with Bits AI SRE is in Preview for all customers.</div>
+The Microsoft Teams integration with Bits Investigation is in Preview for all customers.</div>
 
 ### Datadog Case Management
 
-Datadog Case Management provides a centralized workspace for triaging, tracking, and remediating issues detected by Datadog and third-party integrations. Bits AI SRE automatically delivers its investigation findings to Jira and ServiceNow through Case Management.
+Datadog Case Management provides a centralized workspace for triaging, tracking, and remediating issues detected by Datadog and third-party integrations. Bits Investigation automatically delivers its investigation findings to Jira and ServiceNow through Case Management.
 
 To set up Case Management, and the Jira and ServiceNow integrations:
 1. Create a [Case Management project][5] for your team.
@@ -61,11 +61,11 @@ To set up On-Call, in your monitor, go to {{< ui >}}Configure notifications and 
 ## Pull context from knowledge bases
 
 ### Confluence
-Bits AI SRE integrates with Confluence to:
+Bits Investigation integrates with Confluence to:
 - Find relevant documentation and runbooks to support its monitor alert investigations
 - Let you interact with your Confluence content directly through chat
 
-To set up Bits AI SRE to use Confluence:
+To set up Bits Investigation to use Confluence:
 
 1. Connect your Confluence Cloud account by following the instructions in the [Confluence integration tile][7].
 1. Optionally, enable account crawling to make Confluence a data source within Bits' chat interface. If you don't enable account crawling, Bits can still use Confluence to inform its investigation plan.
@@ -74,7 +74,7 @@ To set up Bits AI SRE to use Confluence:
 
 ## Configure permissions
 
-There are two RBAC permissions that apply to Bits AI SRE:
+There are two RBAC permissions that apply to Bits Investigation:
 
 | Name                                                    | Description                            | Default role           |
 |:--------------------------------------------------------|:---------------------------------------|:-----------------------|
@@ -85,7 +85,7 @@ These permissions are added by default to Managed Roles. If your organization us
 
 ## Configure rate limits
 
-Rate limits define the maximum number of automatic investigations Bits AI SRE can run in a rolling 24-hour period. After you reach a rate limit, you can continue to trigger [manual investigations][9].
+Rate limits define the maximum number of automatic investigations Bits Investigation can run in a rolling 24-hour period. After you reach a rate limit, you can continue to trigger [manual investigations][9].
 
 
 ### Types of rate limits
@@ -95,13 +95,13 @@ Per monitor limit
 : **Default:** Each monitor can trigger one automatic investigation per 24 hours.
 
 Organization limit
-: Defines the total number of automatic investigations Bits AI SRE can run across your entire organization within 24 hours.
+: Defines the total number of automatic investigations Bits Investigation can run across your entire organization within 24 hours.
 : **Default:** No limit.
 
 ### Set a rate limit
 
 To set a rate limit:
-1. Navigate to [{{< ui >}}Bits AI SRE{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Rate Limits{{< /ui >}}][10].
+1. Navigate to [{{< ui >}}Bits Investigation{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Rate Limits{{< /ui >}}][10].
 2. Toggle on the rate limit you want to enable.
 3. Set the maximum number of investigations you want to run within a rolling 24-hour window.
 4. Click {{< ui >}}Save{{< /ui >}}.
@@ -118,7 +118,7 @@ You can monitor user-initiated actions with [Audit Trail][11]. Events are sent w
 
 ## Actions
 
-Bits AI SRE provides three [Actions][15]:
+Bits Investigation provides three [Actions][15]:
 - Trigger Investigation
 - Get Investigation
 - List Investigations

--- a/content/en/bits_ai/bits_ai_sre/investigate_issues.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_issues.md
@@ -1,17 +1,17 @@
 ---
 title: Investigate Issues
-description: "Use Bits AI SRE to automatically investigate monitor alerts and provide root cause analysis for faster incident resolution."
+description: "Use Bits Investigation to automatically investigate monitor alerts and provide root cause analysis for faster incident resolution."
 aliases:
 - /bits_ai/bits_ai_sre/investigate_alerts/
 further_reading:
 - link: "https://www.datadoghq.com/blog/bits-ai-sre-deeper-reasoning"
   tag: "Blog"
-  text: "Meet the new Bits AI SRE: Deeper reasoning, twice as fast"
+  text: "Meet the new Bits Investigation: Deeper reasoning, twice as fast"
 ---
 
-## Start a Bits AI SRE investigation
+## Start a Bits Investigation
 
-You can launch a Bits AI SRE investigation from several entry points:
+You can launch a Bits Investigation from several entry points:
 
 - Monitor alerts, which you can trigger in two ways:
   - [**Manual**](#manual-monitor-alerts): Start from an individual monitor alert
@@ -25,49 +25,49 @@ You can launch a Bits AI SRE investigation from several entry points:
 
 You can invoke Bits on an individual monitor alert or warn event from several entry points:
 
-#### Option 1: Bits AI SRE Monitors list {#monitor-list}
-1. Go to [{{< ui >}}Bits AI SRE{{< /ui >}} > {{< ui >}}Monitors{{< /ui >}} > {{< ui >}}Supported{{< /ui >}}][5].
+#### Option 1: Bits Investigation Monitors list {#monitor-list}
+1. Go to [{{< ui >}}Bits Investigation{{< /ui >}} > {{< ui >}}Monitors{{< /ui >}} > {{< ui >}}Supported{{< /ui >}}][5].
 1. Click {{< ui >}}Investigate Recent Alerts{{< /ui >}} and select an alert.
 
 #### Option 2: Monitor status page
-Navigate to the monitor status page of a [Bits AI SRE-supported monitor](#supported-monitors) and click {{< ui >}}Investigate with Bits AI SRE{{< /ui >}} in the top-right corner.
+Navigate to the monitor status page of a [Bits Investigation-supported monitor](#supported-monitors) and click {{< ui >}}Investigate with Bits Investigation{{< /ui >}} in the top-right corner.
 
 #### Option 3: Monitor event side panel
-In the monitor event side panel of a [Bits AI SRE-supported monitor](#supported-monitors), click {{< ui >}}Investigate with Bits AI SRE{{< /ui >}}.
+In the monitor event side panel of a [Bits Investigation-supported monitor](#supported-monitors), click {{< ui >}}Investigate with Bits Investigation{{< /ui >}}.
 
 #### Option 4: Slack
-To use the Slack integration, [connect your Slack workspace to Bits AI SRE][8].
+To use the Slack integration, [connect your Slack workspace to Bits Investigation][8].
 
 In Slack, reply to a monitor notification with `@Datadog Investigate this alert`.
 
 ### APM latency (Preview)
 
 {{< callout url="http://datadoghq.com/product-preview/bits-ai-sre-pilot-features" >}}
-Bits AI SRE investigations started from APM latency graphs and APM Watchdog stories are in Preview. Click <strong>Request Access</strong> to join the Preview program.
+Bits Investigations started from APM latency graphs and APM Watchdog stories are in Preview. Click <strong>Request Access</strong> to join the Preview program.
 {{< /callout >}}
 
 #### APM latency graphs on service pages
 
 1. In Datadog, navigate to [APM][1] and open the service or resource page you want to investigate. Next to the latency graph, click {{< ui >}}Investigate{{< /ui >}}.
 1. Click and drag your cursor over the point plot visualization to make a rectangular selection over a region that shows unusual latency to seed the analysis. Initial diagnostics on the latency issue appear, including the observed user impact, anomalous tags contributing to the issue, and recent changes. For more information, see [APM Investigator][2].
-1. Click {{< ui >}}Investigate with Bits AI SRE{{< /ui >}} to run a deeper investigation.
+1. Click {{< ui >}}Investigate with Bits Investigation{{< /ui >}} to run a deeper investigation.
 
 #### APM latency Watchdog stories
 
-On a Watchdog APM latency story, click {{< ui >}}Investigate with Bits AI SRE{{< /ui >}}.
+On a Watchdog APM latency story, click {{< ui >}}Investigate with Bits Investigation{{< /ui >}}.
 
 ### Synthetic tests (Preview)
 
 <div class="alert alert-info">
-Bits AI SRE investigations started from Synthetic Browser and API tests are in Preview.</div>
+Bits Investigations started from Synthetic Browser and API tests are in Preview.</div>
 
-When a Synthetic Browser or API test monitor triggers, you can launch a Bits AI SRE investigation to identify the root cause. Bits AI SRE analyzes Synthetic test results and history alongside traces, logs, and metrics. It surfaces a likely root cause and identifies whether the failure reflects a real regression or a misconfiguration.
+When a Synthetic Browser or API test monitor triggers, you can launch a Bits Investigation to identify the root cause. Bits Investigation analyzes Synthetic test results and history alongside traces, logs, and metrics. It surfaces a likely root cause and identifies whether the failure reflects a real regression or a misconfiguration.
 
 #### From the Synthetic test details page
 
 1. On the [Synthetic Tests][18] page, open the Synthetic test you want to investigate and go to the {{< ui >}}Timeline{{< /ui >}} section.
 1. Select the {{< ui >}}Alert Triggered{{< /ui >}} event for the failing test run.
-1. Click {{< ui >}}Investigate with Bits AI SRE{{< /ui >}}.
+1. Click {{< ui >}}Investigate with Bits Investigation{{< /ui >}}.
 
 The investigation opens in a new page, and you can also view it from the test details page after it runs.
 
@@ -91,22 +91,22 @@ Good examples:
 Bad example:
 - App is slow. What’s wrong?
 
-You can also trigger an investigation from Slack.  Mention Datadog in a message: `@Datadog Investigate high CPU in ai-gateway in prod over the last 30 minutes`. If invoked within a Slack thread, Bits AI SRE automatically uses the entire thread as investigation context.
+You can also trigger an investigation from Slack.  Mention Datadog in a message: `@Datadog Investigate high CPU in ai-gateway in prod over the last 30 minutes`. If invoked within a Slack thread, Bits Investigation automatically uses the entire thread as investigation context.
 
 <div class="alert alert-info">
-Starting Bits AI SRE investigations from a prompt is in Preview for all customers. During this period, the number of investigations per day is rate-limited. This limit does not apply to generally available entry points, such as monitors.</div>
+Starting Bits Investigations from a prompt is in Preview for all customers. During this period, the number of investigations per day is rate-limited. This limit does not apply to generally available entry points, such as monitors.</div>
 
 ### Enable automatic investigations
 
 In addition to manual investigations, you can configure Bits to run automatically when a monitor transitions to the alert state:
 
-#### From the Bits AI SRE Monitors list
-1. Go to [{{< ui >}}Bits AI SRE{{< /ui >}} > {{< ui >}}Monitors{{< /ui >}} > {{< ui >}}Supported{{< /ui >}}][5].
+#### From the Bits Investigation Monitors list
+1. Go to [{{< ui >}}Bits Investigation{{< /ui >}} > {{< ui >}}Monitors{{< /ui >}} > {{< ui >}}Supported{{< /ui >}}][5].
 1. Toggle {{< ui >}}Auto-Investigate{{< /ui >}} on for a single monitor, or bulk-edit multiple monitors by selecting multiple monitors, then clicking {{< ui >}}Auto-Investigate All{{< /ui >}}.
 
 #### For a single monitor
 1. Open the monitor's status page and click {{< ui >}}Edit{{< /ui >}}.
-1. Scroll to {{< ui >}}Configure notifications & automations{{< /ui >}} and toggle {{< ui >}}Investigate with Bits AI SRE{{< /ui >}}.
+1. Scroll to {{< ui >}}Configure notifications & automations{{< /ui >}} and toggle {{< ui >}}Investigate with Bits Investigation{{< /ui >}}.
 
 <div class="alert alert-info"><ul><li>Enabling automatic investigations using the Datadog API or Terraform is not supported.</li><li>An investigation initiates when a monitor transitions to the alert state.</li><li>Transitions to the warn or no data state, <a href="/monitors/notify/#renotify">renotifications</a>, and test notifications do not trigger automatic investigations.
 </li></ul></div>
@@ -125,12 +125,12 @@ Bits is able to run investigations on the following monitor types:
   - SLOs (Preview)
   - Synthetics API and Browser tests (Preview)
 
-## How Bits AI SRE investigates
-When Bits AI SRE investigates an issue, it operates in a continuous loop of observation, reasoning, and action. It begins by forming hypotheses about the potential root cause, then uses its tools to query telemetry data to validate or invalidate those hypotheses. Each step builds on prior findings. As new evidence emerges, Bits AI SRE updates its understanding, refines its reasoning, and chains together additional investigative steps—adapting and course-correcting until it converges on the most likely root cause.
+## How Bits Investigation investigates
+When Bits Investigation investigates an issue, it operates in a continuous loop of observation, reasoning, and action. It begins by forming hypotheses about the potential root cause, then uses its tools to query telemetry data to validate or invalidate those hypotheses. Each step builds on prior findings. As new evidence emerges, Bits Investigation updates its understanding, refines its reasoning, and chains together additional investigative steps—adapting and course-correcting until it converges on the most likely root cause.
 
-At the end of an investigation, Bits AI SRE either presents a clear, evidence-backed conclusion or marks the investigation as inconclusive when the available data is insufficient to support a defensible conclusion.
+At the end of an investigation, Bits Investigation either presents a clear, evidence-backed conclusion or marks the investigation as inconclusive when the available data is insufficient to support a defensible conclusion.
 
-{{< img src="bits_ai/bits_ai_sre_investigation_hypotheses.png" alt="Flowchart showing the hypotheses Bits AI SRE built and tested" style="width:100%;" >}}
+{{< img src="bits_ai/bits_ai_sre_investigation_hypotheses.png" alt="Flowchart showing the hypotheses Bits Investigation built and tested" style="width:100%;" >}}
 
 ### Supported data sources
 Bits uses the following data sources during investigations:
@@ -149,7 +149,7 @@ Bits uses the following data sources during investigations:
 - Database Monitoring
 - Continuous Profiler
 
-<div class="alert alert-tip"><b>Add service scoping:</b> For monitors associated with a service, add a service tag to the monitor, or filter or group the monitor query by service. This helps Bits AI SRE correlate data more accurately.</div>
+<div class="alert alert-tip"><b>Add service scoping:</b> For monitors associated with a service, add a service tag to the monitor, or filter or group the monitor query by service. This helps Bits Investigation correlate data more accurately.</div>
 
 #### Third-party integrations
 - Grafana
@@ -174,7 +174,7 @@ Once the investigation is complete, you can switch to the {{< ui >}}Investigatio
 
 ## Reports
 
-The {{< ui >}}Reports{{< /ui >}} tab enables you to track the number of investigations run over time by monitor, user, service, and team. You can also track the mean time to conclusion to assess the impact of Bits AI SRE on your on-call efficiency.
+The {{< ui >}}Reports{{< /ui >}} tab enables you to track the number of investigations run over time by monitor, user, service, and team. You can also track the mean time to conclusion to assess the impact of Bits Investigation on your on-call efficiency.
 
 [1]: https://app.datadoghq.com/apm/home
 [2]: /tracing/guide/latency_investigator/

--- a/content/en/bits_ai/bits_ai_sre/knowledge_sources.md
+++ b/content/en/bits_ai/bits_ai_sre/knowledge_sources.md
@@ -5,25 +5,25 @@ aliases:
 
 ---
 
-Bits AI SRE improves over time by combining three distinct sources of knowledge:
+Bits Investigation improves over time by combining three distinct sources of knowledge:
 - [**Runbooks:**](#runbooks) Step-by-step troubleshooting guidance
 - [**bits.md:**](#bitsmd) Context about your environment
 - [**Feedback and memories:**](#feedback-and-memories) Learnings from investigations
 
 ## Runbooks
-Think of onboarding Bits AI SRE as you would a new teammate: the more context you provide, the better it can investigate.
+Think of onboarding Bits Investigation as you would a new teammate: the more context you provide, the better it can investigate.
 
 You can either add step-by-step troubleshooting instructions directly in the monitor message or link to a Confluence page that contains those instructions.
 
 - **Include Datadog telemetry links**: When adding instructions in the monitor message, include links to the most relevant telemetry. Start with the first place you'd normally look in Datadog when the monitor triggers, such as a dashboard, logs, traces, or a notebook with key widgets. Links don't need special formatting; plain URLs work.
 
-Because these links are user-defined, you have control over what Bits AI SRE reviews, ensuring it focuses on the same data you would, and giving you the flexibility to tailor investigations to your team's workflows.
+Because these links are user-defined, you have control over what Bits Investigation reviews, ensuring it focuses on the same data you would, and giving you the flexibility to tailor investigations to your team's workflows.
 
 - **Notebooks**: Monitors can link to notebooks that contain instructions on how to troubleshoot the monitor or related service. Notebooks support markdown as well as Datadog queries, giving the agent instructions on how to best perform root cause analysis.
 
-- **Confluence integration**: If your runbooks live in Confluence, link the relevant pages in the monitor message. During an investigation, Bits AI SRE reads the page, extracts telemetry links, follows documented troubleshooting steps where possible, and incorporates remediation guidance into its recommendations.
+- **Confluence integration**: If your runbooks live in Confluence, link the relevant pages in the monitor message. During an investigation, Bits Investigation reads the page, extracts telemetry links, follows documented troubleshooting steps where possible, and incorporates remediation guidance into its recommendations.
 
-To maximize the value of this integration, document the services, dependencies, and systems involved in detail, and provide clear, step-by-step instructions for resolving the issue. Well-structured, specific runbooks enable Bits AI SRE to conduct more accurate and effective investigations.
+To maximize the value of this integration, document the services, dependencies, and systems involved in detail, and provide clear, step-by-step instructions for resolving the issue. Well-structured, specific runbooks enable Bits Investigation to conduct more accurate and effective investigations.
 
 {{< img src="bits_ai/optimization_example.png" alt="Example monitor with optimization steps applied" style="width:100%;" >}}
 
@@ -32,7 +32,7 @@ To maximize the value of this integration, document the services, dependencies, 
 <div class="alert alert-info">
 Bits.md is in Preview for all customers.</div>
 
-You can proactively guide how Bits investigates your environment by creating a `bits.md` file at [{{< ui >}}Bits AI SRE{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Bits.md{{< /ui >}}][2].
+You can proactively guide how Bits investigates your environment by creating a `bits.md` file at [{{< ui >}}Bits Investigation{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Bits.md{{< /ui >}}][2].
 
 `bits.md` is a Markdown file that provides structured context about your environment to Bits. It serves as lightweight guidance to improve investigation accuracy, query construction, and terminology alignment. Add team-specific knowledge such as tagging conventions, architectural patterns, glossary terms, and investigation best practices.
 
@@ -103,18 +103,18 @@ Rule:
 
 ## Feedback and memories
 
-At the end of an investigation, let Bits AI SRE know whether the conclusion it made was correct.
+At the end of an investigation, let Bits Investigation know whether the conclusion it made was correct.
 
 {{< img src="bits_ai/help_bits_ai_learn_2.png" alt="Post-investigation root cause feedback flow" style="width:100%;" >}}
 
-If the conclusion was inaccurate, provide Bits AI SRE with the correct root cause, highlighting what it missed, and explaining what it should do differently next time. Your feedback should:
+If the conclusion was inaccurate, provide Bits Investigation with the correct root cause, highlighting what it missed, and explaining what it should do differently next time. Your feedback should:
 - Identify the actual root cause (not just observed effects or symptoms)
 - Specify relevant services, components, or metrics
 - Include telemetry links that point to the root cause
 
 **Example high-quality root cause feedback**: "High memory usage in auth-service pod due to memory leak in session cache, causing OOM kills every 2 hours starting at 2025-11-15 14:30 UTC. This is evidenced by `https://app.datadoghq.com/logs?<rest_of_link>`"
 
-All positive feedback, as well as any negative feedback that includes details provided in the Bits' chat, creates a **memory**. Bits AI SRE dynamically selects which memories to use in future investigations to improve its performance. It applies past corrections in similar contexts, reuses effective queries, and refines how it prioritizes investigative steps. Over time, this enables Bits AI SRE to adapt to your environment, becoming more accurate and efficient with each investigation.
+All positive feedback, as well as any negative feedback that includes details provided in the Bits' chat, creates a **memory**. Bits Investigation dynamically selects which memories to use in future investigations to improve its performance. It applies past corrections in similar contexts, reuses effective queries, and refines how it prioritizes investigative steps. Over time, this enables Bits Investigation to adapt to your environment, becoming more accurate and efficient with each investigation.
 
 To manage memories, including viewing and deleting them, go to the {{< ui >}}Memories{{< /ui >}} column of the [Monitor Management][1] page.
 

--- a/content/en/bits_ai/bits_ai_sre/take_action.md
+++ b/content/en/bits_ai/bits_ai_sre/take_action.md
@@ -4,16 +4,16 @@ aliases:
 - /bits_ai/bits_ai_sre/remediate_issues/
 ---
 
-## Suggested code fixes from the Bits AI Dev Agent
+## Suggested code fixes from Bits Code
 {{< callout url="http://datadoghq.com/product-preview/bits-ai-sre-pilot-features" >}}
-Suggested code fixes from the Bits AI Dev Agent is in Preview. Click <strong>Request Access</strong> to join the Preview program.
+Suggested code fixes from Bits Code is in Preview. Click <strong>Request Access</strong> to join the Preview program.
 {{< /callout >}}
 
-After Bits AI SRE helps you identify a root cause, it can also help you take action as quickly as possible.
+After Bits Investigation helps you identify a root cause, it can also help you take action as quickly as possible.
 
-Bits AI SRE integrates with [Bits AI Dev Agent][2] to automatically generate code fixes. The Dev Agent connects to GitHub to create production-ready pull requests, iterates on fixes using CI logs and developer feedback, and uses multiple Datadog products to generate contextual fixes.
-1. [Set up the Bits AI Dev Agent][1]. Then, after Bits AI SRE has determined a code-related root cause, you will automatically receive suggested code fixes.
-1. Ask Bits AI Dev Agent to make any additional updates as needed, create a pull request for review in GitHub, and merge when ready to fix the underlying problem.
+Bits Investigation integrates with [Bits Code][2] to automatically generate code fixes. Bits Code connects to GitHub to create production-ready pull requests, iterates on fixes using CI logs and developer feedback, and uses multiple Datadog products to generate contextual fixes.
+1. [Set up Bits Code][1]. Then, after Bits Investigation has determined a code-related root cause, you will automatically receive suggested code fixes.
+1. Ask Bits Code to make any additional updates as needed, create a pull request for review in GitHub, and merge when ready to fix the underlying problem.
 
 {{< img src="bits_ai/bits_ai_sre_suggested_code_fix.png" alt="Flowchart showing Bits' investigation conclusion and a suggested code fix" style="width:100%;" >}}
 
@@ -27,7 +27,7 @@ Supported actions include:
 - Creating cases in Datadog Case Management
 - Opening Jira tickets
 
-Bits AI SRE automatically pulls relevant context from the investigation and your connected integrations to prefill messages, incident descriptions, and ticket metadata. This reduces manual effort, ensures consistency, and accelerates response time.
+Bits Investigation automatically pulls relevant context from the investigation and your connected integrations to prefill messages, incident descriptions, and ticket metadata. This reduces manual effort, ensures consistency, and accelerates response time.
 
 [1]: /bits_ai/bits_ai_dev_agent/setup/
 [2]: /bits_ai/bits_ai_dev_agent

--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -1,6 +1,6 @@
 ---
-title: Bits AI Assistant
-description: "Use Bits AI Assistant in Datadog to explore and act on your observability data using natural language."
+title: Bits Chat
+description: "Use Bits Chat in Datadog to explore and act on your observability data using natural language."
 further_reading:
 - link: "bits_ai/"
   tag: "Documentation"
@@ -10,16 +10,16 @@ further_reading:
   text: "Coordinate incidents with Incident AI"
 - link: "/cloud_cost_management/cloud_cost_skill/"
   tag: "Documentation"
-  text: "Cloud Cost Skill in Bits AI Assistant"
+  text: "Cloud Cost Skill in Bits Chat"
 aliases:
 - /bits_ai/getting_started/
 - /bits_ai/chat_with_bits_ai
 ---
 
 ## Overview
-Bits AI Assistant is an AI-powered companion in Datadog that helps you search and act across Datadog using natural language. Bits AI Assistant is available across the web application, mobile app, and Slack.
+Bits Chat is an AI-powered companion in Datadog that helps you search and act across Datadog using natural language. Bits Chat is available across the web application, mobile app, and Slack.
 
-Ask Bits AI Assistant questions across these categories:
+Ask Bits Chat questions across these categories:
 
 ### Investigate issues and remediate
 - `Summarize high severity incidents that have occurred in the last day`
@@ -47,22 +47,22 @@ Ask Bits AI Assistant questions across these categories:
 - `How can I put a team tag on this monitor?`
 - `Add a timeseries widget for request count over time to this notebook`
 
-{{< img src="bits_ai/getting_started/bits_assistant_full_page.png" alt="Full-page Bits AI Assistant interface showing conversation history and prompt suggestions" style="width:100%;">}}
+{{< img src="bits_ai/getting_started/bits_assistant_full_page.png" alt="Full-page Bits Chat interface showing conversation history and prompt suggestions" style="width:100%;">}}
 
 ### Permissions
 
-#### Access to Bits AI Assistant
+#### Access to Bits Chat
 
-To use Bits AI Assistant, your role must have the **Bits Assistant Access** permission. This permission is enabled by default for all three standard Datadog roles: Datadog Admin, Datadog Standard, and Datadog Read Only.
+To use Bits Chat, your role must have the **Bits Chat Access** permission. This permission is enabled by default for all three standard Datadog roles: Datadog Admin, Datadog Standard, and Datadog Read Only.
 
-To manage this permission for custom roles, go to **Organization Settings** > **Roles**, select a role, and toggle **Bits Assistant Access** under **General Permissions**.
+To manage this permission for custom roles, go to **Organization Settings** > **Roles**, select a role, and toggle **Bits Chat Access** under **General Permissions**.
 
-#### Data access through Bits AI Assistant
+#### Data access through Bits Chat
 
-Bits AI Assistant uses your Datadog role to fetch data, so it can only access the resources you have permission to view or modify. For example, if your role restricts access to a specific set of logs indexes, Bits AI Assistant can only query logs from those indexes. Similarly, if you do not have permission to edit a dashboard, Bits AI Assistant cannot edit that dashboard on your behalf.
+Bits Chat uses your Datadog role to fetch data, so it can only access the resources you have permission to view or modify. For example, if your role restricts access to a specific set of logs indexes, Bits Chat can only query logs from those indexes. Similarly, if you do not have permission to edit a dashboard, Bits Chat cannot edit that dashboard on your behalf.
 
 ### Skills
-Bits AI Assistant has a range of specialized skills for tasks across Datadog. The most commonly used skills are described below.
+Bits Chat has a range of specialized skills for tasks across Datadog. The most commonly used skills are described below.
 
 #### Dashboards
 Build [dashboards][5] and widgets from natural language descriptions.
@@ -95,7 +95,7 @@ Example prompts:
 - `What's the latency bottleneck for this service?`
 
 #### Cloud Cost Management
-Investigate [cloud cost][4] changes and identify the teams or resources responsible. See [Cloud Cost Skill in Bits AI Assistant][9].
+Investigate [cloud cost][4] changes and identify the teams or resources responsible. See [Cloud Cost Skill in Bits Chat][9].
 
 Example prompts:
 - `Investigate why EC2 costs changed between January and February`
@@ -111,31 +111,31 @@ Example prompts:
 
 ### Reports
 
-The Bits AI Assistant Reports page provides visibility into how your organization uses Bits AI Assistant. Go to [**Bits AI** > **Assistant** > **Reports**][10] to view:
+The Bits Chat Reports page provides visibility into how your organization uses Bits Chat. Go to [**Bits AI** > **Chat** > **Reports**][10] to view:
 
-- **Top users**: See which team members use Bits AI Assistant the most, ranked by conversation count.
+- **Top users**: See which team members use Bits Chat the most, ranked by conversation count.
 - **Usage trends**: Track conversation volume over time to understand adoption and identify usage patterns.
 - **Conversation intent distribution**: See how conversations break down by intent category, such as investigating issues, exploring telemetry, learning Datadog concepts, and configuring observability.
 
 Use these insights to understand adoption patterns, identify power users for best-practice sharing, and assess which use cases deliver the most value for your organization.
 
 ### Web application
-There are multiple ways to open Bits AI Assistant in the Datadog web application:
+There are multiple ways to open Bits Chat in the Datadog web application:
 - In the top-right of the navigation bar, click {{< ui >}}Ask Bits{{< /ui >}}
-- In a Datadog product integrated with Bits AI Assistant, click {{< ui >}}Ask Bits{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon)
+- In a Datadog product integrated with Bits Chat, click {{< ui >}}Ask Bits{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon)
 - Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>I</kbd>
 - In the left-side navigation panel, click {{< ui >}}Bits AI{{< /ui >}}
 
-{{< img src="bits_ai/getting_started/bits_assistant_side_panel.png" alt="Bits AI Assistant side panel showing example prompts" style="width:40%;">}}
+{{< img src="bits_ai/getting_started/bits_assistant_side_panel.png" alt="Bits Chat side panel showing example prompts" style="width:40%;">}}
 
 ### Mobile application
 <div class="alert alert-info">
-Bits AI Assistant is available on iOS v5.8.4+ and Android v3.15+.
+Bits Chat is available on iOS v5.8.4+ and Android v3.15+.
 </div>
 
 1. [Download the mobile app and log in][2].
-2. On the home screen, tap {{< ui >}}Bits AI Assistant{{< /ui >}}.
-3. Start chatting with Bits AI Assistant in chat or voice mode.
+2. On the home screen, tap {{< ui >}}Bits Chat{{< /ui >}}.
+3. Start chatting with Bits Chat in chat or voice mode.
 {{< img src="bits_ai/getting_started/bitsai_mobile_app.PNG" alt="View of the Mobile App Home dashboard with Bits AI" style="width:40%;" >}}
 
 ### Slack

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -26,7 +26,7 @@ The following log features are supported:
 **Dashboards and monitors**
 - Dashboards with BYOC Logs data
 - Log monitors on BYOC Logs indexes
-- Bits AI SRE
+- Bits Investigation
 
 **Index management**
 - Multiple indexes with independent retention periods and routing rules

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -12,7 +12,7 @@ further_reading:
     text: "Learn about Tags in Cloud Cost Management"
   - link: "/cloud_cost_management/cloud_cost_skill/"
     tag: "Documentation"
-    text: "Use Cloud Cost skill in Bits AI Assistant"
+    text: "Use Cloud Cost skill in Bits Chat"
   - link: "https://www.datadoghq.com/blog/control-your-cloud-spend-with-datadog-cloud-cost-management/"
     tag: "Blog"
     text: "Gain visibility and control of your cloud spend with Datadog Cloud Cost Management"
@@ -136,9 +136,9 @@ Use this page to troubleshoot data delays or confirm that recent tag pipelines a
 
 ## Use AI for cost analysis
 
-Use the [Cloud Cost Skill in Bits AI Assistant][10] to investigate cost changes, identify likely owners, compare spend against budgets, correlate cost with observability metrics, and create handoff notebooks for engineering teams.
+Use the [Cloud Cost Skill in Bits Chat][10] to investigate cost changes, identify likely owners, compare spend against budgets, correlate cost with observability metrics, and create handoff notebooks for engineering teams.
 
-{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits AI Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
+{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits Chat's investigation summary showing an initial analysis." style="width:60%;" >}}
 
 ## Further reading
 

--- a/content/en/cloud_cost_management/cloud_cost_skill.md
+++ b/content/en/cloud_cost_management/cloud_cost_skill.md
@@ -1,13 +1,13 @@
 ---
-title: Cloud Cost Skill in Bits AI Assistant
-description: Use the Cloud Cost skill in Bits AI Assistant to investigate, explain, and share cloud cost findings.
+title: Cloud Cost Skill in Bits Chat
+description: Use the Cloud Cost skill in Bits Chat to investigate, explain, and share cloud cost findings.
 algolia:
   tags: ["cloud cost", "cloud cost management", "ccm", "finops", "cloud cost skill", "bits ai assistant", "bits assistant", "mcp"]
   rank: 75
 further_reading:
 - link: "/bits_ai/bits_assistant/"
   tag: "Documentation"
-  text: "Bits AI Assistant"
+  text: "Bits Chat"
 - link: "/bits_ai/mcp_server/"
   tag: "Documentation"
   text: "Datadog MCP Server"
@@ -20,12 +20,12 @@ further_reading:
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/bits-assistant/" btn_hidden="false" header="Cloud Cost skill is in Preview" >}}
-The Cloud Cost skill runs in Bits AI Assistant. Fill out the Bits AI Assistant Preview form to request access.
+The Cloud Cost skill runs in Bits Chat. Fill out the Bits Chat Preview form to request access.
 {{< /callout >}}
 
 ## Overview
 
-The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits AI Assistant][1]. It is designed for FinOps tasks, such as root cause analysis, budget tracking, and answering general cost questions. For example, you can ask Bits AI Assistant to:
+The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits Chat][1]. It is designed for FinOps tasks, such as root cause analysis, budget tracking, and answering general cost questions. For example, you can ask Bits Chat to:
 
 - Investigate [cost monitor alerts][2], [cost anomalies][3], and [cost changes][4]
 - Identify teams, services, accounts, regions, or resources driving spend
@@ -36,11 +36,11 @@ The Cloud Cost skill is the Cloud Cost Management analysis workflow in [Bits AI 
 
 ## Prerequisites
 
-To use the Cloud Cost skill in Bits AI Assistant, you must:
+To use the Cloud Cost skill in Bits Chat, you must:
 
 - [Set up Cloud Cost Management][6] for the cost sources you want to analyze
 - Have these permissions:
-  - [Bits Assistant Access][7] permission
+  - [Bits Chat Access][7] permission
   - [Cloud Cost Management permissions][8] for the data you ask about
   - (Optional) [Notebook permissions][9], if you want to create or edit investigation [Notebooks][15]
 
@@ -50,7 +50,7 @@ To use the Cloud Cost skill in Bits AI Assistant, you must:
 
 When you want to start an investigation, such as for a [cost anomaly][3], click {{< ui >}}Investigate{{< /ui >}} or {{< img src="bits_ai/dev_agent/twinkling_stars_icon.png" inline="true" style="width:24px">}} (the twinkling stars icon) to open the Cloud Cost skill.
 
-Alternatively, you can click {{< ui >}}Ask Bits{{< /ui >}} on the top right of the navigation bar on any Datadog page to open Bits AI Assistant and ask a cost question.
+Alternatively, you can click {{< ui >}}Ask Bits{{< /ui >}} on the top right of the navigation bar on any Datadog page to open Bits Chat and ask a cost question.
 
 Example prompts:
 
@@ -62,16 +62,16 @@ Example prompts:
 
 ### Cost change investigations
 
-When you investigate a cost change with the Cloud Cost skill, Bits AI Assistant provides a concise summary, then asks what you want to explore next. The initial analysis typically includes:
+When you investigate a cost change with the Cloud Cost skill, Bits Chat provides a concise summary, then asks what you want to explore next. The initial analysis typically includes:
 
 - A daily cost chart for the baseline and investigation periods
 - The baseline period, investigation period, total dollar amount and percentage change, and projected annual impact when applicable
 - Rate-versus-usage context to help distinguish price changes from consumption changes
 - Owner or team attribution based on your cost tags
 
-{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits AI Assistant's investigation summary showing an initial analysis." style="width:60%;" >}}
+{{< img src="cloud_cost/cc_skill_cost_summary.png" alt="Bits Chat's investigation summary showing an initial analysis." style="width:60%;" >}}
 
-After the initial summary, Bits AI Assistant can:
+After the initial summary, Bits Chat can:
 
 - Find the top services, accounts, regions, resources, or tags driving the change
 - Correlate the cost change with metrics such as CPU requests, memory requests, request count, bucket size, or database usage
@@ -81,14 +81,14 @@ After the initial summary, Bits AI Assistant can:
 
 ### Budgets and forecasting
 
-After setting up [Budgets][5], use the Cloud Cost skill in Bits AI Assistant to explain budget status and spending. Bits AI Assistant can help summarize:
+After setting up [Budgets][5], use the Cloud Cost skill in Bits Chat to explain budget status and spending. Bits Chat can help summarize:
 
 - Actual spend versus budgeted amount
 - Forecasted spend versus budgeted amount
 - Which cost scope a budget covers, based on the budget's filters
 - Which budget entries, teams, services, or providers are contributing to an overage
 
-After the initial summary, Bits AI Assistant can:
+After the initial summary, Bits Chat can:
 
 - Find the top services, accounts, regions, resources, or tags driving spending
 - Identify the teams that own the resources contributing to the cost change

--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -675,7 +675,7 @@ You can act on recommendations to save money and optimize costs. Cloud Cost Reco
   - `-@jira_issues.issue_key:*` - Show only recommendations without a Jira issue
   - `jira_issues.issue_key:ABC*` - Filter by specific Jira project prefix
 
-- **[Bits AI Dev Agent][14] code fixes**: Code fixes are available for applicable S3 and DynamoDB recommendations, as well as the Downsize Kubernetes Deployment recommendation. In these situations, the Bits AI Dev Agent creates production-ready pull requests to implement cloud resource changes and cost optimizations in Terraform or Helm charts, respectively. [Set up the Bits AI Dev Agent][13] to use this feature.
+- **[Bits Code][14] code fixes**: Code fixes are available for applicable S3 and DynamoDB recommendations, as well as the Downsize Kubernetes Deployment recommendation. In these situations, Bits Code creates production-ready pull requests to implement cloud resource changes and cost optimizations in Terraform or Helm charts, respectively. [Set up Bits Code][13] to use this feature.
 - **1-click Workflow Automation actions**: Actions are available for a limited set of recommendations, allowing users to execute suggested actions, such as clicking {{< ui >}}Delete EBS Volume{{< /ui >}}, directly within Cloud Cost Management.
 - **[Cost Optimization Automation][15]**: Set up automations that act on recommendations continuously on a recurring schedule. Automations are scoped to specific accounts, regions, and tags and include safeguards such as pre-action snapshots and optional human approval through Slack or Microsoft Teams.
 - **Datadog Case Management**: Users can go to the recommendation side panel and click {{< ui >}}Create Case{{< /ui >}} to generate a case to manage and take action on recommendations.

--- a/content/en/containers/bits_ai_kubernetes_remediation.md
+++ b/content/en/containers/bits_ai_kubernetes_remediation.md
@@ -51,7 +51,7 @@ When a pod is terminated because the memory usage exceeded its limit, you may be
 2. Adjust your limit so that it is higher than what your container normally uses.
 3. Click {{< ui >}}Fix with Bits AI{{< /ui >}}.
 4. On the next page, select the repository where your deployment is defined, and review the proposed changes. Click {{< ui >}}Fix with Bits{{< /ui >}} to create a pull request.
-5. You are redirected to a Bits [Code Session][3], where you can verify that the Bits AI Dev Agent identified the specific configuration file where your memory limits are defined. Click {{< ui >}}Create Pull Request{{< /ui >}} to initiate the creation of the pull request.
+5. You are redirected to a Bits [Code Session][3], where you can verify that Bits Code identified the specific configuration file where your memory limits are defined. Click {{< ui >}}Create Pull Request{{< /ui >}} to initiate the creation of the pull request.
 6. Click {{< ui >}}View Pull Request{{< /ui >}} to view the pull request in GitHub.
 {{% /collapse-content %}}
 

--- a/content/en/containers/monitoring/_index.md
+++ b/content/en/containers/monitoring/_index.md
@@ -33,7 +33,7 @@ Select the [**Autoscaling**][11] tab in the Kubernetes section to view scaling r
 
 ### Kubernetes Remediation
 
-Select the [**Remediation**][13] tab in the Kubernetes section to investigate and remediate errors with [Bits AI Dev Agent][14]. For more information, read the [Bits AI Kubernetes Remediation documentation][15].
+Select the [**Remediation**][13] tab in the Kubernetes section to investigate and remediate errors with [Bits Code][14]. For more information, read the [Bits AI Kubernetes Remediation documentation][15].
 
 {{< callout url="https://www.datadoghq.com/product-preview/kubernetes-remediation/"
  btn_hidden="false" header="Join the Preview!">}}

--- a/content/en/data_security/data_retention_periods.md
+++ b/content/en/data_security/data_retention_periods.md
@@ -28,13 +28,13 @@ attributes:
     data_type: |
        - **Audit logs (Audit Trail enabled)**: 90 days
        - **Audit logs (Audit Trail disabled)**: 7 days
-  - product: Bits AI Assistant
+  - product: Bits Chat
     data_type: |
        - **Messages**: 15 months
-  - product: Bits AI Dev Agent
+  - product: Bits Code
     data_type: |
        - **Source Code**: 7 days
-  - product: Bits AI SRE
+  - product: Bits Investigation
     data_type: |
        - **Investigations**: Retained for the duration of the account
   - product: Browser RUM

--- a/content/en/datadog_cloudcraft/overlays/_index.md
+++ b/content/en/datadog_cloudcraft/overlays/_index.md
@@ -22,7 +22,7 @@ Cloudcraft provides the following built-in overlays:
 - [Observability][2]: See where the Datadog Agent is installed and which features are enabled per host.
 - [Security][3]: Identify security exposures, misconfigurations, and vulnerabilities in your architecture.
 - [Cloud Cost Management (CCM)][4]: Discover savings opportunities with cost recommendations shown directly on resources.
-- [Monitors][5] (Preview): View monitor states for your resources and services, and investigate alerting monitors with Bits AI SRE.
+- [Monitors][5] (Preview): View monitor states for your resources and services, and investigate alerting monitors with Bits Investigation.
 - [APM][6]: Visualize distributed APM traces between cloud resources on your diagram (AWS only, Preview).
 
 ## Further reading

--- a/content/en/datadog_cloudcraft/overlays/monitors.md
+++ b/content/en/datadog_cloudcraft/overlays/monitors.md
@@ -1,11 +1,11 @@
 ---
 title: Monitors
-description: "Use the Monitors overlay in Cloudcraft to view monitor states for your resources and services, and investigate alerting monitors with Bits AI SRE."
+description: "Use the Monitors overlay in Cloudcraft to view monitor states for your resources and services, and investigate alerting monitors with Bits Investigation."
 site_support_id: cloudcraft_monitors_overlay
 further_reading:
 - link: "/bits_ai/bits_ai_sre/"
   tag: "Documentation"
-  text: "Bits AI SRE"
+  text: "Bits Investigation"
 ---
 
 {{< callout btn_hidden="true" header="" >}}
@@ -37,15 +37,15 @@ Use the legend at the bottom of the diagram to filter monitors by alerting statu
 
 ### Hover panel
 
-Hover over a resource or service with monitors to see a count breakdown of associated monitors by status. The hover panel includes an {{< ui >}}Investigate with Bits AI SRE{{< /ui >}} button that loads the three most recent alerting events for the selected monitor. From there, you can initiate an investigation or view an existing one.
+Hover over a resource or service with monitors to see a count breakdown of associated monitors by status. The hover panel includes an {{< ui >}}Investigate with Bits Investigation{{< /ui >}} button that loads the three most recent alerting events for the selected monitor. From there, you can initiate an investigation or view an existing one.
 
-{{< img src="datadog_cloudcraft/overlays/cloudcraft_monitors_overlay_hover_panel.png" alt="Cloudcraft Monitors overlay hover panel showing a monitor count breakdown by status and the Investigate with Bits AI SRE button." style="width:80%;" >}}
+{{< img src="datadog_cloudcraft/overlays/cloudcraft_monitors_overlay_hover_panel.png" alt="Cloudcraft Monitors overlay hover panel showing a monitor count breakdown by status and the Investigate with Bits Investigation button." style="width:80%;" >}}
 
-For more information, see [Bits AI SRE][1].
+For more information, see [Bits Investigation][1].
 
 ### Side panel
 
-Click a monitor pin on the diagram to open a side panel listing all monitors associated with that resource or service. For resource monitors, you can also initiate or view a [Bits AI SRE][1] investigation for any alerting monitor from this panel.
+Click a monitor pin on the diagram to open a side panel listing all monitors associated with that resource or service. For resource monitors, you can also initiate or view a [Bits Investigation][1] investigation for any alerting monitor from this panel.
 
 {{< img src="datadog_cloudcraft/overlays/cloudcraft_monitors_overlay_side_panel.png" alt="Cloudcraft Monitors overlay side panel showing a list of monitors associated with a resource." style="width:100%;" >}}
 

--- a/content/en/incident_response/incident_management/investigate/incident_ai.md
+++ b/content/en/incident_response/incident_management/investigate/incident_ai.md
@@ -9,7 +9,7 @@ aliases:
 further_reading:
 - link: "/bits_ai/bits_ai_sre/"
   tag: "Documentation"
-  text: "Learn about Bits AI SRE"
+  text: "Learn about Bits Investigation"
 - link: "/incident_response/incident_management/post_incident/postmortems"
   tag: "Documentation"
   text: "Generate AI-assisted postmortems"
@@ -55,11 +55,11 @@ Use natural language prompts to request information or take action from Slack:
 | Find related incidents             | `@Datadog Are there any related incidents?`<br />`@Datadog Find me incidents related to DDoS attacks from the past month`                       |
 | Early detection inquiry            | `@Datadog A customer is unable to check out. Is there an incident?`<br />`@Datadog Are there any incidents now impacting the payments service?` |
 
-## Trigger a Bits AI SRE investigation {#bits-ai-investigation}
+## Trigger a Bits Investigation {#bits-ai-investigation}
 
-Start a Bits AI SRE investigation directly from your incident Slack channel or the Datadog Incident Management web UI, without leaving your incident response workflow. This reduces context switching during active incidents and allows the AI agent to investigate alongside your team using the same shared context.
+Start a Bits Investigation directly from your incident Slack channel or the Datadog Incident Management web UI, without leaving your incident response workflow. This reduces context switching during active incidents and allows the AI agent to investigate alongside your team using the same shared context.
 
-Bits AI SRE must be enabled for your organization and you can only trigger an investigation from a **properly configured Datadog Incident Management Slack channel**. The Incident Investigation flow only activates when the system detects a valid incident channel.
+Bits Investigation must be enabled for your organization and you can only trigger an investigation from a **properly configured Datadog Incident Management Slack channel**. The Incident Investigation flow only activates when the system detects a valid incident channel.
 
 **From Slack,** type `@Datadog investigate` in the incident channel to kick off an investigation during an active incident. You can include additional context inline to help the agent narrow its scope from the start:
 
@@ -70,15 +70,15 @@ Bits AI SRE must be enabled for your organization and you can only trigger an in
 
 When triggered, the agent automatically pulls in the incident's timeline, linked telemetry signals (traces, metrics, and logs), and any context you provide in the prompt. It then posts updates back to the channel as a thread reply, with a final root cause summary and recommended next steps surfaced to the broader channel when the investigation completes.
 
-{{< img src="incident_response/incident_management/incident_ai/Triggering_investigations_slack.png" alt="A Datadog incident Slack channel showing a completed Bits AI SRE investigation with root cause findings and a View Full Investigation button" >}}
+{{< img src="incident_response/incident_management/incident_ai/Triggering_investigations_slack.png" alt="A Datadog incident Slack channel showing a completed Bits Investigation with root cause findings and a View Full Investigation button" >}}
 
 **From the web UI**, you can trigger an investigation directly from the "Investigation" section on the incident overview page.
 
-{{< img src="incident_response/incident_management/incident_ai/Triggering_investigations_web.png" alt="The Incident Management overview page showing a completed Bits AI SRE investigation in the Investigation section with a View Full Investigation button" >}}
+{{< img src="incident_response/incident_management/incident_ai/Triggering_investigations_web.png" alt="The Incident Management overview page showing a completed Bits Investigation in the Investigation section with a View Full Investigation button" >}}
 
-When triggered, the investigation is embedded in the incident web UI, and Bits AI SRE appears as a responder in the Responder Roles section of the page.
+When triggered, the investigation is embedded in the incident web UI, and Bits Investigation appears as a responder in the Responder Roles section of the page.
 
-For a full walkthrough of the investigation workflow, see [Bits AI SRE][4].
+For a full walkthrough of the investigation workflow, see [Bits Investigation][4].
 
 ## Further reading
 

--- a/content/en/mobile/_index.md
+++ b/content/en/mobile/_index.md
@@ -100,7 +100,7 @@ To log out, navigate to the **Settings** page on the mobile app and click on **L
 
 The On-Call page provides a comprehensive view of On-Call shifts, schedules, pages, and escalation policies. You can filter the information by user, team, urgency, status, or date to quickly find relevant details. Tapping **Escalate** prompts you to confirm the escalation to the next policy level. Tapping **Declare Incident** prompts you to enter a title and provide relevant incident attributes.
 
-You can initiate a page to an individual or team, and also override existing shifts by tapping on the shift you would like to override. You can view Bits AI SRE monitor investigations for initial findings and conclusions. For more information, see [Datadog On-Call][20].
+You can initiate a page to an individual or team, and also override existing shifts by tapping on the shift you would like to override. You can view Bits Investigation monitor investigations for initial findings and conclusions. For more information, see [Datadog On-Call][20].
 
 To configure On-Call notifications on your mobile device, see the guide to [Set up your Mobile Device for Datadog On-Call][21].
 
@@ -287,23 +287,23 @@ On the Services page, you can view, search and filter all services that you have
 {{% /tab %}}
 {{< /tabs >}}
 
-On the Bits AI home page, you can ask questions about your organization's system health. Bits AI supports natural language querying for logs and APM traces. For more information, see [Bits AI Assistant][27].
+On the Bits AI home page, you can ask questions about your organization's system health. Bits AI supports natural language querying for logs and APM traces. For more information, see [Bits Chat][27].
 
-### Bits AI SRE
+### Bits Investigation
 {{< tabs >}}
 {{% tab "iOS" %}}
 
-{{< img src="service_management/mobile/ios_bits_sre.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Bits AI SRE investigation results displayed on an On-Call page">}}
+{{< img src="service_management/mobile/ios_bits_sre.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Bits Investigation results displayed on an On-Call page">}}
 
 {{% /tab %}}
 {{% tab "Android" %}}
 
-{{< img src="service_management/mobile/android_bits_sre.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Bits AI SRE investigation results displayed on an On-Call page">}}
+{{< img src="service_management/mobile/android_bits_sre.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Bits Investigation results displayed on an On-Call page">}}
 
 {{% /tab %}}
 {{< /tabs >}}
 
-When enabled, Bits AI SRE initiates investigations directly on On-Call pages. These investigations present initial findings and conclusions to help responders identify potential root causes and next steps. For more information, see [Bits AI SRE][28].
+When enabled, Bits Investigation initiates investigations directly on On-Call pages. These investigations present initial findings and conclusions to help responders identify potential root causes and next steps. For more information, see [Bits Investigation][28].
 
 ## Frequently Asked Question
 ### How do I remain logged into the mobile app?

--- a/content/en/security/code_security/_index.md
+++ b/content/en/security/code_security/_index.md
@@ -4,7 +4,7 @@ disable_toc: false
 further_reading:
 - link: "https://www.datadoghq.com/blog/bitsai-dev-agent-code-security"
   tag: "Blog"
-  text: "Introducing Bits AI Dev Agent for Code Security"
+  text: "Introducing Bits Code for Code Security"
 - link: "https://www.datadoghq.com/blog/remediate-faster-code-security"
   tag: "Blog"
   text: "Remediate transitive vulnerabilities faster with Datadog Software Composition Analysis"

--- a/content/en/security/code_security/static_analysis/_index.md
+++ b/content/en/security/code_security/static_analysis/_index.md
@@ -9,7 +9,7 @@ algolia:
 further_reading:
 - link: "https://www.datadoghq.com/blog/bitsai-dev-agent-code-security"
   tag: "Blog"
-  text: "Introducing Bits AI Dev Agent for Code Security"
+  text: "Introducing Bits Code for Code Security"
 - link: https://www.datadoghq.com/blog/code-security-secret-scanning
   tag: Blog
   text: Detect and block exposed credentials with Datadog Secret Scanning

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Using LLMs to filter out false positives from static code analysis'
     - link: "https://www.datadoghq.com/blog/bitsai-dev-agent-code-security"
       tag: "Blog"
-      text: "Introducing Bits AI Dev Agent for Code Security"
+      text: "Introducing Bits Code for Code Security"
 ---
 
 Static Code Analysis (SAST) uses AI to help automate detection, validation, and remediation across the vulnerability management lifecycle.
@@ -145,7 +145,7 @@ Each finding includes a section with an explanation of the assessment. You can p
 
 ## Remediation
 
-Datadog SAST uses the [Bits AI Dev Agent][10] to generate code fixes for vulnerabilities. You can remediate individual vulnerabilities or fix multiple vulnerabilities using bulk remediation campaigns.
+Datadog SAST uses the [Bits Code][10] to generate code fixes for vulnerabilities. You can remediate individual vulnerabilities or fix multiple vulnerabilities using bulk remediation campaigns.
 
 To view and remediate vulnerabilities:
 
@@ -170,7 +170,7 @@ Selecting this option opens a **Create a new Bits AI Bulk Fix Campaign** modal w
 - **PR grouping options**: How Bits AI should group findings into pull requests (for example, one PR per repository, file, or finding). You can also limit the number of open PRs and the number of findings per PR.
 - **Custom instructions** (optional): Additional guidance for how Bits AI should generate fixes, such as changelog requirements or pull request title formatting.
 
-After you create a campaign, Bits AI Dev Agent loads the in-scope findings, generates patches based on your grouping rules, and (if enabled) creates pull requests. You can review and edit each session before merging changes.
+After you create a campaign, Bits Code loads the in-scope findings, generates patches based on your grouping rules, and (if enabled) creates pull requests. You can review and edit each session before merging changes.
 
 <div class="alert alert-info">
 <ul>
@@ -181,11 +181,11 @@ After you create a campaign, Bits AI Dev Agent loads the in-scope findings, gene
 
 #### View campaign progress
 
-To view all campaigns, navigate to [**Bits AI** > **Dev Agent** > **Code Sessions** > **Campaigns**][12].
+To view all campaigns, navigate to [**Bits AI** > **Bits Code** > **Code Sessions** > **Campaigns**][12].
 
-Click a campaign to view details including session status, pull requests by repository, and remediated findings. You can click on individual sessions to review, edit, and merge fixes with the [Bits AI Dev Agent][10].
+Click a campaign to view details including session status, pull requests by repository, and remediated findings. You can click on individual sessions to review, edit, and merge fixes with the [Bits Code][10].
 
-{{< img src="/code_security/static_analysis/campaigner-hero-image.png" alt="Campaigns page in Bits AI Dev Agent" style="width:100%;">}}
+{{< img src="/code_security/static_analysis/campaigner-hero-image.png" alt="Campaigns page in Bits Code" style="width:100%;">}}
 
 ### Remediation session details
 
@@ -200,7 +200,7 @@ To open the remediation session, select the vulnerability from the [**Vulnerabil
 
 You can also navigate to remediation sessions through the [**Campaigns**][12] and [**Code Sessions**][7] views.
 
-{{< img src="/code_security/static_analysis/single-session-sql-injection-fix-light-png.png" alt="Concluded remediation session in Bits AI Dev Agent showing generated fixes and pull request options" style="width:100%;">}}
+{{< img src="/code_security/static_analysis/single-session-sql-injection-fix-light-png.png" alt="Concluded remediation session in Bits Code showing generated fixes and pull request options" style="width:100%;">}}
 
 ## Further reading
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -156,7 +156,7 @@ This method avoids unnecessary CI failures and saves developer time.
 
 ## AI-powered flaky test fixes
 
-Bits AI Dev Agent can automatically diagnose and fix flaky tests that have been detected by Test Optimization. When a flaky test is identified, Bits AI analyzes the test failure patterns and generates production-ready fixes that can be submitted as GitHub pull requests.
+Bits Code can automatically diagnose and fix flaky tests that have been detected by Test Optimization. When a flaky test is identified, Bits AI analyzes the test failure patterns and generates production-ready fixes that can be submitted as GitHub pull requests.
 
 For Bits AI to create a fix, the flaky test must meet the following criteria:
 - **Failure rate**: At least 5%
@@ -164,11 +164,11 @@ For Bits AI to create a fix, the flaky test must meet the following criteria:
 - **Failed pipelines**: At least 2 pipelines
 - **Branch**: Must have flaked in the default branch
 
-{{< img src="tests/bits_ai_flaky_test_fixes-2.png" alt="Bits AI Dev Agent displaying a proposed fix for a flaky test" style="width:100%;" >}}
+{{< img src="tests/bits_ai_flaky_test_fixes-2.png" alt="Bits Code displaying a proposed fix for a flaky test" style="width:100%;" >}}
 
 ### Setup
 
-To enable AI-powered flaky test fixes, enable Bits AI Dev Agent for Test Optimization by following the setup instructions in the [Bits AI Dev Agent documentation][16]. Bits AI Dev Agent automatically create fixes for flaky tests detected by Test Optimization.
+To enable AI-powered flaky test fixes, enable Bits Code for Test Optimization by following the setup instructions in the [Bits Code documentation][16]. Bits Code automatically create fixes for flaky tests detected by Test Optimization.
 
 <div class="alert alert-info">A flaky test must have at least one failed execution that includes both <code>@error.message</code> and <code>@test.source.file</code> tags to be eligible for a fix. Generating a fix may take some time.</div>
 


### PR DESCRIPTION
## What

Updates all English documentation references to reflect the Bits product renames:

| Old name(s) | New name |
|---|---|
| Bits Assistant, Bits AI Assistant | **Bits Chat** |
| Bits AI SRE | **Bits Investigation** |
| Bits Dev, Bits AI Dev, Bits AI Dev Agent, Bits Dev Agent | **Bits Code** |
| Agent Builder, Datadog Agent Builder | **Bits Agent Builder** |

28 content files in `content/en/` plus the English side nav (`config/_default/menus/main.en.yaml`).

## Scope & decisions

- **Prose only.** URLs, directory names (`bits_ai_sre/`, `bits_ai_dev_agent/`, `actions/agents/`), image filenames, anchors, and permission **codes** (e.g. `bits_dev_write`) are left unchanged to avoid broken links. Nav `url:`/`identifier:` fields unchanged; only `name:` labels updated.
- **Permission display names** updated, codes preserved: "Bits Assistant Access" → "Bits Chat Access"; "Bits Dev Agent Write" → "Bits Code Write" (code stays `bits_dev_write`).
- **Nav labels** smoothed: "Bits AI > Assistant" → "Bits AI > Chat"; "Bits AI > Dev Agent" → "Bits AI > Code".
- **Redundancy collapsed:** "a Bits AI SRE investigation" → "a Bits Investigation" (not "...Investigation investigation").
- **Left untouched:** the umbrella brand **Bits AI** and the separate **Bits AI Security Analyst** product.
- English only — translated content and nav files (es/fr/ja/ko) are not included.

## Follow-ups for reviewers

- Confirm the inferred nav menu item names ("Chat", "Code") match the actual UI.
- Screenshot **content** still shows old names; alt text was updated but images need re-capturing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)