### PR TITLE
Document AI Obs End-user Feedback Feature

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5515,6 +5515,11 @@ menu:
       parent: llm_obs_evaluations
       identifier: llm_obs_external_evaluations
       weight: 403
+    - name: End-User Feedback
+      url: llm_observability/evaluations/end_user_feedback
+      parent: llm_obs_evaluations
+      identifier: llm_obs_end_user_feedback
+      weight: 4030
     - name: Developer Guide
       url: llm_observability/evaluations/evaluation_developer_guide
       parent: llm_obs_evaluations

--- a/content/en/llm_observability/evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/_index.md
@@ -30,7 +30,7 @@ Datadog builds and supports [managed evaluations][2] to support common use cases
 
 ### Submit external evaluations
 
-You can also submit [external evaluations][3] using Datadog's API. This mechanism is great if you have your own evaluation system, but would like to centralize evaluation results within Datadog.
+You can also submit [external evaluations][3] using Datadog's API. Use this approach when you have your own evaluation system but want to centralize evaluation results within Datadog.
 
 ### Building custom evaluators
 

--- a/content/en/llm_observability/evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/_index.md
@@ -24,9 +24,13 @@ Agent Observability offers several ways to support evaluations. They can be conf
 
 Datadog builds and supports [managed evaluations][2] to support common use cases. You can enable and configure them within the Agent Observability application.
 
+### Submit end-user feedback
+
+[End-user feedback][13] lets you submit thumbs-up or thumbs-down ratings, accepted changes, free-text comments, and other user or agent feedback to Datadog. Feedback can be connected to spans, traces, sessions, or customer-defined entities with a feedback join key.
+
 ### Submit external evaluations
 
-You can also submit [external evaluations][3] using Datadog's API. This mechanism is great if you have your own evaluation system, but would like to centralize that information within Datadog.
+You can also submit [external evaluations][3] using Datadog's API. This mechanism is great if you have your own evaluation system, but would like to centralize evaluation results within Datadog.
 
 ### Building custom evaluators
 
@@ -73,3 +77,4 @@ Agent Observability offers an [Export API][9] that you can use to retrieve spans
 [10]: /llm_observability/guide/evaluation_developer_guide
 [11]: /llm_observability/evaluations/annotation_queues
 [12]: /security/sensitive_data_scanner/scanning_rules/library_rules/
+[13]: /llm_observability/evaluations/end_user_feedback

--- a/content/en/llm_observability/evaluations/end_user_feedback.md
+++ b/content/en/llm_observability/evaluations/end_user_feedback.md
@@ -1,0 +1,122 @@
+---
+title: End-User Feedback
+description: Submit end-user feedback to Agent Observability and connect it to spans, traces, sessions, or external entities.
+further_reading:
+    - link: '/llm_observability/instrumentation/api/#evaluations-api'
+      tag: 'Documentation'
+      text: 'Learn about the Evaluations API'
+    - link: '/llm_observability/evaluations/external_evaluations'
+      tag: 'Documentation'
+      text: 'Learn about submitting external evaluations'
+    - link: '/llm_observability/evaluations/annotation_queues'
+      tag: 'Documentation'
+      text: 'Learn about Annotation Queues'
+---
+
+## Overview
+
+End-user feedback lets you bring signals from the users of your LLM application into Agent Observability. Examples include thumbs-up or thumbs-down ratings, whether a user accepted an agent's change, and free-text comments about a response.
+
+Feedback is different from an evaluation. Use feedback for signals submitted by an end user. Use [external evaluations][1] for results produced by your own evaluator logic, where who submitted the evaluation is not relevant. Use [Annotation Queues][2] for structured review workflows run by your team.
+
+Submitted feedback will appear when viewing AI Observability sessions, traces, or spans.
+
+## Submit feedback
+
+Submit feedback with the [Evaluations API][3] by setting `event_kind` to `feedback`.
+
+Feedback events require:
+
+- `event_kind: "feedback"`
+- `submitter.id`, which identifies the user or agent that submitted the feedback
+- Exactly one target field: `span_id`, `trace_id`, `session_id`, or `feedback_join_key`
+- A value field that matches `metric_type`
+
+Feedback events must not include `join_on`. If `eval_scope` is omitted, Datadog infers it from the target field. If `eval_scope` is provided, it must match the selected target.
+
+### Target feedback
+
+| Target | Field | Use when |
+|--------|-------|----------|
+| Span | `span_id` | The feedback applies to one span. |
+| Trace | `trace_id` | The feedback applies to an entire trace. |
+| Session | `session_id` | The feedback applies to an entire session. |
+| External entity | `feedback_join_key` | The feedback applies to a customer-defined entity, such as an incident ID, report ID, task ID, or release check ID. |
+
+### Use a feedback join key
+
+Use `feedback_join_key` when feedback is not tied to a single span, trace, or session. First, enrich your spans with the `feedback_join_key` tag related to the external entity using the SDK's [Enriching spans][4] workflow or the [Spans API][5]. Then, submit feedback with the same `feedback_join_key`.
+
+## Examples
+
+### Submit thumbs-down feedback for a span
+
+{{< code-block lang="json" >}}
+{
+  "data": {
+    "type": "evaluation_metric",
+    "attributes": {
+      "metrics": [
+        {
+          "event_kind": "feedback",
+          "span_id": "20245611112024561111",
+          "ml_app": "weather-bot",
+          "timestamp_ms": 1765990800016,
+          "metric_type": "categorical",
+          "label": "thumbs",
+          "categorical_value": "down",
+          "assessment": "fail",
+          "submitter": {
+            "id": "user-123",
+            "type": "user"
+          }
+        }
+      ]
+    }
+  }
+}
+{{< /code-block >}}
+
+### Submit free-text feedback with a feedback join key
+
+{{< code-block lang="json" >}}
+{
+  "data": {
+    "type": "evaluation_metric",
+    "attributes": {
+      "metrics": [
+        {
+          "event_kind": "feedback",
+          "feedback_join_key": "incident-123",
+          "ml_app": "incident-agent",
+          "timestamp_ms": 1765990800016,
+          "metric_type": "text",
+          "label": "user_comment",
+          "text_value": "The investigation missed the customer impact.",
+          "assessment": "fail",
+          "submitter": {
+            "id": "user-123",
+            "type": "user"
+          }
+        }
+      ]
+    }
+  }
+}
+{{< /code-block >}}
+
+## Analyze feedback
+
+To create a dashboard widget for feedback, create the widget as you would for an evaluation and add the filter `@event_kind:feedback`.
+
+<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback will be added soon. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> until feedback filtering is available.</div>
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /llm_observability/evaluations/external_evaluations
+[2]: /llm_observability/evaluations/annotation_queues
+[3]: /llm_observability/instrumentation/api/#evaluations-api
+[4]: /llm_observability/instrumentation/sdk/?tab=python#enriching-spans
+[5]: /llm_observability/instrumentation/api/?tab=model#spans-api

--- a/content/en/llm_observability/evaluations/end_user_feedback.md
+++ b/content/en/llm_observability/evaluations/end_user_feedback.md
@@ -109,7 +109,7 @@ Use `feedback_join_key` when feedback is not tied to a single span, trace, or se
 
 To create a dashboard widget for feedback, create the widget as you would for an evaluation and add the filter `@event_kind:feedback`.
 
-<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback will be added soon. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> until feedback filtering is available.</div>
+<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback is not available. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> instead.</div>
 
 ## Further Reading
 

--- a/content/en/llm_observability/evaluations/end_user_feedback.md
+++ b/content/en/llm_observability/evaluations/end_user_feedback.md
@@ -15,11 +15,11 @@ further_reading:
 
 ## Overview
 
-End-user feedback lets you bring signals from the users of your LLM application into Agent Observability. Examples include thumbs-up or thumbs-down ratings, whether a user accepted an agent's change, and free-text comments about a response.
+End-user feedback captures input from users of your LLM application in Agent Observability. Examples include thumbs-up or thumbs-down ratings, whether a user accepted an agent's change, and free-text comments about a response.
 
 Feedback is different from an evaluation. Use feedback for signals submitted by an end user. Use [external evaluations][1] for results produced by your own evaluator logic, where who submitted the evaluation is not relevant. Use [Annotation Queues][2] for structured review workflows run by your team.
 
-Submitted feedback will appear when viewing AI Observability sessions, traces, or spans.
+Submitted feedback appears when viewing Agent Observability sessions, traces, or spans.
 
 ## Submit feedback
 

--- a/content/en/llm_observability/evaluations/external_evaluations.md
+++ b/content/en/llm_observability/evaluations/external_evaluations.md
@@ -25,7 +25,7 @@ further_reading:
 
 ## Overview
 
-In the context of LLM applications, it's important to evaluate the quality of your LLM application's responses.
+Evaluations measure the quality of your LLM application's responses.
 While Agent Observability provides a few out-of-the-box evaluations for your traces, you can submit your own evaluations to Agent Observability in two ways: with Datadog's [SDK](#submitting-evaluations-with-the-sdk), or with the [Agent Observability API](#submitting-evaluations-with-the-api). Use this naming convention for the evaluation label:
 
 * Evaluation labels must start with a letter.

--- a/content/en/llm_observability/evaluations/external_evaluations.md
+++ b/content/en/llm_observability/evaluations/external_evaluations.md
@@ -1,6 +1,6 @@
 ---
 title: External Evaluations
-description: Submit custom evaluations to Agent Observability using the Python SDK or the Agent Observability API to track user feedback and response quality.
+description: Submit custom evaluations to Agent Observability using the Python SDK or the Agent Observability API to track response quality.
 aliases:
     - /tracing/llm_observability/submit_evaluations
     - /llm_observability/submit_evaluations
@@ -18,11 +18,14 @@ further_reading:
     - link: '/llm_observability/evaluations/submit_nemo_evaluations'
       tag: 'Documentation'
       text: 'Learn about submitting evaluations from NVIDIA NeMo'
+    - link: '/llm_observability/evaluations/end_user_feedback'
+      tag: 'Documentation'
+      text: 'Learn about submitting end-user feedback'
 ---
 
 ## Overview
 
-In the context of LLM applications, it's important to track user feedback and evaluate the quality of your LLM application's responses.
+In the context of LLM applications, it's important to evaluate the quality of your LLM application's responses.
 While Agent Observability provides a few out-of-the-box evaluations for your traces, you can submit your own evaluations to Agent Observability in two ways: with Datadog's [SDK](#submitting-evaluations-with-the-sdk), or with the [Agent Observability API](#submitting-evaluations-with-the-api). Use this naming convention for the evaluation label:
 
 * Evaluation labels must start with a letter.
@@ -36,6 +39,8 @@ While Agent Observability provides a few out-of-the-box evaluations for your tra
 Evaluation labels must be unique for a given LLM application (<code>ml_app</code>) and organization.
 
 </div>
+
+<div class="alert alert-info">For feedback submitted by your users such as thumbs-up or thumbs-down ratings, accepted changes, free-text comments, and other signals, see <a href="/llm_observability/evaluations/end_user_feedback/">End-User Feedback</a>.</div>
 
 ## Submitting external evaluations with the SDK
 
@@ -97,16 +102,12 @@ To submit evaluations for <a href="/llm_observability/instrumentation/otel_instr
               "value": "1123132"
             }
           },
-          "span_id": "20245611112024561111",
-          "trace_id": "13932955089405749200",
           "ml_app": "weather-bot",
-          "timestamp_ms": 1609479200,
+          "timestamp_ms": 1765990800016,
           "metric_type": "score",
           "label": "Accuracy",
           "score_value": 3,
-          // source:otel required only for OpenTelemetry spans
           "tags": ["source:otel"],
-          "timestamp_ms": 1765990800016,
           "assessment": "pass",
           "reasoning": "it makes sense"
         }

--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -373,7 +373,7 @@ Use `feedback_join_key` when feedback applies to an external entity, such as an 
 
 To create dashboard widgets from feedback, create the widget as you would for an evaluation and add the filter `@event_kind:feedback`.
 
-<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback will be added soon. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> until feedback filtering is available.</div>
+<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback is not available. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> instead.</div>
 
 ### Request
 

--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -55,6 +55,7 @@ Method
     "attributes": {
       "ml_app": "weather-bot",
       "session_id": "1",
+      "feedback_join_key": "weather-request-123",
       "tags": [
         "service:weather-bot",
         "env:staging",
@@ -309,6 +310,7 @@ Type: `Dict[key (string), float64]`
 | apm_trace_id | string      | The ID of the associated APM trace. Defaults to match the `trace_id` field.   |
 | metrics     | Dict[key (string), float64]           | Datadog metrics to collect. See [Metrics](#metrics) for common metric names.         |
 | session_id  | string     | The span's `session_id`. Overrides the top-level `session_id` field.    |
+| feedback_join_key | string | A customer-defined key used to connect feedback to this span. Overrides the top-level `feedback_join_key` field. For details, see [End-User Feedback][4]. |
 | tags        | [[Tag](#tag)] | A list of tags to apply to this particular span.       |
 | service | string | The service name. |
 | ml_app | string | The LLM application name for this span. Overrides the top-level `ml_app` field. |
@@ -326,6 +328,7 @@ Type: `Dict[key (string), float64]`
 | spans [*required*]  | [[Span](#span)] | A list of spans.           |
 | tags                | [[Tag](#tag)]   | A list of top-level tags to apply to each span.        |
 | session_id          | string              | The session the list of spans belongs to. Can be overridden or set on individual spans as well. |
+| feedback_join_key   | string              | A customer-defined key used to connect feedback to the spans in the payload. Can be overridden or set on individual spans as well. For details, see [End-User Feedback][4]. |
 
 #### Tag
 
@@ -350,7 +353,7 @@ The name can be up to 193 characters long and may not contain contiguous or trai
 
 <div class="alert alert-info">For comprehensive examples and guidance on building custom evaluators, see the <a href="/llm_observability/guide/evaluation_developer_guide/">Evaluation Developer Guide</a>.</div>
 
-Use this endpoint to send evaluations to Datadog at the span, trace, or session level.
+Use this endpoint to send evaluations and end-user feedback to Datadog. Evaluations can be associated with spans, traces, or sessions. End-user feedback can be associated with spans, traces, sessions, or a customer-defined feedback join key.
 
 Endpoint
 : `https://api.{{< region-param key="dd_site" code="true" >}}/api/intake/llm-obs/v2/eval-metric`
@@ -358,12 +361,19 @@ Endpoint
 Method
 : `POST`
 
-Use the `eval_scope` field to set the granularity of the evaluation:
+Use the `eval_scope` field to set the granularity of an evaluation:
 
 - **`span`** (default): The evaluation is associated with a specific span. Use `join_on` to identify the target span with a tag key-value pair or a span ID and trace ID combination.
 - **`trace`**: The evaluation is associated with an entire trace. Use `join_on` to identify the root span of the trace.
 - **`session`**: The evaluation is associated with a session. Provide `session_id` instead of `join_on`.
 
+To submit feedback, set `event_kind` to `feedback`. Feedback events must include `submitter.id`, omit `join_on`, and provide exactly one target field: `span_id`, `trace_id`, `session_id`, or `feedback_join_key`. If `eval_scope` is omitted, Datadog infers it from the target field.
+
+Use `feedback_join_key` when feedback applies to an external entity, such as an incident ID, report ID, task ID, or release check ID, instead of a single span, trace, or session. To make the feedback appear with related telemetry, set the same `feedback_join_key` on the related spans when you submit them with the [Spans API](#spans-api) or by adding a `feedback_join_key:incident-1234` tag through [Enriching spans][5].
+
+To create dashboard widgets from feedback, create the widget as you would for an evaluation and add the filter `@event_kind:feedback`.
+
+<div class="alert alert-info">Support for filtering spans, traces, or sessions by feedback will be added soon. For example, you cannot yet filter traces to only traces with thumbs-down feedback. Use dashboards scoped to <code>@event_kind:feedback</code> until feedback filtering is available.</div>
 
 ### Request
 
@@ -448,6 +458,20 @@ Use the `eval_scope` field to set the granularity of the evaluation:
             },
             "passed_checks": ["coherence", "relevance", "factuality"]
           }
+        },
+        {
+          "event_kind": "feedback",
+          "feedback_join_key": "weather-request-123",
+          "ml_app": "weather-bot",
+          "timestamp_ms": 1765990800016,
+          "metric_type": "text",
+          "label": "user_comment",
+          "text_value": "The response did not answer whether I needed a jacket.",
+          "assessment": "fail",
+          "submitter": {
+            "id": "user-123",
+            "type": "user"
+          }
         }
       ]
     }
@@ -464,7 +488,7 @@ Use the `eval_scope` field to set the granularity of the evaluation:
 | Field   | Type                        | Description                              | Guaranteed |
 |---------|-----------------------------|------------------------------------------|------------|
 | ID      | string                      | Response UUID generated upon submission. | Yes        |
-| metrics | [[EvalMetric](#evalmetric)] | A list of evaluations.                   | Yes        |
+| metrics | [[EvalMetric](#evalmetric)] | A list of evaluations or feedback events. | Yes        |
 {{% /tab %}}
 
 {{% tab "Example" %}}
@@ -540,6 +564,22 @@ Use the `eval_scope` field to set the granularity of the evaluation:
             },
             "passed_checks": ["coherence", "relevance", "factuality"]
           }
+        },
+        {
+          "id": "fedbk34-h4i5-6j78-9k01-lmn2opq3rst4",
+          "event_kind": "feedback",
+          "eval_scope": "external",
+          "feedback_join_key": "weather-request-123",
+          "ml_app": "weather-bot",
+          "timestamp_ms": 1765990800016,
+          "metric_type": "text",
+          "label": "user_comment",
+          "text_value": "The response did not answer whether I needed a jacket.",
+          "assessment": "fail",
+          "submitter": {
+            "id": "user-123",
+            "type": "user"
+          }
         }
       ]
     }
@@ -555,28 +595,43 @@ Use the `eval_scope` field to set the granularity of the evaluation:
 
 | Field   | Type         | Description                                         |
 |---------|--------------|-----------------------------------------------------|
-| metrics [*required*] | [[EvalMetric](#evalmetric)] | A list of evaluations each associated with a span. |
-| tags        | [[Tag](#tag)] | A list of tags to apply to all the evaluations in the payload.       |
+| metrics [*required*] | [[EvalMetric](#evalmetric)] | A list of evaluations or feedback events. |
+| tags        | [[Tag](#tag)] | A list of tags to apply to all the evaluations or feedback events in the payload. |
 
 #### EvalMetric
 
 | Field                                                              | Type                | Description                                                                                            |
 |--------------------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------|
 | ID                                                                 | string              | Evaluation metric UUID (generated upon submission).                                                    |
-| eval_scope                                                         | string              | The granularity of the evaluation: `"span"` (default), `"trace"`, or `"session"`.                     |
-| join_on [*required for span and trace scope*]                      | [[JoinOn](#joinon)] | How the evaluation is joined to a span or trace. Required when `eval_scope` is `"span"` or `"trace"`. Must be absent when `eval_scope` is `"session"`. |
-| session_id [*required for session scope*]                          | string              | The session ID the evaluation is associated with. Required when `eval_scope` is `"session"`. Must be absent when `eval_scope` is `"span"` or `"trace"`. |
+| event_kind                                                         | string              | The kind of event. Accepted values are `"evaluation"` and `"feedback"`. Defaults to `"evaluation"` when omitted. |
+| eval_scope                                                         | string              | The granularity of the event: `"span"` (default for evaluations), `"trace"`, `"session"`, or `"external"` for feedback targeted by `feedback_join_key`. For feedback, this can be omitted and inferred from the target field. |
+| join_on [*required for span and trace scope evaluations*]          | [[JoinOn](#joinon)] | How an evaluation is joined to a span or trace. Required for evaluations when `eval_scope` is `"span"` or `"trace"`. Must be absent for feedback and for session evaluations. |
+| span_id                                                            | string              | For feedback, the ID of the span the feedback is associated with. Use this as one of the feedback target fields. |
+| trace_id                                                           | string              | For feedback, the ID of the trace the feedback is associated with. Use this as one of the feedback target fields. |
+| session_id [*required for session scope evaluations*]              | string              | The session ID the event is associated with. Required for evaluations when `eval_scope` is `"session"`. For feedback, use this as one of the feedback target fields. Must be absent when non-feedback `eval_scope` is `"span"` or `"trace"`. |
+| feedback_join_key                                                  | string              | For feedback, a customer-defined key for feedback that applies to an external entity instead of a single span, trace, or session. Must be absent for evaluations. |
+| submitter [*required for feedback*]                                | [Submitter](#submitter) | The user, agent, or other entity that submitted the feedback. |
 | timestamp_ms [*required*]                                          | int64               | A UTC UNIX timestamp in milliseconds representing the time the request was sent.                       |
 | ml_app [*required*]                                                | string              | The name of your LLM application. See [Application naming guidelines](#application-naming-guidelines). |
-| metric_type [*required*]                                           | string              | The type of evaluation: `"categorical"`, `"score"`, `"boolean"`, or `"json"`.                          |
-| label [*required*]                                                 | string              | The unique name or label for the provided evaluation .                                                 |
-| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category that the evaluation belongs to.                                     |
-| score_value [*required if the metric_type is "score"*]             | number              | A score value of the evaluation.                                                                       |
-| boolean_value [*required if the metric_type is "boolean"*]         | boolean             | A boolean value of the evaluation.                                                                     |
-| json_value [*required if the metric_type is "json"*]               | Dict[key (string), value] | A JSON object value of the evaluation.                                                           |
+| metric_type [*required*]                                           | string              | The value type: `"categorical"`, `"score"`, `"boolean"`, `"json"`, or `"text"`. The `"text"` type is supported only for feedback events. |
+| label [*required*]                                                 | string              | The unique name or label for the provided evaluation or feedback.                                      |
+| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category value.                                                              |
+| score_value [*required if the metric_type is "score"*]             | number              | A score value.                                                                                         |
+| boolean_value [*required if the metric_type is "boolean"*]         | boolean             | A boolean value.                                                                                       |
+| json_value [*required if the metric_type is "json"*]               | Dict[key (string), value] | A JSON object value.                                                                              |
+| text_value [*required if the metric_type is "text"*]               | string              | A text value. This is supported only for feedback events and is useful for free-text feedback.          |
 | assessment                                                         | string              | An assessment of this evaluation. Accepted values are `pass` and `fail`.                               |
 | reasoning                                                          | string              | A text explanation of the evaluation result.                                                           |
 | tags                                                               | [[Tag](#tag)]       | A list of tags to apply to this particular evaluation metric.                                          |
+
+For feedback events, provide exactly one of `span_id`, `trace_id`, `session_id`, or `feedback_join_key`. If you provide `eval_scope`, it must match the target field: `span_id` maps to `"span"`, `trace_id` maps to `"trace"`, `session_id` maps to `"session"`, and `feedback_join_key` maps to `"external"`.
+
+#### Submitter
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id [*required*] | string | Identifier for the user, agent, or other entity that submitted the feedback. |
+| type | string | Category for the submitter. Recommended values are `user` and `agent`. |
 
 #### JoinOn
 
@@ -614,3 +669,5 @@ Use the `eval_scope` field to set the granularity of the evaluation:
 [1]: /llm_observability/setup/sdk/
 [2]: /llm_observability/terms/
 [3]: /getting_started/tagging/
+[4]: /llm_observability/evaluations/end_user_feedback
+[5]: /llm_observability/instrumentation/sdk/?tab=python#enriching-spans


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds customer-facing docs for the new end-user feedback feature in Agent Observability.

It adds a new End-User Feedback page under Evaluations, updates the Evaluations overview and navigation, and expands the HTTP API reference to document `event_kind: feedback`, `submitter`, `text_value`, and `feedback_join_key`.

Motivation
----------
Customers need docs for submitting thumbs-up/down ratings, accepted changes, free-text comments, and other feedback signals without treating them as normal external evaluations.

This follows the user feedback RFC: https://docs.google.com/document/d/1OpFg6L5dj3yleyClRb1yRyG1QP93Ma3Pf6gNlroqsOc/edit

Source Code PRs
---------------
- Data model: https://github.com/DataDog/dd-source/pull/442890
- Standalone feedback event processing: https://github.com/DataDog/dd-source/pull/443018
- Feedback eval-metric intake: https://github.com/DataDog/dd-source/pull/444661
- Feedback eval-metric validation: https://github.com/DataDog/dd-source/pull/447413
- Release Agent feedback instrumentation: https://github.com/DataDog/dd-source/pull/452124
- `feedback_join_key` as a first-class span attribute: https://github.com/DataDog/dd-source/pull/458526

Important Details
-----------------
The docs call out the current limitation that filtering spans, traces, or sessions by feedback is not available yet. Dashboard widgets should be created like evaluation widgets and filtered with `@event_kind:feedback`.

These features will land soon and before this feature is GA.

AI Assistance
-------------
This PR was written with AI assistance and reviewed locally before opening.

QA
--
https://docs-staging.datadoghq.com/mtl/end-user-feedback-docs/llm_observability/evaluations/end_user_feedback
