### PR TITLE
[DOCS-14426] Add disable instructions for Bits Investigation

### DIFF
--- a/content/en/bits_ai/bits_ai_sre/configure.md
+++ b/content/en/bits_ai/bits_ai_sre/configure.md
@@ -2,7 +2,9 @@
 title: Configure Integrations and Settings
 ---
 
-Set up integrations to extend Bits Investigation’s capabilities:
+<div class="alert alert-danger">Bits Investigation does not have an org-level disable option. To stop using the feature, see <a href="#disable-bits-investigation">Disable Bits Investigation</a>.</div>
+
+Set up integrations to extend Bits Investigation's capabilities:
 - [Integrate with third-party observability and SCM platforms](#integrate-with-third-party-observability-and-scm-platforms) to enrich investigations with external telemetry and code context.
 - [Send investigation findings to ITSM and collaboration platforms](#send-investigation-findings-to-itsm-and-collaboration-platforms) to streamline incident response.
 - [Pull context from knowledge bases](#pull-context-from-knowledge-bases) to incorporate runbooks and documentation into investigations.
@@ -82,6 +84,10 @@ There are two RBAC permissions that apply to Bits Investigation:
 | Bits Investigations Write (`bits_investigations_write`) | Run and configure Bits investigations. | Datadog Standard Role  |
 
 These permissions are added by default to Managed Roles. If your organization uses Custom Roles or has previously modified the default roles, an admin with the User Access Manage permission needs to manually add these permissions to the appropriate roles. For details, see [Access Control][8].
+
+### Disable Bits Investigation
+
+There is no org-level option to disable Bits Investigation. To prevent your organization from using the feature, an admin with the User Access Manage permission must remove the `bits_investigations_read` and `bits_investigations_write` permissions from all roles. For details, see [Access Control][8].
 
 ## Configure rate limits
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-14426](https://datadoghq.atlassian.net/browse/DOCS-14426)

Adds a top-of-page alert and a `### Disable Bits Investigation` subsection to the Configure Integrations and Settings page. Documents that there is no org-level kill switch for Bits Investigation and directs admins to remove the `bits_investigations_read` and `bits_investigations_write` RBAC permissions from all roles as the workaround.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14426]: https://datadoghq.atlassian.net/browse/DOCS-14426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ