### PR TITLE
Clarify Maximum Access Period behavior for no-expiration invites

### DIFF
--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -67,7 +67,7 @@ To share a dashboard with one or more email addresses:
 
 By default, invitations do not expire. To require invitations to expire after a specific amount of time, an organization admin can turn on Maximum Access Period in [Organization Settings > Public Sharing][3]. When this setting is enabled, you can specify the maximum number of days an invitation remains valid.
 
-To allow invitations with no expiration date, ensure Maximum Access Period is turned off. If you are configuring this setting through the API, set the value to `null`. In the UI, setting Maximum Access Period to `0` turns off the setting and sets the value to `null`.
+To allow invitations with no expiration date, turn off Maximum Access Period. If you are configuring this setting through the API, set the value to `null`. In the UI, setting Maximum Access Period to `0` turns off the setting and sets the value to `null`.
 
 **Note**: Maximum Access Period is enforced by exact timestamp. For example, with a Maximum Access Period of one day, an invitation created at Jan 1st 11:00AM must expire by Jan 2nd 11:00AM.
 

--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -65,11 +65,9 @@ To share a dashboard with one or more email addresses:
 
 **Note**: Invited emails lose access at 12:00 a.m. local time on the expiration date.
 
-The Maximum Access Period of an invitation can be configured by an organization admin in [Organization Settings > Public Sharing][3]. By default, it is not configured.
+The Maximum Access Period of an invitation can be configured by an organization admin in [Organization Settings > Public Sharing][3]. By default, it is not configured. To allow invitations with no expiration date, turn off the Maximum Access Period setting. If you are configuring this with the API, set the value to `null`. In the UI, setting the Maximum Access Period to `0` turns off the setting and sets the value to `null`.
 
 **Note**: Maximum Access Period is enforced by exact timestamp. For example, with a Maximum Access Period of one day, an invitation created at Jan 1st 11:00AM must expire by Jan 2nd 11:00AM.
-
-To allow invitations with no expiration date, turn off the Maximum Access Period setting. If you are configuring this with the API, set the value to `null`. In the UI, setting the Maximum Access Period to `0` turns off the setting and sets the value to `null`.
 
 ### Access an invite-only shared dashboard
 

--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -65,7 +65,9 @@ To share a dashboard with one or more email addresses:
 
 **Note**: Invited emails lose access at 12:00 a.m. local time on the expiration date.
 
-The Maximum Access Period of an invitation can be configured by an organization admin in [Organization Settings > Public Sharing][3]. By default, it is not configured. To allow invitations with no expiration date, turn off the Maximum Access Period setting. If you are configuring this with the API, set the value to `null`. In the UI, setting the Maximum Access Period to `0` turns off the setting and sets the value to `null`.
+By default, invitations do not expire. To require invitations to expire after a specific amount of time, an organization admin can turn on Maximum Access Period in [Organization Settings > Public Sharing][3]. When this setting is enabled, you can specify the maximum number of days an invitation remains valid.
+
+To allow invitations with no expiration date, ensure Maximum Access Period is turned off. If you are configuring this setting through the API, set the value to `null`. In the UI, setting Maximum Access Period to `0` turns off the setting and sets the value to `null`.
 
 **Note**: Maximum Access Period is enforced by exact timestamp. For example, with a Maximum Access Period of one day, an invitation created at Jan 1st 11:00AM must expire by Jan 2nd 11:00AM.
 

--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -69,6 +69,8 @@ The Maximum Access Period of an invitation can be configured by an organization 
 
 **Note**: Maximum Access Period is enforced by exact timestamp. For example, with a Maximum Access Period of one day, an invitation created at Jan 1st 11:00AM must expire by Jan 2nd 11:00AM.
 
+To allow invitations with no expiration date, turn off the Maximum Access Period setting. If you are configuring this with the API, set the value to `null`. In the UI, setting the Maximum Access Period to `0` turns off the setting and sets the value to `null`.
+
 ### Access an invite-only shared dashboard
 
 Invitees to shared dashboards are sent an email with a limited-time access link. The email recipients need to click on the link within 1 hour to gain access to the shared dashboard.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Clarifies how the Maximum Access Period org configuration interacts with invite expiration on the [Invite-only shared dashboards](https://docs.datadoghq.com/dashboards/sharing/shared_dashboards/#invite-only-shared-dashboards) page:

- To allow invites with no expiration date, the setting must be turned off (API value: `null`).
- In the UI, setting the value to `0` turns the setting off and stores `null`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes