### PR TITLE
[DOCS-14572] Add memory buffer configurability to comparison table

### DIFF
--- a/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
+++ b/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
@@ -57,7 +57,7 @@ This table compares the differences between the memory and disk buffer.
 
 | Property                                                 | Memory Buffer             | Disk Buffer                          |
 | -------------------------------------------------------- | ------------------------- | ------------------------------------ |
-| Default size                                             | Configurable<br>Default: 500 events<br>Minimum buffer size: 1 MB<br>Maximum buffer size: 128 GB | Configurable<br>Minimum buffer size: 256 MB<br> Maximum buffer size: 500 GB       |
+| Default size                                             | Configurable<br>Minimum buffer size: 1 MB<br>Maximum buffer size: 128 GB | Configurable<br>Minimum buffer size: 256 MB<br> Maximum buffer size: 500 GB       |
 | Performance                                              | Higher                    | Lower                                |
 | Durability through an unexpected Worker restart or crash | None                      | Events flushed to disk latest every 500 ms        |
 | Data loss due to an unexpected restart or crash          | All buffered data is lost | All buffered data is retained        |

--- a/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
+++ b/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
@@ -57,7 +57,7 @@ This table compares the differences between the memory and disk buffer.
 
 | Property                                                 | Memory Buffer             | Disk Buffer                          |
 | -------------------------------------------------------- | ------------------------- | ------------------------------------ |
-| Default size                                             | 500 events                | Configurable<br>Minimum buffer size: 256 MB<br> Maximum buffer size: 500 GB       |
+| Default size                                             | Configurable<br>Default: 500 events<br>Minimum buffer size: 1 MB<br>Maximum buffer size: 128 GB | Configurable<br>Minimum buffer size: 256 MB<br> Maximum buffer size: 500 GB       |
 | Performance                                              | Higher                    | Lower                                |
 | Durability through an unexpected Worker restart or crash | None                      | Events flushed to disk latest every 500 ms        |
 | Data loss due to an unexpected restart or crash          | All buffered data is lost | All buffered data is retained        |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the table to say that the memory buffer size is configurable.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes