### PR TITLE
[DOCS-11737] Add dd-trace-api dependency note for Java manual log correlation

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -392,30 +392,7 @@ writer.file     = log.txt
 
 If APM is enabled for this application, you can correlate logs and traces by enabling trace ID injection. See [Connecting Java Logs and Traces][4].
 
-If you are manually injecting trace IDs using the Datadog `CorrelationIdentifier` API, add the `dd-trace-api` dependency to your project:
-
-{{< tabs >}}
-{{% tab "Maven" %}}
-
-```xml
-<dependency>
-    <groupId>com.datadoghq</groupId>
-    <artifactId>dd-trace-api</artifactId>
-    <version>${dd-trace-java.version}</version>
-</dependency>
-```
-
-{{% /tab %}}
-{{% tab "Gradle" %}}
-
-```groovy
-implementation 'com.datadoghq:dd-trace-api'
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-Replace `${dd-trace-java.version}` with the same version as your Datadog Java Agent (`dd-java-agent`).
+If you are manually injecting trace IDs using the Datadog `CorrelationIdentifier` API, you must add the `dd-trace-api` dependency to your build. See [Connecting Java Logs and Traces][4] for the dependency snippets and code examples.
 
 If you are _not_ correlating logs and traces, remove the MDC placeholders (`%X{dd.trace_id} %X{dd.span_id}`) from the log patterns included in the previous configuration examples.
 

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -392,6 +392,31 @@ writer.file     = log.txt
 
 If APM is enabled for this application, you can correlate logs and traces by enabling trace ID injection. See [Connecting Java Logs and Traces][4].
 
+If you are manually injecting trace IDs using the Datadog `CorrelationIdentifier` API, add the `dd-trace-api` dependency to your project:
+
+{{< tabs >}}
+{{% tab "Maven" %}}
+
+```xml
+<dependency>
+    <groupId>com.datadoghq</groupId>
+    <artifactId>dd-trace-api</artifactId>
+    <version>${dd-trace-java.version}</version>
+</dependency>
+```
+
+{{% /tab %}}
+{{% tab "Gradle" %}}
+
+```groovy
+implementation 'com.datadoghq:dd-trace-api'
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Replace `${dd-trace-java.version}` with the same version as your Datadog Java Agent (`dd-java-agent`).
+
 If you are _not_ correlating logs and traces, remove the MDC placeholders (`%X{dd.trace_id} %X{dd.span_id}`) from the log patterns included in the previous configuration examples.
 
 For example, if you are using Log4j 2 but not correlating logs and traces, remove the following block from the example log layout template, `MyLayout.json`:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-11737

The Java log collection page references MDC trace-ID placeholders but never states that manual injection with the `CorrelationIdentifier` API requires the `dd-trace-api` build dependency. This adds an explicit note making that requirement clear.

To avoid duplicating (and risking drift from) the dependency snippets, the note links to the canonical Maven/Gradle examples already documented on the [Connecting Java Logs and Traces](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/java/#manual-injection) page. That page already satisfies the connect-page side of the ticket, so no changes are needed there.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

