### PR TITLE
Remove preview banner for gateway topology on Fleet

### DIFF
--- a/content/en/opentelemetry/integrations/datadog_extension.md
+++ b/content/en/opentelemetry/integrations/datadog_extension.md
@@ -96,10 +96,6 @@ The Collector automatically attaches `service.name`, `service.version`, and `ser
 
 ### 5. (Optional) Configure gateway topology (preview)
 
-<div class="alert alert-info">
-The Gateway topology view in <a href="https://app.datadoghq.com/fleet">Fleet Automation</a> is a preview feature. Please contact Datadog support to join the preview. The Datadog Extension config fields below are available in OpenTelemetry Collector v0.150.0 and later.
-</div>
-
 When you have an OpenTelemetry Collector gateway setup that forwards telemetry through one or more gateway Collectors before reaching Datadog, the Datadog Extension can publish the topology so it appears as a connected pipeline graph in [Fleet Automation][7]:
 
 {{< img src="opentelemetry/integrations/datadog_extension_gateway_topology.png" alt="Gateway topology view in Fleet Automation showing DaemonSet Collectors forwarding through two layers of gateway Collectors to Datadog" style="width:100%;" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Remove preview banner for gateway topology on Fleet. We remove the FF so it's available to all customers.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
