### PR TITLE
Fix ToC incorrect highlight and search input text overlap [WEB-9223]

### DIFF
--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -122,7 +122,7 @@ export function onScroll() {
         // Treat hidden headings (e.g. display:none) as being below the
         // scroll-spy threshold so they are never active/highlighted in TOC.
         const rect = header.getBoundingClientRect();
-        return rect.height === 0 && rect.width === 0 ? (localOffset+1) : rect.top;
+        return rect.height === 0 && rect.width === 0 ? Infinity : rect.top;
     }
     
     const isCustomizableDoc = document.getElementById('cdoc-selector') ? true : false;
@@ -145,11 +145,16 @@ export function onScroll() {
         // TOC mapping
         for (let i = 0; i < sidenavMapping.length; i++) {
             const sideNavItem = sidenavMapping[i];
-            let j = i + 1;
-            if (j > sidenavMapping.length) {
-                j = 0;
+            // Skip hidden headings when finding the next sibling so that a
+            // section before a hidden heading correctly hands off to the next
+            // visible section.
+            let nextSideNavItem;
+            for (let j = i + 1; j < sidenavMapping.length; j++) {
+                if (getHeaderTop(sidenavMapping[j].header) !== Infinity) {
+                    nextSideNavItem = sidenavMapping[j];
+                    break;
+                }
             }
-            const nextSideNavItem = sidenavMapping[j];
             sideNavItem.navLink.classList.remove('toc_scrolled');
 
             if (

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -117,7 +117,14 @@ export function onScroll() {
     const windowTopPosition = scrollTop(window);
     const windowHeight = window.innerHeight;
     let localOffset = 65;
-
+    
+    const getHeaderTop = (header) => {
+        // Treat hidden headings (e.g. display:none) as being below the
+        // scroll-spy threshold so they are never active/highlighted in TOC.
+        const rect = header.getBoundingClientRect();
+        return rect.height === 0 && rect.width === 0 ? (localOffset+1) : rect.top;
+    }
+    
     const isCustomizableDoc = document.getElementById('cdoc-selector') ? true : false;
     if (isCustomizableDoc) {
         localOffset += 65;
@@ -147,9 +154,9 @@ export function onScroll() {
 
             if (
                 windowTopPosition !== 0 &&
-                sideNavItem.header.getBoundingClientRect().top <= 0 + localOffset &&
+                getHeaderTop(sideNavItem.header) <= localOffset &&
                 (typeof nextSideNavItem === 'undefined' ||
-                    nextSideNavItem.header.getBoundingClientRect().top > 0 + localOffset)
+                    getHeaderTop(nextSideNavItem.header) > localOffset)
             ) {
                 sideNavItem.navLink.classList.add('toc_scrolled');
                 // Add toc open to parents of this toc_scrolled

--- a/assets/styles/instantsearch/search-page.scss
+++ b/assets/styles/instantsearch/search-page.scss
@@ -22,6 +22,9 @@
     .ais-SearchBox-input {
         background-color: #e6e6e6;
         padding-right: 30px;
+        @media screen and (max-width: 1280px) {
+            padding-right: initial;
+        }
     }
 
     #count {

--- a/assets/styles/instantsearch/search-page.scss
+++ b/assets/styles/instantsearch/search-page.scss
@@ -21,6 +21,7 @@
 
     .ais-SearchBox-input {
         background-color: #e6e6e6;
+        padding-right: 30px;
     }
 
     #count {

--- a/assets/styles/instantsearch/searchbar-with-dropdown.scss
+++ b/assets/styles/instantsearch/searchbar-with-dropdown.scss
@@ -43,6 +43,7 @@
     .ais-SearchBox-input {
         font-feature-settings: 'lnum' 1;
         padding-left: 9px;
+        padding-right: 30px;
         margin-right: 8px;
 
         &:focus-visible {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

1. **ToC incorrect highlight (Catalog page)**: The `site-region` shortcode renders region-gated headings in a `display:none` container. `getBoundingClientRect()` returns all zeros for hidden elements, so the scroll-spy treated those headings as always at the top of the page, causing the heading before them to stay highlighted indefinitely. 
   - **Fix:** `getHeaderTop()` returns `Infinity` for zero-sized elements, and the next-sibling lookup skips hidden headings so the active section correctly hands off to the next visible one.

3. **Search input text overlap with "/" shortcut indicator**: The `::after` keyboard shortcut hint element overlaps long query text at certain viewport widths. 
   - **Fix:** added `padding-right: 30px` to `.ais-SearchBox-input` on the search results page and navbar search.

**motivation**: bug fix: [WEB-9223](https://datadoghq.atlassian.net/browse/WEB-9223)

**preview**:
- https://docs-staging.datadoghq.com/stefon.simmons/web-9223/internal_developer_portal/catalog/
    - scroll through the page and check that only the currently active heading is highlighted in the ToC
- https://docs-staging.datadoghq.com/stefon.simmons/web-9223/search/?s=what%20are%20the%20command%20line%20tools%20Datadog%20provides%3F
- https://docs-staging.datadoghq.com/stefon.simmons/web-9223/infrastructure/?s=what%20are%20the%20command%20line%20tools%20Datadog%20provides%3F
    - check that keyboard shortcut hint (`[ / ]`) does not overlap long search input

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Claude Code assisted with root cause analysis and initial implementation.

### Additional notes

[WEB-9223]: https://datadoghq.atlassian.net/browse/WEB-9223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ