### PR TITLE
(DOCS-14612): Adjust Fleet Automation site-support

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,7 +280,6 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
-  fleet_view: [gov, gov2]
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]
@@ -335,7 +334,7 @@ unsupported_sites:
   fips-compliance: [us,us3,us5,eu,ap1,ap2]
   fips-integrations: [us,us3,us5,eu,ap1,ap2]
   fips-proxy: [us,us3,us5,eu,ap1,ap2,gov2]
-  fleet_automation: [gov,gov2]
+  fleet-automation-standard-features: [gov,gov2]
   forwarding_audit_events: [gov,gov2]
   gcp-private-service-connect: [us,us3,gov,gov2,ap1,ap2]
   getting_started_feature_flags: [gov,gov2]

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -280,6 +280,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  fleet_view: [gov, gov2]
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]

--- a/content/en/agent/fleet_automation/_index.md
+++ b/content/en/agent/fleet_automation/_index.md
@@ -23,6 +23,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/fleet-automation/"
   tag: "Blog"
   text: "Centrally govern and remotely manage Datadog Agents at scale with Fleet Automation"
+site-support-id: fleet-automation-standard-features
 ---
 
 ## Overview

--- a/content/en/agent/fleet_automation/configure_agents.md
+++ b/content/en/agent/fleet_automation/configure_agents.md
@@ -8,6 +8,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
+site-support-id: fleet-automation-standard-features  
 ---
 
 Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes through guided workflows in the UI or with custom YAML files.

--- a/content/en/agent/fleet_automation/configure_integrations.md
+++ b/content/en/agent/fleet_automation/configure_integrations.md
@@ -11,6 +11,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
+site-support-id: fleet-automation-standard-features  
 ---
 
 {{< callout btn_hidden="true" header="Join the Preview!" >}}

--- a/content/en/agent/fleet_automation/fleet_view.md
+++ b/content/en/agent/fleet_automation/fleet_view.md
@@ -10,13 +10,12 @@ further_reading:
   text: "Send a flare"
 ---
 
-<div class="alert alert-info">
 {{< site-region region="gov,gov2" >}}
+<div class="alert alert-info">
 Fleet View is in Preview on Datadog Government sites (US1-FED and US2-FED).<br><br>
 Additional Fleet Automation functionality such as Configuring Agents, Upgrading Agents and Upgrading SDKs are not supported for your selected Datadog site ({{< region-param key=dd_site_name >}}).
-{{< /site-region >}}
 </div>
-
+{{< /site-region >}}
 
 Use [Fleet View][1] to gain insight into observability gaps on your hosts, outdated Agents or OTel Collectors, and Agents with integration issues.
 

--- a/content/en/agent/fleet_automation/fleet_view.md
+++ b/content/en/agent/fleet_automation/fleet_view.md
@@ -10,11 +10,12 @@ further_reading:
   text: "Send a flare"
 ---
 
+<div class="alert alert-info">
 {{< site-region region="gov,gov2" >}}
-Fleet View is in Preview on Datadog Government sites (US1-FED and US2-FED).
-
-Additional Fleet Automation functionality such as Configuring Agents, Upgrading Agents and Upgrading SDKs are still not supported for your selected Datadog site.
+Fleet View is in Preview on Datadog Government sites (US1-FED and US2-FED).<br><br>
+Additional Fleet Automation functionality such as Configuring Agents, Upgrading Agents and Upgrading SDKs are not supported for your selected Datadog site ({{< region-param key=dd_site_name >}}).
 {{< /site-region >}}
+</div>
 
 
 Use [Fleet View][1] to gain insight into observability gaps on your hosts, outdated Agents or OTel Collectors, and Agents with integration issues.

--- a/content/en/agent/fleet_automation/fleet_view.md
+++ b/content/en/agent/fleet_automation/fleet_view.md
@@ -10,6 +10,13 @@ further_reading:
   text: "Send a flare"
 ---
 
+{{< site-region region="gov,gov2" >}}
+Fleet View is in Preview on Datadog Government sites (US1-FED and US2-FED).
+
+Additional Fleet Automation functionality such as Configuring Agents, Upgrading Agents and Upgrading SDKs are still not supported for your selected Datadog site.
+{{< /site-region >}}
+
+
 Use [Fleet View][1] to gain insight into observability gaps on your hosts, outdated Agents or OTel Collectors, and Agents with integration issues.
 
 For each Datadog Agent, you can see:

--- a/content/en/agent/fleet_automation/upgrade_agents.md
+++ b/content/en/agent/fleet_automation/upgrade_agents.md
@@ -8,6 +8,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
+site-support-id: fleet-automation-standard-features
 ---
 
 Fleet Automation allows you to remotely upgrade Datadog Agents across your fleet without direct access to individual hosts. You can trigger upgrades immediately, schedule them during maintenance windows, or automate them through the API.

--- a/content/en/agent/fleet_automation/upgrade_sdks.md
+++ b/content/en/agent/fleet_automation/upgrade_sdks.md
@@ -5,6 +5,7 @@ further_reading:
 - link: "/agent/fleet_automation/"
   tag: "Documentation"
   text: "Fleet Automation"
+site-support-id: fleet-automation-standard-features
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/remote-upgrade-of-sdk-versions/" btn_hidden="false" header="Join the Preview!" >}}


### PR DESCRIPTION
Fleet View is in preview on gov sites, which means we can no longer use a blanket support parameter for Fleet Automation. This PR adds a site-support-id to most Fleet Automation pages and a banner to Fleet View scoped to gov 1 and 2.