### PR TITLE
[PROF-14577] Document profiling toolset as generally available

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -614,6 +614,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `networks`: Tools for [Cloud Network Monitoring][37] analysis and [Network Device Monitoring][38]
 - `onboarding`: Agentic onboarding tools for guided Datadog setup and configuration
 - `product-analytics`: Tools for interacting with [Product Analytics][41] queries
+- `profiling`: Tools for discovering, exploring, and analyzing [Continuous Profiler][58] data across services, runtimes, and traces
 - `reference-tables`: Tools for managing [Reference Tables][48], including listing tables, reading rows, appending rows, and creating tables from cloud storage
 - `security`: Tools for code security scanning and searching [security signals][39] and [security findings][40]
 - `software-delivery`: Tools for interacting with Software Delivery ([CI Visibility][30] and [Test Optimization][31])
@@ -809,3 +810,4 @@ Local authentication is recommended for Cline and when remote authentication is 
 [55]: https://claude.com/plugins/datadog
 [56]: https://claude.ai/directory/connectors/datadog
 [57]: /real_user_monitoring/
+[58]: /profiler/

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -902,8 +902,7 @@ Tools for discovering, exploring, and analyzing [Continuous Profiler][62] data a
 Returns available profile types and families given a query context (time range and query string) or a trace and span context. Use this tool first to discover what profiling data is queryable.
 
 - What profile types are available for the `checkout` service in the last hour?
-- Show me profiling families available in the production environment.
-- What profiling data exists for this trace?
+- What types of profiling data can I query for this trace?
 
 ### `get_profiling_services`
 *Toolset: **profiling***\
@@ -911,14 +910,12 @@ Returns available profile types and families given a query context (time range a
 Lists profiled services and their profiling families in scope.
 
 - Which services have profiling enabled in production?
-- List all services with CPU profiling data in the last hour.
 
 ### `get_profiling_runtime_ids`
 *Toolset: **profiling***\
 *Permissions Required: `Continuous Profiler Read`*\
-Returns individual profiled runtime IDs (processes or containers) in scope. Defaults to the top runtime by CPU usage.
+Returns individual profiled runtime IDs (processes or containers) to enable process-level analysis/comparisons. Defaults to the top runtime by CPU usage.
 
-- Show me the top profiled runtimes for the `payments` service.
 - List runtime IDs for the `checkout` service in the last 30 minutes.
 
 ### `get_profiling_service_insights`
@@ -928,31 +925,29 @@ Returns pre-computed service insights, including a high-level performance summar
 
 - What are the top performance issues in the `checkout` service?
 - Show me profiling insights for `service:payments` in the last hour.
-- Are there any known CPU hot spots in the API service?
 
 ### `explore_profiling_flame_graph`
 *Toolset: **profiling***\
 *Permissions Required: `Continuous Profiler Read`*\
-Returns the top-N stack traces by value contribution for a given profile type. Supports filtering by frame, endpoint, or attribute regex. Accepts a service and family, or a trace context.
+Returns the top-N stack traces by value contribution for a given profile type. Supports filtering by frame, endpoint, or attribute regex. Accepts a query context (timeframe and query string) or a trace context.
 
 - Show me the top CPU-consuming functions in the `checkout` service.
-- Get the flame graph for CPU usage in `service:payments` over the last 15 minutes.
-- Show me the flame graph for the span from this trace.
+- Show me what objects are responsible for high memory usage in the `payments` service.
 
 ### `explore_profiling_call_graph`
 *Toolset: **profiling***\
 *Permissions Required: `Continuous Profiler Read`*\
 Returns a call-graph view (caller to callee edges) of the hottest functions for a given profile type. Defaults to top 20 nodes, 5% cutoff, and 5 edges per node.
 
-- Show me the call graph for memory allocations in the `api` service.
+- Show me the call graph for top memory allocators in the `api` service.
 - What functions are calling the hot database methods in `service:payments`?
 
 ### `explore_profiling_timeline`
 *Toolset: **profiling***\
 *Permissions Required: `Continuous Profiler Read`*\
-Returns a timeline of lane groups (threads, GC, and so on) with CPU and I/O activity. Supports critical-path mode (Go only, requires trace context) to identify latency bottlenecks within a span.
+Returns a timeline of application activity broken down by lane groups (threads/routines and runtime activity) and activity type (e.g. CPU, I/O, Lock Contention). Supports critical-path mode (Go only, requires trace context) to identify hot-paths within a trace.
 
-- Show me the thread timeline for `service:api` during the latency spike.
+- Summarize thread activity for `service:api` during the latency spike.
 - Analyze the critical path of this Go span to find latency bottlenecks.
 
 ### `get_profiling_timeseries`
@@ -969,15 +964,14 @@ Returns profiling data aggregated as timeseries (rate metrics). Best for trends,
 *Permissions Required: `Continuous Profiler Read`*\
 Discovers available tag names (such as `service`, `host`, `env`, `version`, and `family`) for filtering profiling data. Returns up to 50 results sorted by relevance.
 
-- What tags can I use to filter profiling data?
-- Show me available tag names for profiling.
+- What tag can I use to filter profiling data?
 
 ### `get_profiling_tag_values`
 *Toolset: **profiling***\
 *Permissions Required: `Continuous Profiler Read`*\
 Returns values for a specific profiling tag, such as all values for the `service` tag. Returns up to 50 results sorted by frequency.
 
-- What values are available for the `service` tag in profiling data?
+- Which versions of service `api` do we have profiling data for during the last hour?
 - List all environments that have profiling data.
 
 ### `get_profiling_fields`
@@ -986,7 +980,6 @@ Returns values for a specific profiling tag, such as all values for the `service
 Discovers frame and context facet fields (such as `@stack.function` and `@labels.trace_endpoint`) usable in `get_profiling_timeseries` for groupBy and filter operations. Scoped by sample type.
 
 - What fields can I group by in profiling timeseries queries?
-- Show me available frame fields for CPU profiling.
 
 ### `get_profiling_field_values`
 *Toolset: **profiling***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -892,6 +892,110 @@ Guides you through uploading source maps for RUM error mapping.
 
 - Help me upload source maps so my RUM errors show original source code.
 
+## Profiling
+
+Tools for discovering, exploring, and analyzing [Continuous Profiler][62] data across services, runtimes, and traces.
+
+### `get_profiling_profile_types`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns available profile types and families given a query context (time range and query string) or a trace and span context. Use this tool first to discover what profiling data is queryable.
+
+- What profile types are available for the `checkout` service in the last hour?
+- Show me profiling families available in the production environment.
+- What profiling data exists for this trace?
+
+### `get_profiling_services`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Lists profiled services and their profiling families in scope.
+
+- Which services have profiling enabled in production?
+- List all services with CPU profiling data in the last hour.
+
+### `get_profiling_runtime_ids`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns individual profiled runtime IDs (processes or containers) in scope. Defaults to the top runtime by CPU usage.
+
+- Show me the top profiled runtimes for the `payments` service.
+- List runtime IDs for the `checkout` service in the last 30 minutes.
+
+### `get_profiling_service_insights`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns pre-computed service insights, including a high-level performance summary, contextual signals such as affected methods, packages, and processes, and recommended next steps.
+
+- What are the top performance issues in the `checkout` service?
+- Show me profiling insights for `service:payments` in the last hour.
+- Are there any known CPU hot spots in the API service?
+
+### `explore_profiling_flame_graph`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns the top-N stack traces by value contribution for a given profile type. Supports filtering by frame, endpoint, or attribute regex. Accepts a service and family, or a trace context.
+
+- Show me the top CPU-consuming functions in the `checkout` service.
+- Get the flame graph for CPU usage in `service:payments` over the last 15 minutes.
+- Show me the flame graph for the span from this trace.
+
+### `explore_profiling_call_graph`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns a call-graph view (caller to callee edges) of the hottest functions for a given profile type. Defaults to top 20 nodes, 5% cutoff, and 5 edges per node.
+
+- Show me the call graph for memory allocations in the `api` service.
+- What functions are calling the hot database methods in `service:payments`?
+
+### `explore_profiling_timeline`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns a timeline of lane groups (threads, GC, and so on) with CPU and I/O activity. Supports critical-path mode (Go only, requires trace context) to identify latency bottlenecks within a span.
+
+- Show me the thread timeline for `service:api` during the latency spike.
+- Analyze the critical path of this Go span to find latency bottlenecks.
+
+### `get_profiling_timeseries`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns profiling data aggregated as timeseries (rate metrics). Best for trends, cross-service comparison, and regression detection. Supports groupBy on frame fields, contexts, and tags.
+
+- Show me CPU usage trends for the `payments` service over the last 24 hours.
+- Compare wall-time profiling across services in the production environment.
+- Detect memory allocation regressions for `service:api` compared to yesterday.
+
+### `get_profiling_tag_names`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Discovers available tag names (such as `service`, `host`, `env`, `version`, and `family`) for filtering profiling data. Returns up to 50 results sorted by relevance.
+
+- What tags can I use to filter profiling data?
+- Show me available tag names for profiling.
+
+### `get_profiling_tag_values`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns values for a specific profiling tag, such as all values for the `service` tag. Returns up to 50 results sorted by frequency.
+
+- What values are available for the `service` tag in profiling data?
+- List all environments that have profiling data.
+
+### `get_profiling_fields`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Discovers frame and context facet fields (such as `@stack.function` and `@labels.trace_endpoint`) usable in `get_profiling_timeseries` for groupBy and filter operations. Scoped by sample type.
+
+- What fields can I group by in profiling timeseries queries?
+- Show me available frame fields for CPU profiling.
+
+### `get_profiling_field_values`
+*Toolset: **profiling***\
+*Permissions Required: `Continuous Profiler Read`*\
+Returns values for a specific frame or context field discovered with `get_profiling_fields`. Results are sorted by frequency.
+
+- What are the most common values for `@stack.function` in the `checkout` service?
+- Show me trace endpoint values for CPU profiling data.
+
 ## Reference Tables
 
 Tools for managing [Reference Tables][45], including listing tables, reading rows, appending rows, and creating tables from cloud storage.
@@ -1400,3 +1504,4 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [57]: /notebooks/
 [58]: /real_user_monitoring/
 [59]: /real_user_monitoring/rum_without_limits/
+[62]: /profiler/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the Datadog MCP Server profiling toolset as generally available, replacing its previous preview/internal-only status.

Changes:
- `content/en/mcp_server/setup.md`: adds `profiling` to the GA toolsets list with a brief description
- `content/en/mcp_server/tools.md`: adds a full Profiling section documenting all 12 tools (`get_profiling_profile_types`, `get_profiling_services`, `get_profiling_runtime_ids`, `get_profiling_service_insights`, `explore_profiling_flame_graph`, `explore_profiling_call_graph`, `explore_profiling_timeline`, `get_profiling_timeseries`, `get_profiling_tag_names`, `get_profiling_tag_values`, `get_profiling_fields`, `get_profiling_field_values`) with permissions and example prompts

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes