### PR TITLE
Add respect-site-support param to callout shortcode

### DIFF
--- a/content/en/account_management/plan_and_usage/_index.md
+++ b/content/en/account_management/plan_and_usage/_index.md
@@ -5,7 +5,7 @@ description: Access usage reports, plan settings, and billing history for your D
 
 [Administrators][1] can access the [organization settings][2] by clicking Plan & Usage from the Account menu in the bottom of the left side navigation or by selecting Plan & Usage from the header dropdown at the top of the Personal Settings page.
 
-{{< callout url="" btn_hidden="true" header="New: Bill Overview" >}}
+{{< callout url="" btn_hidden="true" header="New: Bill Overview" respect-site-support="false" >}}
 A new **Bill Overview** experience is now in Limited Availability and will start rolling out automatically to all organizations starting March 2026. [Learn more](/account_management/plan_and_usage/bill_overview/).
 {{< /callout >}}
 

--- a/content/en/account_management/plan_and_usage/cost_details.md
+++ b/content/en/account_management/plan_and_usage/cost_details.md
@@ -13,7 +13,7 @@ further_reading:
   text: "Managing multiple-organization accounts"
 ---
 
-{{< callout url="" btn_hidden="true" header="New: Bill Overview" >}}
+{{< callout url="" btn_hidden="true" header="New: Bill Overview" respect-site-support="false" >}}
 A new Bill Overview experience is now in Limited Availability and will start rolling out automatically to all organizations starting March 2026. [Learn more](/account_management/plan_and_usage/bill_overview/).
 {{< /callout >}}
 

--- a/content/en/account_management/plan_and_usage/usage_details.md
+++ b/content/en/account_management/plan_and_usage/usage_details.md
@@ -5,7 +5,7 @@ aliases:
   - /account_management/billing/usage_details/
 ---
 
-{{< callout url="" btn_hidden="true" header="New: Bill Overview" >}}
+{{< callout url="" btn_hidden="true" header="New: Bill Overview" respect-site-support="false" >}}
 A new Bill Overview experience is now in Limited Availability and will start rolling out automatically to all organizations starting March 2026. [Learn more](/account_management/plan_and_usage/bill_overview/).
 {{< /callout >}}
 

--- a/content/en/dashboards/guide/slo_data_source.md
+++ b/content/en/dashboards/guide/slo_data_source.md
@@ -25,7 +25,7 @@ To get started, pick one of the standard visualization types from the dashboard 
 
 For the {{< ui >}}Measure{{< /ui >}} parameter, see the table below for more information on what each measure visualizes. The {{< ui >}}Display{{< /ui >}} parameter allows you to break out the query by the groups that are already configured for the SLO. 
 
-{{< callout url="#" btn_hidden="true" header="Key Information">}}
+{{< callout url="#" btn_hidden="true" header="Key Information" respect-site-support="false">}}
   When using an SLO data source measures in the Timeseries widget, the value shown at each point is based on the default rollup in the widget, not rolling time period of the SLO. 
 {{< /callout >}}
 

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -23,7 +23,7 @@ products:
 
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
-{{< callout btn_hidden="true" header="Suppression evaluation" >}}
+{{< callout btn_hidden="true" header="Suppression evaluation" respect-site-support="false" >}}
 There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created. They are not re-evaluated when a signal is updated. Log and event attribute suppressions prevent matching events from new signals and updated existing signals. Datadog recommends using log and event attribute suppressions to reliably exclude specific activity.
 {{< /callout >}}
 

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,5 +1,18 @@
 {{- $btn_hidden := (.Get "btn_hidden") | default "false" -}}
 {{- $header := .Get "header" -}}
+{{- $respect_site_support := (.Get "respect-site-support") | default "true" -}}
+{{- $unsupported := partial "site_support_banner/get_unsupported_regions.html" . -}}
+{{- $wrap := and (eq $respect_site_support "true") (gt (len $unsupported) 0) -}}
+{{- if $wrap -}}
+{{- $supported := slice -}}
+{{- range .Site.Params.allowedRegions -}}
+    {{- if not (in $unsupported .value) -}}
+        {{- $supported = $supported | append .value -}}
+    {{- end -}}
+{{- end -}}
+{{- $supported_csv := delimit $supported "," -}}
+<div class="d-none site-region-container" data-region="{{ $supported_csv }}">
+{{- end }}
 <div class="card callout-card mb-4">
 
     <div class="card-body d-flex flex-column">
@@ -19,3 +32,6 @@
         {{- end -}}
     </div>
 </div>
+{{- if $wrap }}
+</div>
+{{- end -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

See: 
- [DOCS-14714](https://datadoghq.atlassian.net/browse/DOCS-14714)

Adds a `respect-site-support` boolean parameter (default `true`) to the `callout` shortcode.

It's confusing to users when we show a banner stating that a feature is unsupported along with a separate banner inviting them to try the feature out in preview. This setting uses the existing  `unsupported_sites` config in `params.yaml` to hide preview callouts for regions that are listed as unsupported. You can set `respect-site-support` to `false` to ignore site-support.

For an example, see [Dynamic Metric Quotas](https://docs-staging.datadoghq.com/heston/callout-site-support/metrics/guide/dynamic_quotas/?site=gov). The preview callout should disappear on the gov sites and the site-support warning should appear.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

To opt out on a specific callout: `{{< callout respect-site-support="false" ... >}}`

[DOCS-14714]: https://datadoghq.atlassian.net/browse/DOCS-14714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ