### PR TITLE
llm_observability: document llm-obs-eval-bootstrap --emit-dataset mode

### DIFF
--- a/content/en/llm_observability/guide/claude_code_skills.md
+++ b/content/en/llm_observability/guide/claude_code_skills.md
@@ -26,7 +26,7 @@ Datadog provides a set of [Claude Code][1] skills that bring LLM Observability a
 | `/llm-obs-trace-rca` | Root cause analysis on failing production LLM traces |
 | `/llm-obs-experiment-analyzer` | Analyze and compare LLM experiment results |
 | `/llm-obs-experiment-py-bootstrap` | Generate Python experiment code using the `ddtrace.llmobs` SDK. Introspects your application to wire a real `task_fn` (no placeholder), auto-discovers credentials from `.env`, and accepts a free-form `--purpose` that directs evaluator selection |
-| `/llm-obs-eval-bootstrap` | Generate evaluator code or publish online LLM-judge evaluators from trace data |
+| `/llm-obs-eval-bootstrap` | Generate evaluator code from traces, publish online LLM-judge evaluators, or sample traces into a dataset for use in an experiment |
 | `/llm-obs-eval-pipeline` | Eight-phase guided pipeline from production traces through evaluators, datasets, experiments, and analysis. Stop early with `--stop-after`, re-enter mid-flow with `--start-at`. |
 
 The skills produce structured, actionable output — RCA reports with before/after fix proposals, generated evaluator code, experiment comparisons — that you can pass directly to a coding agent to apply fixes to your application. When Claude Code has access to your codebase, it can search for the relevant system prompt, tool definitions, or routing logic and propose specific diffs without leaving the session.
@@ -175,15 +175,16 @@ The dataset source can be: a local `DatasetRecordRaw[]` JSON file (inlined into 
 
 ### Bootstrap evaluators from trace data
 
-`/llm-obs-eval-bootstrap` analyzes production traces from an ml_app (or an RCA report already in context) and proposes a suite of evaluators that would catch the observed failure modes. It outputs one of three artifacts:
+`/llm-obs-eval-bootstrap` analyzes production traces from an ml_app (or an RCA report already in context) and proposes a suite of evaluators that would catch the observed failure modes. It outputs one of four artifacts:
 
 | Mode | Flag | Output |
 |------|------|--------|
 | SDK code (default) | — | Python `BaseEvaluator` / `LLMJudge` classes ready to drop into an [LLM Experiment][3] |
 | JSON spec | `--data-only` | Framework-agnostic evaluator spec, suitable for review or manual implementation |
 | Online judges | `--publish` | LLM-judge evaluators published directly to Datadog and enabled on your ml_app |
+| Dataset emission | `--emit-dataset <path>` | A `DatasetRecordRaw[]` JSON file sampled from production traces, shaped for `LLMObs.create_dataset(records=...)`. Skips the evaluator workflow entirely — this mode produces a dataset, not evaluators |
 
-The generated Python file is self-contained and ready to hand to a coding agent for integration into your experiment harness or CI pipeline.
+The first three modes share the same evaluator-proposal workflow and differ only in how the suite is materialized. The fourth mode (`--emit-dataset`) is independent — it samples root spans for the `ml_app` (filtered to `@status:ok`), extracts `input_data` and `expected_output` per record, runs a PII scrub on string values, and writes a JSON file you can publish to Datadog as a dataset and then run an experiment against. Per-record `tags` are auto-normalized (bare strings wrapped as `tag:<value>`) so `Dataset.append()` does not reject the record. The `expected_output` field is documented as the **production behavior baseline**, not ground truth — useful for regression-style experiments (does my refactor change observed outputs?) before being promoted to a labelled gold set.
 
 **Examples**
 
@@ -191,6 +192,7 @@ The generated Python file is self-contained and ready to hand to a coding agent 
 /llm-obs-eval-bootstrap ml_app=my-chatbot
 /llm-obs-eval-bootstrap ml_app=my-chatbot --publish
 /llm-obs-eval-bootstrap ml_app=my-chatbot --data-only
+/llm-obs-eval-bootstrap ml_app=my-chatbot --emit-dataset ./datasets/my_chatbot_seed.json --trace-limit 25
 ```
 
 ### Run the end-to-end pipeline

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -185,7 +185,7 @@ Restart Claude Code after running both commands for the skills to appear.
 | Trace RCA | `/llm-obs-trace-rca` | Root cause analysis on failing production traces |
 | Experiment analyzer | `/llm-obs-experiment-analyzer` | Analyze and compare LLM experiment results |
 | Experiment Python codegen | `/llm-obs-experiment-py-bootstrap` | Generate Python experiment code using the `ddtrace.llmobs` SDK. Introspects your app to wire a real `task_fn`, auto-discovers `.env` credentials, and accepts a free-form `--purpose` that directs evaluator selection |
-| Eval bootstrap | `/llm-obs-eval-bootstrap` | Generate evaluator code or publish online LLM-judge evaluators |
+| Eval bootstrap | `/llm-obs-eval-bootstrap` | Generate evaluator code, publish online LLM-judge evaluators, or sample traces into a dataset for use in an experiment |
 | Eval pipeline | `/llm-obs-eval-pipeline` | Eight-phase guided pipeline from production traces through evaluators, datasets, experiments, and analysis. Stop early with `--stop-after`, resume mid-flow with `--start-at` |
 
 #### Session classification
@@ -211,12 +211,13 @@ When Claude Code has access to your codebase, the skill can search for the relev
 
 #### Evaluator bootstrap
 
-`/llm-obs-eval-bootstrap` analyzes production traces and proposes a suite of evaluators targeting the observed failure modes. It outputs one of three artifacts: Python `BaseEvaluator` / `LLMJudge` classes for offline experiments, a framework-agnostic JSON spec, or online LLM-judge evaluators published directly to Datadog.
+`/llm-obs-eval-bootstrap` analyzes production traces and proposes a suite of evaluators targeting the observed failure modes. It outputs one of four artifacts: Python `BaseEvaluator` / `LLMJudge` classes for offline experiments, a framework-agnostic JSON spec, online LLM-judge evaluators published directly to Datadog, or — via `--emit-dataset <path>` — a `DatasetRecordRaw[]` JSON sampled from production traces and shaped for `LLMObs.create_dataset(records=...)`. The dataset-emit mode skips the evaluator workflow entirely; it produces a dataset suitable for use as the input to an experiment.
 
 ```
 /llm-obs-eval-bootstrap ml_app=my-chatbot
 /llm-obs-eval-bootstrap ml_app=my-chatbot --publish
 /llm-obs-eval-bootstrap ml_app=my-chatbot --data-only
+/llm-obs-eval-bootstrap ml_app=my-chatbot --emit-dataset ./datasets/my_chatbot_seed.json
 ```
 
 #### Experiment analyzer


### PR DESCRIPTION
## What

Adds the fourth output mode (`--emit-dataset <path>`) to the `llm-obs-eval-bootstrap` documentation. The skill previously had three modes (SDK code, JSON spec, online judges); the new mode samples production traces into a `DatasetRecordRaw[]` JSON ready for `LLMObs.create_dataset(records=...)` — useful as the input to an experiment.

## Why

The mode was added to `datadog-labs/agent-skills` (PR #55) and `DataDog/llm-obs` (PR #387, merged) to let users seed a Datadog dataset directly from production behavior. Without docs, users invoking `--emit-dataset` see a working mode that isn't reflected anywhere on docs.datadoghq.com.

## How `--emit-dataset` differs from the other three modes

The first three modes (`sdk_code` default, `--data-only`, `--publish`) share the same evaluator-proposal workflow — they each materialize the proposed evaluator suite differently. The fourth mode is independent: it skips the evaluator workflow entirely and produces a dataset, not evaluators.

Per-record handling matches what the rest of the dd-llmo skill set expects:

- **PII scrub** on string values (email, phone, SSN, API-key patterns) before write.
- **Tag normalization** — bare strings auto-wrapped as `tag:<value>`, empty/None entries dropped — so `Dataset.append()` doesn't reject the record at publish time.
- **`expected_output` is documented as the production behavior baseline, not ground truth** — useful for regression-style experiments before the dataset is curated into a labelled gold set.

## Sections changed

- `content/en/llm_observability/guide/claude_code_skills.md`
  - **Skills overview table** — eval-bootstrap row updated to mention the new dataset-sampling capability
  - **Bootstrap evaluators from trace data** section — modes table goes from 3 rows to 4, plus a new paragraph distinguishing the dataset-emit mode (no evaluator workflow) from the three evaluator modes, plus a fourth example
- `content/en/llm_observability/mcp_server.md`
  - **Available skills** table — same one-line summary update
  - **Evaluator bootstrap** section — fourth mode added to the one-paragraph summary and the example block

## Companion doc PRs

Three doc PRs total, one per skill that was updated:

1. `llm-obs-eval-pipeline` 8-phase workflow → #37187
2. `llm-obs-experiment-py-bootstrap` purpose + introspection + .env → #37188
3. (this PR) `llm-obs-eval-bootstrap` — `--emit-dataset` mode

Mirrors agent-skills changes in `datadog-labs/agent-skills#55` and `DataDog/llm-obs#387` (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)