### PR TITLE
Remove US1-Fed from Case Management unsupported sites banner

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -305,7 +305,7 @@ unsupported_sites:
   bits_ai_sre: [gov,gov2]
   bits_data_analysis: [gov,gov2]
   byoti: [gov, gov2]
-  case_management: [gov,gov2]
+  case_management: [gov2]
   ci_visibility: [gov,gov2]
   cloudcraft_monitors_overlay: [gov,gov2]
   cloudprem: [gov,gov2]


### PR DESCRIPTION
## Summary
- Case Management is now GA on US1-Fed (gov). Remove `gov` from the `case_management` unsupported sites list so the "not available on your site" banner no longer shows for US1-Fed users.
<img width="795" height="203" alt="image" src="https://github.com/user-attachments/assets/af894ea3-41b3-4320-a8a8-65bf7970090d" />

- US2-Fed (`gov2`) remains unsupported.

## Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)