### PR TITLE
Clarify deployment_type description in Datadog Extension config table

### DIFF
--- a/content/en/opentelemetry/integrations/datadog_extension.md
+++ b/content/en/opentelemetry/integrations/datadog_extension.md
@@ -271,7 +271,7 @@ The DaemonSet forwards to `monitoring/otelcol-gateway-l2`, the Layer-2 gateway f
 | `hostname` | Custom hostname for the Collector. | Auto-detected |
 | `http.endpoint` | Local HTTP server endpoint. | `localhost:9875` |
 | `http.path` | HTTP server path for metadata. | `/metadata` |
-| `deployment_type` | Deployment type for the Collector. One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
+| `deployment_type` | Identifies how the Collector is deployed. This value appears in [Fleet Automation][7] and is required for [gateway topology](#5-optional-configure-gateway-topology-preview). Set to `daemonset` for agent or DaemonSet Collectors, or `gateway` for gateway Collectors. One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
 | `installation_method` | How the Collector was installed. One of: `kubernetes`, `bare-metal`, `docker`, `ecs-fargate`, `eks-fargate`, or unset. Available in Collector v0.148.0 and later. | unset |
 | `gateway_service` | Set on **gateway** Collectors only. The Kubernetes Service fronting the gateway Collector pods. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |
 | `gateway_destination` | Set on any Collector that forwards telemetry to a downstream gateway. The Kubernetes Service that this Collector forwards telemetry to. Must match `gateway_service` on the receiving gateway Collector. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |

--- a/content/en/opentelemetry/integrations/datadog_extension.md
+++ b/content/en/opentelemetry/integrations/datadog_extension.md
@@ -271,7 +271,7 @@ The DaemonSet forwards to `monitoring/otelcol-gateway-l2`, the Layer-2 gateway f
 | `hostname` | Custom hostname for the Collector. | Auto-detected |
 | `http.endpoint` | Local HTTP server endpoint. | `localhost:9875` |
 | `http.path` | HTTP server path for metadata. | `/metadata` |
-| `deployment_type` | Identifies how the Collector is deployed. This value appears in [Fleet Automation][7] and is required for [gateway topology](#5-optional-configure-gateway-topology-preview). Set to `daemonset` for agent or DaemonSet Collectors, or `gateway` for gateway Collectors. One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
+| `deployment_type` | Identifies how the Collector is deployed. This value appears in [Fleet Automation][7] and is required for [gateway topology](#5-optional-configure-gateway-topology-preview). One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
 | `installation_method` | How the Collector was installed. One of: `kubernetes`, `bare-metal`, `docker`, `ecs-fargate`, `eks-fargate`, or unset. Available in Collector v0.148.0 and later. | unset |
 | `gateway_service` | Set on **gateway** Collectors only. The Kubernetes Service fronting the gateway Collector pods. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |
 | `gateway_destination` | Set on any Collector that forwards telemetry to a downstream gateway. The Kubernetes Service that this Collector forwards telemetry to. Must match `gateway_service` on the receiving gateway Collector. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Expands the `deployment_type` parameter description in the Datadog Extension configuration options table to explain:
- **What it controls**: visibility in Fleet Automation
- **When it's required**: gateway topology feature
- **What to set it to**: `daemonset` for agent/DaemonSet Collectors, `gateway` for gateway Collectors

Previously the description only listed the accepted values without explaining their purpose, which made it hard for readers to know when or why to set this field.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Prompted by user feedback in #otel-docs.