### PR TITLE
[SOURCE-323] Add review signals to claude_review action

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -3,19 +3,25 @@
 #
 # Security model — read before editing:
 #
-# 1. The pipeline has three jobs: `gate` (verify the /review caller
-#    has repo write access and resolve the PR head SHA), `review`
-#    (run Claude with read-only tools and produce a JSON review
-#    artifact), and `post` (sanitize and submit the review via the
-#    GitHub API). Treat the checked-out tree and PR/comment
-#    metadata as hostile input subject to prompt injection.
+# 1. The pipeline has five jobs: `gate` (verify the /review caller
+#    has repo write access and resolve the PR head SHA), `start_signal`
+#    (acknowledge the request and create the PR status), `review` (run
+#    Claude with read-only tools and produce a JSON review artifact),
+#    `post` (sanitize and submit the review via the GitHub API), and
+#    `finish_signal` (finalize the PR status and request reaction).
+#    Treat the checked-out tree and PR/comment metadata as hostile
+#    input subject to prompt injection.
 #
 # 2. Permissions are scoped per job:
 #      gate:    contents: read,  pull-requests: read
+#      signal:  pull-requests: write, statuses: write
 #      review:  contents: read,  pull-requests: read  (no write)
 #      post:    contents: read,  pull-requests: write
 #    Claude runs in `review`, which has no write capability on
-#    GitHub. Only `post` writes, and it never runs Claude.
+#    GitHub. `start_signal` and `finish_signal` write only the
+#    requester reaction and commit status after authorization; neither is
+#    in Claude's execution path. `post` writes the review, and it
+#    never runs Claude.
 #
 # 3. Do NOT add any other secrets (API keys, tokens, etc.) to the
 #    review job via `env:`, `with:`, or `secrets.*`. A prompt-
@@ -164,6 +170,78 @@ jobs:
         [ -n "$base_sha" ] || { echo "::error::empty base_sha"; exit 1; }
         echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
         echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+  start_signal:
+    name: Acknowledge request
+    needs: gate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+    outputs:
+      reaction_id: ${{ steps.start.outputs.reaction_id }}
+    steps:
+    - name: Add reaction and create PR status
+      id: start
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const issueNumber = context.issue.number;
+          const commentId = context.payload.comment.id;
+          const headSha = process.env.HEAD_SHA;
+          const runUrl = process.env.RUN_URL;
+          const statusContext = "Claude review";
+
+          const deleteReaction = async (reactionId) => {
+            try {
+              await github.rest.reactions.deleteForIssueComment({
+                owner, repo,
+                comment_id: commentId,
+                reaction_id: reactionId,
+              });
+            } catch (e) {
+              core.warning(`could not remove reaction ${reactionId}: ${e.message}`);
+            }
+          };
+
+          try {
+            const { data: reactions } = await github.rest.reactions.listForIssueComment({
+              owner, repo,
+              comment_id: commentId,
+              per_page: 100,
+            });
+            for (const reaction of reactions || []) {
+              if (!["eyes", "+1", "-1"].includes(reaction.content)) continue;
+              if (reaction.user?.login !== "github-actions[bot]") continue;
+              await deleteReaction(reaction.id);
+            }
+          } catch (e) {
+            core.warning(`could not look up existing bot reactions: ${e.message}`);
+          }
+
+          try {
+            const { data: reaction } = await github.rest.reactions.createForIssueComment({
+              owner, repo,
+              comment_id: commentId,
+              content: "eyes",
+            });
+            core.setOutput("reaction_id", String(reaction.id));
+          } catch (e) {
+            core.warning(`could not add eyes reaction: ${e.message}`);
+          }
+
+          await github.rest.repos.createCommitStatus({
+            owner, repo,
+            sha: headSha,
+            state: "pending",
+            context: statusContext,
+            target_url: runUrl,
+            description: `Claude is reviewing PR #${issueNumber}.`,
+          });
 
   review:
     name: Run Claude review (read-only)
@@ -454,7 +532,7 @@ jobs:
           write(parsed);
 
     - name: Upload review artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: review-${{ github.run_id }}
         path: _review/review.json
@@ -473,6 +551,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      check_conclusion: ${{ steps.post_review.outputs.check_conclusion }}
     steps:
     - name: Checkout trusted scripts (default branch, sparse)
       # Same shape as the review job's trusted-scripts step:
@@ -494,7 +574,7 @@ jobs:
       # an abort condition. The github-script step below detects a
       # missing/unreadable file and posts a failure-shape review.
       continue-on-error: true
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: review-${{ github.run_id }}
         path: _review
@@ -508,6 +588,7 @@ jobs:
         npm ci --ignore-scripts
 
     - name: Sanitize and post review
+      id: post_review
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
@@ -529,7 +610,15 @@ jobs:
           const headSha = process.env.HEAD_SHA;
           const runUrl = process.env.RUN_URL;
           const agentName = process.env.AGENT_NAME;
-          const failure = (body) => ({ body, event: "COMMENT", comments: [] });
+          let reviewFailed = false;
+          const failure = (body) => {
+            reviewFailed = true;
+            return { body, event: "COMMENT", comments: [] };
+          };
+          const failureBody = (body) =>
+            typeof body === "string" &&
+            (body.startsWith("Review failed:") ||
+             body.startsWith("Review aborted:"));
 
           // Read the artifact; fall back to failure shape on I/O error.
           let review;
@@ -559,6 +648,7 @@ jobs:
               "during post-job re-scan. The review was not posted to " +
               "avoid leaking credentials. Re-run `/review` to retry.");
           }
+          if (failureBody(review.body)) reviewFailed = true;
 
           // Compose the review body (transparency header + Claude's body + footer).
           const parts = [];
@@ -586,6 +676,7 @@ jobs:
               event: "COMMENT",
               comments: review.comments,
             });
+            core.setOutput("check_conclusion", reviewFailed ? "failure" : "success");
           } catch (e) {
             core.error(`createReview failed: ${e.message}`);
             await github.rest.issues.createComment({
@@ -595,4 +686,85 @@ jobs:
                 `(${runUrl}) for details. Re-run \`/review\` to retry.`,
             });
             throw e;
+          }
+
+  finish_signal:
+    name: Finalize request signal
+    needs: [gate, start_signal, post]
+    if: ${{ always() && needs.gate.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+    - name: Complete PR status and update reaction
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        CHECK_CONCLUSION: ${{ needs.post.outputs.check_conclusion }}
+        EYES_REACTION_ID: ${{ needs.start_signal.outputs.reaction_id }}
+        HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        POST_RESULT: ${{ needs.post.result }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const commentId = context.payload.comment.id;
+          const headSha = process.env.HEAD_SHA;
+          const postSucceeded = process.env.POST_RESULT === "success";
+          const reviewSucceeded = process.env.CHECK_CONCLUSION === "success";
+          const succeeded = postSucceeded && reviewSucceeded;
+          const runUrl = process.env.RUN_URL;
+          const statusContext = "Claude review";
+          const description = succeeded
+            ? "Claude posted a review on this PR."
+            : "Claude did not post a review successfully.";
+
+          await github.rest.repos.createCommitStatus({
+            owner, repo,
+            sha: headSha,
+            state: succeeded ? "success" : "failure",
+            context: statusContext,
+            target_url: runUrl,
+            description,
+          });
+
+          const deleteReaction = async (reactionId) => {
+            try {
+              await github.rest.reactions.deleteForIssueComment({
+                owner, repo,
+                comment_id: commentId,
+                reaction_id: reactionId,
+              });
+            } catch (e) {
+              core.warning(`could not remove reaction ${reactionId}: ${e.message}`);
+            }
+          };
+
+          const reactionId = Number(process.env.EYES_REACTION_ID);
+          if (reactionId) {
+            await deleteReaction(reactionId);
+          }
+          try {
+            const { data: reactions } = await github.rest.reactions.listForIssueComment({
+              owner, repo,
+              comment_id: commentId,
+              per_page: 100,
+            });
+            for (const reaction of reactions || []) {
+              if (!["eyes", "+1", "-1"].includes(reaction.content)) continue;
+              if (reaction.user?.login !== "github-actions[bot]") continue;
+              if (reaction.id === reactionId) continue;
+              await deleteReaction(reaction.id);
+            }
+          } catch (e) {
+            core.warning(`could not look up existing bot reactions: ${e.message}`);
+          }
+          try {
+            await github.rest.reactions.createForIssueComment({
+              owner, repo,
+              comment_id: commentId,
+              content: succeeded ? "+1" : "-1",
+            });
+          } catch (e) {
+            core.warning(`could not add final reaction: ${e.message}`);
           }


### PR DESCRIPTION
## Summary

- Add start and finish signal jobs that manage requester reactions and the `Claude review` commit status.
- Harden reaction cleanup so stale bot eyes/thumb reactions are removed before setting the current result.
- Update the Claude review artifact upload/download action pins from the sandbox work.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude_review.yml"); puts "YAML OK"'`
- `git diff --cached --check`
