### PR TITLE
Add Flutter network headers capture documentation

### DIFF
--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
@@ -210,7 +210,7 @@ To enable Datadog [distributed tracing][13], you must set the `DatadogConfigurat
 
 ### Capture resource headers
 
-When [tracking resources automatically][10], you can capture HTTP request and response headers on RUM Resources by setting `trackResourceHeaders` on `DatadogRumConfiguration`. This option applies to all Datadog HTTP tracking clients (Tracking HTTP Client, `DatadogClient`, Dio interceptor, and GQL Link). This option is disabled by default.
+When [tracking resources automatically][10], you can capture HTTP request and response headers on RUM Resources by setting `trackResourceHeaders` on `DatadogRumConfiguration`. This option applies to all Datadog HTTP tracking clients (Tracking HTTP Client, `DatadogClient`, Dio Interceptor, and GQL Link), but does not apply to the gRPC Interceptor. This option is disabled by default.
 
 Captured headers appear on the RUM Resource event under `resource.request.headers` and `resource.response.headers`. You can query them in the RUM Explorer.
 
@@ -228,7 +228,7 @@ With no arguments, `ResourceHeadersExtractor` captures a predefined set of safe 
 | Request | `cache-control`, `content-type` |
 | Response | `age`, `cache-control`, `content-encoding`, `content-length`, `content-type`, `etag`, `expires`, `server-timing`, `vary`, `x-cache` |
 
-To capture additional headers on top of the defaults, pass them through `captureHeaders`. To skip the defaults, set `includeDefaults: false`.
+To capture additional headers in addition to the defaults, pass them through `captureHeaders`. To skip the defaults, set `includeDefaults: false`.
 
 ```dart
 DatadogRumConfiguration(
@@ -245,7 +245,7 @@ Sensitive headers, such as tokens and API keys, are filtered out automatically, 
 
 ### Track resources from other packages
 
-While `Datadog Tracking HTTP Client` can track most common network calls in Flutter, Datadog supplies packages for integration into specific networking libraries, including gRPC, GraphQL and Dio. For more information about these libraries, see [Integrated Libraries][22].
+While [Datadog Tracking HTTP Client][10] can track most common network calls in Flutter, Datadog supplies packages for integration into specific networking libraries, including gRPC, GraphQL and Dio. For more information about these libraries, see [Integrated Libraries][22].
 
 ## Enrich user sessions
 

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
@@ -66,7 +66,7 @@ The flavor (variant) of the application. For stack trace deobfuscation, this mus
 `firstPartyHosts`
 : Optional  
 **Type**: List&lt;String&gt;  
-A list of first party hosts, used in conjunction with Datadog network tracking packages. Overrides any values set in `firstPartyHostsWithTracinHeaders`. To specify different headers per host, use `firstPartyHostsWithTracingHeaders` instead.
+A list of first party hosts, used in conjunction with Datadog network tracking packages. Overrides any values set in `firstPartyHostsWithTracingHeaders`. To specify different headers per host, use `firstPartyHostsWithTracingHeaders` instead.
 
 `firstPartyHostsWithTracingHeaders`
 : Optional  
@@ -207,6 +207,41 @@ To enable Datadog [distributed tracing][13], you must set the `DatadogConfigurat
 - `firstPartyHosts` does not allow wildcards, but matches any subdomains for a given domain. For example, `api.example.com` matches `staging.api.example.com` and `prod.api.example.com`, not `news.example.com`.
 
 - `DatadogRumConfiguration.traceSampleRate` sets a default sampling rate of 20%. If you want all resources requests to generate a full distributed trace, set this value to `100.0`.
+
+### Capture resource headers
+
+When [tracking resources automatically][10], you can capture HTTP request and response headers on RUM Resources by setting `trackResourceHeaders` on `DatadogRumConfiguration`. This option applies to all Datadog HTTP tracking clients (Tracking HTTP Client, `DatadogClient`, Dio interceptor, and GQL Link). This option is disabled by default.
+
+Captured headers appear on the RUM Resource event under `resource.request.headers` and `resource.response.headers`. You can query them in the RUM Explorer.
+
+```dart
+DatadogRumConfiguration(
+  applicationId: '<rum-application-id>',
+  trackResourceHeaders: ResourceHeadersExtractor(),
+)
+```
+
+With no arguments, `ResourceHeadersExtractor` captures a predefined set of safe headers:
+
+| Direction | Headers |
+|-----------|---------|
+| Request | `cache-control`, `content-type` |
+| Response | `age`, `cache-control`, `content-encoding`, `content-length`, `content-type`, `etag`, `expires`, `server-timing`, `vary`, `x-cache` |
+
+To capture additional headers on top of the defaults, pass them through `captureHeaders`. To skip the defaults, set `includeDefaults: false`.
+
+```dart
+DatadogRumConfiguration(
+  applicationId: '<rum-application-id>',
+  trackResourceHeaders: ResourceHeadersExtractor(
+    captureHeaders: ['x-request-id', 'x-custom-header'],
+  ),
+)
+```
+
+{% alert level="info" %}
+Sensitive headers, such as tokens and API keys, are filtered out automatically, even if you list them explicitly.
+{% /alert %}
 
 ### Track resources from other packages
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for the `trackResourceHeaders` / `ResourceHeadersExtractor` API in the Flutter RUM advanced configuration page.

This follows the same pattern established in #36291, which added "Capture resource headers" sections for Android, iOS, and Browser SDKs.

Changes:
- Added a new **"### Capture resource headers"** subsection under **"## Automatically track resources"** in `layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md`
- Documents the `ResourceHeadersExtractor` class and `trackResourceHeaders` config option
- Includes the default header table (matching Android/iOS), `captureHeaders` usage, and the sensitive-headers alert

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Aligns with #36291.