### PR TITLE
docs(flaky-management): add Slack handle troubleshooting section

### DIFF
--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -240,18 +240,12 @@ To use Flaky Tests Management features, you must use Datadog's native instrument
 
 ### Slack notifications are not delivered
 
-If Slack notifications are not being delivered, verify that the handle format in your
-notification rule includes the Slack account name:
+If Slack notifications are not being delivered, check that your notification rule uses the `@slack-ACCOUNT-CHANNEL` format.
 
-- `@slack-ACCOUNT-CHANNEL` — recommended; routes to the named channel in the specified
-  Slack account (the name you gave the workspace in the [Datadog Slack integration][5]).
-- `@slack-CHANNEL` — works only if your organization has a single Slack account
-  connected. For organizations with multiple Slack workspaces, omitting the account name
-  causes the notification to be routed to the first configured account, which may not be
-  the intended workspace.
+If you are using `@slack-CHANNEL` (without the account name), the notification is routed to the first configured Slack account. For organizations with multiple Slack workspaces, this may not be the intended workspace.
 
 To find your account name, go to the [Slack integration tile][5] and check the
-**Account Name** field for the workspace you want to target.
+**Account Name** field for the workspace you want to use.
 
 ## Further reading
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -236,6 +236,23 @@ To use Flaky Tests Management features, you must use Datadog's native instrument
 | [Ruby][11]      | 1.13.0+                       | 1.17.0+                      |
 | [Swift][12]     | 2.6.1+                        | 2.6.1+                       |
 
+## Troubleshooting
+
+### Slack notifications are not delivered
+
+If Slack notifications are not being delivered, verify that the handle format in your
+notification rule includes the Slack account name:
+
+- `@slack-ACCOUNT-CHANNEL` — recommended; routes to the named channel in the specified
+  Slack account (the name you gave the workspace in the [Datadog Slack integration][5]).
+- `@slack-CHANNEL` — works only if your organization has a single Slack account
+  connected. For organizations with multiple Slack workspaces, omitting the account name
+  causes the notification to be routed to the first configured account, which may not be
+  the intended workspace.
+
+To find your account name, go to the [Slack integration tile][5] and check the
+**Account Name** field for the workspace you want to target.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
## Summary

Adding a **Troubleshooting** section to the Flaky Tests Management page.

Documents the `@slack-ACCOUNT-CHANNEL` vs `@slack-CHANNEL` handle format edge case: a channel-only handle resolves to the first configured Slack account, which is ambiguous for orgs with multiple Slack workspaces connected.

Do not merge immediately.