### PR TITLE
[WEB-9189] Add TechArticle JSON-LD structured data to docs pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,7 +29,7 @@
     {{- partial "meta.html" . -}}
   {{- end -}}
 
-  {{- if and .IsPage .File -}}
+  {{- if and (or .IsPage .IsSection) (not .IsHome) .File -}}
     {{- partial "structured-data.html" . -}}
   {{- end -}}
 </head>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,6 +28,10 @@
   {{- if and (ne $.Params.disable_opengraph_meta_tags true) .File -}}
     {{- partial "meta.html" . -}}
   {{- end -}}
+
+  {{- if and .IsPage .File -}}
+    {{- partial "structured-data.html" . -}}
+  {{- end -}}
 </head>
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -1,0 +1,30 @@
+{{- $title := .Title | default .Params.title | default .Site.Params.meta_title -}}
+{{- $description := .Description | default .Params.description | default .Site.Params.meta_description -}}
+{{- $lang := cond (eq .Site.Language.Lang "en") "en-US" .Site.Language.Lang -}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "name": "{{ $title | safeJS }}",
+  "headline": "{{ $title | safeJS }}",
+  "description": "{{ $description | safeJS }}",
+  "inLanguage": "{{ $lang | safeJS }}",
+  "isFamilyFriendly": true,
+  "url": "{{ .Permalink | safeJS }}",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ .Permalink | safeJS }}"
+  },
+  "author": { "@id": "https://www.datadoghq.com/#organization" },
+  "publisher": { "@id": "https://www.datadoghq.com/#organization" }
+  {{- with .Date }},
+  "datePublished": "{{ .UTC.Format "2006-01-02T15:04:05Z" }}"
+  {{- end }}
+  {{- with .Lastmod }},
+  "dateModified": "{{ .UTC.Format "2006-01-02T15:04:05Z" }}"
+  {{- end }}
+  {{- if gt .WordCount 0 }},
+  "wordCount": {{ .WordCount }}
+  {{- end }}
+}
+</script>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes WEB-9189

Adds a `TechArticle` JSON-LD structured data block to every leaf page on docs.datadoghq.com. This gives search engines and AI inference systems a machine-readable signal connecting docs content to Datadog as its publisher.

Changes:
- New partial `layouts/partials/structured-data.html` — emits a `TechArticle` JSON-LD block using existing Hugo frontmatter fields (`title`, `description`, `lastmod`, word count). No new frontmatter required.
- `layouts/_default/baseof.html` — includes the partial in `<head>`, gated on `.IsPage && .File` so it only fires on leaf pages, not section/list pages.

The `publisher` and `author` fields reference `https://www.datadoghq.com/#organization`, the canonical Organization node already defined on the marketing site.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Validate after deploy using https://validator.schema.org against a sample of docs pages.