### PR TITLE
[DOCS-14668] Add clarifying note about ANRException in Android ANR reporting

### DIFF
--- a/content/en/error_tracking/frontend/mobile/android.md
+++ b/content/en/error_tracking/frontend/mobile/android.md
@@ -482,6 +482,8 @@ Rum.enable(rumConfig);
 
 ANRs are only reported through the SDK (not through Logs).
 
+**Note**: If you see `com.datadog.android.rum.internal.anr.ANRException` in your crash reports, the Datadog SDK did not cause the ANR. `ANRException` is the SDK's mechanism for detecting and surfacing ANRs in Error Tracking. The root cause is always application code blocking the main thread.
+
 #### Reporting fatal ANRs
 Fatal ANRs result in crashes. The application reports them when it's unresponsive, leading to the Android OS displaying a popup dialog to the user, who chooses to force quit the app through the popup.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a note to the Android ANR reporting section to address customer confusion about `ANRException` appearing in crash reports.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes