### PR TITLE
[APPSEC-67657] Add OpenAI and Anthropic to AI Guard automatic integrations

### DIFF
--- a/content/en/security/ai_guard/setup/automatic_integrations.md
+++ b/content/en/security/ai_guard/setup/automatic_integrations.md
@@ -134,7 +134,7 @@ AI Guard automatically evaluates the following OpenAI operations:
 - [Responses API][3]:
   - `client.responses.create()`
 
-**Note**: Streaming requests (`stream: true`) are not evaluated by AI Guard.
+**Note:** Streaming requests (`stream: true`) are not evaluated by AI Guard.
 
 [1]: https://github.com/openai/openai-node
 [2]: https://platform.openai.com/docs/api-reference/chat

--- a/content/en/security/ai_guard/setup/automatic_integrations.md
+++ b/content/en/security/ai_guard/setup/automatic_integrations.md
@@ -19,14 +19,17 @@ AI Guard can automatically evaluate LLM calls made through supported AI ecosyste
 {{< tabs >}}
 {{% tab "Python" %}}
 | Package                      | Supported Versions | SDK Version |
-|------------------------------|--------------------|----------------|
-| [LangChain](#langchain)      | >= 0.1.20          | >= 3.14.0      |
+|------------------------------|--------------------|-------------|
+| [LangChain](#langchain)      | >= 0.1.20          | >= 3.14.0   |
+| [OpenAI](#openai)            | >= 1.102.0         | >= 4.10.0   |
+| [Anthropic](#anthropic)      | >= 0.28.0          | >= 4.11.0   |
 
 {{% /tab %}}
 {{% tab "Node.js" %}}
 | Package                          | Supported Versions | SDK Version |
-|----------------------------------|--------------------|----------------|
-| [AI SDK](#vercel-ai-sdk)         | v6                 | >=5.95.0       |
+|----------------------------------|--------------------|-------------|
+| [AI SDK](#ai-sdk)                | v6                 | >= 5.95.0   |
+| [OpenAI](#openai-1)              | >= 4.87.0          | >= 5.105.0  |
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -35,12 +38,13 @@ AI Guard can automatically evaluate LLM calls made through supported AI ecosyste
 
 ## Integrations
 
+### Python
+
 {{< tabs >}}
-{{% tab "Python" %}}
-<!-- TODO: confirm traced methods and add details specific to AI Guard -->
+{{% tab "LangChain" %}}
 The LangChain integration automatically applies AI Guard evaluations to calls made through the [LangChain Python SDK][1].
 
-### Traced operations
+#### Traced operations
 
 AI Guard automatically evaluates the following LangChain operations:
 
@@ -55,10 +59,54 @@ AI Guard automatically evaluates the following LangChain operations:
 [2]: https://docs.langchain.com/oss/python/langchain/models
 [3]: https://docs.langchain.com/oss/python/langchain/tools
 {{% /tab %}}
-{{% tab "Node.js" %}}
+{{% tab "OpenAI" %}}
+The OpenAI integration automatically applies AI Guard evaluations to calls made through the [OpenAI Python SDK][1].
+
+#### Traced operations
+
+AI Guard automatically evaluates the following OpenAI operations:
+
+- [Chat completions][2]:
+  - `client.chat.completions.create()`
+  - `client.chat.completions.parse()`
+- [Responses API][3]:
+  - `client.responses.create()`
+  - `client.responses.parse()`
+
+[1]: https://github.com/openai/openai-python
+[2]: https://platform.openai.com/docs/api-reference/chat
+[3]: https://platform.openai.com/docs/api-reference/responses
+{{% /tab %}}
+{{% tab "Anthropic" %}}
+The Anthropic integration automatically applies AI Guard evaluations to calls made through the [Anthropic Python SDK][1].
+
+#### Traced operations
+
+AI Guard automatically evaluates the following Anthropic operations:
+
+- [Messages][2]:
+  - `client.messages.create()`
+  - `client.messages.stream()`
+
+For Anthropic SDK >= 0.37.0, AI Guard also evaluates beta messages operations:
+
+- [Beta messages][3]:
+  - `client.beta.messages.create()`
+  - `client.beta.messages.stream()`
+
+[1]: https://github.com/anthropics/anthropic-sdk-python
+[2]: https://docs.anthropic.com/en/api/messages
+[3]: https://docs.anthropic.com/en/api/messages
+{{% /tab %}}
+{{< /tabs >}}
+
+### Node.js
+
+{{< tabs >}}
+{{% tab "AI SDK" %}}
 The [AI SDK][1] integration automatically applies AI Guard evaluations to text and object generation, embeddings, and tool calls.
 
-### Traced operations
+#### Traced operations
 
 - [Text generation][2]:
   - `generateText`
@@ -74,9 +122,27 @@ The [AI SDK][1] integration automatically applies AI Guard evaluations to text a
 [3]: https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data
 [4]: https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
 {{% /tab %}}
+{{% tab "OpenAI" %}}
+The OpenAI integration automatically applies AI Guard evaluations to calls made through the [OpenAI Node.js SDK][1].
+
+#### Traced operations
+
+AI Guard automatically evaluates the following OpenAI operations:
+
+- [Chat completions][2]:
+  - `client.chat.completions.create()`
+  - `client.chat.completions.parse()`
+- [Responses API][3]:
+  - `client.responses.create()`
+
+**Note**: Streaming requests (`stream: true`) are not evaluated by AI Guard.
+
+[1]: https://github.com/openai/openai-node
+[2]: https://platform.openai.com/docs/api-reference/chat
+[3]: https://platform.openai.com/docs/api-reference/responses
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-

--- a/content/en/security/ai_guard/setup/automatic_integrations.md
+++ b/content/en/security/ai_guard/setup/automatic_integrations.md
@@ -20,16 +20,16 @@ AI Guard can automatically evaluate LLM calls made through supported AI ecosyste
 {{% tab "Python" %}}
 | Package                      | Supported Versions | SDK Version |
 |------------------------------|--------------------|-------------|
-| [LangChain](#langchain)      | >= 0.1.20          | >= 3.14.0   |
-| [OpenAI](#openai)            | >= 1.102.0         | >= 4.10.0   |
-| [Anthropic](#anthropic)      | >= 0.28.0          | >= 4.11.0   |
+| [LangChain](#python)         | >= 0.1.20          | >= 3.14.0   |
+| [OpenAI](#python)            | >= 1.102.0         | >= 4.10.0   |
+| [Anthropic](#python)         | >= 0.28.0          | >= 4.11.0   |
 
 {{% /tab %}}
 {{% tab "Node.js" %}}
 | Package                          | Supported Versions | SDK Version |
 |----------------------------------|--------------------|-------------|
-| [AI SDK](#ai-sdk)                | v6                 | >= 5.95.0   |
-| [OpenAI](#openai-1)              | >= 4.87.0          | >= 5.105.0  |
+| [AI SDK](#nodejs)                | v6                 | >= 5.95.0   |
+| [OpenAI](#nodejs)                | >= 4.87.0          | >= 5.105.0  |
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -88,15 +88,14 @@ AI Guard automatically evaluates the following Anthropic operations:
   - `client.messages.create()`
   - `client.messages.stream()`
 
-For Anthropic SDK >= 0.37.0, AI Guard also evaluates beta messages operations:
+For the `anthropic` package >= 0.37.0, AI Guard also evaluates the following beta messages operations:
 
-- [Beta messages][3]:
+- Beta messages:
   - `client.beta.messages.create()`
   - `client.beta.messages.stream()`
 
 [1]: https://github.com/anthropics/anthropic-sdk-python
 [2]: https://docs.anthropic.com/en/api/messages
-[3]: https://docs.anthropic.com/en/api/messages
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes APPSEC-67657

Adds OpenAI and Anthropic automatic integrations to the AI Guard setup page, and restructures the Integrations section for better navigation.

Changes:
- Updated the **Supported frameworks and libraries** table to include OpenAI (Python >= 1.102.0 / dd-trace-py >= 4.10.0, Node.js >= 4.87.0 / dd-trace-js >= 5.105.0) and Anthropic (Python >= 0.28.0 / dd-trace-py >= 4.11.0)
- Restructured the **Integrations** section from a single Python/Node.js tab set into separate **Python** and **Node.js** subsections, each with per-library tabs (LangChain, OpenAI, Anthropic for Python; AI SDK, OpenAI for Node.js)
- Added traced operations for each new integration, sourced from dd-trace-py and dd-trace-js source code

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes