### PR TITLE
Add documentation of security finding URL redirect

### DIFF
--- a/content/en/security/guide/findings-schema.md
+++ b/content/en/security/guide/findings-schema.md
@@ -1764,6 +1764,10 @@ There are eleven different categories for security findings. Click on a category
 {{% /tab %}}
 {{< /tabs >}}
 
+## Linking to findings
+
+The direct URL for a finding in Datadog varies by finding type. Use `/finding/[finding_id]`, where `[finding_id]` is the root-level `finding_id` value, to open the finding in the appropriate explorer. This format is useful when linking from AI agents or automations.
+
 ## Schema Reference
 
 The following sections describe all available attributes in the Security Findings schema, organized by namespace.

--- a/content/en/security/guide/findings-schema.md
+++ b/content/en/security/guide/findings-schema.md
@@ -1766,7 +1766,7 @@ There are eleven different categories for security findings. Click on a category
 
 ## Linking to findings
 
-The direct URL for a finding in Datadog varies by finding type. Use `/finding/[finding_id]`, where `[finding_id]` is the root-level `finding_id` value, to open the finding in the appropriate explorer. This format is useful when linking from AI agents or automations.
+The direct URL for a finding in Datadog varies by finding type. Use `/security/finding/[finding_id]`, where `[finding_id]` is the root-level `finding_id` value, to open the finding in the appropriate explorer. This format is useful when linking from AI agents or automations.
 
 ## Schema Reference
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add an explanation of the security finding redirect URL to the finding schema documentation. I'm not sure this is the perfect location, but it seems like the most likely place that a user (or AI agent) will find it since it's closely linked to the schema.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Manually written, used AI review to better match the style guide
