### PR TITLE
[DBM] Database Investigator: MySQL and Oracle Database in early access

### DIFF
--- a/content/en/database_monitoring/database_investigator/_index.md
+++ b/content/en/database_monitoring/database_investigator/_index.md
@@ -20,11 +20,9 @@ further_reading:
 Database Investigator is in Preview for all customers monitoring Postgres or SQL Server with Database Monitoring. MySQL and Oracle Database support is in early access: open a MySQL or Oracle Database host within Database Monitoring and click <strong>Get early access</strong> to request it. Support for other databases covered by Database Monitoring is in development.
 {{< /callout >}}
 
-## Overview
-
 Database Investigator is an AI agent inside Database Monitoring that helps you investigate, optimize, and understand the databases you monitor. It analyzes the telemetry Database Monitoring already collects including health signals, query metrics, explain plans, instance and infrastructure metrics, calling APM services, related incidents, and recent events. For investigations, it returns a structured root cause analysis with concrete remediation steps.
 
-Both DBAs and the platform or application teams that own database-backed services can make use of Database Investigator. Describe an issue in plain language and it runs the investigation. Deep database expertise is not required.
+Both database administrators and the platform or application teams that own database-backed services can make use of Database Investigator. Describe an issue in plain language and it runs the investigation. Deep database expertise is not required.
 
 Use Database Investigator to answer questions like:
 
@@ -34,13 +32,18 @@ Use Database Investigator to answer questions like:
 - `Which upstream service is driving the workload change?`
 - `How can I reduce lock contention on this table?`
 
+Database Investigator is included with Database Monitoring, and each Datadog organization can run up to 100 investigations per month.
+
+<div class="alert alert-info">Database Investigator operates under zero-retention and zero-training agreements with the third-party AI service providers that power it. Data processed during an investigation is not retained by those providers and is not used to train or improve their models.
+</div>
+
 {{< img src="database_monitoring/database_investigator/suggested_prompts.png" alt="Database Investigator opened with suggested prompts" style="width:100%;" >}}
 
 ## Initiate Database Investigation
 
 Open Database Investigator from any of the following surfaces in Database Monitoring:
 
-- The Investigate button on a **database Overview page**
+- The **Investigate** button on a database **Overview** page
 - A metric in the **Metrics** tab of a database host
 - A **Blocking Queries** or **Deadlocks** panel
 - A normalized query in **Query Metrics**
@@ -78,33 +81,7 @@ Past conversations are listed in the history view inside Database Investigator. 
 
 To use Database Investigator, your role must have the **Database Monitoring Read** permission. Database Investigator uses your Datadog role to fetch data, so it can only access the resources you have permission to view.
 
-## FAQ
-
-### What data does Database Investigator access?
-
-Database Investigator reads the telemetry your account already collects, including query metrics, query samples, explain plans, instance and host metrics. It also reads related APM service dependencies, incidents, events, and metrics in your Datadog organization. It accesses only the resources permitted by your role.
-
-### Is data sent to Database Investigator used to train AI models?
-
-Database Investigator operates under zero-retention and zero-training agreements with the third-party AI service providers that power it. Data processed during an investigation is not retained by those providers and is not used to train or improve their models.
-
-### Does Database Investigator modify the database?
-
-No. Database Investigator reads observability data and produces recommendations. It does not connect to your database, run SQL against it, or change configuration. SQL changes in its responses are suggestions for you to review and apply.
-
-### Which databases are supported?
-
-Postgres and SQL Server are supported in Preview for all Database Monitoring customers. MySQL and Oracle Database are supported in early access. Request access from inside Database Monitoring on a MySQL or Oracle Database host. Support for other databases covered by Database Monitoring is in development.
-
-### Are there usage limits?
-
-Database Investigator is included with Database Monitoring. Each Datadog organization can run up to 100 investigations per month.
-
-### Does Database Investigator answer general database questions?
-
-Yes. Database Investigator covers diagnosing performance regressions, recommending indexes and optimizations, explaining execution plans, and answering questions about database features, configuration, and best practices. When a question is grounded in your environment, it pulls from the telemetry your account already collects.
-
-### Is programmatic access available?
+## Programmatic access
 
 The data sources that Database Investigator uses are also exposed through the [Datadog MCP server][3]. You can call them from your own AI tooling.
 

--- a/content/en/database_monitoring/database_investigator/_index.md
+++ b/content/en/database_monitoring/database_investigator/_index.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="Database Investigator is in Preview" >}}
-Database Investigator is in Preview for all customers monitoring Postgres or SQL Server with Database Monitoring.
+Database Investigator is in Preview for all customers monitoring Postgres or SQL Server with Database Monitoring. MySQL and Oracle Database support is in early access: open a MySQL or Oracle Database host within Database Monitoring and click <strong>Get early access</strong> to request it. Support for other databases covered by Database Monitoring is in development.
 {{< /callout >}}
 
 ## Overview
@@ -94,7 +94,7 @@ No. Database Investigator reads observability data and produces recommendations.
 
 ### Which databases are supported?
 
-Postgres and SQL Server are supported in Preview for all Database Monitoring customers.
+Postgres and SQL Server are supported in Preview for all Database Monitoring customers. MySQL and Oracle Database are supported in early access. Request access from inside Database Monitoring on a MySQL or Oracle Database host. Support for other databases covered by Database Monitoring is in development.
 
 ### Are there usage limits?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Database Investigator docs to note that MySQL and Oracle Database are supported in early access. This reuses the same early-access language the page previously used for SQL Server (before it graduated to Preview). Postgres and SQL Server remain in Preview.

Changes:
- Callout: adds the MySQL and Oracle Database early-access notice with the **Get early access** request instructions.
- "Which databases are supported?" FAQ: adds the same early-access details for MySQL and Oracle Database.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

