### PR TITLE
Fix link within tab (again)

### DIFF
--- a/content/en/agent/guide/datadog-disaster-recovery.md
+++ b/content/en/agent/guide/datadog-disaster-recovery.md
@@ -160,7 +160,7 @@ Then, follow the prompt to scope the hosts and telemetry (metrics, logs, traces)
 
 <div class="alert alert-danger">Cloud Integrations can only run in either your primary or DDR Datadog site, but not both at the same time, so failing them over ceases Cloud Integration data in your primary site. <strong>During an integration failover, integrations run only in the DDR data center.</strong> When no longer in failover, disable the failover policy to return integration data collection to the primary org.</div>
 
-[13]: https://app.datadoghq.com/fleet
+[100]: https://app.datadoghq.com/fleet
 
 {{% /tab %}}
 
@@ -308,6 +308,7 @@ During testing, integration telemetry is spread over both organizations. If you 
 [10]: /account_management/org_settings/service_accounts/
 [11]: /agent/remote_config/?tab=configurationyamlfile
 [12]: /agent/fleet_automation/#overview
+[13]: https://app.datadoghq.com/fleet
 [14]: mailto:success@datadoghq.com
 [15]: https://www.datadoghq.com/support/
 [16]: https://app.datadoghq.com/signup

--- a/content/en/agent/guide/datadog-disaster-recovery.md
+++ b/content/en/agent/guide/datadog-disaster-recovery.md
@@ -148,7 +148,7 @@ Contact your Datadog Customer Success Manager to schedule dedicated time windows
 {{< tabs >}}
 {{% tab "Using Fleet Automation (recommended)" %}}
 
-From the [Fleet Automation][13] page in your failover org, on the {{< ui >}}Configure Agents{{< /ui >}} tab, you can create a failover policy or reuse an existing one, and apply it to your fleet of Agents. Soon after the policy is enabled, Agents begin dual-shipping telemetry to both the primary and DDR (failover) observability sites.
+From the [Fleet Automation][100] page in your failover org, on the {{< ui >}}Configure Agents{{< /ui >}} tab, you can create a failover policy or reuse an existing one, and apply it to your fleet of Agents. Soon after the policy is enabled, Agents begin dual-shipping telemetry to both the primary and DDR (failover) observability sites.
 
 To create a failover policy, click on {{< ui >}}Create Failover Policy{{< /ui >}}.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The same link is used in both normal body text _and_ content within a tab, and when I noticed and fixed the link within the tab, I accidentally broke the body text version. The link reference needs to be within the tab itself, so we can't actually use the same link reference for both. This PR adds back the original reference (`[13]`) and updates the reference within the tab to use `[100]` (because presumably we won't have enough links on the page ever to cause a collision).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

None, all natural

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
