### PR TITLE
Add Request Headers step to SentinelOne connection setup

### DIFF
--- a/content/en/bits_ai/bits_security_analyst.md
+++ b/content/en/bits_ai/bits_security_analyst.md
@@ -94,10 +94,10 @@ Rule eligibility depends on whether Datadog has built the investigation capabili
            <li>Under {{< ui >}}Token Auth{{< /ui >}}, enter a name for your token in the {{< ui >}}Token Name{{< /ui >}} field, and your API token in the {{< ui >}}Token Value{{< /ui >}} field.</li>
          </ul>
        </li>
-       <li>Still under {{< ui >}}Token Auth{{< /ui >}}, select the {{< ui >}}Headers{{< /ui >}} tab. Under {{< ui >}}Request Headers{{< /ui >}}, add the following headers:
+       <li>Still under {{< ui >}}Token Auth{{< /ui >}}, select the {{< ui >}}Headers{{< /ui >}} tab. Under {{< ui >}}Request Headers{{< /ui >}}, click {{< ui >}}Add a Header{{< /ui >}} and add the following two headers, entering each header's name in the {{< ui >}}Name{{< /ui >}} field and its value in the {{< ui >}}Value{{< /ui >}} field:
          <ul>
-           <li>In the {{< ui >}}Authorization{{< /ui >}} header, enter <code>Bearer</code> followed by a space, then insert your {{< ui >}}Token Value{{< /ui >}}.</li>
-           <li>Add a {{< ui >}}Content-Type{{< /ui >}} header with the value <code>application/json</code>.</li>
+           <li>Name: <code>Authorization</code>. Value: <code>Bearer</code> followed by a space, then insert your {{< ui >}}Token Value{{< /ui >}}.</li>
+           <li>Name: <code>Content-Type</code>. Value: <code>application/json</code>.</li>
          </ul>
        </li>
        <li>Click {{< ui >}}Next, Confirm Access{{< /ui >}} to verify your connection.</li>

--- a/content/en/bits_ai/bits_security_analyst.md
+++ b/content/en/bits_ai/bits_security_analyst.md
@@ -94,6 +94,12 @@ Rule eligibility depends on whether Datadog has built the investigation capabili
            <li>Under {{< ui >}}Token Auth{{< /ui >}}, enter a name for your token in the {{< ui >}}Token Name{{< /ui >}} field, and your API token in the {{< ui >}}Token Value{{< /ui >}} field.</li>
          </ul>
        </li>
+       <li>Still under {{< ui >}}Token Auth{{< /ui >}}, select the {{< ui >}}Headers{{< /ui >}} tab. Under {{< ui >}}Request Headers{{< /ui >}}, add the following headers:
+         <ul>
+           <li>In the {{< ui >}}Authorization{{< /ui >}} header, enter <code>Bearer</code> followed by a space, then insert your {{< ui >}}Token Value{{< /ui >}}.</li>
+           <li>Add a {{< ui >}}Content-Type{{< /ui >}} header with the value <code>application/json</code>.</li>
+         </ul>
+       </li>
        <li>Click {{< ui >}}Next, Confirm Access{{< /ui >}} to verify your connection.</li>
      </ol>
      {{< /collapse-content >}}

--- a/content/en/bits_ai/bits_security_analyst.md
+++ b/content/en/bits_ai/bits_security_analyst.md
@@ -82,27 +82,43 @@ Rule eligibility depends on whether Datadog has built the investigation capabili
    - Click {{< ui >}}Rule Settings{{< /ui >}} to configure investigations for individual rules. You can change the minimum severity for signals to be investigated, and enable or disable individual rules for investigation.
    - Click {{< ui >}}Query Filter{{< /ui >}} to write a signal query filter, so Bits Security Analyst only investigates signals that match your filter.
 1. Some log sources require credentials to run or enhance investigations by accessing logs, telemetry, or other data that isn't in Datadog. To add credentials, click {{< ui >}}Edit credentials{{< /ui >}}. In the {{< ui >}}Select or Add Connection{{< /ui >}} window that opens, follow the prompts to select an [existing connection][4] from Actions Catalog, or add a connection. Datadog securely stores and restricts all credentials using Actions Catalog.
-   - Some log sources require additional setup so you can create HTTP connections. Here's an example:
-     {{< collapse-content title="Configure SentinelOne" level="h4" expanded=false id="sentinelone" >}}
-     <ol>
-       <li>In SentinelOne, ensure you have permission to create an API token. Create an S1 API service user, then assign the {{< ui >}}Viewer{{< /ui >}} role to that user.</li>
-       <li>In Datadog, in the {{< ui >}}Select or Add Connection{{< /ui >}} window, in the dropdown, select {{< ui >}}New Connection{{< /ui >}}, then click the {{< ui >}}HTTP{{< /ui >}} tile.</li>
-       <li>Add the following information:
-         <ul>
-           <li>In the {{< ui >}}Description{{< /ui >}} field, Datadog recommends adding your token expiry date, to make it easily accessible.</li>
-           <li>In the {{< ui >}}Base URL{{< /ui >}} field, enter your SentinelOne Management Console URL.</li>
-           <li>Under {{< ui >}}Token Auth{{< /ui >}}, enter a name for your token in the {{< ui >}}Token Name{{< /ui >}} field, and your API token in the {{< ui >}}Token Value{{< /ui >}} field.</li>
-         </ul>
-       </li>
-       <li>Still under {{< ui >}}Token Auth{{< /ui >}}, select the {{< ui >}}Headers{{< /ui >}} tab. Under {{< ui >}}Request Headers{{< /ui >}}, click {{< ui >}}Add a Header{{< /ui >}} and add the following two headers, entering each header's name in the {{< ui >}}Name{{< /ui >}} field and its value in the {{< ui >}}Value{{< /ui >}} field:
-         <ul>
-           <li>Name: <code>Authorization</code>. Value: <code>Bearer</code> followed by a space, then insert the {{< ui >}}Token Name{{< /ui >}} you defined.</li>
-           <li>Name: <code>Content-Type</code>. Value: <code>application/json</code>.</li>
-         </ul>
-       </li>
-       <li>Click {{< ui >}}Next, Confirm Access{{< /ui >}} to verify your connection.</li>
-     </ol>
-     {{< /collapse-content >}}
+   
+   Some log sources require additional setup so you can create HTTP connections. Here's an example:
+   {{< collapse-content title="Configure SentinelOne" level="h4" expanded=false id="sentinelone" >}}
+   <ol>
+     <li>In SentinelOne, ensure you have permission to create an API token. Create an S1 API service user, then assign the {{< ui >}}Viewer{{< /ui >}} role to that user.</li>
+     <li>In Datadog, in the {{< ui >}}Select or Add Connection{{< /ui >}} window, in the dropdown, select {{<  ui >}}New Connection{{< /ui >}}, then click the {{< ui >}}HTTP{{< /ui >}} tile.</li>
+     <li>Add the following information:
+       <ul>
+         <li>In the {{< ui >}}Description{{< /ui >}} field, Datadog recommends adding your token expiry date, to make it easily accessible.</li>
+         <li>In the {{< ui >}}Base URL{{< /ui >}} field, enter your SentinelOne Management Console URL.</li>
+         <li>Under {{< ui >}}Token Auth{{< /ui >}}:
+           <ol>
+             <li>Enter a name for your token in the {{< ui >}}Token Name{{< / ui >}} field, and your API token in the {{< ui >}}Token Value{{< /ui >}} field.</li>
+             <li>On the {{< ui >}}Headers{{< /ui >}} tab, under {{< ui  >}}Request Headers{{< /ui >}}, click {{< ui >}}Add a Header{{< /ui >}}. Add the following two headers:
+               <table>
+                 <thead>
+                   <tr>
+                     <th>Name</th>
+                     <th>Value</th>
+                   </tr>
+                 </thead>
+                 <tr>
+                   <td><code>Authorization</code></td>
+                   <td><code>Bearer</code> followed by a space, then insert the  {{< ui >}}Token Name{{< /ui >}} you defined</td>
+                 </tr>
+                 <tr>
+                   <td><code>Content-Type</code></td>
+                   <td><code>application/json</code></td>
+                 </tr>
+               </table>
+             </li>
+           </ol>
+       </ul>
+     </li>
+     <li>Click {{< ui >}}Next, Confirm Access{{< /ui >}} to verify your connection.</li>
+   </ol>
+   {{< /collapse-content >}}
 
 ## Disable Bits Security Analyst
 

--- a/content/en/bits_ai/bits_security_analyst.md
+++ b/content/en/bits_ai/bits_security_analyst.md
@@ -96,7 +96,7 @@ Rule eligibility depends on whether Datadog has built the investigation capabili
        </li>
        <li>Still under {{< ui >}}Token Auth{{< /ui >}}, select the {{< ui >}}Headers{{< /ui >}} tab. Under {{< ui >}}Request Headers{{< /ui >}}, click {{< ui >}}Add a Header{{< /ui >}} and add the following two headers, entering each header's name in the {{< ui >}}Name{{< /ui >}} field and its value in the {{< ui >}}Value{{< /ui >}} field:
          <ul>
-           <li>Name: <code>Authorization</code>. Value: <code>Bearer</code> followed by a space, then insert your {{< ui >}}Token Value{{< /ui >}}.</li>
+           <li>Name: <code>Authorization</code>. Value: <code>Bearer</code> followed by a space, then insert the {{< ui >}}Token Name{{< /ui >}} you defined.</li>
            <li>Name: <code>Content-Type</code>. Value: <code>application/json</code>.</li>
          </ul>
        </li>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a missing step to the **Configure SentinelOne** HTTP connection setup in the Bits Security Analyst doc.

When creating the SentinelOne HTTP connection, users must configure request headers under **Token Auth** > **Headers** before confirming access:
- `Authorization`: `Bearer ` + the inserted **Token Value**
- `Content-Type`: `application/json`

Without these headers, the connection to the SentinelOne Management Console API fails. This step is inserted between "Add the following information" and "Click Next, Confirm Access".

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)