### PR TITLE
Add SMTP docs for Status pages and Org Settings

### DIFF
--- a/content/en/account_management/org_settings.md
+++ b/content/en/account_management/org_settings.md
@@ -109,6 +109,10 @@ The {{< ui >}}Audit Trail{{< /ui >}} tab in the Organization Settings page opens
 
 The {{< ui >}}Audit Trail Settings{{< /ui >}} tab allows you to set the retention period of audit trails and enable archiving to other cloud storage services.
 
+### SMTP configuration
+
+The [**SMTP Configuration**][17] page lets you connect your own SMTP server so that status page subscription emails are sent from your own domain.
+
 ## General
 
 ### Preferences
@@ -169,3 +173,4 @@ Users with the `Org Management` permission can enable or disable the idle time s
 [14]: /account_management/safety_center
 [15]: /account_management/org_settings/mobile_third_party_access
 [16]: /help/
+[17]: /account_management/org_settings/smtp_configuration

--- a/content/en/account_management/org_settings/smtp_configuration.md
+++ b/content/en/account_management/org_settings/smtp_configuration.md
@@ -1,0 +1,51 @@
+---
+title: SMTP Configuration
+description: Connect your own SMTP server to send status page subscription emails from your own domain.
+further_reading:
+- link: "/incident_response/status_pages/"
+  tag: "Documentation"
+  text: "Status Pages"
+---
+
+## Overview
+
+The SMTP Configuration page in Organization Settings lets you connect your own SMTP server so that status page subscription emails are sent from your own domain instead of the default Datadog sender address. This improves branding, builds subscriber trust, and reduces the likelihood of notifications being filtered as spam.
+
+<div class="alert alert-danger">You must have <code>org_management</code> permissions to add and manage SMTP servers.</div>
+
+## Add an SMTP server
+
+1. In Datadog, go to [**Organization Settings** > **SMTP Configuration**][1].
+1. Click **Add SMTP Server**.
+1. Fill in the required fields from your email provider and click **Add SMTP Server**.
+1. Select the server and click **Test Connection** to verify the configuration.
+
+After you add and validate your SMTP server, you can select it as the email sender domain on your [status pages][2].
+
+## Supported providers
+
+The following email providers are supported:
+
+| Provider | SMTP Host | TLS Ports |
+|---|---|---|
+| SendGrid | `smtp.sendgrid.net` | 587, 465 |
+| Mailgun | `smtp.mailgun.org` | 587, 465 |
+| Amazon SES | `*.amazonaws.com` | 587, 465 |
+| Postmark | `smtp.postmarkapp.com` | 587, 465 |
+| SparkPost | `smtp.sparkpostmail.com` | 587, 465 |
+| Mandrill (Mailchimp Transactional) | `smtp.mandrillapp.com` | 587, 465 |
+| Brevo (formerly Sendinblue) | `smtp-relay.brevo.com` | 587, 465 |
+| Elastic Email | `smtp.elasticemail.com` | 587, 465 |
+| Google Workspace / Gmail | `smtp.gmail.com` | 587, 465 |
+| Google Workspace / Gmail (Relay) | `smtp-relay.gmail.com` | 587, 465 |
+| Microsoft 365 / Outlook | `smtp.office365.com` | 587, 465 |
+
+If your provider isn't listed, [submit a request][3] to have it added.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://app.datadoghq.com/organization-settings/smtp-configuration/smtp-servers
+[2]: /incident_response/status_pages/#configure-a-custom-email-sender-domain
+[3]: https://app.datadoghq.com/forms/share/0e60439939478dc5063c2bc665a8cfdaf1b9ec19f6df55821c82096cbd3f9672

--- a/content/en/incident_response/status_pages/_index.md
+++ b/content/en/incident_response/status_pages/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Status Pages
+description: Communicate service availability, incidents, and planned maintenance with customers or internal stakeholders through a shareable status page.
 aliases:
 - /service_management/status_pages/
 further_reading:
@@ -202,9 +203,20 @@ For **internal** status pages, the subscription process is the same, but users m
 
 {{< img src="/service_management/status_pages/status_pages_subscription_1.png" alt="Screenshot of the Status Page subscription modal with fields filled out" style="width:70%;" >}}
 
+## Configure a custom email sender domain
+
+By default, status page subscription emails are sent from a Datadog email address. To send notifications from your own domain, configure a custom SMTP server in Organization Settings.
+
+<div class="alert alert-danger">The <code>org_management</code> permission is required to add SMTP servers in Organization Settings. The <code>status_pages_settings_write</code> permission is required to select the email sender domain on a status page.</div>
+
+1. In your status page, go to **Settings** > **Subscriptions**.
+1. Under **Email Sender Domain**, click **Organization Settings**.
+1. In Organization Settings, [add and validate an SMTP server][3].
+1. Return to **Settings** > **Subscriptions** and select your SMTP server as the email sender domain.
+
 ## Set a custom domain
 
-To match your branding, you have the option to map your status page to a custom domain like `status.acme.com`.
+To match your branding, you have the option to map your status page URL to a custom domain like `status.acme.com`. This is separate from [configuring a custom email sender domain](#configure-a-custom-email-sender-domain), which controls the from address on subscription emails.
 
 1. From your status page, click **Settings**.
 1. Select **Custom Domain**.
@@ -217,7 +229,7 @@ To match your branding, you have the option to map your status page to a custom 
 
 - DNS propagation may take several minutes.
 - You can revert to the default Datadog domain at any time.
-- Ensure DNS changes are made by someone with access to your domain registrar.
+- DNS changes must be made by someone with access to your domain registrar.
 
 ## Further reading
 
@@ -225,3 +237,4 @@ To match your branding, you have the option to map your status page to a custom 
 
 [1]: /account_management/rbac/
 [2]: https://app.datadoghq.com/status-pages
+[3]: /account_management/org_settings/smtp_configuration

--- a/content/en/incident_response/status_pages/_index.md
+++ b/content/en/incident_response/status_pages/_index.md
@@ -209,7 +209,7 @@ By default, status page subscription emails are sent from a Datadog email addres
 
 <div class="alert alert-danger">The <code>org_management</code> permission is required to add SMTP servers in Organization Settings. The <code>status_pages_settings_write</code> permission is required to select the email sender domain on a status page.</div>
 
-1. In your status page, go to **Settings** > **Subscriptions**.
+1. On your status page, go to **Settings** > **Subscriptions**.
 1. Under **Email Sender Domain**, click **Organization Settings**.
 1. In Organization Settings, [add and validate an SMTP server][3].
 1. Return to **Settings** > **Subscriptions** and select your SMTP server as the email sender domain.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Resolves [DOCS-14490](https://datadoghq.atlassian.net/browse/DOCS-14490)
- Add SMTP docs in Org Settings
- Add section to Status Pages to implement this feature

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
**Do not merge**: Pending GA next week


[DOCS-14490]: https://datadoghq.atlassian.net/browse/DOCS-14490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ