### PR TITLE
Fix formatting in dd.propagate.context Java config entry

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -430,8 +430,7 @@ When set to `true`, stop extracting trace context when a valid one is found.
 `dd.propagate.context`
 : **Environment Variable**: `DD_PROPAGATE_CONTEXT`<br>
 **Default**: `false`<br>
-When `true`, distributed trace context (for example, `tracecontext` and `baggage` headers) is extracted and injected even when tracing is disabled (`dd.trace.enabled=false`). Spans are created to carry and propagate  context, but traces are not reported to Datadog. This lets a service participate in context propagation without sending trace data. Has no effect when tracing is enabled.
-
+When `true`, distributed trace context (for example, `tracecontext` and `baggage` headers) is extracted and injected even when tracing is disabled (`dd.trace.enabled=false`). Spans are created to carry and propagate context, but traces are not reported to Datadog. This lets a service participate in context propagation without sending trace data. Has no effect when tracing is enabled.
 
 ### JMX metrics
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Cleans up two minor formatting issues in the `dd.propagate.context` entry on the Java tracing library configuration page: a double space ("propagate  context") and an extra blank line before the **JMX metrics** heading.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

