### PR TITLE
Fix Developer Platform link in OAuth2 in Datadog doc

### DIFF
--- a/content/en/extend/authorization/oauth2_in_datadog.md
+++ b/content/en/extend/authorization/oauth2_in_datadog.md
@@ -114,5 +114,5 @@ The [PKCE protocol][11] integrates with the authorization code grant flow by com
 [13]: https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
 [14]: https://datatracker.ietf.org/doc/html/rfc7636#section-4.3
 [15]: https://datatracker.ietf.org/doc/html/rfc6234#section-4.1
-[16]: https://app.datadoghq.com/apps
+[16]: https://app.datadoghq.com/publishing-platform
 [17]: /getting_started/site/

--- a/content/en/extend/authorization/oauth2_in_datadog.md
+++ b/content/en/extend/authorization/oauth2_in_datadog.md
@@ -85,7 +85,7 @@ To mitigate such attacks, the PKCE extension includes the following parameters t
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Code Verifier         | A dynamically-generated cryptographic random string.                                                                                 |
 | Code Challenge        | A transformation of the code verifier. The `code_challenge` must use a `base64url` encoding.                                           |
-| Code Challenge Method | The method used to derive the `code_challenge` from the `code_verifier`. You must use [SHA-256][16] to compute the `code_challenge`. |
+| Code Challenge Method | The method used to derive the `code_challenge` from the `code_verifier`. You must use SHA-256 to compute the `code_challenge`. |
 
 The [PKCE protocol][11] integrates with the authorization code grant flow by completing the following actions:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the \"Developer Platform\" link in the \"Implement the OAuth protocol\" section from `https://app.datadoghq.com/apps` to `https://app.datadoghq.com/publishing-platform`.

**Note:** There is a second occurrence of `https://app.datadoghq.com/apps` on this page — it appears as the anchor text for \"SHA-256\" in the Code Challenge Method table of the \"Use the PKCE extension\" section. That link appears to be a dead end / incorrect target, but I'm not sure what it should point to instead. Leaving it for a follow-up.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes