### PR TITLE
[Auto] DOCS-14674: Added `resource_catalog_policies: [gov, gov2]` to params.yaml with site_support_id on _index.md cascade

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  resource_catalog_policies: [gov, gov2]
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]

--- a/content/en/infrastructure/resource_catalog/policies/_index.md
+++ b/content/en/infrastructure/resource_catalog/policies/_index.md
@@ -16,6 +16,8 @@ further_reading:
   - link: https://www.datadoghq.com/blog/automate-infrastructure-operations-with-datadog-infrastructure-management
     tag: Blog
     text: Automate infrastructure operations with Datadog Infrastructure Management
+cascade:
+    site_support_id: resource_catalog_policies
 ---
 
 {{< site-region region="gov,gov2" >}}<div class="alert alert-danger"> Resource Catalog Policies is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>


### PR DESCRIPTION
## [DOCS-14674] Documentation Portal Update: Infrastructure > Resources > Policies

**Jira:** [DOCS-14674](https://datadoghq.atlassian.net//browse/DOCS-14674)

**Changes:** Added `resource_catalog_policies: [gov, gov2]` to params.yaml with site_support_id on _index.md cascade

[DOCS-14674]: https://datadoghq.atlassian.net/browse/DOCS-14674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14674]: https://datadoghq.atlassian.net/browse/DOCS-14674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ