### PR TITLE
[Auto] DOCS-14652: Added `source-code-management: [gov, gov2]` to params.yaml

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  source-code-management: [gov, gov2]
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]


### PR DESCRIPTION
## [DOCS-14652] Source Code Management Providers - Add US1-FED/US2-FED GitLab unsupported callout

**Jira:** [DOCS-14652](https://datadoghq.atlassian.net//browse/DOCS-14652)

**Changes:** Added `source-code-management: [gov, gov2]` to params.yaml

[DOCS-14652]: https://datadoghq.atlassian.net/browse/DOCS-14652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14652]: https://datadoghq.atlassian.net/browse/DOCS-14652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ