### PR TITLE
[DOCS-ATO] Move Account Takeover Protection under App and API Protection

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7481,31 +7481,26 @@ menu:
       parent: security_platform
       identifier: security_access_control
       weight: 9
-    - name: Account Takeover Protection
-      url: security/account_takeover_protection
-      parent: security_platform
-      identifier: security_ato_protection
-      weight: 10
     - name: Ticketing Integrations
       url: security/ticketing_integrations
       parent: security_platform
       identifier: security_ticketing_integrations
-      weight: 11
+      weight: 10
     - name: Research Feed
       url: security/research_feed
       parent: security_platform
       identifier: security_research_feed
-      weight: 12
+      weight: 11
     - name: Security MCP Tools
       url: security/mcp_server
       parent: security_platform
       identifier: security_mcp_server
-      weight: 13
+      weight: 12
     - name: Guides
       url: security/guide
       parent: security_platform
       identifier: security_guides
-      weight: 14
+      weight: 13
     - name: Cloud SIEM
       url: security/cloud_siem/
       pre: siem
@@ -8145,11 +8140,16 @@ menu:
       parent: application_security
       identifier: aws_waf_int
       weight: 8
+    - name: Account Takeover Protection
+      url: security/application_security/account_takeover_protection/
+      parent: application_security
+      identifier: security_ato_protection
+      weight: 9
     - name: API Posture
       url: security/application_security/api_posture/
       parent: application_security
       identifier: application_security_api_security
-      weight: 9
+      weight: 10
     - name: API Inventory
       url: security/application_security/api_posture/api_inventory/
       parent: application_security_api_security
@@ -8164,12 +8164,12 @@ menu:
       url: security/application_security/guide/
       parent: application_security
       identifier: appsec_guides
-      weight: 10
+      weight: 11
     - name: Troubleshooting
       url: security/application_security/troubleshooting/
       parent: application_security
       identifier: appsec_troubleshooting
-      weight: 11
+      weight: 12
     - name: AI Guard
       url: /security/ai_guard/
       pre: siem

--- a/config/_default/menus/main.es.yaml
+++ b/config/_default/menus/main.es.yaml
@@ -6182,26 +6182,21 @@ menu:
       parent: security_platform
       identifier: security_access_control
       weight: 8
-    - name: Protección contra la apropiación de cuentas
-      url: security/account_takeover_protection
-      parent: security_platform
-      identifier: security_ato_protection
-      weight: 9
     - name: Ticketing Integrations
       url: security/ticketing_integrations
       parent: security_platform
       identifier: security_ticketing_integrations
-      weight: 10
+      weight: 9
     - name: Research Feed
       url: security/research_feed
       parent: security_platform
       identifier: security_research_feed
-      weight: 11
+      weight: 10
     - name: Guías
       url: security/guide
       parent: security_platform
       identifier: security_guides
-      weight: 12
+      weight: 11
     - name: Cloud SIEM
       url: security/cloud_siem/
       pre: siem
@@ -6651,21 +6646,26 @@ menu:
       parent: application_security
       identifier: aws_waf_int
       weight: 8
+    - name: Protección contra la apropiación de cuentas
+      url: security/application_security/account_takeover_protection/
+      parent: application_security
+      identifier: security_ato_protection
+      weight: 9
     - name: Inventario de seguridad de la API
       url: security/application_security/api-inventory/
       parent: application_security
       identifier: asm_api_security
-      weight: 9
+      weight: 10
     - name: Guías
       url: security/application_security/guide/
       parent: application_security
       identifier: appsec_guides
-      weight: 10
+      weight: 11
     - name: Solucionar problemas
       url: security/application_security/troubleshooting/
       parent: application_security
       identifier: appsec_troubleshooting
-      weight: 11
+      weight: 12
     - name: Sensitive Data Scanner
       url: /security/sensitive_data_scanner/
       pre: sensitive-data-scanner

--- a/config/_default/menus/main.fr.yaml
+++ b/config/_default/menus/main.fr.yaml
@@ -6187,26 +6187,21 @@ menu:
       parent: security_platform
       identifier: security_access_control
       weight: 8
-    - name: Account Takeover Protection
-      url: security/account_takeover_protection
-      parent: security_platform
-      identifier: security_ato_protection
-      weight: 9
     - name: Ticketing Integrations
       url: security/ticketing_integrations
       parent: security_platform
       identifier: security_ticketing_integrations
-      weight: 10
+      weight: 9
     - name: Research Feed
       url: security/research_feed
       parent: security_platform
       identifier: security_research_feed
-      weight: 11
+      weight: 10
     - name: Guides
       url: security/guide
       parent: security_platform
       identifier: security_guides
-      weight: 12
+      weight: 11
     - name: Cloud SIEM
       url: security/cloud_siem/
       pre: siem
@@ -6656,21 +6651,26 @@ menu:
       parent: application_security
       identifier: aws_waf_int
       weight: 8
+    - name: Account Takeover Protection
+      url: security/application_security/account_takeover_protection/
+      parent: application_security
+      identifier: security_ato_protection
+      weight: 9
     - name: API Security Inventory
       url: security/application_security/api-inventory/
       parent: application_security
       identifier: asm_api_security
-      weight: 9
+      weight: 10
     - name: Guides
       url: security/application_security/guide/
       parent: application_security
       identifier: appsec_guides
-      weight: 10
+      weight: 11
     - name: Dépannage
       url: security/application_security/troubleshooting/
       parent: application_security
       identifier: appsec_troubleshooting
-      weight: 11
+      weight: 12
     - name: Sensitive Data Scanner
       url: /security/sensitive_data_scanner/
       pre: sensitive-data-scanner

--- a/config/_default/menus/main.ja.yaml
+++ b/config/_default/menus/main.ja.yaml
@@ -6187,26 +6187,21 @@ menu:
       parent: security_platform
       identifier: security_access_control
       weight: 8
-    - name: Account Takeover Protection
-      url: security/account_takeover_protection
-      parent: security_platform
-      identifier: security_ato_protection
-      weight: 9
     - name: Ticketing Integrations
       url: security/ticketing_integrations
       parent: security_platform
       identifier: security_ticketing_integrations
-      weight: 10
+      weight: 9
     - name: Research Feed
       url: security/research_feed
       parent: security_platform
       identifier: security_research_feed
-      weight: 11
+      weight: 10
     - name: Guides
       url: security/guide
       parent: security_platform
       identifier: security_guides
-      weight: 12
+      weight: 11
     - name: Cloud SIEM
       url: security/cloud_siem/
       pre: siem
@@ -6656,21 +6651,26 @@ menu:
       parent: application_security
       identifier: aws_waf_int
       weight: 8
+    - name: Account Takeover Protection
+      url: security/application_security/account_takeover_protection/
+      parent: application_security
+      identifier: security_ato_protection
+      weight: 9
     - name: API Security Inventory
       url: security/application_security/api-inventory/
       parent: application_security
       identifier: asm_api_security
-      weight: 9
+      weight: 10
     - name: ガイド
       url: security/application_security/guide/
       parent: application_security
       identifier: appsec_guides
-      weight: 10
+      weight: 11
     - name: トラブルシューティング
       url: security/application_security/troubleshooting/
       parent: application_security
       identifier: appsec_troubleshooting
-      weight: 11
+      weight: 12
     - name: Sensitive Data Scanner
       url: /security/sensitive_data_scanner/
       pre: sensitive-data-scanner

--- a/config/_default/menus/main.ko.yaml
+++ b/config/_default/menus/main.ko.yaml
@@ -6187,26 +6187,21 @@ menu:
       parent: security_platform
       identifier: security_access_control
       weight: 8
-    - name: 계정 인수 보호
-      url: security/account_takeover_protection
-      parent: security_platform
-      identifier: security_ato_protection
-      weight: 9
     - name: Ticketing Integrations
       url: security/ticketing_integrations
       parent: security_platform
       identifier: security_ticketing_integrations
-      weight: 10
+      weight: 9
     - name: Research Feed
       url: security/research_feed
       parent: security_platform
       identifier: security_research_feed
-      weight: 11
+      weight: 10
     - name: Guides
       url: security/guide
       parent: security_platform
       identifier: security_guides
-      weight: 12
+      weight: 11
     - name: 클라우드 보안 정보와 이벤트 관리(SIEM)
       url: security/cloud_siem/
       pre: siem
@@ -6656,21 +6651,26 @@ menu:
       parent: application_security
       identifier: aws_waf_int
       weight: 8
+    - name: 계정 인수 보호
+      url: security/application_security/account_takeover_protection/
+      parent: application_security
+      identifier: security_ato_protection
+      weight: 9
     - name: API 보안 인벤토리
       url: security/application_security/api-inventory/
       parent: application_security
       identifier: asm_api_security
-      weight: 9
+      weight: 10
     - name: 가이드
       url: security/application_security/guide/
       parent: application_security
       identifier: appsec_guides
-      weight: 10
+      weight: 11
     - name: 트러블슈팅
       url: security/application_security/troubleshooting/
       parent: application_security
       identifier: appsec_troubleshooting
-      weight: 11
+      weight: 12
     - name: 민감한 데이터 스캐너
       url: /security/sensitive_data_scanner/
       pre: sensitive-data-scanner

--- a/content/en/security/application_security/account_takeover_protection.md
+++ b/content/en/security/application_security/account_takeover_protection.md
@@ -1,6 +1,8 @@
 ---
 title: Account Takeover Protection
 disable_toc: false
+aliases:
+  - /security/account_takeover_protection/
 further_reading:
 - link: "security/application_security/terms/"
   tag: "Documentation"

--- a/content/en/security/application_security/guide/manage_account_theft_appsec.md
+++ b/content/en/security/application_security/guide/manage_account_theft_appsec.md
@@ -702,7 +702,7 @@ In this guide, you did the following:
 
 This is general guidance. Depending on your applications and environments, there might be a need for additional response strategies.
 
-[1]: /security/account_takeover_protection/
+[1]: /security/application_security/account_takeover_protection/
 [2]: https://app.datadoghq.com/services?query=service%3Auser-auth&env=%2A&fromUser=false&hostGroup=%2A&lens=Security&sort=-fave%2C-team&start=1735636008863&end=1735639608863
 [3]: /security/application_security/setup/compatibility/
 [4]: /remote_configuration
@@ -716,7 +716,7 @@ This is general guidance. Depending on your applications and environments, there
 [12]: https://app.datadoghq.com/organization-settings/remote-config?resource_type=agents
 [13]: /security/application_security/how-it-works/add-user-info/?tab=set_user#tracking-business-logic-information-without-modifying-the-code
 [14]: https://app.datadoghq.com/security/appsec/threat
-[15]: /security/account_takeover_protection/#attacker-strategies
+[15]: /security/application_security/account_takeover_protection/#attacker-strategies
 [16]: https://app.datadoghq.com/security/appsec/detection-rules?query=type%3Aapplication_security%20tag%3A%22category%3Aaccount_takeover%22&deprecated=hide&groupBy=none&sort=date&viz=rules
 [17]: /security/notifications/
 [18]: https://app.datadoghq.com/security/configuration/notification-rules/new?notificationData=

--- a/content/en/security/application_security/policies/inapp_waf_rules.md
+++ b/content/en/security/application_security/policies/inapp_waf_rules.md
@@ -145,4 +145,4 @@ Next, [configure detection rules to create security signals][1] based on those s
 [3]: /security/application_security/setup/
 [4]: https://app.datadoghq.com/security/appsec/in-app-waf?config_by=custom-rules
 [5]: https://app.datadoghq.com/security/appsec/policies/in-app-waf?config_by=suggested-rules
-[6]: /security/account_takeover_protection
+[6]: /security/application_security/account_takeover_protection/

--- a/content/es/security/application_security/account_takeover_protection.md
+++ b/content/es/security/application_security/account_takeover_protection.md
@@ -1,5 +1,7 @@
 ---
 disable_toc: false
+aliases:
+  - /es/security/account_takeover_protection/
 further_reading:
 - link: security/application_security/terms/
   tag: Documentación

--- a/content/es/security/application_security/policies/inapp_waf_rules.md
+++ b/content/es/security/application_security/policies/inapp_waf_rules.md
@@ -145,4 +145,4 @@ A continuación, [configura reglas de detección para crear señales de segurida
 [3]: /es/security/application_security/setup/
 [4]: https://app.datadoghq.com/security/appsec/in-app-waf?config_by=custom-rules
 [5]: https://app.datadoghq.com/security/appsec/policies/in-app-waf?config_by=suggested-rules
-[6]: /es/security/account_takeover_protection
+[6]: /es/security/application_security/account_takeover_protection/

--- a/content/ja/security/application_security/account_takeover_protection.md
+++ b/content/ja/security/application_security/account_takeover_protection.md
@@ -1,5 +1,7 @@
 ---
 disable_toc: false
+aliases:
+  - /ja/security/account_takeover_protection/
 further_reading:
 - link: security/application_security/terms/
   tag: ドキュメント

--- a/content/ja/security/application_security/threats/_index.md
+++ b/content/ja/security/application_security/threats/_index.md
@@ -82,5 +82,5 @@ AAP に付属するデフォルト ルールを補完するために、アプリ
 [8]: /ja/security/workload_protection/security_signals/
 [9]: /ja/security/application_security/exploit-prevention/
 [10]: /ja/security/default_rules/?category=cat-application-security
-[11]: /ja/security/account_takeover_protection/
+[11]: /ja/security/application_security/account_takeover_protection/
 [12]: /ja/security/application_security/troubleshooting/#disabling-threat-management-and-protection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Moves ATO docs (and translations) under App and API Protection (AAP). This is done because ATO is strictly related to AAP only and not other security products.

Updates main menus across all five languages, fixes internal links, and adds aliases.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes