### PR TITLE
Update aws api gateway doc 

### DIFF
--- a/content/en/security/application_security/api_posture/api_inventory.md
+++ b/content/en/security/application_security/api_posture/api_inventory.md
@@ -96,7 +96,7 @@ The following data sources are explored.
 
 #### Amazon API Gateway
 
-<div class="alert alert-info">To disable this integration for a specific API, add the <code>dd_skip_endpoint:true</code> tag to the resource</div>
+<div class="alert alert-info">To disable this integration for a specific API, add the <code>dd_skip_endpoint:true</code> tag to the resource.</div>
 
 The Amazon API Gateway service formally defines your API structure. Datadog AWS integration reads this pre-defined configuration from the Amazon API Gateway, and then Datadog uses this configuration to create API endpoint entries in **Inventory**.
 

--- a/content/en/security/application_security/api_posture/api_inventory.md
+++ b/content/en/security/application_security/api_posture/api_inventory.md
@@ -96,6 +96,8 @@ The following data sources are explored.
 
 #### Amazon API Gateway
 
+<div class="alert alert-info">To disable this integration for a specific API, add the `dd_skip_endpoint:true` tag to the resource</div>
+
 The Amazon API Gateway service formally defines your API structure. Datadog AWS integration reads this pre-defined configuration from the Amazon API Gateway, and then Datadog uses this configuration to create API endpoint entries in **Inventory**.
 
 Use **AWS API Gateway** in **Data Source** to gain visibility into these exposed endpoints. You can also use the query `datasource:aws_apigateway`.

--- a/content/en/security/application_security/api_posture/api_inventory.md
+++ b/content/en/security/application_security/api_posture/api_inventory.md
@@ -96,7 +96,7 @@ The following data sources are explored.
 
 #### Amazon API Gateway
 
-<div class="alert alert-info">To disable this integration for a specific API, add the `dd_skip_endpoint:true` tag to the resource</div>
+<div class="alert alert-info">To disable this integration for a specific API, add the <code>dd_skip_endpoint:true</code> tag to the resource</div>
 
 The Amazon API Gateway service formally defines your API structure. Datadog AWS integration reads this pre-defined configuration from the Amazon API Gateway, and then Datadog uses this configuration to create API endpoint entries in **Inventory**.
 


### PR DESCRIPTION
Update the AAP aws api gateway documentation to mention the newly added way to skip it