### PR TITLE
Exclude system schemas from datadog.column_statistics() in Postgres DBM setup

### DIFF
--- a/content/en/database_monitoring/setup_postgres/alloydb.md
+++ b/content/en/database_monitoring/setup_postgres/alloydb.md
@@ -128,7 +128,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -163,7 +163,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -204,7 +204,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -127,7 +127,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/heroku.md
+++ b/content/en/database_monitoring/setup_postgres/heroku.md
@@ -83,7 +83,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/rds/_index.md
+++ b/content/en/database_monitoring/setup_postgres/rds/_index.md
@@ -223,7 +223,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -186,7 +186,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;

--- a/content/en/database_monitoring/setup_postgres/supabase/agent.md
+++ b/content/en/database_monitoring/setup_postgres/supabase/agent.md
@@ -126,7 +126,9 @@ RETURNS TABLE (
     inherited boolean, correlation real, most_common_freqs real[]
 ) AS
 $$ SELECT schemaname, tablename, attname, n_distinct, avg_width, null_frac,
-          inherited, correlation, most_common_freqs FROM pg_catalog.pg_stats; $$
+          inherited, correlation, most_common_freqs
+          FROM pg_catalog.pg_stats
+          WHERE schemaname NOT IN ('pg_catalog', 'information_schema'); $$
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp;


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds `WHERE schemaname NOT IN ('pg_catalog', 'information_schema')` to the
`datadog.column_statistics()` setup function on all Postgres DBM setup pages.
Without it the function also returns stats for system-catalog columns, which
the Agent collects and then discards. Filtering at the source avoids that
wasted work.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code for the edits.

### Additional notes

Same block updated identically on 8 pages: alloydb, aurora, azure, gcsql,
heroku, rds, selfhosted, supabase/agent.
