### PR TITLE
[DOCS-14458] Document HTTP/2 fallback behavior with CDN-fronted endpoints

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -75,11 +75,18 @@ You may create a test using one of the following options:
 
    {{% tab "Request Options" %}}
    * **HTTP version**: Select `HTTP/1.1 only`, `HTTP/2 only`, or `HTTP/2 fallback to HTTP/1.1`.
+
+     For endpoints fronted by a CDN (such as Akamai, CloudFront, or Fastly), set the HTTP version to `HTTP/2 only` or `HTTP/1.1 only` instead of the default `HTTP/2 with fallback to HTTP/1.1`. HTTP version support varies between probes, and the default setting can cause intermittent [HTTP errors][1] such as:
+     - `MALFORMED_RESPONSE: Unable to parse HTTP response`
+     - `Session closed without receiving a SETTINGS frame`
+     - `Error HTTP2: Error performing HTTP/2 request`
    * **Follow redirects**: Select to have your HTTP test follow up to ten redirects when performing the request.
    * **Ignore server certificate error**: Select to have your HTTP test go on with connection even if there are errors when validating the SSL certificate.
    * **Timeout**: Specify the amount of time in seconds before the test times out.
    * **Request headers**: Define headers to add to your HTTP request. You can also override the default headers (for example, the `user-agent` header).
    * **Cookies**: Define cookies to add to your HTTP request. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
+
+[1]: /synthetics/api_tests/errors/#http-errors
 
    {{% /tab %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14458

Adds a callout under the HTTP version option in Synthetics HTTP test advanced settings documenting the known behavior of `HTTP/2 with fallback to HTTP/1.1` against CDN-fronted endpoints. Customers using the default setting against CDNs like Akamai, CloudFront, or Fastly can experience intermittent probe failures. The recommended workaround (pinning to `HTTP/2 only` or `HTTP/1.1 only`) was previously undocumented on the public page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes