### PR TITLE
Add dd-octo-sts trust policy for llm-obs-docs-agent (staging)

### DIFF
--- a/.github/chainguard/llm-obs-docs-agent.read.sts.yaml
+++ b/.github/chainguard/llm-obs-docs-agent.read.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+subject: 8ea95a57-9481-842b-ea3c-163bdc22d84e
+
+claim_pattern:
+  email: "rapid-ml-observability.llm-obs-docs-agent@kubernetes.us1.staging.dog"
+
+permissions:
+  contents: read
+  pull_requests: read


### PR DESCRIPTION
Authorizes the llm-obs-docs-agent RAPID service to get read-only GitHub tokens for DataDog/documentation via dd-octo-sts. The service uses these to search for and read documentation files that may need updating after a merged PR in the LLM Obs backend.