### PR TITLE
Add Bits Chat integration section to Storage Management S3 docs

### DIFF
--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -332,14 +332,17 @@ Seeing recommendations has the following prerequisites:
 
 ## Identify and act on cost savings with Bits Chat
 
-<div class="alert alert-info">Bits Chat for Storage Management is in Preview and is available through Bits Chat. To try this skill, fill out this [Interest Form][10] </div>
+{{< callout url="https://docs.google.com/forms/d/e/1FAIpQLScbFjbJecpVV-DgJNBt2O205KtaWlD_q6ajThIEX9vTGz6ebA/viewform?usp=publish-editor" >}}
+Bits Chat for Storage Management is in Preview. To try this skill, request access.
+{{< /callout >}} 
 
-FinOps and engineering teams can use Bits Chat and Storage Management to identify personalized S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
+
+FinOps and engineering teams can use Bits Chat and Storage Management to identify S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. To use Bits Chat with Storage Management, enable the `storage` skill in the Bits Chat settings.
 
 With the `storage` skill enabled for Bits Chat, you can:
 
 - **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
-- **Create reports through Notebooks**: Bits Chat generates a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
+- **Create reports through Notebooks**: Generate a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
 - **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
 
 
@@ -349,4 +352,3 @@ With the `storage` skill enabled for Bits Chat, you can:
 [7]: /cloud_cost_management/
 [8]: https://app.datadoghq.com/dash/integration/32296/storage-management-for-amazon-s3
 [9]: https://app.datadoghq.com/storage-management/settings
-[10]: https://docs.google.com/forms/d/e/1FAIpQLScbFjbJecpVV-DgJNBt2O205KtaWlD_q6ajThIEX9vTGz6ebA/viewform?usp=publish-editor

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -332,9 +332,9 @@ Seeing recommendations has the following prerequisites:
 
 ## Identify and act on cost savings with Bits Chat
 
-<div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
+<div class="alert alert-info">Bits Chat for Storage Management is in Preview and is available through Bits Chat. To try this skill, fill out this [Interest Form][10] </div>
 
-FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
+FinOps and engineering teams can use Bits Chat and Storage Management to identify personalized S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
 With the `storage` skill enabled for Bits Chat, you can:
 
@@ -349,3 +349,4 @@ With the `storage` skill enabled for Bits Chat, you can:
 [7]: /cloud_cost_management/
 [8]: https://app.datadoghq.com/dash/integration/32296/storage-management-for-amazon-s3
 [9]: https://app.datadoghq.com/storage-management/settings
+[10]: https://docs.google.com/forms/d/e/1FAIpQLScbFjbJecpVV-DgJNBt2O205KtaWlD_q6ajThIEX9vTGz6ebA/viewform?usp=publish-editor

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -334,15 +334,14 @@ Seeing recommendations has the following prerequisites:
 
 <div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
 
-FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action.
+FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
-With Bits Chat, you can:
+With the `storage` skill enabled for Bits Chat, you can:
 
 - **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
 - **Create reports through Notebooks**: Bits Chat generates a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
 - **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
 
-To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
 [1]: mailto:storage-monitoring@datadoghq.com
 [3]: https://app.datadoghq.com/storage-management

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -330,6 +330,20 @@ Seeing recommendations has the following prerequisites:
 
   {{< img src="infrastructure/storage_management/storage-recs.png" alt="Storage Management Recommendations" responsive="true">}}
 
+## Identify and act on cost savings with Bits Chat
+
+<div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
+
+FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action.
+
+With Bits Chat, you can:
+
+- **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
+- **Create reports through Notebooks**: Bits Chat generates a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
+- **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
+
+To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
+
 [1]: mailto:storage-monitoring@datadoghq.com
 [3]: https://app.datadoghq.com/storage-management
 [4]: /logs/log_configuration/indexes/#exclusion-filters

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -343,7 +343,7 @@ With the `storage` skill enabled for Bits Chat, you can:
 
 - **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
 - **Create reports through Notebooks**: Generate a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
-- **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
+- **Implement changes**: Get step-by-step guidance with [Bits Code][https://docs.datadoghq.com/bits_ai/bits_ai_dev_agent/] to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
 
 
 [1]: mailto:storage-monitoring@datadoghq.com


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a new section, "Identify and act on cost savings with Bits Chat," to the Storage Management for Amazon S3 documentation page.

The section covers:
- Public Preview availability through Bits Chat
- How FinOps and engineering teams can use Bits Chat to find cost savings opportunities, generate Notebook reports, and implement changes
- Instructions to enable the `storage` skill in Bits Chat settings

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes