### PR TITLE
[MCP/ErrorTracking] add manage_datadog_error_tracking_issue_comments tool

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -713,6 +713,15 @@ Updates the state or assignee of an Error Tracking Issue in Datadog.
 - Assign Error Tracking Issue `a3c8f5d2-1b4e-4c9a-8f7d-2e6b9a1c3d5f` to me.
 - Set the state of Error Tracking Issue `7b2d4f6e-9c1a-4e3b-8d5f-1a7c9e2b4d6f` to ignored.
 
+### `manage_datadog_error_tracking_issue_comments`
+*Toolset: **error-tracking***\
+*Permissions Required: `Cases Read`, `Cases Write`, `Error Tracking Read`, and `Error Tracking Write`*\
+Adds, updates, or deletes a comment on a Datadog Error Tracking issue.
+
+- Add a comment to Error Tracking Issue `550e8400-e29b-41d4-a716-446655440000` saying "Investigating this now".
+- Update the comment we just added to say "Fixed in version 2.3.1".
+- Delete the comment we just added from that issue.
+
 ## Feature Flags
 
 Tools for managing [feature flags][51], including creating, listing, and updating flags and their environments.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -716,7 +716,7 @@ Updates the state or assignee of an Error Tracking Issue in Datadog.
 ### `manage_datadog_error_tracking_issue_comments`
 *Toolset: **error-tracking***\
 *Permissions Required: `Cases Read`, `Cases Write`, `Error Tracking Read`, and `Error Tracking Write`*\
-Adds, updates, or deletes a comment on a Datadog Error Tracking issue.
+Adds, updates, or deletes a comment on a Datadog Error Tracking Issue.
 
 - Add a comment to Error Tracking Issue `550e8400-e29b-41d4-a716-446655440000` saying "Investigating this now".
 - Update the comment we just added to say "Fixed in version 2.3.1".


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Tool `manage_datadog_error_tracking_issue_comments ` is currently in the experimental toolset and will be moved to GA (`error-tracking` toolset) soon.

### Merge instructions
Tool is released.

Merge readiness:
- [x] Ready for merge