### PR TITLE
Fix OCI troubleshooting: invalid API/app key credentials (ECI-1737)

### DIFF
--- a/content/en/integrations/guide/oci-integration-troubleshooting.md
+++ b/content/en/integrations/guide/oci-integration-troubleshooting.md
@@ -76,5 +76,5 @@ Still need help? Contact [Datadog support][3].
 [3]: /help/
 [4]: https://cloud.oracle.com/identity/domains/policies
 [5]: https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/mmocs/requesting-service-limit-change.html
-[6]: /organization-settings/api-keys
-[8]: /organization-settings/application-keys
+[6]: https://app.datadoghq.com/organization-settings/api-keys
+[8]: https://app.datadoghq.com/organization-settings/application-keys

--- a/content/en/integrations/guide/oci-integration-troubleshooting.md
+++ b/content/en/integrations/guide/oci-integration-troubleshooting.md
@@ -18,9 +18,26 @@ See configuration issues with your OCI integration on the **Issues** tab of the 
 
 ## Invalid Datadog API or app key credentials
 
-This occurs when Datadog API or App keys configured in the OCI integration tile have expired, or when OCI credentials used by Datadog are incorrect. To remediate this, reapply the existing Datadog integration ORM Stack in your OCI tenancy. 
+This occurs when Datadog API or app keys configured in the OCI integration tile have expired or are invalid. To remediate this, update the key in your integration deployment and reapply it.
 
-**Note**: Do not modify the stack before reapplying it.
+{{< tabs >}}
+{{% tab "QuickStart (ORM stack)" %}}
+
+1. Navigate to [Oracle Resource Manager stacks][6] and locate your Datadog QuickStart stack.
+2. Click **Edit** on the stack.
+3. Click **Next** to reach the **Configure Variables** page.
+4. Update the **Datadog API Key** and/or **Datadog Application Key** values with valid credentials.
+5. Click **Next**, then click **Save changes**.
+6. Click **Apply** to apply the updated configuration.
+
+{{% /tab %}}
+{{% tab "Terraform" %}}
+
+1. Update the `datadog_api_key` and/or `datadog_app_key` values in your Terraform `.tf` file with valid credentials.
+2. Run `terraform apply` to apply the updated configuration.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Required OCI IAM permissions are missing
 
@@ -45,3 +62,4 @@ Still need help? Contact [Datadog support][3].
 [3]: /help/
 [4]: https://cloud.oracle.com/identity/domains/policies
 [5]: https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/mmocs/requesting-service-limit-change.html
+[6]: https://cloud.oracle.com/resourcemanager/stacks

--- a/content/en/integrations/guide/oci-integration-troubleshooting.md
+++ b/content/en/integrations/guide/oci-integration-troubleshooting.md
@@ -37,7 +37,7 @@ To remediate this, generate new credentials and update your integration deployme
 {{< tabs >}}
 {{% tab "QuickStart (ORM stack)" %}}
 
-1. Navigate to [Oracle Resource Manager stacks][7] and locate your Datadog QuickStart stack.
+1. Navigate to [Oracle Resource Manager stacks](https://cloud.oracle.com/resourcemanager/stacks) and locate your Datadog QuickStart stack.
 2. Click **Edit** on the stack.
 3. Click **Next** to reach the **Configure Variables** page.
 4. Update the **Datadog API Key** and **Datadog Application Key** values with the new credentials.
@@ -77,5 +77,4 @@ Still need help? Contact [Datadog support][3].
 [4]: https://cloud.oracle.com/identity/domains/policies
 [5]: https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/mmocs/requesting-service-limit-change.html
 [6]: /organization-settings/api-keys
-[7]: https://cloud.oracle.com/resourcemanager/stacks
 [8]: /organization-settings/application-keys

--- a/content/en/integrations/guide/oci-integration-troubleshooting.md
+++ b/content/en/integrations/guide/oci-integration-troubleshooting.md
@@ -18,22 +18,35 @@ See configuration issues with your OCI integration on the **Issues** tab of the 
 
 ## Invalid Datadog API or app key credentials
 
-This occurs when Datadog API or app keys configured in the OCI integration tile have expired or are invalid. To remediate this, update the key in your integration deployment and reapply it.
+This occurs when the Datadog application key configured in the OCI integration has expired or is invalid. Look for the following error in your ORM stack's job logs to confirm:
+
+```
+Error: unexpected response code '403': {"errors":["Forbidden"]}
+
+  with module.integration[0].restapi_object.datadog_tenancy_integration,
+  on modules/integration/main.tf line 15, in resource "restapi_object" "datadog_tenancy_integration":
+  15: resource "restapi_object" "datadog_tenancy_integration" {
+```
+
+To remediate this:
+
+1. Go to [Application Keys][6] in your Datadog organization settings and generate a new application key.
+2. Update your integration deployment with the new key and reapply it.
 
 {{< tabs >}}
 {{% tab "QuickStart (ORM stack)" %}}
 
-1. Navigate to [Oracle Resource Manager stacks][6] and locate your Datadog QuickStart stack.
+1. Navigate to [Oracle Resource Manager stacks][7] and locate your Datadog QuickStart stack.
 2. Click **Edit** on the stack.
 3. Click **Next** to reach the **Configure Variables** page.
-4. Update the **Datadog API Key** and/or **Datadog Application Key** values with valid credentials.
-5. Click **Next**, then click **Save changes**.
-6. Click **Apply** to apply the updated configuration.
+4. Update the **Datadog Application Key** value with the new application key.
+5. Click **Next**.
+6. Click **Save changes**.
 
 {{% /tab %}}
 {{% tab "Terraform" %}}
 
-1. Update the `datadog_api_key` and/or `datadog_app_key` values in your Terraform `.tf` file with valid credentials.
+1. Update the `datadog_app_key` value in your Terraform `.tf` file with the new application key.
 2. Run `terraform apply` to apply the updated configuration.
 
 {{% /tab %}}
@@ -62,4 +75,5 @@ Still need help? Contact [Datadog support][3].
 [3]: /help/
 [4]: https://cloud.oracle.com/identity/domains/policies
 [5]: https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/mmocs/requesting-service-limit-change.html
-[6]: https://cloud.oracle.com/resourcemanager/stacks
+[6]: /organization-settings/application-keys
+[7]: https://cloud.oracle.com/resourcemanager/stacks

--- a/content/en/integrations/guide/oci-integration-troubleshooting.md
+++ b/content/en/integrations/guide/oci-integration-troubleshooting.md
@@ -18,7 +18,7 @@ See configuration issues with your OCI integration on the **Issues** tab of the 
 
 ## Invalid Datadog API or app key credentials
 
-This occurs when the Datadog application key configured in the OCI integration has expired or is invalid. Look for the following error in your ORM stack's job logs to confirm:
+This occurs when the Datadog API key or application key configured in the OCI integration has expired or is invalid. Both keys are validated during a stack apply. Look for the following error in your ORM stack's job logs to confirm:
 
 ```
 Error: unexpected response code '403': {"errors":["Forbidden"]}
@@ -28,10 +28,11 @@ Error: unexpected response code '403': {"errors":["Forbidden"]}
   15: resource "restapi_object" "datadog_tenancy_integration" {
 ```
 
-To remediate this:
+To remediate this, generate new credentials and update your integration deployment:
 
-1. Go to [Application Keys][6] in your Datadog organization settings and generate a new application key.
-2. Update your integration deployment with the new key and reapply it.
+1. Go to [API Keys][6] in your Datadog organization settings and generate a new API key.
+2. Go to [Application Keys][8] in your Datadog organization settings and generate a new application key.
+3. Update your integration deployment with the new keys and reapply it.
 
 {{< tabs >}}
 {{% tab "QuickStart (ORM stack)" %}}
@@ -39,14 +40,14 @@ To remediate this:
 1. Navigate to [Oracle Resource Manager stacks][7] and locate your Datadog QuickStart stack.
 2. Click **Edit** on the stack.
 3. Click **Next** to reach the **Configure Variables** page.
-4. Update the **Datadog Application Key** value with the new application key.
+4. Update the **Datadog API Key** and **Datadog Application Key** values with the new credentials.
 5. Click **Next**.
 6. Click **Save changes**.
 
 {{% /tab %}}
 {{% tab "Terraform" %}}
 
-1. Update the `datadog_app_key` value in your Terraform `.tf` file with the new application key.
+1. Update the `datadog_api_key` and `datadog_app_key` values in your Terraform `.tf` file with the new credentials.
 2. Run `terraform apply` to apply the updated configuration.
 
 {{% /tab %}}
@@ -75,5 +76,6 @@ Still need help? Contact [Datadog support][3].
 [3]: /help/
 [4]: https://cloud.oracle.com/identity/domains/policies
 [5]: https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/mmocs/requesting-service-limit-change.html
-[6]: /organization-settings/application-keys
+[6]: /organization-settings/api-keys
 [7]: https://cloud.oracle.com/resourcemanager/stacks
+[8]: /organization-settings/application-keys


### PR DESCRIPTION
## Summary

- Clarifies that both the Datadog API key and application key are validated during stack apply, and either can cause a `403 Forbidden` error from `restapi_object.datadog_tenancy_integration`
- Adds the specific error log block users should look for to confirm this is the cause
- Replaces the incorrect "re-apply without modifying" instruction with steps to regenerate both keys and update them before reapplying
- Fixes the ORM stack UI button label: **Save changes** (not "Apply")
- Covers both QuickStart (ORM stack) and Terraform users

## Test plan

- [ ] Verify rendered docs look correct with tabs
- [ ] Verify links to `/organization-settings/api-keys` and `/organization-settings/application-keys` resolve correctly

Fixes ECI-1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)