### PR TITLE
[SCI][PR Gates] warn about required checks not supported on merge queues

### DIFF
--- a/content/en/pr_gates/_index.md
+++ b/content/en/pr_gates/_index.md
@@ -61,7 +61,7 @@ You can configure PR Gates rules for the following categories. Please note that 
 After creating PR Gates rules, Datadog will automatically create checks on your pull requests using the [GitHub integration][5] or [Azure DevOps Source Code integration][6]. Set those checks as required in GitHub or Azure DevOps when you are ready to enforce them.
 
 <div class="alert alert-warning">
-  PR Gates are not supported in pull requests in public repositories, or on pull requests targeting a destination branch in a different repository from the source branch (that is, forked repositories trying to merge into the main repository).
+  PR Gates are not supported in pull requests in public repositories, or on pull requests targeting a destination branch in a different repository from the source branch (that is, forked repositories trying to merge into the main repository). PR Gates can not be set as required on GitHub repositories using a merge queue.
 </div>
 
 ## Rule types


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add a note about PR Gates not being able to be set as required when using merge queues on GitHub repositories.

### Merge instructions

Merge readiness:
- [x] Ready for merge

