### PR TITLE
[DOCS-14474] Clarify Azure PAYG export limitations for CCM

### DIFF
--- a/content/en/cloud_cost_management/setup/azure.md
+++ b/content/en/cloud_cost_management/setup/azure.md
@@ -22,9 +22,7 @@ further_reading:
 
 To use Azure Cloud Cost Management in Datadog, you must configure the Datadog Azure integration and create **amortized** and **actual** exports in Azure. Additionally, Datadog must have permissions to read the exports from the container.
 
-Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes.
-
-To determine your account type, see the [Azure documentation][10].
+Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes. To determine your account type, see the [Azure documentation][10].
 
 <div class="alert alert-info">
 <strong>Pay as you go (PAYG) accounts</strong>

--- a/content/en/cloud_cost_management/setup/azure.md
+++ b/content/en/cloud_cost_management/setup/azure.md
@@ -22,9 +22,20 @@ further_reading:
 
 To use Azure Cloud Cost Management in Datadog, you must configure the Datadog Azure integration and create **amortized** and **actual** exports in Azure. Additionally, Datadog must have permissions to read the exports from the container.
 
-Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes. Pay as you go (PAYG) accounts are in Preview. Contact [Datadog support][11] if you encounter any issues with setup.
+Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes.
 
 To determine your account type, see the [Azure documentation][10]. **Note:** If your account type is listed as "Microsoft Online Services Program", then your account is PAYG.
+
+<div class="alert alert-info">
+<strong>Pay as you go (PAYG) accounts</strong>
+<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG (Microsoft Online Services Program) subscriptions typically provide only <strong>Usage details (usage only)</strong> exports. Because they don't expose the <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports that CCM requires, PAYG accounts can't be set up for CCM. For the export types supported by each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
+<p>If your subscription is PAYG, consider one of the following options:</p>
+<ul>
+<li>Migrate to a Microsoft Customer Agreement (MCA) or Enterprise Agreement (EA), which support the required export types.</li>
+<li>Contact Microsoft Azure support to confirm the export types available for your subscription.</li>
+</ul>
+<p>For help with Datadog CCM setup or to discuss options, contact <a href="/help/">Datadog support</a>.</p>
+</div>
 
 ## Setup
 
@@ -315,7 +326,6 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [8]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports
 [9]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/download-azure-daily-usage
 [10]: https://docs.azure.cn/en-us/cost-management-billing/manage/resolve-past-due-balance#check-the-type-of-your-account
-[11]: /help/
 [12]: /cloud_cost_management/tags
 [13]: /api/latest/cloud-cost-management/#create-cloud-cost-management-azure-configs
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config

--- a/content/en/cloud_cost_management/setup/azure.md
+++ b/content/en/cloud_cost_management/setup/azure.md
@@ -28,7 +28,7 @@ To determine your account type, see the [Azure documentation][10]. **Note:** If 
 
 <div class="alert alert-info">
 <strong>Pay as you go (PAYG) accounts</strong>
-<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG (Microsoft Online Services Program) subscriptions typically provide only <strong>Usage details (usage only)</strong> exports. Because they don't expose the <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports that CCM requires, PAYG accounts can't be set up for CCM. For the export types supported by each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
+<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG (Microsoft Online Services Program) subscriptions typically provide only <strong>Usage details (usage only)</strong> exports, so they can't be set up for CCM. For the export types available to each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
 <p>If your subscription is PAYG, consider one of the following options:</p>
 <ul>
 <li>Migrate to a Microsoft Customer Agreement (MCA) or Enterprise Agreement (EA), which support the required export types.</li>

--- a/content/en/cloud_cost_management/setup/azure.md
+++ b/content/en/cloud_cost_management/setup/azure.md
@@ -24,11 +24,10 @@ To use Azure Cloud Cost Management in Datadog, you must configure the Datadog Az
 
 Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes.
 
-To determine your account type, see the [Azure documentation][10]. **Note:** If your account type is listed as "Microsoft Online Services Program", then your account is PAYG.
-
 <div class="alert alert-info">
 <strong>Pay as you go (PAYG) accounts</strong>
-<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG (Microsoft Online Services Program) subscriptions typically provide only <strong>Usage details (usage only)</strong> exports, so they can't be set up for CCM. For the export types available to each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
+<p>To determine your account type, see the <a href="https://docs.azure.cn/en-us/cost-management-billing/manage/resolve-past-due-balance#check-the-type-of-your-account">Azure documentation</a>. If your account type is listed as <strong>Microsoft Online Services Program</strong>, your account is PAYG.</p>
+<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG subscriptions typically provide only <strong>Usage details (usage only)</strong> exports, so they can't be set up for CCM. For the export types available to each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
 <p>If your subscription is PAYG, consider one of the following options:</p>
 <ul>
 <li>Migrate to a Microsoft Customer Agreement (MCA) or Enterprise Agreement (EA), which support the required export types.</li>
@@ -325,7 +324,6 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [7]:  https://support.microsoft.com
 [8]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports
 [9]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/download-azure-daily-usage
-[10]: https://docs.azure.cn/en-us/cost-management-billing/manage/resolve-past-due-balance#check-the-type-of-your-account
 [12]: /cloud_cost_management/tags
 [13]: /api/latest/cloud-cost-management/#create-cloud-cost-management-azure-configs
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config

--- a/content/en/cloud_cost_management/setup/azure.md
+++ b/content/en/cloud_cost_management/setup/azure.md
@@ -24,10 +24,11 @@ To use Azure Cloud Cost Management in Datadog, you must configure the Datadog Az
 
 Datadog provides cost visibility on a Subscription, Resource Group, and Billing Account Level. Microsoft Customer Agreements (MCA) can be set up at all three scopes.
 
+To determine your account type, see the [Azure documentation][10].
+
 <div class="alert alert-info">
 <strong>Pay as you go (PAYG) accounts</strong>
-<p>To determine your account type, see the <a href="https://docs.azure.cn/en-us/cost-management-billing/manage/resolve-past-due-balance#check-the-type-of-your-account">Azure documentation</a>. If your account type is listed as <strong>Microsoft Online Services Program</strong>, your account is PAYG.</p>
-<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG subscriptions typically provide only <strong>Usage details (usage only)</strong> exports, so they can't be set up for CCM. For the export types available to each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
+<p>Datadog Cloud Cost Management requires <strong>Actual Cost</strong> and <strong>Amortized Cost</strong> exports from Azure. PAYG (Microsoft Online Services Program) subscriptions typically provide only <strong>Usage details (usage only)</strong> exports, so they can't be set up for CCM. For the export types available to each Azure account type, see Microsoft's <a href="https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports">Cost Management exports documentation</a>.</p>
 <p>If your subscription is PAYG, consider one of the following options:</p>
 <ul>
 <li>Migrate to a Microsoft Customer Agreement (MCA) or Enterprise Agreement (EA), which support the required export types.</li>
@@ -324,6 +325,7 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [7]:  https://support.microsoft.com
 [8]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports
 [9]:  https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/download-azure-daily-usage
+[10]: https://docs.azure.cn/en-us/cost-management-billing/manage/resolve-past-due-balance#check-the-type-of-your-account
 [12]: /cloud_cost_management/tags
 [13]: /api/latest/cloud-cost-management/#create-cloud-cost-management-azure-configs
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14474

Clarifies the Pay as you go (PAYG) guidance on the Azure Cloud Cost Management setup page. The previous text only stated that PAYG accounts were "in Preview" and directed users to Datadog support, without explaining the underlying Azure export limitation or what users can do about it.

This PR replaces that sentence with an informational box that:
- Explains that CCM requires **Actual Cost** and **Amortized Cost** exports, while PAYG (Microsoft Online Services Program) subscriptions typically provide only **Usage details (usage only)** exports.
- States that, as a result, PAYG accounts can't be set up for CCM.
- Links to Microsoft's Cost Management exports documentation for the supported export types per account type.
- Provides alternatives (migrate to MCA/EA, or contact Microsoft Azure support) and a path to Datadog support.

Also removes the now-unused `[11]` link reference.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

