### PR TITLE
Add unavailability callout for WIF Agent on US1-FED and US2-FED

### DIFF
--- a/content/en/account_management/workload_identity_federation.md
+++ b/content/en/account_management/workload_identity_federation.md
@@ -243,13 +243,13 @@ The Terraform provider automatically uses your configured AWS credentials to aut
 
 ## Set up Workload Identity Federation for the Datadog Agent
 
-{{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">Workload Identity Federation for the Datadog Agent is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 {{< callout url="/help/" header="Enterprise feature" >}}
 Workload Identity Federation for the Datadog Agent is available for customers on an enterprise plan only. Request access by contacting support.
 {{< /callout >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">Workload Identity Federation for the Datadog Agent is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 Workload Identity Federation for the Agent allows you to authenticate your Agent using AWS credentials instead of managing static API keys. The Agent exchanges an AWS authentication proof for a managed API key that Datadog automatically rotates.
 

--- a/content/en/account_management/workload_identity_federation.md
+++ b/content/en/account_management/workload_identity_federation.md
@@ -243,6 +243,10 @@ The Terraform provider automatically uses your configured AWS credentials to aut
 
 ## Set up Workload Identity Federation for the Datadog Agent
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">Workload Identity Federation for the Datadog Agent is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 {{< callout url="/help/" header="Enterprise feature" >}}
 Workload Identity Federation for the Datadog Agent is available for customers on an enterprise plan only. Request access by contacting support.
 {{< /callout >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a `site-region` danger callout to the "Set up Workload Identity Federation for the Datadog Agent" section indicating this feature is not available on US1-FED (`gov`) or US2-FED (`gov2`) sites.

Uses the standard `{{< site-region region="gov,gov2" >}}` pattern consistent with other pages in the docs.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes