### PR TITLE
[WEB-9185] Clamp integration tile descriptions with ellipsis overflow

### DIFF
--- a/assets/styles/components/_integrations.scss
+++ b/assets/styles/components/_integrations.scss
@@ -538,7 +538,11 @@ $screen-md-max: ($screen-lg-min - 1) !default;
             }
         }
         .blurb {
-            display: block;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 3;
+            overflow: hidden;
+            max-height: 54px;
             font-weight: 200;
             color: #333;
             font-size: 16px;


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes WEB-9185

Integration tiles on the /integrations/ page have a fixed height of 164px. On hover, tiles flip to show the description but long descriptions were silently overflowing the tile bounds with no visual indicator, unlike the Datadog app which shows a trailing ellipsis.

Change: Added -webkit-line-clamp: 4 to .integration.hover .blurb in _integrations.scss. This clamps the description to 4 lines and shows a trailing ellipsis when text overflows, matching the expected behaviour.

<img width="248" height="194" alt="image" src="https://github.com/user-attachments/assets/e9df479c-89d8-4205-8890-df97366c85ee" />

<img width="251" height="189" alt="image" src="https://github.com/user-attachments/assets/885d7baf-993a-49ab-bdb6-f2ba6ef09421" />

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

-webkit-line-clamp has full cross-browser support (Chrome, Firefox, Safari, Edge).