### PR TITLE
[DOCS-14645] Add preview form to Bits Data Analysis page

### DIFF
--- a/content/en/bits_ai/bits_data_analysis/_index.md
+++ b/content/en/bits_ai/bits_data_analysis/_index.md
@@ -15,8 +15,8 @@ cascade:
     site_support_id: bits_data_analysis
 ---
 
-{{< callout url="#" btn_hidden="true" header="false">}}
-  Bits Data Analysis is in Preview. Contact your Datadog representative to sign up.
+{{< callout url="https://www.datadoghq.com/product-preview/bits-data-analysis/" >}}
+  Bits Data Analysis is in Preview. Click <strong>Request Access</strong> to join the Preview program.
 {{< /callout >}}
 
 ## Overview


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The Preview signup form was published just after I merged the initial PR, this adds it.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes