### PR TITLE
Document experiment API filters and CI/CD queries

### DIFF
--- a/content/en/llm_observability/experiments/advanced_runs.md
+++ b/content/en/llm_observability/experiments/advanced_runs.md
@@ -233,6 +233,42 @@ jobs:
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
 ```
 
+### Querying and comparing CI/CD runs via the API
+When creating experiments for a CI/CD pipeline, use the `name` field to include a shared logical pipeline name and a per-run suffix (for example, `my-pipeline-<run-id>`), and use the `metadata` field for commit, branch, or other pipeline context (for example, `"metadata": {"commit": "abc123", "branch": "feat/foo"}`).
+
+To retrieve and compare runs through the API, call `GET /api/v2/llm-obs/v1/experiments` with these filters:
+- `filter[experiment]=<pipeline-name>` returns all runs sharing the same logical pipeline name.
+- `filter[metadata]={"branch":"main"}` returns runs whose metadata contains those key-value pairs.
+- Combine both filters to narrow comparisons, for example: `?filter[experiment]=my-pipeline&filter[metadata]={"commit":"abc123"}`.
+
+Each matching experiment includes `aggregate_data` with pre-computed eval score distributions, token costs, and error rates, so you can compare runs without querying individual spans.
+
+`page[cursor]` is not supported when `filter[experiment]` or `filter[metadata]` is used.
+
+`filter[experiment]` matches the shared logical pipeline name stored in the `experiment` column (for example, `my-pipeline`). This is distinct from the unique per-run `name` field (for example, `my-pipeline-<run-id>`).
+
+```http
+# Create experiment tagged with pipeline context
+POST /api/v2/llm-obs/v1/experiments
+{
+  "data": {
+    "type": "experiments",
+    "attributes": {
+      "project_id": "<project_id>",
+      "dataset_id": "<dataset_id>",
+      "name": "my-pipeline-<run-id>",
+      "metadata": {"commit": "abc123", "branch": "feat/foo"}
+    }
+  }
+}
+
+# Compare all runs of the same pipeline on main branch
+GET /api/v2/llm-obs/v1/experiments?filter[experiment]=my-pipeline&filter[metadata]={"branch":"main"}
+
+# Retrieve a specific commit's run
+GET /api/v2/llm-obs/v1/experiments?filter[experiment]=my-pipeline&filter[metadata]={"commit":"abc123"}
+```
+
 [1]: /llm_observability/instrumentation/sdk?tab=python
 [2]: /llm_observability/experiments/api
 [3]: https://app.datadoghq.com/llm/experiments

--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -397,8 +397,8 @@ List all experiments, sorted by creation date. The most recently-created experim
 | `filter[project_id]` (_required_ if dataset not provided) | string | The ID of a project to retrieve experiments for. |
 | `filter[dataset_id]` | string | The ID of a dataset to retrieve experiments for. |
 | `filter[id]` | string | The ID(s) of an experiment to search for. To query for multiple experiments, use `?filter[id]=<>&filter[id]=<>`. |
-| `filter[experiment]` | string | Filter by the logical experiment name (the shared pipeline name set across all runs of the same pipeline). Composes with `filter[project_id]` and `filter[dataset_id]`. **Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
-| `filter[metadata]` | json (string) | Filter experiments whose metadata contains all the provided key-value pairs. Must be a valid JSON object string (for example, `{"commit":"abc123","branch":"main"}`). Composes with `filter[experiment]` and other filters. **Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
+| `filter[experiment]` | string | Filter by the logical experiment name (the shared pipeline name set across all runs of the same pipeline). Composes with `filter[project_id]` and `filter[dataset_id]`.<br />**Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
+| `filter[metadata]` | json (string) | Filter experiments whose metadata contains all the provided key-value pairs. Must be a valid JSON object string (for example, `{"commit":"abc123","branch":"main"}`). Composes with `filter[experiment]` and other filters.<br />**Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
 | `page[cursor]` | string | List results with a cursor provided in the previous query. Not supported when `filter[experiment]` or `filter[metadata]` is provided. |
 | `page[limit]` | int | Limits the number of results. |
 

--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -397,7 +397,9 @@ List all experiments, sorted by creation date. The most recently-created experim
 | `filter[project_id]` (_required_ if dataset not provided) | string | The ID of a project to retrieve experiments for. |
 | `filter[dataset_id]` | string | The ID of a dataset to retrieve experiments for. |
 | `filter[id]` | string | The ID(s) of an experiment to search for. To query for multiple experiments, use `?filter[id]=<>&filter[id]=<>`. |
-| `page[cursor]` | string | List results with a cursor provided in the previous query. |
+| `filter[experiment]` | string | Filter by the logical experiment name (the shared pipeline name set across all runs of the same pipeline). Composes with `filter[project_id]` and `filter[dataset_id]`. **Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
+| `filter[metadata]` | json (string) | Filter experiments whose metadata contains all the provided key-value pairs. Must be a valid JSON object string (for example, `{"commit":"abc123","branch":"main"}`). Composes with `filter[experiment]` and other filters. **Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
+| `page[cursor]` | string | List results with a cursor provided in the previous query. Not supported when `filter[experiment]` or `filter[metadata]` is provided. |
 | `page[limit]` | int | Limits the number of results. |
 
 **Response**
@@ -419,6 +421,7 @@ List all experiments, sorted by creation date. The most recently-created experim
 | `config` | json | Configuration used when creating the experiment. |
 | `created_at` | timestamp | Timestamp representing when the resource was created. |
 | `updated_at` | timestamp | Timestamp representing when the resource was last updated. |
+| `aggregate_data` | json | Pre-computed aggregate metrics for this experiment run (eval score distributions, token costs, error rates). Present when `filter[experiment]` or `filter[metadata]` is used. |
 
 {{% /collapse-content %}}
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"db67f16b-91af-40c9-a03c-145817cabd99","workflowId":"a47d5ff4-19fb-410f-bf83-b08546c4afc6","codeChangeId":"a47d5ff4-19fb-410f-bf83-b08546c4afc6","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

This PR documents two new query filter parameters added to the `GET /api/v2/llm-obs/v1/experiments` endpoint:

1. `filter[experiment]` - Filter by logical experiment name (shared pipeline name across runs)
2. `filter[metadata]` - Filter by metadata key-value pairs (e.g., commit, branch)

These filters enable CI/CD comparison workflows by allowing users to query and compare multiple runs of the same pipeline. The changes include:

**File 1: `content/en/llm_observability/experiments/api.md`**
- Added two new rows to the GET /experiments Query parameters table for `filter[experiment]` and `filter[metadata]`
- Updated `page[cursor]` description to note incompatibility with the new filters
- Added `aggregate_data` field to the Experiment response object table
- Formatted notes using `<br />` for proper markdown rendering in tables

**File 2: `content/en/llm_observability/experiments/advanced_runs.md`**
- Added new sub-section "Querying and comparing CI/CD runs via the API" under the CI/CD section
- Documented how to tag experiments with pipeline context using `name` and `metadata` fields
- Provided API examples showing how to create experiments and query runs for comparison
- Clarified the distinction between the shared logical `experiment` name and the unique per-run `name` field

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code for initial draft of documentation content and examples.

### Additional notes

The branch name follows the `<name>/<description>` format as required for Datadog Documentation repository CI/CD pipeline.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/db67f16b-91af-40c9-a03c-145817cabd99)

Comment @datadog-staging to request changes