### PR TITLE
[DOCS-14551] Add permissions boundary troubleshooting to AWS manual setup and troubleshooting guides

### DIFF
--- a/content/en/integrations/guide/aws-integration-troubleshooting.md
+++ b/content/en/integrations/guide/aws-integration-troubleshooting.md
@@ -117,6 +117,7 @@ If you are not seeing expected AWS metrics in Datadog, work through the followin
 4. **Check whether the service requires additional enablement.** Some AWS services do not emit metrics to CloudWatch by default and require extra configuration in the AWS console. See [Which AWS services require additional setup beyond the core integration?][26] for a full list.
 5. **Wait for the polling interval.** Allow at least one collection cycle before investigating further. See [Expected metric delays](#expected-metric-delays) for timing by collection method.
 6. **Check for Service Control Policies (SCPs).** If your account is part of an AWS Organization, SCPs applied at the organization or organizational unit (OU) level can override IAM permissions and block API calls. Verify that no SCP denies the required permissions.
+7. **Check for permissions boundaries.** A [permissions boundary][30] sets the maximum permissions a role can have. If the boundary does not include an action required by the Datadog integration, AWS returns `AccessDenied` for that action even when the integration role policy appears to grant it. In the AWS IAM console, open the integration role and check the **Permissions boundary** tab to see whether a boundary is attached.
 
 ### Wrong count of aws.elb.healthy_host_count
 
@@ -221,3 +222,4 @@ By default, host-level tags remain permanently attached to AWS hosts. If you wan
 [27]: /integrations/amazon_elb/
 [28]: https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/overview.html
 [29]: https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/supported-services.html
+[30]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html

--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -142,6 +142,21 @@ After configuring the role, return to the [AWS integration page][1] and save the
 
 If your AWS account is part of an AWS Organization, [Service Control Policies][10] can block the integration even when the IAM role and trust policy are correct. See [Missing metrics][11] in the troubleshooting guide for details.
 
+**Permissions boundaries:**
+
+A [permissions boundary][12] sets the maximum permissions a role can have. Effective permissions are the intersection of the role's identity-based policies and the boundary policy. If the boundary does not include an action required by the Datadog integration, AWS returns `AccessDenied` for that action, and the integration tile may show `Datadog is not authorized to monitor some of your services` even when the integration role policy appears to grant the action.
+
+To check whether a permissions boundary is attached to your integration role:
+
+- **Console**: In the AWS IAM console, open the role, and check the **Permissions boundary** tab.
+- **CLI**: Run the following command:
+  ```
+  aws iam get-role --role-name <DATADOG-INTEGRATION-ROLE> \
+    --query 'Role.{PermissionsBoundary:PermissionsBoundary,RoleName:RoleName}'
+  ```
+
+To resolve the issue, coordinate with your IAM or security team to ensure the boundary policy includes the required Datadog integration actions.
+
 <div class="alert alert-danger">If there is a <code>Datadog is not authorized to perform sts:AssumeRole</code> error, follow the troubleshooting steps recommended in the UI, or read the <a href="https://docs.datadoghq.com/integrations/guide/error-datadog-not-authorized-sts-assume-role/" target="_blank">troubleshooting guide</a>.</div>
 
 \*{{% mainland-china-disclaimer %}}
@@ -157,6 +172,7 @@ If your AWS account is part of an AWS Organization, [Service Control Policies][1
 [9]: /integrations/guide/error-datadog-not-authorized-sts-assume-role/
 [10]: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html
 [11]: /integrations/guide/aws-integration-troubleshooting/#missing-metrics
+[12]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
 {{% /tab %}}
 {{% tab "Access keys" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14551

Adds permissions boundary troubleshooting content to two pages:

- **AWS Manual Setup Guide** (`aws-manual-setup.md`): New **Permissions boundaries** block in the Role delegation tab → Troubleshoot IAM role issues section, after the existing Service Control Policies block. Explains what a permissions boundary is, how it can cause `AccessDenied` errors even when the integration role policy appears correct, and how to check for one via the IAM console or CLI.
- **AWS Integration Troubleshooting Guide** (`aws-integration-troubleshooting.md`): New step 7 added to the Missing metrics checklist covering permissions boundaries.

### Additional notes

### References

- [AWS IAM permissions boundaries documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)