### PR TITLE
[DOCS-14615] Metric Name Pricing: Product Experience Guide

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -34,6 +34,9 @@ Estimated usage metrics are generally available for the following usage types:
 | Ingested Custom Metrics       | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_metric`, `datadog.estimated_usage.metrics.custom.ingested.by_tag`  | Unique ingested Custom Metrics seen in the last hour. |
 | (Preview) Indexed Custom Metric Points | `datadog.estimated_usage.metrics.points.indexed`, `datadog.estimated_usage.metrics.points.indexed.by_tag`, `datadog.estimated_usage.metrics.points.indexed.hourly` | Estimated indexed points for custom metrics. |
 | (Preview) Ingested Custom Metric Points | `datadog.estimated_usage.metrics.points.ingested`, `datadog.estimated_usage.metrics.points.ingested.hourly` | Estimated ingesteds usage for custom metrics. |
+| (Preview) Billable Metric Names | `datadog.estimated_usage.billable.metrics` | Count of metric names with more than 100 indexed points, month-to-date. Applies to organizations on [Metric Name Pricing][7]. |
+| (Preview) Billable Indexed Points | `datadog.estimated_usage.billable.points` | Sum of indexed points above the included 10M points per metric name, month-to-date. Applies to organizations on [Metric Name Pricing][7]. |
+| (Preview) Ingested-to-Indexed Points Ratio | `datadog.estimated_usage.metrics.points.ratio` | Comparison of total ingested points to total indexed points. Applies to organizations on [Metric Name Pricing][7]. |
 | Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes` | Total ingestion of logs in bytes. |
 | Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events` | Total number of ingested events, including excluded logs. |
 | Logs Pipelines Bytes           | `datadog.estimated_usage.logs.ingested_bytes` | Number of logs matched by pipelines in bytes. |
@@ -116,4 +119,5 @@ For billing questions, contact your [Customer Success][2] Manager.
 [4]: /logs/guide/best-practices-for-log-management/#alert-on-indexed-logs-volume-since-the-beginning-of-the-month
 [5]: https://app.datadoghq.com/dashboard/lists/preset/3?q=estimated%20usage
 [6]: /account_management/billing/usage_attribution/
+[7]: /account_management/billing/metric_name_pricing/
 

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -332,9 +332,9 @@ Seeing recommendations has the following prerequisites:
 
 ## Identify and act on cost savings with Bits Chat
 
-<div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
+<div class="alert alert-info">Bits Chat for Storage Management is in Preview and is available through Bits Chat. To try this skill, fill out this [Interest Form][10] </div>
 
-FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
+FinOps and engineering teams can use Bits Chat and Storage Management to identify personalized S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
 With the `storage` skill enabled for Bits Chat, you can:
 
@@ -349,3 +349,4 @@ With the `storage` skill enabled for Bits Chat, you can:
 [7]: /cloud_cost_management/
 [8]: https://app.datadoghq.com/dash/integration/32296/storage-management-for-amazon-s3
 [9]: https://app.datadoghq.com/storage-management/settings
+[10]: https://docs.google.com/forms/d/e/1FAIpQLScbFjbJecpVV-DgJNBt2O205KtaWlD_q6ajThIEX9vTGz6ebA/viewform?usp=publish-editor

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -334,15 +334,14 @@ Seeing recommendations has the following prerequisites:
 
 <div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
 
-FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action.
+FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action. To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
-With Bits Chat, you can:
+With the `storage` skill enabled for Bits Chat, you can:
 
 - **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
 - **Create reports through Notebooks**: Bits Chat generates a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
 - **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
 
-To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
 
 [1]: mailto:storage-monitoring@datadoghq.com
 [3]: https://app.datadoghq.com/storage-management

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -330,6 +330,20 @@ Seeing recommendations has the following prerequisites:
 
   {{< img src="infrastructure/storage_management/storage-recs.png" alt="Storage Management Recommendations" responsive="true">}}
 
+## Identify and act on cost savings with Bits Chat
+
+<div class="alert alert-info">Bits Chat for Storage Management is in Public Preview and is available through Bits Chat.</div>
+
+FinOps and engineering teams can use Bits Chat and Storage Management to identify the largest S3 cost savings opportunities, generate reports in Datadog Notebooks, and implement recommended changes. Bits Chat helps teams of all backgrounds isolate savings opportunities and take action.
+
+With Bits Chat, you can:
+
+- **Find the biggest savings opportunities**: Ask natural language questions to surface the highest-impact prefixes, storage classes, or buckets where lifecycle changes would reduce costs the most.
+- **Create reports through Notebooks**: Bits Chat generates a Datadog Notebook summarizing findings, estimated savings, and recommended actions for your team to review and share.
+- **Implement changes**: Get step-by-step guidance to apply lifecycle policies, transition objects to cheaper storage tiers, or expire non-current versions in the prefixes with the highest savings potential.
+
+To use Bits Chat with Storage Management capability, enable the `storage` skill in the Bits Chat settings.
+
 [1]: mailto:storage-monitoring@datadoghq.com
 [3]: https://app.datadoghq.com/storage-management
 [4]: /logs/log_configuration/indexes/#exclusion-filters

--- a/content/en/metrics/guide/metric_name_pricing_experience.md
+++ b/content/en/metrics/guide/metric_name_pricing_experience.md
@@ -1,0 +1,119 @@
+---
+title: Metrics Experience Changes for Metric Name Pricing
+description: "Learn how the custom metrics experience in Datadog has been updated to reflect Metric Name Pricing, including changes to the Manage Tags modal, Metric side panel, Volume Management page, Plan & Usage page, and estimated usage metrics."
+further_reading:
+- link: "/account_management/billing/metric_name_pricing/"
+  tag: "Documentation"
+  text: "Metric Name Pricing for Custom Metrics"
+- link: "/metrics/metrics-without-limits/"
+  tag: "Documentation"
+  text: "Metrics without Limits™"
+- link: "/account_management/billing/usage_metrics/"
+  tag: "Documentation"
+  text: "Estimated Usage Metrics"
+- link: "/metrics/volume/"
+  tag: "Documentation"
+  text: "Metrics Volume Management"
+algolia:
+  tags: ['metric name pricing', 'custom metrics', 'estimated usage metrics']
+private: true
+---
+
+## Overview
+
+With the [Metric Name Pricing billing model][1] for custom metrics, Datadog has updated the metrics experience to reflect how usage is measured. This guide describes what has changed in the Datadog UI and APIs for organizations on Metric Name Pricing.
+
+**Note**: This page applies only if your organization is on [Metric Name Pricing][1]. If your contract uses Timeseries (cardinality) pricing, your metrics experience is unchanged.
+
+## Summary of changes
+
+| Feature | What changed |
+|---------|-------------|
+| [Manage Tags modal](#manage-tags-modal) | Estimates the impact of tag changes on point volume instead of cardinality volume. |
+| [Metric side panel](#metric-side-panel) | Displays ingested and indexed point volume instead of timeseries volume. |
+| [Volume Management page](#volume-management-page) | Displays ingested and indexed point volume, plus billing dimension graphs for Metric Name Pricing. |
+| [Plan & Usage page](#plan--usage-page) | Reflects the Metric Name Pricing billing breakdown. |
+| [Estimated usage metrics](#estimated-usage-metrics) | New points-volume metrics replace cardinality-based estimated usage metrics. |
+| [Metric volume API endpoints](#metric-volume-api-endpoints) | Behavior changes for the metric volume estimate and volumes endpoints. |
+
+## Manage Tags modal
+
+When configuring tags on custom metrics, the **Manage Tags** modal estimates the impact of tag changes on **point volume** instead of cardinality volume.
+
+For more information on configuring tags, see [Metrics without Limits™][2].
+
+## Metric side panel
+
+The metric details side panel displays **ingested and indexed point volume** instead of timeseries volume.
+
+To open the metric side panel, click any metric name on the [Metrics Summary page][3].
+
+## Volume Management page
+
+The [Metrics Volume Management page][4] displays **ingested and indexed point volume**.
+
+The Volume Overview graphs also display billing dimensions specific to Metric Name Pricing, including:
+
+- Estimated unique metric names
+- Billable indexed point volume
+- Ingested-to-indexed points ratio
+
+## Plan & Usage page
+
+The [Plan & Usage page][5] reflects the Metric Name Pricing billing breakdown for organizations on the new model.
+
+## Estimated usage metrics
+
+Datadog provides estimated usage metrics so you can monitor your Metric Name Pricing usage in real time. Use these metrics to set up monitors and dashboards for cost visibility.
+
+<div class="alert alert-warning">Cardinality-based estimated usage metrics (<code>datadog.estimated_usage.metrics.custom</code> and related metrics) are no longer available for organizations on Metric Name Pricing. Any monitors, dashboards, or other assets that use the cardinality-based metrics stop receiving data. Use the points-volume metrics listed below instead.</div>
+
+### Billable usage metrics
+
+Use these metrics to estimate your month-to-date billable usage under Metric Name Pricing:
+
+| Metric | What it represents |
+|--------|-------------------|
+| `datadog.estimated_usage.billable.metrics` | Count of metric names with more than 100 indexed points, month-to-date. |
+| `datadog.estimated_usage.billable.points` | Sum of indexed points above the included 10M points per metric name, month-to-date. |
+| `datadog.estimated_usage.metrics.points.ratio` | Comparison of total ingested points to total indexed points. |
+
+### Points-volume usage metrics
+
+For more granular analysis, use the following real-time and hourly metrics:
+
+| Metric | What it represents |
+|--------|-------------------|
+| `datadog.estimated_usage.metrics.points.indexed` | Estimated indexed custom metric points over a rolling 60-minute window. |
+| `datadog.estimated_usage.metrics.points.indexed.by_tag` | Estimated indexed custom metric points over a rolling 60-minute window, broken down by usage attribution tags. |
+| `datadog.estimated_usage.metrics.points.indexed.hourly` | Estimated total indexed custom metric points submitted each hour, for cumulative month-to-date calculations. |
+| `datadog.estimated_usage.metrics.points.ingested` | Estimated ingested custom metric points over a rolling 60-minute window. |
+| `datadog.estimated_usage.metrics.points.ingested.hourly` | Estimated total ingested custom metric points submitted each hour, for cumulative month-to-date calculations. |
+
+For more information, see [Estimated Usage Metrics][6].
+
+## Metric volume API endpoints
+
+The following API changes apply for organizations on Metric Name Pricing:
+
+- **`/api/v2/metrics/{metric_name}/estimate`**: This endpoint returns a 403 error. Use `/api/unstable/metrics/{metric_name}/points/estimate` instead to estimate point volume.
+- **`/api/v2/metrics/{metric_name}/volumes`**: This endpoint returns the **total point volume** in the look-back window.
+
+## Troubleshooting
+
+For technical questions, contact [Datadog support][7].
+
+For billing questions, contact your [Customer Success][8] Manager.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /account_management/billing/metric_name_pricing/
+[2]: /metrics/metrics-without-limits/
+[3]: https://app.datadoghq.com/metric/summary
+[4]: https://app.datadoghq.com/metric/volume
+[5]: https://app.datadoghq.com/billing/usage
+[6]: /account_management/billing/usage_metrics/
+[7]: /help/
+[8]: mailto:success@datadoghq.com


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14615

Adds a new guide page documenting the metrics experience changes for organizations on Metric Name Pricing:

- New page at `content/en/metrics/guide/metric_name_pricing_experience.md` covering:
  - Summary of changes table (Manage Tags modal, Metric side panel, Volume Management page, Plan & Usage page, Estimated usage metrics, API endpoint changes)
  - Billable and points-volume estimated usage metrics (with a Warning alert box for the cardinality EUM deprecation)
  - API endpoint behavior changes for the volume estimate and volumes endpoints
- Updated `content/en/account_management/billing/usage_metrics.md` to add three new Preview EUM rows: `datadog.estimated_usage.billable.metrics`, `datadog.estimated_usage.billable.points`, and `datadog.estimated_usage.metrics.points.ratio`

The new page is marked `private: true` pending screenshots from the Metrics Experience team (Racheal Ou).

Related: [DOCS-14030](https://datadoghq.atlassian.net/browse/DOCS-14030) (Metric Name Pricing billing page, PR #36668)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

**Before removing `private: true`:**
- Screenshots needed for all five UI change sections (Racheal Ou to provide)
- Confirm with engineering that documenting the `/api/unstable/metrics/{metric_name}/points/estimate` endpoint publicly is intentional
- `volume.md` and `summary.md` may need targeted updates once UI screenshots are available

[DOCS-14030]: https://datadoghq.atlassian.net/browse/DOCS-14030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ