### PR TITLE
Remove admin step for Databricks experimentation setup

### DIFF
--- a/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
+++ b/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
@@ -160,10 +160,6 @@ Datadog Experiments connects to Databricks through the [Datadog Databricks integ
    1. Click {% ui %}Generate{% /ui %}.
    1. Note your {% ui %}Secret{% /ui %} and {% ui %}Client ID{% /ui %}.
    1. Click {% ui %}Done{% /ui %}.
-1. In the {% ui %}Settings{% /ui %} menu, click {% ui %}Identity and access{% /ui %}.
-1. On the {% ui %}Groups{% /ui %} row, click {% ui %}Manage{% /ui %}, then:
-   1. Click {% ui %}admins{% /ui %}, then {% ui %}Add members{% /ui %}.
-   1. Enter the service principal name and click {% ui %}Add{% /ui %}.
 
 After you create the service principal, continue to [Step 1](#step-1-grant-permissions-to-the-service-principal) to grant the required permissions.
 
@@ -259,6 +255,10 @@ To connect your Databricks Workspace to Datadog for warehouse-native experiment 
 1. Toggle off {% ui %}Jobs Monitoring{% /ui %} and all other products.
 1. Toggle off the {% ui %}Metrics - Model Serving{% /ui %} resource.
 1. Click {% ui %}Save Databricks Workspace{% /ui %}.
+
+{% alert %}
+If you turn on other features in the {% ui %}Configure{% /ui %} tab, additional configuration steps may be required. See the documentation for those features to complete their setup.
+{% /alert %}
 
 {% /if %}
 <!-- end Databricks -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Databricks instructions in the [Connect your Data Warehouse for Warehouse-Native Experiment Analysis](https://docs.datadoghq.com/experiments/guide/connecting_a_data_warehouse/?database=databricks) guide:

- Removes the steps for adding the service principal to the `admins` group (Settings > Identity and access > Groups), which are not required for this setup.
- Adds a note clarifying that turning on other features in the **Configure** tab may require additional configuration steps, and to see the documentation for those features.

### Merge instructions

Merge readiness:
- [x] Ready for merge