### PR TITLE
Add Linux kernel 5.8+ as minimum version requirement for GPU Monitoring

### DIFF
--- a/content/en/gpu_monitoring/setup.md
+++ b/content/en/gpu_monitoring/setup.md
@@ -28,6 +28,7 @@ To begin using Datadog's GPU Monitoring, your environment must meet the followin
 
 - **Datadog Agent**: v7.74
 - **Operating system**: Linux
+- **Linux kernel**: 5.8 and above
 - **NVIDIA driver**: version 450.51
 
 If using Kubernetes, the following additional requirements must be met:


### PR DESCRIPTION
## What does this PR do?

Adds the Linux kernel version requirement (5.8 and above) to the Minimum version requirements section of the GPU Monitoring setup page.

This was missing from the prerequisites list — the kernel version is required for the eBPF probes used by the `gpu_monitoring` system-probe module.

Matches the requirement already documented in the [integrations-core GPU README](https://github.com/DataDog/integrations-core/blob/master/gpu/README.md).

Fixes: AGENT-16266

## Motivation

Customer (Norfolk Southern Corp) and a TSE flagged that the kernel version prerequisite was not listed on the setup page, making it easy to miss.