### PR TITLE
[SEC-32704] Replace list_datadog_security_detection_rule(s) with unified get_datadog_security_detection_rules

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1168,22 +1168,14 @@ Returns the authoring reference and schema for detection rules. Covers supported
 - Show me the schema for sequence detection rules.
 - What tag conventions and query syntax does the detection rules API use?
 
-### `list_datadog_security_detection_rules`
+### `get_datadog_security_detection_rules`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Read`*\
-Lists detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to fetch the full definition of a specific rule.
+Retrieves security detection rules. Supports two modes: provide `rule_id` to get the full definition of a single rule by ID, or omit `rule_id` to list rules (optionally filtered with `query` and token-limited with `max_tokens`). The two modes are mutually exclusive.
 
 - List all enabled Cloud SIEM detection rules.
 - Show me detection rules tagged with `source:cloudtrail`.
-- Which rules are configured for impossible travel detection?
-
-### `get_datadog_security_detection_rule`
-*Toolset: **security***\
-*Permissions Required: `Security Monitoring Rules Read`*\
-Retrieves the full definition of a single detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
-
 - Get the full definition of detection rule `abc-123-def`.
-- Show me the queries and cases for the rule generating this signal.
 - What thresholds and group-by fields does this detection rule use?
 
 ### `get_datadog_security_suppressions`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -101,12 +101,8 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : Returns the authoring reference and schema for detection rules. Covers supported rule types, detection methods, query syntax, tag conventions, and field names that can be used as search facets. Use this before authoring or querying detection rules. Currently supported rule types: log detection and API security.
 : *Permissions required: `Security Monitoring Rules Read`*
 
-`list_datadog_security_detection_rules`
-: Lists detection rules for the organization. Detection rules define the conditions under which security signals are generated. Accepts an optional free-text query to filter results server-side. Use `get_datadog_security_detection_rule` to retrieve the full definition of a specific rule.
-: *Permissions required: `Security Monitoring Rules Read`*
-
-`get_datadog_security_detection_rule`
-: Retrieves the full definition of a single detection rule by ID, including queries, cases, options, filters, and metadata. Use `list_datadog_security_detection_rules` to find rule IDs.
+`get_datadog_security_detection_rules`
+: Retrieves security detection rules. Supports two modes: provide `rule_id` to get the full definition of a single rule by ID, or omit `rule_id` to list rules (optionally filtered with `query` and token-limited with `max_tokens`). The two modes are mutually exclusive.
 : *Permissions required: `Security Monitoring Rules Read`*
 
 ### Suppressions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Replaces the two separate detection rule tools (`list_datadog_security_detection_rules` and `get_datadog_security_detection_rule`) with the unified `get_datadog_security_detection_rules` tool, which supports both listing and single-rule retrieval via its `rule_id` argument.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes