### PR TITLE
Add Flutter network headers capture documentation

### DIFF
--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
@@ -208,6 +208,41 @@ To enable Datadog [distributed tracing][13], you must set the `DatadogConfigurat
 
 - `DatadogRumConfiguration.traceSampleRate` sets a default sampling rate of 20%. If you want all resources requests to generate a full distributed trace, set this value to `100.0`.
 
+### Capture resource headers
+
+When [tracking resources automatically][10], you can capture HTTP request and response headers on RUM Resources by setting `trackResourceHeaders` on `DatadogRumConfiguration`. This option applies to all Datadog HTTP tracking clients (Tracking HTTP Client, `DatadogClient`, and Dio interceptor). This option is disabled by default.
+
+Captured headers appear on the RUM Resource event under `resource.request.headers` and `resource.response.headers`. You can query them in the RUM Explorer.
+
+```dart
+DatadogRumConfiguration(
+  applicationId: '<rum-application-id>',
+  trackResourceHeaders: ResourceHeadersExtractor(),
+)
+```
+
+With no arguments, `ResourceHeadersExtractor` captures a predefined set of safe headers:
+
+| Direction | Headers |
+|-----------|---------|
+| Request | `cache-control`, `content-type` |
+| Response | `age`, `cache-control`, `content-encoding`, `content-length`, `content-type`, `etag`, `expires`, `server-timing`, `vary`, `x-cache` |
+
+To capture additional headers on top of the defaults, pass them via `captureHeaders`. To skip the defaults, set `includeDefaults: false`.
+
+```dart
+DatadogRumConfiguration(
+  applicationId: '<rum-application-id>',
+  trackResourceHeaders: ResourceHeadersExtractor(
+    captureHeaders: ['x-request-id', 'x-custom-header'],
+  ),
+)
+```
+
+{% alert level="info" %}
+Sensitive headers, such as tokens and API keys, are filtered out automatically, even if you list them explicitly.
+{% /alert %}
+
 ### Track resources from other packages
 
 While `Datadog Tracking HTTP Client` can track most common network calls in Flutter, Datadog supplies packages for integration into specific networking libraries, including gRPC, GraphQL and Dio. For more information about these libraries, see [Integrated Libraries][22].


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for the `trackResourceHeaders` / `ResourceHeadersExtractor` API in the Flutter RUM advanced configuration page.

This follows the same pattern established in #36291, which added "Capture resource headers" sections for Android, iOS, and Browser SDKs. Flutter was not included in that PR since the Flutter package shipped slightly later.

Changes:
- Added a new **"### Capture resource headers"** subsection under **"## Automatically track resources"** in `layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md`
- Documents the `ResourceHeadersExtractor` class and `trackResourceHeaders` config option
- Includes the default header table (matching Android/iOS), `captureHeaders` usage, and the sensitive-headers alert

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Aligns with #36291.