### PR TITLE
[DOCS-14565] Document anonymous_id for RUM and Product Analytics

### DIFF
--- a/content/en/product_analytics/data_collected.md
+++ b/content/en/product_analytics/data_collected.md
@@ -22,7 +22,7 @@ Product Analytics collects user activity data as events. Each event has two type
 
 Every event includes the [default attributes](#default-attributes). Each event type also has [specific telemetry and attributes](#event-specific-attributes).
 
-To identify individual users across sessions, Product Analytics relies on the `usr.id` and `usr.email` attributes.
+To identify individual users across sessions, Product Analytics relies on the `usr.id` and `usr.email` attributes. For unauthenticated users or visitors who never log in, the RUM SDK automatically assigns a `usr.anonymous_id` to track activity. See [Track unauthenticated users][4] for details.
 
 <div class="alert alert-info">Product Analytics uses the same SDKs and configuration as Real User Monitoring (RUM) to collect data. Unlike RUM, Product Analytics does not collect Errors, Resources, Long Tasks, or Vitals events. For the full list of RUM event types and attributes, see the data collected pages for <a href="/real_user_monitoring/application_monitoring/browser/data_collected/">browser</a>, <a href="/real_user_monitoring/application_monitoring/ios/data_collected/">iOS</a>, and <a href="/real_user_monitoring/application_monitoring/android/data_collected/">Android</a>.</div>
 
@@ -88,6 +88,7 @@ You can enable [tracking user info][3] globally to collect and apply user attrib
 | `usr.id` | string | Identifier of the user. |
 | `usr.name` | string | Name of the user. |
 | `usr.email` | string | Email of the user. |
+| `usr.anonymous_id` | string | Randomly generated UUID assigned to unauthenticated users. Persists for up to one year. See [Track unauthenticated users][4]. |
 
 ## Event-specific attributes
 
@@ -172,3 +173,4 @@ The following attributes are specific to each event type.
 [1]: /product_analytics/guide/action_management/
 [2]: https://app.datadoghq.com/rum/list
 [3]: /real_user_monitoring/application_monitoring/browser/advanced_configuration/#user-session
+[4]: /real_user_monitoring/application_monitoring/browser/advanced_configuration/#track-unauthenticated-users

--- a/content/en/product_analytics/profiles.md
+++ b/content/en/product_analytics/profiles.md
@@ -21,6 +21,8 @@ User and account profiles are generated from RUM events collected through the RU
 
 User profiles are grouped by the `user_id` attribute, while account profiles are grouped by `account_id`.
 
+For unauthenticated users or visitors who never call `setUser`, the RUM SDK automatically tracks activity using `usr.anonymous_id`. See [Track unauthenticated users][9] for details.
+
 You can also customize these pages by adding attributes that matter most to your team. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how to tailor profile data to your needs.
 
 
@@ -188,3 +190,4 @@ You can filter these custom attributes throughout the product analytics platform
 [6]: https://app.datadoghq.com/product-analytics/segments
 [7]: https://app.datadoghq.com/product-analytics/profiles
 [8]: https://app.datadoghq.com/product-analytics/profiles/accounts
+[9]: /real_user_monitoring/application_monitoring/browser/advanced_configuration/#track-unauthenticated-users

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -887,11 +887,16 @@ window.DD_RUM && window.DD_RUM.clearUser()
 
 ### Track unauthenticated users
 
-If `setUser` is not called—for example, before a user logs in or for visitors who never authenticate—the RUM SDK automatically tracks activity using `usr.anonymous_id`.
+For unauthenticated visitors or users who have not yet logged in, the RUM SDK automatically tracks activity using `usr.anonymous_id`. This lets you analyze user behavior without requiring authentication.
 
-`usr.anonymous_id` is a randomly generated UUID (v4) that is not derived from any user PII, IP address, device fingerprint, or hardware identifier. It is stored in the Datadog session cookie (`_dd_s`) and persists for up to one year across sessions. The ID is scoped per browser and domain and does not track users across sites, devices, or browsers.
+`usr.anonymous_id` is a randomly generated UUID (v4). It is not derived from any user PII, IP address, device fingerprint, or hardware identifier.
 
-The `anonymous_id` is cleared if the user revokes tracking consent with `setTrackingConsent('not-granted')` or clears their cookies.
+The ID has the following properties:
+
+- **Lifetime**: Persists for up to one year across sessions in the Datadog session cookie (`_dd_s`).
+- **Scope**: Per-browser and per-domain. Incognito mode, cookie clearing, or switching browsers or devices produces a new `anonymous_id`.
+
+The ID resets if the user revokes tracking consent with `setTrackingConsent('not-granted')` or clears cookies.
 
 **Note**: `usr.anonymous_id` is enabled by default. To disable it, set `trackAnonymousUser: false` in your `init` config.
 

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -885,6 +885,16 @@ window.DD_RUM && window.DD_RUM.clearUser()
 ```
 {% /if %}
 
+### Track unauthenticated users
+
+If `setUser` is not called—for example, before a user logs in or for visitors who never authenticate—the RUM SDK automatically tracks activity using `usr.anonymous_id`.
+
+`usr.anonymous_id` is a randomly generated UUID (v4) that is not derived from any user PII, IP address, device fingerprint, or hardware identifier. It is stored in the Datadog session cookie (`_dd_s`) and persists for up to one year across sessions. The ID is scoped per browser and domain and does not track users across sites, devices, or browsers.
+
+The `anonymous_id` is cleared if the user revokes tracking consent with `setTrackingConsent('not-granted')` or clears their cookies.
+
+**Note**: `usr.anonymous_id` is enabled by default. To disable it, set `trackAnonymousUser: false` in your `init` config.
+
 ## Account
 
 To group users into different set, use the account concept.

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -893,12 +893,12 @@ For unauthenticated visitors or users who have not yet logged in, the RUM SDK au
 
 The ID has the following properties:
 
-- **Lifetime**: Persists for up to one year across sessions in the Datadog session cookie (`_dd_s`).
+- **Lifetime**: Persists for up to one year across sessions in the Datadog session cookie (`_dd_s_v2`).
 - **Scope**: Per-browser and per-domain. Incognito mode, cookie clearing, or switching browsers or devices produces a new `anonymous_id`.
 
 The ID resets if the user revokes tracking consent with `setTrackingConsent('not-granted')` or clears cookies.
 
-**Note**: `usr.anonymous_id` is enabled by default. To disable it, set `trackAnonymousUser: false` in your `init` config.
+**Note**: `usr.anonymous_id` is enabled by default. To disable it, set [`trackAnonymousUser: false`](https://datadoghq.dev/browser-sdk/interfaces/_datadog_browser-rum.RumInitConfiguration.html#trackanonymoususer) in your `init` config.
 
 ## Account
 

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Configuration
-description: "Configure RUM Browser SDK to modify data collection, override view names, manage user sessions, and control sampling for your application's needs."
+description: "Configure RUM Browser SDK to modify data collection, override view names, manage user sessions, track unauthenticated users, and control sampling for your application's needs."
 aliases:
   - /real_user_monitoring/installation/advanced_configuration/
   - /real_user_monitoring/browser/modifying_data_and_context/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14565

Adds documentation for the `usr.anonymous_id` feature, which the RUM SDK automatically assigns to unauthenticated users or visitors who never call `setUser` for RUM and PA audiences.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes