### PR TITLE
[K9VULN-16251] Add agentic Bits AI docs

### DIFF
--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -155,7 +155,7 @@ In the SAST rule side panel, expand the false positive reports accordion to revi
 
 For supported SAST rules, Bits AI uses an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
 
-This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies to SAST findings only.
+This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies only to SAST findings.
 
 ## Remediation
 

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -153,9 +153,9 @@ In the SAST rule side panel, expand the false positive reports accordion to revi
 
 ### Agentic false positive filtering
 
-For supported SAST rules, Bits AI uses an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
+For supported SAST rules, Bits AI uses an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect the surrounding directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
 
-This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies only to SAST findings.
+The additional repository context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies only to SAST findings.
 
 ## Remediation
 

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -153,7 +153,9 @@ In the SAST rule side panel, expand the false positive reports accordion to revi
 
 ### Agentic false positive filtering
 
-For supported SAST rules, Bits AI uses an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect the surrounding directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
+Bits AI uses an agentic approach to gather repository context before classifying findings for injection-related SAST rules (for example, SQL injection and command injection). Support for additional rule categories is being rolled out over time.
+
+Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
 
 The additional repository context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies only to SAST findings.
 

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -151,11 +151,11 @@ Bits AI Memories lets teams add rule-specific context that Bits AI uses when ass
 
 In the SAST rule side panel, expand the false positive reports accordion to review reports shared by your organization for the selected rule. Use the custom context tab in the same section to add guidance for future Bits AI assessments. Memories apply at the organization and rule level for SAST. They apply only to security category SAST rules in Datadog's default rulesets and do not apply to custom rules.
 
-### Agentic Bits AI assessments
+### Agentic false positive filtering
 
-For supported SAST rules, Bits AI assessments use an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
+For supported SAST rules, Bits AI uses an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
 
-This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic Bits AI assessments apply to SAST findings only.
+This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic false positive filtering applies to SAST findings only.
 
 ## Remediation
 

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -151,6 +151,12 @@ Bits AI Memories lets teams add rule-specific context that Bits AI uses when ass
 
 In the SAST rule side panel, expand the false positive reports accordion to review reports shared by your organization for the selected rule. Use the custom context tab in the same section to add guidance for future Bits AI assessments. Memories apply at the organization and rule level for SAST. They apply only to security category SAST rules in Datadog's default rulesets and do not apply to custom rules.
 
+### Agentic Bits AI assessments
+
+For supported SAST rules, Bits AI assessments use an agentic approach to gather repository context before classifying findings. Bits AI can read related files and search for symbols and patterns. It can also inspect nearby directory structure to verify definitions, call paths, sanitizers, and framework wiring that are not visible in a single file.
+
+This extra context helps Bits AI distinguish true positives from false positives for findings that depend on cross-file behavior. Agentic Bits AI assessments apply to SAST findings only.
+
 ## Remediation
 
 Datadog SAST uses [Bits Code][10] to generate code fixes for vulnerabilities. You can also create an [automation][13] to automatically generate fixes for vulnerabilities as they are found or on a schedule.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a short agentic Bits AI assessments section to AI Enhanced Static Code Analysis.

Related release note PR
https://github.com/DataDog/web-ui/pull/319445
