### PR TITLE
docs(cloud-security): add Triage and Prioritize section with Runtime Prioritization Engine

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7998,7 +7998,7 @@ menu:
       url: security/cloud_security_management/review_remediate
       parent: csm
       identifier: csm_review_remediate
-      weight: 9
+      weight: 10
     - name: Mute Issues
       url: security/cloud_security_management/review_remediate/mute_issues
       parent: csm_review_remediate
@@ -8009,11 +8009,21 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Severity Scoring
-      url: security/cloud_security_management/severity_scoring/
+    - name: Triage and Prioritize
+      url: security/cloud_security_management/triage_and_prioritize/
       parent: csm
+      identifier: csm_triage_and_prioritize
+      weight: 9
+    - name: Runtime Prioritization Engine
+      url: security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
+      parent: csm_triage_and_prioritize
+      identifier: csm_runtime_prioritization_engine
+      weight: 101
+    - name: Severity Scoring
+      url: security/cloud_security_management/triage_and_prioritize/severity_scoring/
+      parent: csm_triage_and_prioritize
       identifier: csm_severity_scoring
-      weight: 10
+      weight: 102
     - name: Guides
       url: security/cloud_security_management/guide/
       parent: csm

--- a/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
@@ -12,7 +12,7 @@ further_reading:
   text: "Review prioritized findings in the Security Inbox"
 ---
 
-Cloud Security generates findings across vulnerabilities, misconfigurations, and identity risks. Triage and Prioritize covers two related capabilities: the engine that identifies the findings truly exposing your business-critical resources, and the scoring framework that translates that judgment into a per-finding severity score you can sort, filter, and route on.
+Cloud Security generates findings across vulnerabilities, misconfigurations, and identity risks. Triage and Prioritize covers two related capabilities: the engine that identifies the findings that expose your business-critical resources, and the scoring framework that translates that judgment into a per-finding severity score you can sort, filter, and route on.
 
 ## Runtime Prioritization Engine
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
@@ -20,7 +20,7 @@ The [Runtime Prioritization Engine][1] combines runtime observability and securi
 
 ## Severity Scoring
 
-[Severity Scoring][2] turns the Runtime Prioritization Engine's output into a Datadog Severity Score on each finding. For vulnerabilities, it strictly follows the [CVSS 4.0][3] algorithm, enriching the base score with temporal factors (active exploits, exploitation probability) and environmental factors (runtime context, exposure, criticality of the affected resource). For misconfigurations and identity risks, severity is computed using a likelihood × impact matrix that weighs how an adversary could abuse the finding against the damage that abuse would cause.
+[Severity Scoring][2] turns the Runtime Prioritization Engine's output into a Datadog Severity Score on each finding. For vulnerabilities, it follows the [CVSS 4.0][3] algorithm, enriching the base score with temporal factors (such as active exploits or exploitation probability) and environmental factors (such as runtime context, exposure, or criticality of the affected resource). For misconfigurations and identity risks, it computes severity using a likelihood × impact matrix that weighs how an adversary could abuse the finding against the damage that abuse would cause.
 
 ## Further reading
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/_index.md
@@ -1,0 +1,31 @@
+---
+title: Triage and Prioritize
+further_reading:
+- link: "/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/"
+  tag: "Documentation"
+  text: "Runtime Prioritization Engine"
+- link: "/security/cloud_security_management/triage_and_prioritize/severity_scoring/"
+  tag: "Documentation"
+  text: "Severity Scoring"
+- link: "/security/security_inbox/"
+  tag: "Documentation"
+  text: "Review prioritized findings in the Security Inbox"
+---
+
+Cloud Security generates findings across vulnerabilities, misconfigurations, and identity risks. Triage and Prioritize covers two related capabilities: the engine that identifies the findings truly exposing your business-critical resources, and the scoring framework that translates that judgment into a per-finding severity score you can sort, filter, and route on.
+
+## Runtime Prioritization Engine
+
+The [Runtime Prioritization Engine][1] combines runtime observability and security data to identify the ~5% of findings truly exposing your business-critical resources. It evaluates each finding across five dimensions: reachability, exposure, exploitability, business criticality, and actionability. Available in Preview for Cloud Security Vulnerabilities; coverage for misconfigurations and identity risks is in development.
+
+## Severity Scoring
+
+[Severity Scoring][2] turns the Runtime Prioritization Engine's output into a Datadog Severity Score on each finding. For vulnerabilities, it strictly follows the [CVSS 4.0][3] algorithm, enriching the base score with temporal factors (active exploits, exploitation probability) and environmental factors (runtime context, exposure, criticality of the affected resource). For misconfigurations and identity risks, severity is computed using a likelihood × impact matrix that weighs how an adversary could abuse the finding against the damage that abuse would cause.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
+[2]: /security/cloud_security_management/triage_and_prioritize/severity_scoring/
+[3]: https://www.first.org/cvss/v4-0/

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -54,11 +54,6 @@ When ownership is known, the engine can route findings to the right team instead
 2. Enable [Runtime Package Tracking][4] on the Agent to surface the *package in use* signal on vulnerability findings.
 3. Open the [Cloud Security Summary][5] in Datadog. Prioritized findings are surfaced at the top of each funnel and in the [Security Inbox][6].
 
-## What's next
-
-- **Live attack corroboration**: elevate findings on resources receiving confirmed attack traffic from Cloud SIEM, App and API Protection, and Workload Protection.
-- **Ownership inference**: extend ownership coverage with tags, audit logs, infrastructure-as-code, and resource catalog signals.
-- **Container-aware severity adjustment**: tune severity based on whether the affected container runs as root or with elevated privileges.
 
 ## Further reading
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -1,0 +1,78 @@
+---
+title: Runtime Prioritization Engine
+further_reading:
+- link: "/security/cloud_security_management/triage_and_prioritize/severity_scoring/"
+  tag: "Documentation"
+  text: "Understand Cloud Security severity scoring"
+- link: "/security/cloud_security_management/vulnerabilities/"
+  tag: "Documentation"
+  text: "Detect and remediate vulnerabilities with Cloud Security"
+- link: "/security/security_inbox/"
+  tag: "Documentation"
+  text: "Review prioritized findings in the Security Inbox"
+---
+
+{{< callout url="#" btn_hidden="true" header="Runtime Prioritization Engine is in Preview" >}}
+The Runtime Prioritization Engine is available in Preview for Cloud Security Vulnerabilities. Coverage for misconfigurations and identity risks is in active development.
+{{< /callout >}}
+
+Security scanners surface thousands of findings per environment. Most teams default to ranking by CVSS severity, but static scores flag many "critical" findings that are never exploited in practice. Real risk depends on live context: is the vulnerable code running, is an exploit available, and does the affected resource touch sensitive data or a business-critical workflow?
+
+The Datadog Runtime Prioritization Engine combines runtime behavior, exploitability, exposure, and business context from Observability and Security data to identify the 5% of findings that pose real, exploitable risk, so you can focus only on what matters.
+
+## How it works
+
+The Runtime Prioritization Engine is designed to be explainable. For each finding, Datadog evaluates five risk dimensions using production context and shows why the finding was prioritized.
+
+| Dimension | Question it answers | Example signals |
+|---|---|---|
+| **Reachability** | Is the vulnerable component actually running? | Affected image observed running on a production workload. Vulnerable package observed executing at runtime. |
+| **Exposure** | Can attackers reach it? | Resource publicly accessible from static network analysis. Runtime evidence of exposure to active attacks. |
+| **Exploitability** | Are attackers likely to exploit it? | Public exploit code exists. Finding actively exploited in the wild (listed in [CISA KEV][1]). High exploit probability ([EPSS][2]). |
+| **Business criticality** | Would a compromise have high impact? | Resource supports a critical business function (Crown Jewel). Runs with elevated privileges and processes sensitive data. |
+| **Actionability** | Can the right team fix it? | Service owner identified. Fix or mitigation available. |
+
+A finding is prioritized when these signals show real, exploitable risk in your environment. Findings that do not meet the prioritization criteria stay visible, but move out of the active triage queue.
+
+## Crown Jewels
+
+Crown Jewels are the resources (services, hosts, databases, containers, and more) that support your most critical business functions. Datadog automatically infers them from observability data such as APM trace flow, service dependencies (fan-in), SLOs, traffic, incidents, and more.
+
+Crown Jewels update continuously as your environment changes. You can also add your own Crown Jewels manually in Datadog Cloud Security.
+
+## Ownership
+
+Ownership identifies the team or service owner responsible for fixing a security finding. Datadog infers ownership from observability metadata such as service tags, team tags, deployment metadata, on-call configuration, source control links, service catalog entries, and more.
+
+When ownership is known, the engine can route findings to the right team instead of leaving security teams to manually chase remediation owners.
+
+## Coverage
+
+| Finding type | Coverage |
+|---|---|
+| Vulnerabilities (host and container) | Preview |
+| Misconfigurations | In development |
+| Identity risks | In development |
+
+## Get started
+
+1. Deploy the Datadog Agent version 7.79 or later with Cloud Security enabled. See [Setting Up Cloud Security][3].
+2. Enable [Runtime Package Tracking][4] on the Agent to surface the *package in use* signal on vulnerability findings.
+3. Open the [Cloud Security Summary][5] in Datadog. Prioritized findings are surfaced at the top of each funnel and in the [Security Inbox][6].
+
+## What's next
+
+- **Live attack corroboration**: elevate findings on resources receiving confirmed attack traffic from Cloud SIEM, App and API Protection, and Workload Protection.
+- **Ownership inference**: extend ownership coverage with tags, audit logs, infrastructure-as-code, and resource catalog signals.
+- **Container-aware severity adjustment**: tune severity based on whether the affected container runs as root or with elevated privileges.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+[2]: https://www.first.org/epss/
+[3]: /security/cloud_security_management/setup/
+[4]: /security/cloud_security_management/setup/agent/
+[5]: https://app.datadoghq.com/security/csm
+[6]: /security/security_inbox/

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -36,7 +36,7 @@ A finding is prioritized when these signals show real, exploitable risk in your 
 
 ## Crown Jewels
 
-Crown Jewels are the resources (services, hosts, databases, containers, and more) that support your most critical business functions. Datadog automatically infers them from observability data such as APM trace flow, service dependencies (fan-in), SLOs, traffic, incidents, and more.
+Crown Jewels are the resources that support your most critical business functions (services, hosts, databases, containers, etc.). Datadog automatically infers them from observability data such as APM trace flow, service dependencies (fan-in), SLOs, traffic, incidents, and more.
 
 Crown Jewels update continuously as your environment changes. You can also add your own Crown Jewels manually in Datadog Cloud Security.
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -12,8 +12,9 @@ further_reading:
   text: "Review prioritized findings in the Security Inbox"
 ---
 
-{{< callout url="#" btn_hidden="true" header="Runtime Prioritization Engine is in Preview" >}}
-The Runtime Prioritization Engine is available in Preview for Cloud Security Vulnerabilities. Coverage for misconfigurations and identity risks is in active development.
+{{< callout url=https://www.datadoghq.com/product-preview/runtime-prioritization-engine/
+ btn_hidden="false" header="Join the Preview!">}}
+Runtime Prioritization Engine is in Preview for Cloud Security Vulnerabilities. Use this form to request access.
 {{< /callout >}}
 
 Security scanners surface thousands of findings per environment. Most teams default to ranking by CVSS severity, but static scores flag many "critical" findings that are never exploited in practice. Real risk depends on live context: is the vulnerable code running, is an exploit available, and does the affected resource touch sensitive data or a business-critical workflow?

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -47,13 +47,6 @@ Ownership identifies the team or service owner responsible for fixing a security
 
 When ownership is known, the engine can route findings to the right team instead of leaving security teams to manually chase remediation owners.
 
-## Coverage
-
-| Finding type | Coverage |
-|---|---|
-| Vulnerabilities (host and container) | Preview |
-| Misconfigurations | In development |
-| Identity risks | In development |
 
 ## Get started
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -30,7 +30,7 @@ The Runtime Prioritization Engine is designed to be explainable. For each findin
 | **Reachability** | Is the vulnerable component actually running? | Affected image observed running on a production workload. Vulnerable package observed executing at runtime. |
 | **Exposure** | Can attackers reach it? | Resource publicly accessible from static network analysis. Runtime evidence of exposure to active attacks. |
 | **Exploitability** | Are attackers likely to exploit it? | Public exploit code exists. Finding actively exploited in the wild (listed in [CISA KEV][1]). High exploit probability ([EPSS][2]). |
-| **Business criticality** | Would a compromise have high impact? | Resource supports a critical business function (Crown Jewel). Runs with elevated privileges and processes sensitive data. |
+| **Business criticality** | Would a compromise have high impact? | Resource supports a critical business function ([Crown Jewel](#crown-jewels)). Runs with elevated privileges and processes sensitive data. |
 | **Actionability** | Can the right team fix it? | Service owner identified. Fix or mitigation available. |
 
 A finding is prioritized when these signals show real, exploitable risk in your environment. Findings that do not meet the prioritization criteria stay visible, but move out of the active triage queue.

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -33,7 +33,7 @@ The Runtime Prioritization Engine is designed to be explainable. For each findin
 | **Business criticality** | Would a compromise have high impact? | Resource supports a critical business function ([Crown Jewel](#crown-jewels)). Runs with elevated privileges and processes sensitive data. |
 | **Actionability** | Can the right team fix it? | Service owner identified. Fix or mitigation available. |
 
-A finding is prioritized when these signals show real, exploitable risk in your environment. Findings that do not meet the prioritization criteria stay visible, but move out of the active triage queue.
+The Runtime Prioritization Engine prioritizes a finding when these signals indicate real, exploitable risk in your environment. Findings that do not meet the prioritization criteria stay visible, but move out of the active triage queue.
 
 ## Crown Jewels
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -17,7 +17,7 @@ further_reading:
 Runtime Prioritization Engine is in Preview for Cloud Security Vulnerabilities. Use this form to request access.
 {{< /callout >}}
 
-Security scanners surface thousands of findings per environment. Most teams default to ranking by CVSS severity, but static scores flag many "critical" findings that are never exploited in practice. Real risk depends on live context: is the vulnerable code running, is an exploit available, and does the affected resource touch sensitive data or a business-critical workflow?
+Security scanners surface thousands of findings per environment. Most teams default to ranking by CVSS severity, but static scores flag many findings that are never exploited in practice as critical. Real risk depends on live context: is the vulnerable code running, is an exploit available, and does the affected resource touch sensitive data or a business-critical workflow?
 
 The Datadog Runtime Prioritization Engine combines runtime behavior, exploitability, exposure, and business context from Observability and Security data to identify the 5% of findings that pose real, exploitable risk, so you can focus only on what matters.
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/severity_scoring.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/severity_scoring.md
@@ -1,5 +1,7 @@
 ---
 title: Severity Scoring
+aliases:
+- /security/cloud_security_management/severity_scoring/
 further_reading:
 - link: "/security/cloud_security_management/misconfigurations/"
   tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a new **Triage and Prioritize** section under Cloud Security, sitting between **OOTB Rules** and **Review and Remediate** in the left nav. The section groups:

- **Runtime Prioritization Engine** (new page, Preview): how Datadog combines runtime observability and security data to identify the ~5% of findings truly exposing business-critical resources. Covers the five evaluation dimensions (reachability, exposure, exploitability, business criticality, actionability), Crown Jewels, ownership inference, coverage, and setup.
- **Severity Scoring** (moved page): the existing severity scoring page, relocated under the new section. A URL alias preserves the legacy ``/security/cloud_security_management/severity_scoring/`` path so inbound links from ``security_inbox.md``, blog posts, and ``further_reading`` blocks continue to resolve.

Menu changes:
- New parent entry ``Triage and Prioritize`` at weight 9
- New child entry ``Runtime Prioritization Engine`` at weight 101
- Moved ``Severity Scoring`` under the new parent at weight 102
- Bumped ``Review and Remediate`` weight 9 → 10

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Branch preview will exercise:
- New nav order: OOTB Rules → Triage and Prioritize (expandable) → Review and Remediate
- Legacy ``/severity_scoring/`` URL resolves via Hugo alias
- New ``/triage_and_prioritize/runtime_prioritization_engine/`` page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)