### PR TITLE
docs: fix broken anchor link in Workflow Automation Test and Debug page

### DIFF
--- a/content/en/actions/workflows/test_and_debug.md
+++ b/content/en/actions/workflows/test_and_debug.md
@@ -61,5 +61,5 @@ The initial run history for a workflow provides a panel with the list of previou
 
 <br>Do you have questions or feedback? Join the **#workflows** channel on the [Datadog Community Slack][10].
 
-[6]: #test-expressions-and-functions
+[6]: /actions/workflows/expressions/
 [10]: https://chat.datadoghq.com/


### PR DESCRIPTION
## docs: fix broken reference link on Workflow Automation Test and Debug page

---

### Problem

The `actions/workflows/test_and_debug` page contains this reference link definition at the bottom of the file:

```
[6]: #test-expressions-and-functions
```

This anchor (`#test-expressions-and-functions`) does not exist anywhere on this page. When a user clicks the link:

> "For more information, see [Test expressions and functions][6]."

...it goes nowhere.

### Fix

Updated reference `[6]` to point to the correct Expressions page:

**Before:**
```
[6]: #test-expressions-and-functions
```

**After:**
```
[6]: /actions/workflows/expressions/
```

**File changed:** `content/en/actions/workflows/test_and_debug.md`

---

### Checklist
- [x] Docs only change — no source code modified
- [x] Verified `/actions/workflows/expressions/` is the correct destination page
- [x] Link text in the page body is unchanged
- [x] No other lines were modified