### PR TITLE
llm_observability: document llm-obs-eval-pipeline 8-phase workflow

### DIFF
--- a/content/en/llm_observability/guide/claude_code_skills.md
+++ b/content/en/llm_observability/guide/claude_code_skills.md
@@ -27,7 +27,7 @@ Datadog provides a set of [Claude Code][1] skills that bring LLM Observability a
 | `/llm-obs-experiment-analyzer` | Analyze and compare LLM experiment results |
 | `/llm-obs-experiment-py-bootstrap` | Generate Python experiment code using the `ddtrace.llmobs` SDK from a labeled dataset or sample fixtures |
 | `/llm-obs-eval-bootstrap` | Generate evaluator code or publish online LLM-judge evaluators from trace data |
-| `/llm-obs-eval-pipeline` | End-to-end pipeline: classify sessions → root cause analysis → bootstrap evaluators |
+| `/llm-obs-eval-pipeline` | Eight-phase guided pipeline from production traces through evaluators, datasets, experiments, and analysis. Stop early with `--stop-after`, re-enter mid-flow with `--start-at`. |
 
 The skills produce structured, actionable output — RCA reports with before/after fix proposals, generated evaluator code, experiment comparisons — that you can pass directly to a coding agent to apply fixes to your application. When Claude Code has access to your codebase, it can search for the relevant system prompt, tool definitions, or routing logic and propose specific diffs without leaving the session.
 
@@ -181,38 +181,78 @@ The generated Python file is self-contained and ready to hand to a coding agent 
 
 ### Run the end-to-end pipeline
 
-`/llm-obs-eval-pipeline` chains the three skills above into a single supervised workflow. It is the recommended starting point when you have no existing evaluators and want to go from raw production traces to a working evaluator suite.
+`/llm-obs-eval-pipeline` chains the dd-llmo sub-skills into a single supervised, narrated workflow that walks from production traces through evaluators, datasets, experiments, and analysis. Every phase has the same envelope — a banner that names the entity being produced, a pedagogy block explaining its purpose, the action (a sub-skill call or a small executable step), and a checkpoint that waits for your confirmation. It is the recommended starting point when you have no existing evaluators or experiments and want a deterministic walkthrough.
 
 ```
-Phase 1: llm-obs-session-classify  →  classify a sample of recent traces
-Phase 2: llm-obs-trace-rca         →  root cause the failures
-Phase 3: llm-obs-eval-bootstrap    →  generate evaluators for each root cause
+Phase 1: Classify ml_app traces      → llm-obs-session-classify (ml_app mode)
+Phase 2: Root cause analysis         → llm-obs-trace-rca
+Phase 3: Bootstrap evaluators        → llm-obs-eval-bootstrap
+Phase 4: Create dataset from traces  → llm-obs-eval-bootstrap --emit-dataset
+Phase 5: Publish dataset             → LLMObs.create_dataset(records=...) (creates the project lazily)
+Phase 6: Generate experiment code    → llm-obs-experiment-py-bootstrap
+Phase 7: Run experiment              → python <generated_file>
+Phase 8: Analyze experiment          → llm-obs-experiment-analyzer
 ```
 
-The pipeline pauses for your review and approval between each phase. You can exclude specific traces, adjust the failure taxonomy, or redirect the evaluator proposal before moving on.
+Phases 5 and 7 are the only two that execute code on your machine; the rest are read-only or write generated files to `--output-dir`. The classic three-phase eval-pipeline behavior (classify → RCA → bootstrap evaluators only) is preserved by passing `--stop-after eval-bootstrap`.
+
+**Enter and exit at any phase.** The pipeline persists each phase's primary output (classification summary, RCA report, evaluator suite, dataset, published dataset name, experiment file, experiment run, analyzer report) to `<output-dir>/state/0N-<name>.{md,json}` before each checkpoint renders. This means:
+
+- **`stop`** at any checkpoint (or `--stop-after <phase>` from the top) ends the run cleanly, leaving a re-enterable artifact on disk.
+- **`--start-at <phase>`** loads every prior phase's state file (or accepts an override flag if you supplied one) and skips directly to the named phase. You can resume hours or days later, or jump straight to "just re-analyze this experiment" without re-running anything earlier.
+
+Checkpoint vocabulary at every phase: `continue` advances, `stop` exits cleanly, `redo` re-runs the current phase (with optional adjustment notes appended), `back` steps backward one phase. Any other input is treated as adjustment.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `<ml_app>` | — (required) | The instrumented LLM application to onboard / evaluate against |
+| `--project-name` | derived from `pyproject.toml` / `setup.cfg` / `setup.py` / `package.json` / cwd | The Datadog project the pipeline writes datasets and experiments into. Surfaced in the Precheck and created lazily by `LLMObs.enable(project_name=...)` in Phase 5 |
+| `--timeframe` | `now-7d` | Lookback window for Phase 1 classification and Phase 4 dataset sampling |
+| `--trace-limit` | `20` | Sampling cap for Phase 4. Phase 1 internally uses `min(20, --trace-limit)` for the classification sample |
+| `--format` | `py` | Passed to `llm-obs-experiment-py-bootstrap` in Phase 6: `py` (script) or `ipynb` (Jupyter notebook) |
+| `--evaluator-style` | `function` | Passed to Phase 3 and Phase 6: `function`, `class`, or `remote` |
+| `--data-only` | off | Phase 3 pass-through: emit a framework-agnostic JSON evaluator spec instead of Python SDK code |
+| `--publish` | off | Phase 3 pass-through: publish online LLM-judge evaluators to Datadog |
+| `--stop-after` | `analyze` (run everything) | Stop after the named phase completes. Accepts: `classify`, `rca`, `eval-bootstrap` *(matches the classic 3-phase behavior)*, `dataset`, `publish`, `experiment`, `run`, `analyze` |
+| `--start-at` | `classify` (start at the top) | Skip earlier phases and begin at the named phase. Same vocabulary as `--stop-after`. Auto-loads prior phase artifacts from `<output-dir>/state/` |
+| `--classification-summary` | auto-loaded from `state/01-classification.md` | Override the Phase 1 output that Phase 2 consumes (used with `--start-at rca` or later) |
+| `--rca-report` | auto-loaded from `state/02-rca-report.md` | Override the Phase 2 output that Phase 3 consumes |
+| `--dataset-file` | auto-loaded from `state/04-dataset.json` | The local `DatasetRecordRaw[]` JSON that Phase 5 publishes |
+| `--dataset-name` | auto-loaded from `state/05-published-dataset.json` | Name of the published Datadog dataset that Phase 6 wires the experiment to |
+| `--experiment-file` | auto-loaded from `state/06-experiment.json` | The generated experiment file Phase 7 executes |
+| `--experiment-id` / `--experiment-url` | auto-loaded from `state/07-experiment-run.json` | The Datadog experiment Phase 8 analyzes (mutually exclusive) |
+| `--app-root` | resolved from cwd / `pyproject.toml` etc. | Restricts Phase 6's task-function introspection to this directory tree |
+| `--env-file` | none (auto-discovery walks standard locations) | Explicit `.env` path for credential loading; surfaced in the Precheck |
+| `--output-dir` | `./experiments` | Where the dataset JSON, publish script, generated experiment file, and `state/` directory are written |
 
 **Examples**
 
 ```
-/llm-obs-eval-pipeline my-chatbot
-/llm-obs-eval-pipeline my-chatbot --timeframe now-30d --publish
-```
+# Full eight-phase walkthrough for a brand new ml_app
+/llm-obs-eval-pipeline my-chatbot --project-name my-chatbot
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--timeframe` | `now-7d` | Lookback window for trace sampling |
-| `--trace-limit` | `20` | Max traces to classify in Phase 1 |
-| `--data-only` | off | Emit a JSON evaluator spec instead of Python code |
-| `--publish` | off | Publish online LLM-judge evaluators to Datadog |
+# Classic three-phase eval-pipeline behavior — preserves backward compatibility
+/llm-obs-eval-pipeline my-chatbot --stop-after eval-bootstrap
+
+# Resume from where a previous run stopped
+/llm-obs-eval-pipeline my-chatbot --start-at experiment
+
+# Re-analyze a previous experiment run without re-running it
+/llm-obs-eval-pipeline my-chatbot --start-at analyze --experiment-id <UUID>
+
+# Run a single phase in isolation
+/llm-obs-eval-pipeline my-chatbot --start-at dataset --stop-after dataset
+```
 
 ## Typical workflow
 
 If you are new to evaluating an LLM application, the recommended flow is:
 
-1. **Run the pipeline** to get an initial read on where your app is failing and generate a first evaluator suite:
+1. **Run the pipeline** to walk from production traces all the way through evaluators, a seed dataset, an experiment, and analysis:
    ```
-   /llm-obs-eval-pipeline <ml_app>
+   /llm-obs-eval-pipeline <ml_app> --project-name <project>
    ```
+   To stop at the classic evaluator-only output (no dataset or experiment), pass `--stop-after eval-bootstrap`. To resume a previous run, pass `--start-at <phase>` — the pipeline reloads prior state from `<output-dir>/state/` and continues from there.
 
 2. **Apply fixes.** The RCA report produced in Phase 2 includes specific before/after fix proposals grounded in trace evidence. Pass the report to a coding agent (or act on it directly) to fix system prompts, tool definitions, or routing logic in your codebase.
 

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -186,7 +186,7 @@ Restart Claude Code after running both commands for the skills to appear.
 | Experiment analyzer | `/llm-obs-experiment-analyzer` | Analyze and compare LLM experiment results |
 | Experiment Python codegen | `/llm-obs-experiment-py-bootstrap` | Generate Python experiment code using the `ddtrace.llmobs` SDK |
 | Eval bootstrap | `/llm-obs-eval-bootstrap` | Generate evaluator code or publish online LLM-judge evaluators |
-| Eval pipeline | `/llm-obs-eval-pipeline` | End-to-end pipeline: classify → RCA → bootstrap evaluators |
+| Eval pipeline | `/llm-obs-eval-pipeline` | Eight-phase guided pipeline from production traces through evaluators, datasets, experiments, and analysis. Stop early with `--stop-after`, resume mid-flow with `--start-at` |
 
 #### Session classification
 
@@ -240,11 +240,24 @@ When Claude Code has access to your codebase, the skill can search for the relev
 
 #### End-to-end eval pipeline
 
-`/llm-obs-eval-pipeline` chains session classification, trace RCA, and evaluator bootstrap into a single supervised workflow with user checkpoints between phases. It is the recommended starting point when you have no existing evaluators for an application.
+`/llm-obs-eval-pipeline` walks from production traces through evaluators, datasets, experiments, and analysis in eight narrated phases, with a user checkpoint between each:
+
+1. **Classify ml_app traces** — sample and classify recent traces from your `ml_app`
+2. **Root cause analysis** — diagnose why failing traces are failing
+3. **Bootstrap evaluators** — propose an evaluator suite targeting the observed failure modes
+4. **Create dataset from prod traces** — extract input / expected_output pairs into a `DatasetRecordRaw[]` JSON
+5. **Publish dataset** — push the dataset to Datadog under your project (created lazily)
+6. **Generate experiment code** — emit a runnable `.py` or `.ipynb` that pulls the dataset and wires your app's task function
+7. **Run experiment** — execute the generated file end-to-end and capture `experiment.url`
+8. **Analyze experiment** — produce an analysis report with metric breakdowns and recommendations
+
+Each phase persists its output to `<output-dir>/state/0N-<name>.{md,json}` before its checkpoint renders, so you can `stop` cleanly at any point and resume later with `--start-at <next-phase>` — no re-running required. Pass `--stop-after eval-bootstrap` to preserve the classic three-phase eval-only behavior.
 
 ```
-/llm-obs-eval-pipeline my-chatbot
-/llm-obs-eval-pipeline my-chatbot --timeframe now-30d --publish
+/llm-obs-eval-pipeline my-chatbot --project-name my-chatbot
+/llm-obs-eval-pipeline my-chatbot --stop-after eval-bootstrap          # classic 3-phase
+/llm-obs-eval-pipeline my-chatbot --start-at experiment                # resume mid-flow
+/llm-obs-eval-pipeline my-chatbot --start-at analyze --experiment-id <UUID>
 ```
 
 For a complete guide to these skills and a recommended end-to-end workflow, see [Analyze LLM Applications with Claude Code Skills][9].


### PR DESCRIPTION
## What

Expands the documentation for the `llm-obs-eval-pipeline` Claude Code skill from the original three-phase behavior (classify → RCA → bootstrap evaluators) to the full eight-phase guided workflow it now supports: classify → RCA → bootstrap evaluators → create dataset → publish → generate experiment → run → analyze.

The classic three-phase behavior is preserved exactly — pass `--stop-after eval-bootstrap` to get it. Existing users invoking the skill with no flags will see additional phases unless they opt out.

## Why

The skill on the `datadog-labs/agent-skills` and `DataDog/llm-obs` sides has been extended to walk from production traces all the way through to a runnable experiment, so a first-time user can go from "I have an instrumented `ml_app`" to "here's an experiment showing what's failing and why" in one supervised session. The docs were written against the old three-phase scope and don't surface the new flags (`--project-name`, `--start-at`, `--stop-after`, per-phase overrides) or the new behaviors (state persistence, mid-run exit/resume).

Mirrors agent-skills changes in `datadog-labs/agent-skills#57` and `DataDog/llm-obs#390`.

## Sections changed

- `content/en/llm_observability/guide/claude_code_skills.md`
  - **Skills overview table** — eval-pipeline row updated to mention the eight-phase scope and the `--start-at` / `--stop-after` controls
  - **Run the end-to-end pipeline** section — rewritten to describe all eight phases, the standardized banner/checkpoint envelope, state persistence to `<output-dir>/state/`, the checkpoint vocabulary (`continue`/`stop`/`redo`/`back`), and the full options table (15 flags vs the previous 4)
  - **Typical workflow** — opening step updated to surface `--project-name` and the `--stop-after eval-bootstrap` shortcut for classic behavior
- `content/en/llm_observability/mcp_server.md`
  - **Available skills** table — same one-line eval-pipeline summary update
  - **End-to-end eval pipeline** section — phase-by-phase breakdown + the four most common invocation patterns (full run, classic 3-phase, mid-flow resume, re-analyze a previous run)

## New options documented

| Option | Purpose |
|---|---|
| `--project-name <name>` | Datadog project the dataset and experiment land in. Created lazily on first `LLMObs.enable()` call in Phase 5. |
| `--stop-after <phase>` | Exit cleanly after a named phase. 8 valid values; `eval-bootstrap` reproduces the classic 3-phase behavior. |
| `--start-at <phase>` | Skip earlier phases and resume mid-flow. Auto-loads prior phase artifacts from `<output-dir>/state/`. |
| `--classification-summary`, `--rca-report`, `--dataset-file`, `--dataset-name`, `--experiment-file`, `--experiment-id`/`--experiment-url` | Per-phase override flags when auto-loading from state can't find the file. |
| `--evaluator-style` | Passes through to both Phase 3 (eval-bootstrap) and Phase 6 (experiment-py-bootstrap). |
| `--app-root`, `--env-file`, `--output-dir` | Orchestrator knobs. |

## Companion doc PRs (planned, this is the first)

Three doc PRs total, one per skill that was updated:

1. (this PR) `llm-obs-eval-pipeline` — 8-phase workflow + new flags
2. `llm-obs-experiment-py-bootstrap` — `--purpose`, application introspection, `.env` auto-discovery
3. `llm-obs-eval-bootstrap` — `--emit-dataset` mode

Mirrors the split in `datadog-labs/agent-skills#55`, `#56`, `#57` and `DataDog/llm-obs#387`, `#390`, `#391`.

## Preview

After merge, the eval-pipeline section in the public docs will go from describing a four-flag, three-phase skill to documenting the full eight-phase workflow with state persistence and the resume/exit semantics. No removed information — everything in the old docs (classify → RCA → bootstrap framing, `--data-only`, `--publish`, `--timeframe`, `--trace-limit`) is preserved, just relocated within the broader 8-phase context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)