### PR TITLE
Remove .NET 6 or later requirement from OTLP Trace Export preview docs

### DIFF
--- a/content/en/opentelemetry/instrument/dd_sdks/otlp_trace_export.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/otlp_trace_export.md
@@ -50,7 +50,6 @@ Select your language to see the minimum SDK version and supported OTLP protocols
 {{< programming-lang lang=".net" >}}
 - **Minimum version**: v3.41.0
 - **Supported protocols**: `http/json` (default), `http/protobuf` (v3.45.0+)
-- **Requirements**: .NET 6 or later
 {{< /programming-lang >}}
 
 {{< /programming-lang-wrapper >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removes a restriction from the OTLP trace export feature in the Datadog .NET SDK that is no longer present

### Merge instructions
I'd like to get approval from @duncanhewett before merging.

Merge readiness:
- [x] Ready for merge

### AI assistance

N/A

### Additional notes
N/A
