### PR TITLE
[Auto] DOCS-14612: Added `fleet_view: [gov, gov2]` to params.yaml

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  fleet_view: [gov, gov2]
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]


### PR DESCRIPTION
## [DOCS-14612] Documentation Portal Update: Fleet View

**Jira:** [DOCS-14612](https://datadoghq.atlassian.net//browse/DOCS-14612)

**Changes:** Added `fleet_view: [gov, gov2]` to params.yaml

[DOCS-14612]: https://datadoghq.atlassian.net/browse/DOCS-14612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14612]: https://datadoghq.atlassian.net/browse/DOCS-14612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ