### PR TITLE
Add estimated usage metrics to AI Credits page

### DIFF
--- a/content/en/account_management/billing/ai_credits.md
+++ b/content/en/account_management/billing/ai_credits.md
@@ -78,7 +78,7 @@ To manage permissions, go to **Organization Settings > Roles**, select a role, a
 | Product | Metric | Description |
 |---|---|---|
 | [Bits Chat][1] | `datadog.estimated_usage.bits_chat.ai_credits` | AI Credits consumed by Bits Chat. |
-| [Bits Investigation][3] | `datadog.estimated_usage.bits_investigations.ai_credits` | AI Credits consumed by Bits Investigation. |
+| [Bits Investigation][3] | `datadog.estimated_usage.bits_investigation.ai_credits` | AI Credits consumed by Bits Investigation. |
 | [Bits Code][2] | `datadog.estimated_usage.bits_code.ai_credits` | AI Credits consumed by Bits Code. |
 | [Bits Agent Builder][4] | `datadog.estimated_usage.bits_agent_builder.ai_credits` | AI Credits consumed by Bits Agent Builder. |
 

--- a/content/en/account_management/billing/ai_credits.md
+++ b/content/en/account_management/billing/ai_credits.md
@@ -73,6 +73,15 @@ All AI Credits products are enabled by default with the Datadog Standard Role. T
 
 To manage permissions, go to **Organization Settings > Roles**, select a role, and toggle the relevant permission.
 
+## Monitor usage
+
+| Product | Metric | Description |
+|---|---|---|
+| [Bits Chat][1] | `datadog.estimated_usage.bits_chat.ai_credits` | AI Credits consumed by Bits Chat. |
+| [Bits Investigation][3] | `datadog.estimated_usage.bits_investigations.ai_credits` | AI Credits consumed by Bits Investigation. |
+| [Bits Code][2] | `datadog.estimated_usage.bits_code.ai_credits` | AI Credits consumed by Bits Code. |
+| [Bits Agent Builder][4] | `datadog.estimated_usage.bits_agent_builder.ai_credits` | AI Credits consumed by Bits Agent Builder. |
+
 ## Availability
 
 AI Credits are available to all Datadog customers except:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a "Monitor usage" section to the AI Credits billing page with a table of `datadog.estimated_usage` metrics for each AI Credits product (Bits Chat, Bits Investigation, Bits Code, Bits Agent Builder).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes