### PR TITLE
Add search syntax section to Dashboard List docs

### DIFF
--- a/content/en/dashboards/list/_index.md
+++ b/content/en/dashboards/list/_index.md
@@ -76,7 +76,6 @@ Preset lists are out-of-the-box dashboard lists in Datadog:
 | All Integrations         | Automatic dashboards created by Datadog when you install an integration.  |
 | All Shared               | Dashboards with authenticated or public link sharing enabled.             |
 | Created By You           | Custom dashboards created by the current user.                            |
-| Frequently Viewed By You | All dashboards frequently viewed by the current user.                     |
 | Recently Deleted         | Dashboards deleted within the last 30 days. [Restore deleted dashboards](#restore-deleted-dashboards) from this list.|
 | Security and Compliance  | Out-of-the-box Security dashboards.                                       |
 
@@ -87,6 +86,10 @@ Use the preset {{< ui >}}Recently Deleted{{< /ui >}} list to restore deleted das
 {{< img src="dashboards/list/recently_deleted_restore.png" alt="Restore deleted dashboard on the Recently Deleted list" style="width:100%;">}}
 
 ## Search syntax
+
+{{< callout url="#" btn_hidden="true" header="New" >}}
+Dashboard search syntax is available on the updated Dashboard List page.
+{{< /callout >}}
 
 Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, boolean operators, and range comparisons.
 
@@ -109,6 +112,7 @@ Narrow results to a specific field using `field:value` syntax.
 | `title:<value>` | Dashboard title | `title:elasticsearch` |
 | `description:<value>` | Dashboard description | `description:latency` |
 | `team:<value>` | Team tag | `team:dashboards-backend` |
+| `favorites:true` | Dashboards you have starred | `favorites:true` |
 | `type:<value>` | Dashboard type. Use `custom`, `integration`, or concrete values such as `custom_timeboard`, `custom_screenboard`, `integration_timeboard`, `integration_screenboard`. | `type:integration` |
 | `is_shared:true` | Dashboards with link sharing enabled | `is_shared:true` |
 | `popularity:<range>` | Popularity score (0–1) | `popularity:>=0.5` |
@@ -120,8 +124,6 @@ Narrow results to a specific field using `field:value` syntax.
 | `template_variables.prefix:<value>` | Template variable prefix | `template_variables.prefix:env` |
 | `template_variables.defaults:<value>` | Template variable default value | `template_variables.defaults:prod` |
 | `template_variables.available_values:<value>` | Available template variable value | `template_variables.available_values:us-east` |
-
-**Note**: `team:` works as a tag filter. Any tag in `key:value` format can be searched the same way—for example, `env:prod` or `service:web`.
 
 ### Boolean operators
 
@@ -143,10 +145,6 @@ Use `<`, `>`, `<=`, and `>=` with numeric fields.
 | `widgets.count:<N` | Fewer than N widgets | `widgets.count:<3` |
 | `widgets.count:>=N` | N or more widgets | `widgets.count:>=10` |
 | `popularity:>=N` | Popularity at or above threshold | `popularity:>=0.2` |
-
-### Favorites
-
-Use the {{< ui >}}Starred{{< /ui >}} toggle above the dashboard table to show only dashboards you have starred. This is separate from the search bar.
 
 ## Further Reading
 

--- a/content/en/dashboards/list/_index.md
+++ b/content/en/dashboards/list/_index.md
@@ -91,7 +91,7 @@ Use the preset {{< ui >}}Recently Deleted{{< /ui >}} list to restore deleted das
 Dashboard search syntax is in Preview.
 {{< /callout >}}
 
-Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, boolean operators, and range comparisons.
+Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, Boolean operators, and range comparisons.
 
 ### Free-text search
 
@@ -115,7 +115,7 @@ Narrow results to a specific field using `key:value` syntax.
 | `favorites:true` | Dashboards you have starred | `favorites:true` |
 | `type:<value>` | Dashboard type. Use `custom`, `integration`, or concrete values such as `custom_timeboard`, `custom_screenboard`, `integration_timeboard`, `integration_screenboard`. | `type:integration` |
 | `is_shared:true` | Dashboards with link sharing enabled | `is_shared:true` |
-| `popularity:<range>` | Popularity score (0–1) | `popularity:>=0.5` |
+| `popularity:<range>` | Popularity score (0 to 1) | `popularity:>=0.5` |
 | `widgets.count:<range>` | Number of widgets | `widgets.count:<5` |
 | `widgets.title:<value>` | Widget title | `widgets.title:cpu` |
 | `widgets.type:<value>` | Widget type | `widgets.type:geomap` |

--- a/content/en/dashboards/list/_index.md
+++ b/content/en/dashboards/list/_index.md
@@ -87,8 +87,8 @@ Use the preset {{< ui >}}Recently Deleted{{< /ui >}} list to restore deleted das
 
 ## Search syntax {#search-syntax}
 
-{{< callout url="#" btn_hidden="true" header="New" >}}
-Dashboard search syntax is available on the Dashboard List page.
+{{< callout url="#" btn_hidden="true" header="Preview" >}}
+Dashboard search syntax is in Preview.
 {{< /callout >}}
 
 Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, boolean operators, and range comparisons.

--- a/content/en/dashboards/list/_index.md
+++ b/content/en/dashboards/list/_index.md
@@ -85,10 +85,10 @@ Use the preset {{< ui >}}Recently Deleted{{< /ui >}} list to restore deleted das
 
 {{< img src="dashboards/list/recently_deleted_restore.png" alt="Restore deleted dashboard on the Recently Deleted list" style="width:100%;">}}
 
-## Search syntax
+## Search syntax {#search-syntax}
 
 {{< callout url="#" btn_hidden="true" header="New" >}}
-Dashboard search syntax is available on the updated Dashboard List page.
+Dashboard search syntax is available on the Dashboard List page.
 {{< /callout >}}
 
 Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, boolean operators, and range comparisons.
@@ -104,11 +104,11 @@ Type one or more words to search across dashboard titles, descriptions, author n
 
 ### Key:value filters
 
-Narrow results to a specific field using `field:value` syntax.
+Narrow results to a specific field using `key:value` syntax.
 
 | Filter | Description | Example |
 |--------|-------------|---------|
-| `author:<value>` | Dashboards whose author handle or display name matches | `author:brandon` |
+| `author:<value>` | Dashboards whose author handle or display name matches | `author:jane.doe` |
 | `title:<value>` | Dashboard title | `title:elasticsearch` |
 | `description:<value>` | Dashboard description | `description:latency` |
 | `team:<value>` | Team tag | `team:dashboards-backend` |
@@ -134,7 +134,7 @@ Combine filters with `AND`, `OR`, and `NOT` (case-sensitive). The `-` prefix and
 | `AND` | Both conditions must match | `type:integration AND team:platform` |
 | `OR` | Either condition must match | `k8s OR kubernetes` |
 | `NOT` / `-` / `!` | Exclude matching dashboards | `NOT type:integration` |
-| `field:(A OR B)` | Match either value for the same field | `team:(backend OR frontend)` |
+| `field:(A OR B)` | Match either value within a single field | `team:(backend OR frontend)` |
 
 ### Range operators
 

--- a/content/en/dashboards/list/_index.md
+++ b/content/en/dashboards/list/_index.md
@@ -86,6 +86,68 @@ Use the preset {{< ui >}}Recently Deleted{{< /ui >}} list to restore deleted das
 
 {{< img src="dashboards/list/recently_deleted_restore.png" alt="Restore deleted dashboard on the Recently Deleted list" style="width:100%;">}}
 
+## Search syntax
+
+Use the search bar at the top of the Dashboard List page to filter dashboards by name, author, tags, or widget content. The search supports free-text queries, key:value filters, boolean operators, and range comparisons.
+
+### Free-text search
+
+Type one or more words to search across dashboard titles, descriptions, author names, tags, and widget content.
+
+- **Single token**: `redis` matches dashboards with "redis" in the title, author, tags, or widgets.
+- **Multiple tokens**: `redis postgres` is equivalent to `redis AND postgres`—both tokens must appear.
+- **Quoted phrase**: `"web latency"` matches that exact phrase.
+- **Wildcard**: `elastic*` matches "elasticsearch", "elastic-search", and similar.
+
+### Key:value filters
+
+Narrow results to a specific field using `field:value` syntax.
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `author:<value>` | Dashboards whose author handle or display name matches | `author:brandon` |
+| `title:<value>` | Dashboard title | `title:elasticsearch` |
+| `description:<value>` | Dashboard description | `description:latency` |
+| `team:<value>` | Team tag | `team:dashboards-backend` |
+| `type:<value>` | Dashboard type. Use `custom`, `integration`, or concrete values such as `custom_timeboard`, `custom_screenboard`, `integration_timeboard`, `integration_screenboard`. | `type:integration` |
+| `is_shared:true` | Dashboards with link sharing enabled | `is_shared:true` |
+| `popularity:<range>` | Popularity score (0–1) | `popularity:>=0.5` |
+| `widgets.count:<range>` | Number of widgets | `widgets.count:<5` |
+| `widgets.title:<value>` | Widget title | `widgets.title:cpu` |
+| `widgets.type:<value>` | Widget type | `widgets.type:geomap` |
+| `widgets.metrics:<value>` | Metric used in a widget | `widgets.metrics:system.cpu.user` |
+| `template_variables.name:<value>` | Template variable name | `template_variables.name:service` |
+| `template_variables.prefix:<value>` | Template variable prefix | `template_variables.prefix:env` |
+| `template_variables.defaults:<value>` | Template variable default value | `template_variables.defaults:prod` |
+| `template_variables.available_values:<value>` | Available template variable value | `template_variables.available_values:us-east` |
+
+**Note**: `team:` works as a tag filter. Any tag in `key:value` format can be searched the same way—for example, `env:prod` or `service:web`.
+
+### Boolean operators
+
+Combine filters with `AND`, `OR`, and `NOT` (case-sensitive). The `-` prefix and `!` prefix are equivalent to `NOT`.
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `AND` | Both conditions must match | `type:integration AND team:platform` |
+| `OR` | Either condition must match | `k8s OR kubernetes` |
+| `NOT` / `-` / `!` | Exclude matching dashboards | `NOT type:integration` |
+| `field:(A OR B)` | Match either value for the same field | `team:(backend OR frontend)` |
+
+### Range operators
+
+Use `<`, `>`, `<=`, and `>=` with numeric fields.
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `widgets.count:<N` | Fewer than N widgets | `widgets.count:<3` |
+| `widgets.count:>=N` | N or more widgets | `widgets.count:>=10` |
+| `popularity:>=N` | Popularity at or above threshold | `popularity:>=0.2` |
+
+### Favorites
+
+Use the {{< ui >}}Starred{{< /ui >}} toggle above the dashboard table to show only dashboards you have starred. This is separate from the search bar.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

**Search syntax (new section)**
The "Syntax Help" link in the search bar points to an internal Confluence page. This adds the public version: a search syntax section on the Dashboard List docs page covering free-text queries, key:value filters (`author:`, `team:`, `favorites:true`, `type:`, `widgets.*`, and more), boolean/range operators, wildcards, and quoted phrases.

All syntax was checked against the actual `dashbooks-search-query` implementation and `dashboards_v3` ES index, not the wiki.

**Preset lists cleanup**
Removes "Frequently Viewed By You" — that list is no longer supported.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- Companion PR DataDog/web-ui#317359 updates `DEFAULT_SEARCH_HELP_URL` to point to `https://docs.datadoghq.com/dashboards/list/#search-syntax`. Merge this first so the anchor is live before the feature flag rolls out.
- Vale needs the `datadog-vale` styles repo to run locally — CI will cover it.