### PR TITLE
node.js webpack experimental support

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -153,11 +153,11 @@ Datadog recommends you have custom-built bundler plugins. These plugins are able
 
 **Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 
-#### Bundling with esbuild
+#### Bundling with ESBuild
 
-This library provides experimental esbuild support in the form of an esbuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
+This library provides ESBuild support in the form of an ESBuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
 
-Here's an example of how one might use `dd-trace` with esbuild:
+Here's an example of how one might use `dd-trace` with ESBuild:
 
 ```javascript
 const ddPlugin = require('dd-trace/esbuild')
@@ -188,10 +188,62 @@ esbuild.build({
 })
 ```
 
+**Note**: Every application is different and you may need to experiment with the list of `external` packages.
+
+#### Bundling with Webpack
+
+This library provides experimental Webpack support in the form of a Webpack plugin. To use the plugin, make sure you have `dd-trace@5.94.0+` installed, and then require the `dd-trace/webpack` module when building your bundle.
+
+Here's an example of how one might use `dd-trace` with Webpack:
+
+```javascript
+const path = require('path')
+const webpack = require('webpack')
+const DatadogWebpackPlugin = require('dd-trace/webpack')
+
+const compiler = webpack({
+  entry: 'main.js',
+  target: 'node',
+  externalsType: 'commonjs',
+  output: {
+    filename: 'out.js',
+    path: __dirname,
+    hashFunction: 'sha256',
+  },
+  externals: [
+    // Node.js built-in not in Webpack's default list for target: 'node'
+    'diagnostics_channel',
+
+    // dead code paths introduced by knex
+    'pg',
+    'mysql2',
+    'better-sqlite3',
+    'sqlite3',
+    'mysql',
+    'oracledb',
+    'pg-query-stream',
+    'tedious',
+    '@yaacovcr/transform',
+
+    // optional native dd-trace modules
+    '@datadog/native-appsec',
+    '@datadog/native-iast-taint-tracking',
+    '@datadog/native-metrics',
+    '@datadog/pprof',
+    '@datadog/libdatadog',
+  ],
+  plugins: [
+    new DatadogWebpackPlugin(),
+  ],
+})
+```
+
+**Note**: Every application is different and you may need to experiment with the list of `externals` packages.
+
 #### Bundling with Next.js
 
-If you are using Next.js or another framework relying on webpack to bundle your application, add a declaration
-similar to the one for webpack inside your `next.config.js` configuration file:
+If you are using Next.js to bundle your application, add a declaration
+similar to the one for Webpack inside your `next.config.js` configuration file:
 
 ```javascript
 /** @type {import('next').NextConfig} */

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -153,11 +153,11 @@ Datadog recommends you have custom-built bundler plugins. These plugins are able
 
 **Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 
-#### Bundling with ESBuild
+#### Bundling with esbuild
 
-This library provides ESBuild support in the form of an ESBuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
+This library provides esbuild support in the form of an esbuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
 
-Here's an example of how one might use `dd-trace` with ESBuild:
+Here's an example of how one might use `dd-trace` with esbuild:
 
 ```javascript
 const ddPlugin = require('dd-trace/esbuild')

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -194,7 +194,7 @@ esbuild.build({
 
 This library provides experimental Webpack support in the form of a Webpack plugin. To use the plugin, make sure you have `dd-trace@5.94.0+` installed, and then require the `dd-trace/webpack` module when building your bundle.
 
-Here's an example of how one might use `dd-trace` with Webpack:
+The following example shows how to use `dd-trace` with Webpack:
 
 ```javascript
 const path = require('path')

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -188,8 +188,6 @@ esbuild.build({
 })
 ```
 
-**Note**: Every application is different and you may need to experiment with the list of `external` packages.
-
 #### Bundling with Webpack
 
 This library provides experimental Webpack support in the form of a Webpack plugin. To use the plugin, make sure you have `dd-trace@5.94.0+` installed, and then require the `dd-trace/webpack` module when building your bundle.
@@ -237,8 +235,6 @@ const compiler = webpack({
   ],
 })
 ```
-
-**Note**: Every application is different and you may need to experiment with the list of `externals` packages.
 
 #### Bundling with Next.js
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- Documents the experimental Webpack support for the Node.js tracer.
- Changes `esbuild` to `ESBuild` as per their website.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

- none

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
