### PR TITLE
[DOCS-14652] Add GitLab GovCloud unsupported callout to SCM providers page

### DIFF
--- a/content/en/source_code/source-code-management.md
+++ b/content/en/source_code/source-code-management.md
@@ -19,6 +19,10 @@ To use most source code-related features, you must connect your Git repositories
 
 ## Source code management providers
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">The GitLab Source Code integration is not supported on your selected site ({{< region-param key="dd_site_name" >}}). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
+{{< /site-region >}}
+
 Datadog supports the following features for the SCM providers listed below. See [Features][1] for more details about each feature:
 
 | Feature | GitHub | GitLab | Azure DevOps | Bitbucket |
@@ -28,10 +32,6 @@ Datadog supports the following features for the SCM providers listed below. See 
 | **Context Links** | Yes | Yes | Yes | Yes |
 | **Code Snippets** | Yes | Yes | Yes | No |
 | **PR Comments** | Yes | Yes | Yes | No |
-
-{{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">The GitLab Source Code integration is not supported on US1-FED (app.ddog-gov.com) or US2-FED (us2.ddog-gov.com). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
-{{< /site-region >}}
 
 {{< tabs >}}
 {{% tab "GitHub (SaaS & On-Prem)" %}}
@@ -49,7 +49,7 @@ Install Datadog's [GitHub integration][101] using the [integration tile][102] or
 {{% tab "GitLab (SaaS & On-Prem)" %}}
 
 {{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">The GitLab Source Code integration is not supported on US1-FED (app.ddog-gov.com) or US2-FED (us2.ddog-gov.com). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
+<div class="alert alert-danger">The GitLab Source Code integration is not supported on your selected site ({{< region-param key="dd_site_name" >}}). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">

--- a/content/en/source_code/source-code-management.md
+++ b/content/en/source_code/source-code-management.md
@@ -29,6 +29,10 @@ Datadog supports the following features for the SCM providers listed below. See 
 | **Code Snippets** | Yes | Yes | Yes | No |
 | **PR Comments** | Yes | Yes | Yes | No |
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">The GitLab Source Code integration is not supported on US1-FED (app.ddog-gov.com) or US2-FED (us2.ddog-gov.com). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
+{{< /site-region >}}
+
 {{< tabs >}}
 {{% tab "GitHub (SaaS & On-Prem)" %}}
 
@@ -43,6 +47,10 @@ Install Datadog's [GitHub integration][101] using the [integration tile][102] or
 
 {{% /tab %}}
 {{% tab "GitLab (SaaS & On-Prem)" %}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">The GitLab Source Code integration is not supported on US1-FED (app.ddog-gov.com) or US2-FED (us2.ddog-gov.com). On GovCloud, use the <a href="/integrations/github/">GitHub integration</a> for source code connectivity.</div>
+{{< /site-region >}}
 
 <div class="alert alert-info">
 Repositories from GitLab instances are supported for both GitLab.com (SaaS) and GitLab Self-Managed/Dedicated (On-Prem). For GitLab Self-Managed, your instance must be accessible from the internet. If needed, you can allowlist <a href="https://docs.datadoghq.com/api/latest/ip-ranges/">Datadog's <code>webhooks</code> IP addresses</a> to allow Datadog to connect to your instance.</br>If your instance is hosted on an internal/private network but exposed through a public DNS alias (recommended), configure the integration using the public hostname, then <a href="/help">contact Datadog Support</a> with both the public hostname and the internal hostname to enable hostname aliasing.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14652

Adds `site-region` danger banners (gov/gov2 only) to the Source Code Management Providers page, noting that the GitLab Source Code integration is not supported on US1-FED or US2-FED:

- One banner before the provider feature table.
- One banner inside the **GitLab (SaaS & On-Prem)** tab.

Both direct GovCloud users to the GitHub integration for source code connectivity. On all other sites the page renders unchanged.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Verify on `?site=gov` and `?site=gov2` after the preview builds.