### PR TITLE
Update java.md with dd.propagate.context details

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -427,6 +427,12 @@ Available since version 1.9.0
 **Default**: `false`<br>
 When set to `true`, stop extracting trace context when a valid one is found.
 
+`dd.propagate.context`
+: **Environment Variable**: `DD_PROPAGATE_CONTEXT`<br>
+**Default**: `false`<br>
+When `true`, distributed trace context (for example, `tracecontext` and `baggage` headers) is extracted and injected even when tracing is disabled (`dd.trace.enabled=false`). Spans are created to carry and propagate  context, but traces are not reported to Datadog. This lets a service participate in context propagation without sending trace data. Has no effect when tracing is enabled.
+
+
 ### JMX metrics
 
 `dd.jmxfetch.enabled`


### PR DESCRIPTION
Added details about the 'dd.propagate.context' environment variable and its behavior regarding trace context propagation.

### What does this PR do? What is the motivation?

Update docs to reflect the change in https://github.com/DataDog/dd-trace-java/pull/11624

### Merge instructions
Wait for release of https://github.com/DataDog/dd-trace-java/pull/11624

Merge readiness:
- [ ] Ready for merge