### PR TITLE
[DOCS-14561] Clarify as_count() effect on GAUGE metrics in monitors

### DIFF
--- a/content/en/metrics/custom_metrics/type_modifiers.md
+++ b/content/en/metrics/custom_metrics/type_modifiers.md
@@ -79,7 +79,11 @@ Depending on the metric type you applied them to, the behavior differs:
 {{% /tab %}}
 {{% tab "GAUGE" %}}
 
-`GAUGE` metric types represent the absolute and final value of a metric; `as_count()` and `as_rate()` modifiers have no effect on them.
+`GAUGE` metric types represent the absolute and final value of a metric; `as_count()` and `as_rate()` modifiers have no effect on how a gauge is stored or displayed in the Metrics Explorer.
+
+**Note**: In monitors, applying `as_count()` to a gauge metric changes the evaluation path for rollup-dependent functions like `pct_change()`:
+- Without `as_count()`: the function is applied per-bucket and those values are summed over the evaluation window, which can produce large negative values for sparse gauges.
+- With `as_count()`: the timeseries is bucketed and aggregated before the function is applied, matching the intended window-level computation.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -76,16 +76,16 @@ sum(last_5m):total
 
 In general, **`avg`** time aggregation with **`.as_rate()`** is reasonable, but **`sum`** aggregation with **`.as_count()`** is recommended for error rates. Aggregation methods other than **`sum`** do not make sense to use with (and cannot be used with) **`.as_count()`**.
 
-## GAUGE metrics and pct_change()
+## Gauge metrics and pct_change()
 
-The evaluation path also affects GAUGE metrics when used with rollup-dependent functions like `pct_change()`. Without `as_count()`, the monitor uses the classic evaluation path: `pct_change()` is computed per-bucket and those values are summed over the evaluation window. For sparse GAUGE metrics, this can produce values well below -100%.
+The evaluation path also affects gauge metrics when used with rollup-dependent functions like `pct_change()`. Without `as_count()`, the monitor uses the classic evaluation path: `pct_change()` is computed per-bucket and those values are summed over the evaluation window. For sparse gauge metrics, this can produce values well below -100%.
 
-| Path | Evaluation order | Effect on sparse GAUGE metrics |
+| Path | Evaluation order | Effect on sparse gauge metrics |
 |:-----|:-----------------|:-------------------------------|
 | **`classic_eval_path`** (no `as_count()`) | `pct_change()` applied per-bucket; values summed over the window | Can produce large negative values (for example, -1,500%) |
 | **`as_count_eval_path`** | Timeseries bucketed and aggregated first; `pct_change()` applied at the window level | Produces the intended window-level result |
 
-To use the count-style evaluation path on a GAUGE metric, add `as_count()` to the query.
+To use the count-style evaluation path on a gauge metric, add `as_count()` to the query.
 
 [Reach out to the Datadog support team][1] if you have any questions.
 

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -78,7 +78,7 @@ In general, **`avg`** time aggregation with **`.as_rate()`** is reasonable, but 
 
 ## Gauge metrics and pct_change()
 
-The evaluation path also affects gauge metrics when used with rollup-dependent functions like `pct_change()`. Without `as_count()`, the monitor uses the classic evaluation path: `pct_change()` is computed per-bucket and those values are summed over the evaluation window. For sparse gauge metrics, this can produce values well below -100%.
+The evaluation path also affects gauge metrics when used with rollup-dependent functions like `pct_change()`. Without `as_count()`, the monitor uses the classic evaluation path, in which `pct_change()` is computed per-bucket and those values are summed over the evaluation window. For sparse gauge metrics, this can produce values well below -100%.
 
 | Path | Evaluation order | Effect on sparse gauge metrics |
 |:-----|:-----------------|:-------------------------------|

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -76,6 +76,17 @@ sum(last_5m):total
 
 In general, **`avg`** time aggregation with **`.as_rate()`** is reasonable, but **`sum`** aggregation with **`.as_count()`** is recommended for error rates. Aggregation methods other than **`sum`** do not make sense to use with (and cannot be used with) **`.as_count()`**.
 
+## GAUGE metrics and pct_change()
+
+The evaluation path also affects GAUGE metrics when used with rollup-dependent functions like `pct_change()`. Without `as_count()`, the monitor uses the classic evaluation path: `pct_change()` is computed per-bucket and those values are summed over the evaluation window. For sparse GAUGE metrics, this can produce values well below -100%.
+
+| Path | Evaluation order | Effect on sparse GAUGE metrics |
+|:-----|:-----------------|:-------------------------------|
+| **`classic_eval_path`** (no `as_count()`) | `pct_change()` applied per-bucket; values summed over the window | Can produce large negative values (for example, -1,500%) |
+| **`as_count_eval_path`** | Timeseries bucketed and aggregated first; `pct_change()` applied at the window level | Produces the intended window-level result |
+
+To use the count-style evaluation path on a GAUGE metric, add `as_count()` to the query.
+
 [Reach out to the Datadog support team][1] if you have any questions.
 
 [1]: /help/

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -82,8 +82,8 @@ The evaluation path also affects gauge metrics when used with rollup-dependent f
 
 | Path | Evaluation order | Effect on sparse gauge metrics |
 |:-----|:-----------------|:-------------------------------|
-| **`classic_eval_path`** (no `as_count()`) | `pct_change()` applied per-bucket; values summed over the window | Can produce large negative values (for example, -1,500%) |
-| **`as_count_eval_path`** | Timeseries bucketed and aggregated first; `pct_change()` applied at the window level | Produces the intended window-level result |
+| **`classic_eval_path`** (no `as_count()`) | `pct_change()` is applied per-bucket, then values are summed over the window | Can produce large negative values (for example, -1,500%) |
+| **`as_count_eval_path`** | Timeseries is bucketed and aggregated first, then `pct_change()` is applied at the window level | Produces the intended window-level result |
 
 To use the count-style evaluation path on a gauge metric, add `as_count()` to the query.
 

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -7,7 +7,7 @@ aliases:
 
 ## Overview
 
-Queries using **`as_count()`** and **`as_rate()`** modifiers are calculated in ways that can yield different results in monitor evaluations. Monitors involving arithmetic and at least 1 **`as_count()`** modifier use a separate evaluation path that changes the order in which arithmetic and time aggregation are performed.
+Queries using **`as_count()`** and **`as_rate()`** modifiers are calculated in ways that can yield different results in monitor evaluations. Monitors involving at least one **`as_count()`** modifier use a separate evaluation path that changes the order in which operations and time aggregation are performed.
 
 ## Error rate example
 

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -1,6 +1,6 @@
 ---
 title: as_count() in Monitor Evaluations
-description: "Understanding how as_count() and as_rate() modifiers affect monitor evaluations and arithmetic operations in different evaluation paths."
+description: "Understanding how as_count() and as_rate() modifiers affect monitor evaluations and the order of operations in different evaluation paths."
 aliases:
   - /monitors/guide/as-count-monitor-evaluation
 ---

--- a/content/en/monitors/types/change-alert.md
+++ b/content/en/monitors/types/change-alert.md
@@ -91,7 +91,7 @@ This is a break down of the query with the following conditions:
     - To compare your notebook graph to the change alert monitor evaluation, scope your timeframe to match the change alert. 
     - For example, if you are looking to verify the value of a monitor evaluation over the last five minutes at 1:30, scope your notebook to 1:25 - 1:30. 
 
-**Note**: If your metric is a GAUGE type, the evaluation path affects how `pct_change()` is calculated. Without `as_count()`, the percentage change is computed per-bucket and those values are summed over the evaluation window, which can produce unexpectedly large negative values for sparse metrics. Add `as_count()` to the query to switch to the count-style evaluation path. See [as_count() in Monitor Evaluations][4] for details.
+**Note**: If your metric is a gauge type and `pct_change()` is producing unexpectedly large negative values, add `as_count()` to the query. See [as_count() in Monitor Evaluations][4] for details.
 
 ## Further reading
 

--- a/content/en/monitors/types/change-alert.md
+++ b/content/en/monitors/types/change-alert.md
@@ -91,6 +91,8 @@ This is a break down of the query with the following conditions:
     - To compare your notebook graph to the change alert monitor evaluation, scope your timeframe to match the change alert. 
     - For example, if you are looking to verify the value of a monitor evaluation over the last five minutes at 1:30, scope your notebook to 1:25 - 1:30. 
 
+**Note**: If your metric is a GAUGE type, the evaluation path affects how `pct_change()` is calculated. Without `as_count()`, the percentage change is computed per-bucket and those values are summed over the evaluation window, which can produce unexpectedly large negative values for sparse metrics. Add `as_count()` to the query to switch to the count-style evaluation path. See [as_count() in Monitor Evaluations][4] for details.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -101,3 +103,4 @@ This is a break down of the query with the following conditions:
 [7]: /monitors/notify/
 [8]: /monitors/configuration/?tab=thresholdalert#configure-notifications-and-automations
 [9]: https://app.datadoghq.com/monitors/create/metric/change
+[4]: /monitors/guide/as-count-in-monitor-evaluations/

--- a/content/en/monitors/types/change-alert.md
+++ b/content/en/monitors/types/change-alert.md
@@ -91,7 +91,7 @@ This is a break down of the query with the following conditions:
     - To compare your notebook graph to the change alert monitor evaluation, scope your timeframe to match the change alert. 
     - For example, if you are looking to verify the value of a monitor evaluation over the last five minutes at 1:30, scope your notebook to 1:25 - 1:30. 
 
-**Note**: If your metric is a gauge type and `pct_change()` is producing unexpectedly large negative values, add `as_count()` to the query. See [as_count() in Monitor Evaluations][4] for details.
+**Note**: If your metric is a gauge and `pct_change()` is producing unexpectedly large negative values, add `as_count()` to the query. See [as_count() in Monitor Evaluations][4] for details.
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14561

The Metric Type Modifiers page states that `as_count()` and `as_rate()` have no effect on GAUGE metrics. This is accurate for Metrics Explorer but not for monitors. In monitors, applying `as_count()` to a gauge metric switches the evaluation path for rollup-dependent functions like `pct_change()`, which can produce significantly different results for sparse gauges.

Changes:

- **Metric Type Modifiers** (`metrics/custom_metrics/type_modifiers.md`): Qualifies the existing "no effect" statement to apply to Metrics Explorer, and adds a Note with before/after bullets explaining the monitor evaluation path difference.
- **as_count() in Monitor Evaluations** (`monitors/guide/as-count-in-monitor-evaluations.md`): Adds a new section covering GAUGE metrics and `pct_change()`, with a comparison table mirroring the existing error-rate example structure.
- **Change Alert Monitor** (`monitors/types/change-alert.md`): Adds a cross-reference Note at the end of the troubleshooting section routing users to the as-count guide when their metric is a GAUGE type.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
