### PR TITLE
AAP Standalone: clarify billing motivation and scope

### DIFF
--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -28,7 +28,7 @@ Standalone App and API Protection is supported for the following SDK versions:
 | Go       | N/A     |
 | Java     | 1.47.0  |
 | Node.js  | 5.40.0  |
-| PHP      | N/A     |
+| PHP      | 1.8.0   |
 | Python   | 3.2.0   |
 | Ruby     | 2.13.0  |
 

--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -1,8 +1,6 @@
 ---
 title: Set Up App and API Protection Without APM or Infrastructure Monitoring
 disable_toc: false
-aliases:
-- /security/application_security/guide/standalone_application_security/
 ---
 
 Datadog App and API Protection (AAP) is built on top of [APM][3] and runs alongside [Infrastructure Monitoring][7] by default. While Datadog recommends using AAP together with APM and Infrastructure Monitoring to adopt DevSecOps practices, you can also run AAP on its own. This configuration is referred to as Standalone App and API Protection.

--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -23,7 +23,7 @@ Standalone App and API Protection is supported for the following SDK versions:
 | Language | Version |
 | -------- | ------- |
 | .NET     | 3.12.0  |
-| Go       | N/A     |
+| Go       | 1.73.0  |
 | Java     | 1.47.0  |
 | Node.js  | 5.40.0  |
 | PHP      | 1.8.0   |

--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -45,14 +45,14 @@ To disable Infrastructure Monitoring, set the Datadog Agent infrastructure mode 
 
 For more details, see [Datadog Agent infrastructure mode][8].
 
-### Disable APM tracing and enable AAP on the SDK
+### Disable APM tracing and enable AAP on the service
 
 On the instrumented service, set the following environment variables:
 
 - `DD_APM_TRACING_ENABLED=false`
 - `DD_APPSEC_ENABLED=true`
 
-`DD_APM_TRACING_ENABLED=false` limits the amount of APM data sent to the minimum required by App and API Protection. This environment variable can be combined with other [App and API Protection configuration options][4].
+`DD_APM_TRACING_ENABLED=false` disabled APM tracing and limits the amount of APM data sent to the minimum required by App and API Protection. This environment variable can be combined with other [App and API Protection configuration options][4].
 
 
 [1]: /security/workload_protection/

--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -1,15 +1,21 @@
 ---
-title: Set Up App and API Protection Products without using APM
+title: Set Up App and API Protection Without APM or Infrastructure Monitoring
 disable_toc: false
+aliases:
+- /security/application_security/guide/standalone_application_security/
 ---
 
-Datadog AAP is built on top of [APM][3]. While Datadog recommends using AAP with APM and adopting DevSecOps practices, you can also use these security products without using APM. This configuration is referred to as Standalone App and API Protection. This guide explains how to set up Standalone App and API Protection.
+Datadog App and API Protection (AAP) is built on top of [APM][3] and runs alongside [Infrastructure Monitoring][7] by default. While Datadog recommends using AAP together with APM and Infrastructure Monitoring to adopt DevSecOps practices, you can also run AAP on its own. This configuration is referred to as Standalone App and API Protection.
+
+Running standalone allows to be billed primarily for App and API Protection. Some APM intake is still present to support AAP features (for example, security traces), and is expected to appear on your bill.
+
+This guide explains how to disable APM tracing and infrastructure monitoring.
 
 ## Prerequisites
 
 This guide assumes you have the following:
 
-- **Datadog Agent:** [Install the Datadog Agent][6] and configure it for your application's operating system, container, cloud, or virtual environment. [Infrastructure Monitoring][7] is enabled by default in the Datadog Agent; disabling it requires version 7.77.0 or newer.
+- **Datadog Agent:** [Install the Datadog Agent][6] and configure it for your application's operating system, container, cloud, or virtual environment. Disabling Infrastructure Monitoring requires Datadog Agent version 7.77.0 or newer.
 - **Supported SDK:** The Datadog SDK used by your application or service supports App and API Protection. For more details, see the guide for [App and API Protection][4].
 
 ## Compatibility
@@ -28,22 +34,27 @@ Standalone App and API Protection is supported for the following SDK versions:
 
 ## Setup
 
-### Agent configuration
+Standalone App and API Protection requires two pieces of configuration: disabling Infrastructure Monitoring on the Datadog Agent, and disabling APM tracing on the SDK while enabling AAP.
 
-Standalone App and API Protection uses the same Datadog Agent setup as APM. For more details, see the guide for [installing the Datadog Agent][6].
+### Disable Infrastructure Monitoring on the Datadog Agent
 
-To disable Infrastructure Monitoring, set the Datadog Agent infrastructure mode to `none` using either:
+Standalone App and API Protection uses the same Datadog Agent installation as APM. For installation steps, see [Install the Datadog Agent][6].
+
+To disable Infrastructure Monitoring, set the Datadog Agent infrastructure mode to `none` (requires Datadog Agent 7.77.0 or newer) using either:
 
 - The `DD_INFRASTRUCTURE_MODE=none` environment variable
 - The `infrastructure_mode: none` setting in the `datadog.yaml` configuration file
 
-For more details, see the configuration page for [the Datadog Agent infrastructure mode][8].
+For more details, see [Datadog Agent infrastructure mode][8].
 
-### SDK configuration
+### Disable APM tracing and enable AAP on the SDK
 
-Standalone App and API Protection is configured at the SDK level using the following environment variables on the instrumented service: `DD_APM_TRACING_ENABLED=false` and `DD_APPSEC_ENABLED=true`.
+On the instrumented service, set the following environment variables:
 
-`DD_APM_TRACING_ENABLED=false` limits the amount of APM data sent to the minimum required by App and API Protection. The environment variable can be combined with other [App and API Protection configuration options][4].
+- `DD_APM_TRACING_ENABLED=false`
+- `DD_APPSEC_ENABLED=true`
+
+`DD_APM_TRACING_ENABLED=false` limits the amount of APM data sent to the minimum required by App and API Protection. This environment variable can be combined with other [App and API Protection configuration options][4].
 
 
 [1]: /security/workload_protection/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Improves the [Standalone App and API Protection guide](https://docs.datadoghq.com/security/application_security/guide/standalone_application_security/):

- Updates the title to cover both APM and Infrastructure Monitoring, matching the actual setup steps. Adds an alias so the existing URL keeps resolving.
- Adds a short paragraph explaining the billing motivation for running AAP standalone, and notes that some residual APM intake is expected.
- Repeats the Datadog Agent 7.77.0 requirement inline with the ``DD_INFRASTRUCTURE_MODE=none`` snippet so it is visible at the point of use, not only in the Prerequisites section.
- Reorganizes Setup into two action-named subsections and reflows the SDK environment variables as a list.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes