### PR TITLE
rum: track clicks to dd-database-monitoring-example repo from IaC docs

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -108,3 +108,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+
+document.addEventListener('click', (e) => {
+    const link = e.target.closest('a[href*="github.com/DataDog/dd-database-monitoring-example"]');
+    if (link && window.DD_RUM) {
+        window.DD_RUM.addAction('dbm_terraform_example_repo_click', {
+            href: link.href,
+            page: window.location.pathname,
+        });
+    }
+});


### PR DESCRIPTION
## Summary

- Adds a delegated `click` listener on `document` that fires a `dbm_terraform_example_repo_click` RUM custom action whenever a visitor clicks any link to `github.com/DataDog/dd-database-monitoring-example`.
- Captures `href` (full link target) and `page` (originating `window.location.pathname`) so we can measure which docs pages drive traffic to the example repo.
- Uses `e.target.closest()` so clicks on child elements inside the `<a>` tag are also caught.

## Why

The [IaC setup page](https://docs.datadoghq.com/database_monitoring/setup_agent_terraform/) links to `DataDog/dd-database-monitoring-example`. This action lets us track click-through rate from the docs page to the example repo in the [DBM Docs Usage dashboard](https://dd-corpsite.datadoghq.com/dashboard/cwb-bac-us3) without any backend changes.

## Test plan

- [ ] Open the [IaC setup page](https://docs.datadoghq.com/database_monitoring/setup_agent_terraform/) in a preview build
- [ ] Click the example repo link
- [ ] Confirm `dbm_terraform_example_repo_click` appears in RUM Explorer with correct `href` and `page` attributes
- [ ] Verify no JS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)