### PR TITLE
[CONTP-1760] Document configuring Autodiscovery with the DatadogInstrumentation CRD

### DIFF
--- a/hugo/content/en/containers/cluster_agent/endpointschecks.md
+++ b/hugo/content/en/containers/cluster_agent/endpointschecks.md
@@ -261,8 +261,6 @@ ad.datadoghq.com/endpoints.logs: '[<LOGS_CONFIG>]'
 
 This syntax supports a `%%host%%` [template variable][11] which is replaced by the IP of each endpoint. The `kube_namespace`, `kube_service`, and `kube_endpoint_ip` tags are automatically added to the instances.
 
-To manage the same endpoint-check configuration without annotating the Service, use a `DatadogInstrumentation` resource with `targetRef.kind: Service`. See [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
 **Note**: Custom endpoints log configuration is only supported during Docker socket log collection, and not Kubernetes log file collection.
 
 #### Example: HTTP check on an NGINX-backed service with an NGINX check on the service's endpoints
@@ -396,6 +394,29 @@ spec:
 [14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets
 {{% /tab %}}
 {{< /tabs >}}
+
+### Configuration from DatadogInstrumentation CRD
+
+To manage endpoint-check configuration without annotating the Service, use a `DatadogInstrumentation` resource that targets a Service. For setup steps and an example, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: nginx-endpoints
+spec:
+  targetRef:
+    apiVersion: v1
+    kind: Service
+    name: nginx
+  config:
+    checks:
+      - integration: nginx
+        initConfig: {}
+        instances:
+          - name: "My Nginx Service Endpoints"
+            nginx_status_url: "http://%%host%%:%%port%%/status/"
+```
 
 ## Further Reading
 

--- a/hugo/content/en/containers/cluster_agent/endpointschecks.md
+++ b/hugo/content/en/containers/cluster_agent/endpointschecks.md
@@ -22,6 +22,8 @@ The cluster check feature provides the ability to [Autodiscover][1] and perform 
 
 The [Cluster Agent][2] discovers endpoint check configurations based on [Autodiscovery][1] annotations on the Kubernetes services. The Cluster Agent then dispatches these configurations to node-based Agents to individually run. Endpoint checks are dispatched to Agents that run on the same node as the Pod(s) that back the endpoint(s) of the monitored Kubernetes service. This dispatching logic allows the Agent to add the Pod and container tags it has already collected for each respective Pod.
 
+You can also configure endpoint checks for a Service with the [`DatadogInstrumentation` custom resource][14], instead of Kubernetes service annotations.
+
 The Agents connect to the Cluster Agent every ten seconds and retrieve the check configurations to run. Metrics coming from endpoints checks are submitted with service tags, [Kubernetes tags][3], host tags, and the `kube_endpoint_ip` tag based on the evaluated IP address.
 
 **Versioning**:
@@ -259,6 +261,8 @@ ad.datadoghq.com/endpoints.logs: '[<LOGS_CONFIG>]'
 
 This syntax supports a `%%host%%` [template variable][11] which is replaced by the IP of each endpoint. The `kube_namespace`, `kube_service`, and `kube_endpoint_ip` tags are automatically added to the instances.
 
+To manage the same endpoint-check configuration without annotating the Service, use a `DatadogInstrumentation` resource with `targetRef.kind: Service`. See [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+
 **Note**: Custom endpoints log configuration is only supported during Docker socket log collection, and not Kubernetes log file collection.
 
 #### Example: HTTP check on an NGINX-backed service with an NGINX check on the service's endpoints
@@ -319,6 +323,7 @@ spec:
 [11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
 [12]: /integrations/nginx/
 [13]: /getting_started/tagging/unified_service_tagging
+[14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets
 
 {{% /tab %}}
 
@@ -388,6 +393,7 @@ spec:
 [11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
 [12]: /integrations/nginx/
 [13]: /getting_started/tagging/unified_service_tagging
+[14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -408,3 +414,4 @@ spec:
 [11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
 [12]: /integrations/nginx/
 [13]: /getting_started/tagging/unified_service_tagging
+[14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets

--- a/hugo/content/en/containers/cluster_agent/endpointschecks.md
+++ b/hugo/content/en/containers/cluster_agent/endpointschecks.md
@@ -407,7 +407,6 @@ spec:
   config:
     checks:
       - integration: nginx
-        initConfig: {}
         instances:
           - name: "My NGINX Service Endpoints"
             nginx_status_url: "http://%%host%%:%%port%%/status/"

--- a/hugo/content/en/containers/cluster_agent/endpointschecks.md
+++ b/hugo/content/en/containers/cluster_agent/endpointschecks.md
@@ -20,7 +20,7 @@ further_reading:
 
 The cluster check feature provides the ability to [Autodiscover][1] and perform checks on load-balanced cluster services, such as Kubernetes services. _Endpoints checks_ extend this mechanism to monitor each endpoint managed by a Kubernetes service.
 
- The [Cluster Agent][2] discovers endpoint check configurations based on [Autodiscovery][1] annotations on the Kubernetes services or with a [`DatadogInstrumentation` custom resource][14]. The Cluster Agent then dispatches these configurations to node-based Agents to individually run. Endpoint checks are dispatched to Agents that run on the same node as the Pod(s) that back the endpoint(s) of the monitored Kubernetes service. This dispatching logic allows the Agent to add the Pod and container tags it has already collected for each respective Pod.
+The [Cluster Agent][2] discovers endpoint check configurations from [Autodiscovery][1] annotations on Kubernetes services or from a [`DatadogInstrumentation` custom resource][14]. The Cluster Agent then dispatches these configurations to node-based Agents to individually run. Endpoint checks are dispatched to Agents that run on the same node as the Pod(s) that back the endpoint(s) of the monitored Kubernetes service. This dispatching logic allows the Agent to add the Pod and container tags it has already collected for each respective Pod.
 
 The Agents connect to the Cluster Agent every ten seconds and retrieve the check configurations to run. Metrics coming from endpoints checks are submitted with service tags, [Kubernetes tags][3], host tags, and the `kube_endpoint_ip` tag based on the evaluated IP address.
 
@@ -319,8 +319,6 @@ spec:
 [11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
 [12]: /integrations/nginx/
 [13]: /getting_started/tagging/unified_service_tagging
-[14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets
-
 {{% /tab %}}
 
 {{% tab "Kubernetes (AD v1)" %}}
@@ -389,7 +387,6 @@ spec:
 [11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
 [12]: /integrations/nginx/
 [13]: /getting_started/tagging/unified_service_tagging
-[14]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/#service-targets
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -412,7 +409,7 @@ spec:
       - integration: nginx
         initConfig: {}
         instances:
-          - name: "My Nginx Service Endpoints"
+          - name: "My NGINX Service Endpoints"
             nginx_status_url: "http://%%host%%:%%port%%/status/"
 ```
 

--- a/hugo/content/en/containers/cluster_agent/endpointschecks.md
+++ b/hugo/content/en/containers/cluster_agent/endpointschecks.md
@@ -20,9 +20,7 @@ further_reading:
 
 The cluster check feature provides the ability to [Autodiscover][1] and perform checks on load-balanced cluster services, such as Kubernetes services. _Endpoints checks_ extend this mechanism to monitor each endpoint managed by a Kubernetes service.
 
-The [Cluster Agent][2] discovers endpoint check configurations based on [Autodiscovery][1] annotations on the Kubernetes services. The Cluster Agent then dispatches these configurations to node-based Agents to individually run. Endpoint checks are dispatched to Agents that run on the same node as the Pod(s) that back the endpoint(s) of the monitored Kubernetes service. This dispatching logic allows the Agent to add the Pod and container tags it has already collected for each respective Pod.
-
-You can also configure endpoint checks for a Service with the [`DatadogInstrumentation` custom resource][14], instead of Kubernetes service annotations.
+ The [Cluster Agent][2] discovers endpoint check configurations based on [Autodiscovery][1] annotations on the Kubernetes services or with a [`DatadogInstrumentation` custom resource][14]. The Cluster Agent then dispatches these configurations to node-based Agents to individually run. Endpoint checks are dispatched to Agents that run on the same node as the Pod(s) that back the endpoint(s) of the monitored Kubernetes service. This dispatching logic allows the Agent to add the Pod and container tags it has already collected for each respective Pod.
 
 The Agents connect to the Cluster Agent every ten seconds and retrieve the check configurations to run. Metrics coming from endpoints checks are submitted with service tags, [Kubernetes tags][3], host tags, and the `kube_endpoint_ip` tag based on the evaluated IP address.
 
@@ -397,7 +395,7 @@ spec:
 
 ### Configuration from DatadogInstrumentation CRD
 
-To manage endpoint-check configuration without annotating the Service, use a `DatadogInstrumentation` resource that targets a Service. For setup steps and an example, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+Use a `DatadogInstrumentation` resource targeting the Service. For more details, see [Configure Autodiscovery with DatadogInstrumentation CRD][14].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/hugo/content/en/containers/guide/_index.md
+++ b/hugo/content/en/containers/guide/_index.md
@@ -29,6 +29,7 @@ disable_toc: true
     {{< nextlink href="/containers/guide/ad_identifiers" >}}Container identifiers: Apply an Autodiscovery configuration file template to a specific container{{< /nextlink >}}
     {{< nextlink href="/containers/guide/template_variables" >}}Autodiscovery template variables: Dynamically populate configuration settings{{< /nextlink >}}
     {{< nextlink href="/containers/guide/auto_conf" >}}Autodiscovery auto-configuration: Default base configuration for common integrations{{< /nextlink >}}
+    {{< nextlink href="/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd" >}}Configure Autodiscovery with DatadogInstrumentation CRD{{< /nextlink >}}
     {{< nextlink href="/containers/guide/autodiscovery-examples" >}}Detailed Autodiscovery template examples{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/hugo/content/en/containers/guide/auto_conf.md
+++ b/hugo/content/en/containers/guide/auto_conf.md
@@ -50,9 +50,9 @@ When the Agent runs as a container, [Autodiscovery][49] tries to discover other 
 The `auto_conf.yaml` configuration files cover all required parameters to set up a specific integration, with their corresponding [Autodiscovery Templates Variables][43] in place to take into account the containerized environment.
 
 ## Override auto-configuration
-Each `auto_conf.yaml` file provides a default configuration. To override this, you can add a custom configuration in [Kubernetes annotations][50] or [Docker Labels][51].
+Each `auto_conf.yaml` file provides a default configuration. To override this on Kubernetes, you can add a custom configuration in [Kubernetes annotations][50] or use the [`DatadogInstrumentation` custom resource][52]. For Docker, use [Docker Labels][51].
 
-Kubernetes annotations and Docker Labels take precedence over `auto_conf.yaml` files, but `auto_conf.yaml` files take precedence over Autodiscovery configuration set in the Datadog Operator and Helm charts. To use Datadog Operator or Helm to configure Autodiscovery for an integration in the table on this page, you must [disable auto-configuration](#disable-auto-configuration).
+Kubernetes annotations take precedence over `DatadogInstrumentation` resources and `auto_conf.yaml` files. `DatadogInstrumentation` resources take precedence over `auto_conf.yaml` files, and `auto_conf.yaml` files take precedence over Autodiscovery configuration set in the Datadog Operator and Helm charts. To use Datadog Operator or Helm to configure Autodiscovery for an integration in the table on this page, you must [disable auto-configuration](#disable-auto-configuration).
 
 ## Disable auto-configuration
 
@@ -161,3 +161,4 @@ DD_IGNORE_AUTOCONF="redisdb istio"
 [49]: /getting_started/containers/autodiscovery
 [50]: /containers/kubernetes/integrations/?tab=annotations#configuration
 [51]: /containers/docker/integrations/
+[52]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/guide/autodiscovery-examples.md
+++ b/hugo/content/en/containers/guide/autodiscovery-examples.md
@@ -31,7 +31,7 @@ For more information about containers and integrations, see [Docker and Integrat
 
 All examples make use of Datadog's Autodiscovery feature, which allows you to define configuration templates for Agent Checks on designated sets of containers. For more information about Autodiscovery, see [Getting Started with Containers: Autodiscovery][1].
 
-To configure these checks for a specific workload without using pod annotations, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13] (beta).
+To configure these checks for a specific workload without using pod annotations, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 ## Redis integration for all Redis containers
 

--- a/hugo/content/en/containers/guide/autodiscovery-examples.md
+++ b/hugo/content/en/containers/guide/autodiscovery-examples.md
@@ -17,6 +17,9 @@ further_reading:
 - link: "/agent/kubernetes/tag/"
   tag: "Documentation"
   text: "Assign tags to all data emitted by a container"
+- link: "/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/"
+  tag: "Documentation"
+  text: "Configure Autodiscovery with the DatadogInstrumentation CRD"
 ---
 
 This page contains detailed example templates for configuring integrations in containerized environments in the following scenarios:
@@ -27,6 +30,8 @@ This page contains detailed example templates for configuring integrations in co
 For more information about containers and integrations, see [Docker and Integrations][2] and [Kubernetes and Integrations][3].
 
 All examples make use of Datadog's Autodiscovery feature, which allows you to define configuration templates for Agent Checks on designated sets of containers. For more information about Autodiscovery, see [Getting Started with Containers: Autodiscovery][1].
+
+To configure these checks for a specific workload without using pod annotations, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13] (beta).
 
 ## Redis integration for all Redis containers
 
@@ -636,3 +641,4 @@ All of these examples use [Autodiscovery template variables][7]:
 [10]: https://github.com/DataDog/integrations-core/blob/master/apache/datadog_checks/apache/data/conf.yaml.example
 [11]: /extend/write_agent_check/#updating-the-collection-interval
 [12]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example
+[13]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/guide/autodiscovery-examples.md
+++ b/hugo/content/en/containers/guide/autodiscovery-examples.md
@@ -155,7 +155,6 @@ spec:
     checks:
       - integration: redisdb
         containerName: redis
-        initConfig: {}
         instances:
           - host: "%%host%%"
             port: "6379"
@@ -468,13 +467,11 @@ spec:
     checks:
       - integration: apache
         containerName: apache
-        initConfig: {}
         instances:
           - apache_status_url: "http://%%host%%/server-status?auto"
             min_collection_interval: 30
       - integration: http_check
         containerName: apache
-        initConfig: {}
         instances:
           - name: "my_website_1"
             url: "http://%%host%%/website_1"

--- a/hugo/content/en/containers/guide/autodiscovery-examples.md
+++ b/hugo/content/en/containers/guide/autodiscovery-examples.md
@@ -19,7 +19,7 @@ further_reading:
   text: "Assign tags to all data emitted by a container"
 - link: "/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/"
   tag: "Documentation"
-  text: "Configure Autodiscovery with the DatadogInstrumentation CRD"
+  text: "Configure Autodiscovery with DatadogInstrumentation CRD"
 ---
 
 This page contains detailed example templates for configuring integrations in containerized environments in the following scenarios:
@@ -31,7 +31,7 @@ For more information about containers and integrations, see [Docker and Integrat
 
 All examples make use of Datadog's Autodiscovery feature, which allows you to define configuration templates for Agent Checks on designated sets of containers. For more information about Autodiscovery, see [Getting Started with Containers: Autodiscovery][1].
 
-To configure these checks for a specific workload without using pod annotations, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+To configure these checks for a specific workload without using pod annotations, see [Configure Autodiscovery with DatadogInstrumentation CRD][13].
 
 ## Redis integration for all Redis containers
 
@@ -133,6 +133,39 @@ spec:
       image: redis:latest
       ports:
         - containerPort: 6379
+```
+
+{{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+In a `DatadogInstrumentation` resource:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: redis-instrumentation
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redis
+  config:
+    checks:
+      - integration: redisdb
+        containerName: redis
+        initConfig: {}
+        instances:
+          - host: "%%host%%"
+            port: "6379"
+            password: "%%env_REDIS_PASSWORD%%"
+    logs:
+      - containerName: redis
+        type: file
+        path: /var/log/redis_6379.log
+        source: redis
+        service: redis_service
 ```
 
 {{% /tab %}}
@@ -413,6 +446,42 @@ spec:
   containers:
     - name: apache
   # (...)
+```
+
+{{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+In a `DatadogInstrumentation` resource:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: apache-instrumentation
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: apache
+  config:
+    checks:
+      - integration: apache
+        containerName: apache
+        initConfig: {}
+        instances:
+          - apache_status_url: "http://%%host%%/server-status?auto"
+            min_collection_interval: 30
+      - integration: http_check
+        containerName: apache
+        initConfig: {}
+        instances:
+          - name: "my_website_1"
+            url: "http://%%host%%/website_1"
+            timeout: 1
+          - name: "my_website_2"
+            url: "http://%%host%%/website_2"
+            timeout: 1
 ```
 
 {{% /tab %}}

--- a/hugo/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/hugo/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -70,7 +70,7 @@ Use one of the following methods:
 
 In this method, a JMX check configuration is applied using annotations on your Java-based Pods. This allows the Agent to automatically configure the JMX check when a new container starts. Ensure these annotations are on the created Pod, and not on the object (Deployment, DaemonSet, etc.) creating the Pod. 
 
-Alternatively, use the [`DatadogInstrumentation` custom resource][8] to define the same check as a separate Kubernetes resource.
+Alternatively, use the [`DatadogInstrumentation` custom resource][8] to define the same check as a separate Kubernetes resource, instead of an Autodiscovery annotation.
 
 Use the following template for Autodiscovery annotations:
 

--- a/hugo/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/hugo/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -63,11 +63,14 @@ agents:
 Use one of the following methods:
 
 - [Autodiscovery annotations](#autodiscovery-annotations) (recommended)
+- [`DatadogInstrumentation` custom resource][8]: for supported workloads where you want to configure integrations without modifying your workload.
 - [Autodiscovery configuration files](#autodiscovery-configuration-files): for heavy customization of configuration parameters
 
 ### Autodiscovery annotations
 
 In this method, a JMX check configuration is applied using annotations on your Java-based Pods. This allows the Agent to automatically configure the JMX check when a new container starts. Ensure these annotations are on the created Pod, and not on the object (Deployment, DaemonSet, etc.) creating the Pod. 
+
+Alternatively, use the [`DatadogInstrumentation` custom resource][8] to define the same check as a separate Kubernetes resource.
 
 Use the following template for Autodiscovery annotations:
 
@@ -514,6 +517,7 @@ Alternatively use `jmx` as your `<INTEGRATION_NAME>` to set up a basic JMX integ
 [5]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
 [6]: /integrations/java/
 [7]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+[8]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
 [41]: /integrations/activemq/
 [42]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml
 [43]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/conf.yaml.example

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -213,18 +213,57 @@ When more than one configuration source applies to a workload, Datadog resolves 
 2. `DatadogInstrumentation` resources
 3. Static configuration, such as auto-configuration or mounted files
 
-If a workload already has annotation-based Autodiscovery configuration for a check, your `DatadogInstrumentation` configuration will not override it.
+If a workload already has annotation-based Autodiscovery configuration for a check, your `DatadogInstrumentation` configuration does not override it.
 
 ## One resource per target
 
-A workload or Service can be the target of only one `DatadogInstrumentation` resource within a namespace. A validation webhook will reject a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
+A workload or Service can be the target of only one `DatadogInstrumentation` resource within a namespace. A validation webhook rejects a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
 
-## Check the status
+## Verify scheduled checks
 
-The controller reports the result of reconciling each resource through Kubernetes status conditions. Use the status to view the state of the check configuration, including target resolution and whether the configuration was applied:
+Resource status confirms that the configuration was accepted. To confirm that the resulting checks are scheduled, run `agent configcheck` in the Node Agent running on a node where the target workload is scheduled.
 
-```shell
-kubectl describe datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE>
+Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider, and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis service:
+
+```text
+> agent configcheck
+# other configs...
+
+=== redisdb check ===
+Configuration provider: instrumentation-checks
+Configuration source: datadoginstrumentation:cache/redis-instrumentation
+Config for instance ID: redisdb:d5dd267b580bc10e
+host: 10.244.0.7
+password: "********"
+port: 6379
+tags:
+  - container_id:86fd26bd7ee8c8cd1864103b2a575cdac0d23b1d0961085c000cb96d0f4a2cc9
+  - container_name:redis
+  - display_container_name:redis_redis-6b4c7b565b-6dhfh
+  - env:staging
+  - image_id:********@sha256:0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973
+  - image_name:redis
+  - image_tag:latest
+  - kube_container_name:redis
+  - kube_deployment:redis
+  - kube_namespace:cache
+  - kube_ownerref_kind:replicaset
+  - kube_ownerref_name:redis-6b4c7b565b
+  - kube_qos:BestEffort
+  - kube_replica_set:redis-6b4c7b565b
+  - kube_service:redis
+  - pod_name:redis-6b4c7b565b-6dhfh
+  - pod_phase:running
+  - service:redis
+  - short_image:redis
+~
+Init Config:
+{}
+Log Config:
+- service: redis
+  source: redis
+Auto-discovery IDs:
+* redis
 ```
 
 ## Further reading

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -1,0 +1,198 @@
+---
+title: Configure Autodiscovery with the DatadogInstrumentation CRD
+description: Configure Autodiscovery checks for Kubernetes workloads through the DatadogInstrumentation custom resource instead of pod annotations.
+further_reading:
+- link: "/containers/kubernetes/integrations/"
+  tag: "Documentation"
+  text: "Configure integrations with Autodiscovery"
+- link: "/getting_started/containers/autodiscovery/"
+  tag: "Documentation"
+  text: "Getting Started with Autodiscovery"
+- link: "/containers/guide/autodiscovery-examples/"
+  tag: "Documentation"
+  text: "Autodiscovery scenarios and examples"
+- link: "/containers/cluster_agent/"
+  tag: "Documentation"
+  text: "Datadog Cluster Agent"
+---
+
+<div class="alert alert-info">Configuring Autodiscovery with the <code>DatadogInstrumentation</code> custom resource is in beta.</div>
+
+## Overview
+
+The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks for specific Kubernetes workloads through a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and roll back integration configurations without editing pod specs or triggering Agent or application rollouts.
+
+Use the `DatadogInstrumentation` CR when you want to:
+
+- Configure Autodiscovery checks without modifying workload manifests or adding annotations.
+- Centrally manage per-workload check configuration as a dedicated, version-controlled Kubernetes resource.
+- Update or remove check configuration without restarting your application pods.
+
+The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent generates the corresponding check configurations and applies them to the matching workload's containers.
+
+## Requirements
+
+- Datadog Agent and Cluster Agent v7.81 or later.
+- To install the CRD and enable the controller, Datadog Operator v1.28 or later, or Datadog Helm chart v2.223.0 or later.
+
+## Enable the controller
+
+The `DatadogInstrumentation` controller runs in the Cluster Agent and is disabled by default. Enable it with the Datadog Operator or Helm.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+While the feature is in beta, opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.81.0 or later.
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    agent.datadoghq.com/instrumentation-crd-enabled: "true"
+spec:
+  global:
+    [...]
+```
+
+Apply the change:
+
+```shell
+kubectl apply -f datadog-agent.yaml
+```
+
+The Operator sets the required environment variables and RBAC on the Cluster Agent automatically.
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+In your `datadog-values.yaml` file, enable the controller:
+
+```yaml
+datadog:
+  instrumentationCrd:
+    enabled: true
+```
+
+Upgrade your release:
+
+```shell
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+When the controller is enabled, it waits for the `DatadogInstrumentation` CRD to be installed in the cluster before it starts reconciling resources.
+
+## Configure a check
+
+A `DatadogInstrumentation` resource has two main parts:
+
+- `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
+- `spec.config.checks`: a list of Autodiscovery check configurations to apply to the target workload's containers.
+
+The following example configures the [Redis integration][4] for a `Deployment` named `redis`, including log collection. It mirrors the [annotation-based example][2], using the same [template variables][5] such as `%%host%%`:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: redis-instrumentation
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redis
+  config:
+    checks:
+      - integration: redisdb
+        containerImage:
+          - redis
+        initConfig: {}
+        instances:
+          - host: "%%host%%"
+            port: "6379"
+            password: "%%env_REDIS_PASSWORD%%"
+        logs:
+          - type: file
+            path: /var/log/redis_6379.log
+            source: redis
+            service: redis_service
+```
+
+Apply the resource:
+
+```shell
+kubectl apply -f redis-instrumentation.yaml
+```
+
+Each entry in `checks` accepts the following fields:
+
+`integration`
+: The name of the Datadog integration to run, such as `redisdb`.
+
+`containerImage`
+: A list of container image identifiers to match against the target workload's containers. The check is applied to containers whose image matches an entry in this list.
+
+`initConfig`
+: The `init_config` section for the integration. This section is usually empty (`{}`).
+
+`instances`
+: A list of instance configurations for the check. Each instance supports [Autodiscovery template variables][5], such as `%%host%%`.
+
+`logs`
+: The log collection configuration for the matching containers.
+
+### Endpoint and cluster checks
+
+To configure an [endpoint check][6], set `targetRef` to a `Service`:
+
+```yaml
+spec:
+  targetRef:
+    apiVersion: v1
+    kind: Service
+    name: my-service
+```
+
+## Precedence
+
+When more than one configuration source applies to a workload, Datadog resolves them in the following order (highest precedence first):
+
+1. Pod annotations
+2. `DatadogInstrumentation` resources
+3. Static configuration (such as auto-configuration or mounted files)
+
+If a workload already has annotation-based Autodiscovery configuration for a check, the `DatadogInstrumentation` configuration does not override it.
+
+## One resource per workload
+
+A workload can be the target of only one `DatadogInstrumentation` resource within a namespace. A validating admission webhook rejects a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
+
+## Check the status
+
+The controller reports the result of reconciling each resource through Kubernetes status conditions. To view the status, including whether the configuration was applied and the resolved target workload:
+
+```shell
+kubectl describe datadoginstrumentation redis-instrumentation
+```
+
+## Limitations
+
+- This capability is in beta.
+- The `DatadogInstrumentation` CRD is served at `apiVersion: datadoghq.com/v1alpha1`.
+- This page covers Autodiscovery checks only. Configuring APM Single Step Instrumentation through the `DatadogInstrumentation` resource is tracked separately.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /getting_started/containers/autodiscovery/
+[2]: /containers/kubernetes/integrations/
+[3]: /containers/cluster_agent/
+[4]: /integrations/redisdb/
+[5]: /containers/guide/template_variables/
+[6]: /containers/cluster_agent/endpointschecks/

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -221,7 +221,7 @@ A workload or Service can be the target of only one `DatadogInstrumentation` res
 
 ## Verify scheduled checks
 
-Resource status confirms that the configuration was accepted. To confirm that the resulting checks are scheduled, run `agent configcheck` in the Node Agent running on a node where the target workload is scheduled.
+The resource status shows whether the Cluster Agent accepted the configuration. To verify that the checks are scheduled, run `agent configcheck` on the Node Agent where the target workload runs.
 
 Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider, and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis workload:
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -1,6 +1,6 @@
 ---
 title: Configure Autodiscovery with the DatadogInstrumentation CRD
-description: Configure Autodiscovery checks for Kubernetes workloads through the DatadogInstrumentation custom resource instead of pod annotations.
+description: Configure Autodiscovery checks and logs for Kubernetes workloads through the DatadogInstrumentation custom resource instead of pod annotations.
 further_reading:
 - link: "/containers/kubernetes/integrations/"
   tag: "Documentation"
@@ -18,24 +18,24 @@ further_reading:
 
 ## Overview
 
-The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks for specific Kubernetes workloads through a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and roll back integration configurations without editing pod specs or triggering Agent or application rollouts.
+The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks and logs for specific Kubernetes workloads through a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and roll back integration configurations without editing pod specs or triggering Agent or application rollouts.
 
 Use the `DatadogInstrumentation` CR when you want to:
 
-- Configure Autodiscovery checks without modifying workload manifests or adding annotations.
+- Configure Autodiscovery checks and logs without modifying workload manifests or adding annotations.
 - Use a structured resource spec with validation instead of raw JSON in annotations.
-- Centrally manage per-workload check configuration as a dedicated, version-controlled Kubernetes resource.
-- Update or remove check configuration without restarting your application pods.
+- Centrally manage per-workload Autodiscovery configuration as a dedicated, version-controlled Kubernetes resource.
+- Update or remove Autodiscovery configuration without restarting your application pods.
 
-The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent validates the target, reports resource status, and schedules checks against the targeted workload.
+The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent validates the target, reports resource status, and applies the Autodiscovery configuration to the targeted workload.
 
 ## Requirements
 
-- Datadog Agent and Cluster Agent v7.81 or later.
+- Datadog Agent and Cluster Agent v7.82 or later.
 
 To install the CRD and enable the controller, use one of the following:
 
-- Datadog Operator v1.28 or later.
+- Datadog Operator v1.29 or later.
 - Datadog Helm chart v2.223.0 or later.
 
 ## Enable the controller
@@ -45,7 +45,7 @@ The `DatadogInstrumentation` controller runs in the Cluster Agent and is disable
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.81.0 or later.
+Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -99,12 +99,13 @@ If you manage Datadog CRDs separately, install or upgrade the Datadog CRDs Helm 
 helm upgrade --install datadog-crds datadog/datadog-crds
 ```
 
-## Configure a workload check
+## Configure a workload
 
-A `DatadogInstrumentation` resource has two main parts:
+A `DatadogInstrumentation` resource has three main parts:
 
 - `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
-- `spec.config.checks`: defines the Autodiscovery configurations applied to the target.
+- `spec.config.checks`: defines integration checks to run against your workload.
+- `spec.config.logs`: defines logs to collect from your workload.
 
 You can target the following Kubernetes resources:
 
@@ -131,16 +132,16 @@ spec:
   config:
     checks:
       - integration: redisdb
-        containerImage:
-          - redis
+        containerName: redis
         initConfig: {}
         instances:
           - host: "%%host%%"
             port: "6379"
             password: "%%env_REDIS_PASSWORD%%"
-        logs:
-          - source: redis
-            service: redis_service
+    logs:
+      - containerName: redis
+        tags:
+          - env:demo
 ```
 
 Apply the resource:
@@ -155,13 +156,13 @@ Check the resource status:
 kubectl describe datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE>
 ```
 
-Each entry in `checks` accepts the following fields. For workload targets, provide `instances`, `logs`, or both. If neither is provided, the resource is rejected.
+Each entry in `checks` accepts the following fields:
 
 `integration`
 : Required. The name of the Datadog integration to run, for example `redisdb`.
 
-`containerImage`
-: Required for workload targets. Not used for Service targets. A list of container image identifiers to match against the target workload's containers.
+`containerName`
+: Optional. For workload targets, use the pod container name to apply the check to a specific container. Not used for Service targets.
 
 `initConfig`
 : Optional. The `init_config` section for the integration.
@@ -169,8 +170,7 @@ Each entry in `checks` accepts the following fields. For workload targets, provi
 `instances`
 : Optional. Check instance settings. Each instance can use [Autodiscovery template variables][5], including `%%host%%`.
 
-`logs`
-: Optional. The log collection configuration for the matching containers.
+Each entry in `logs` accepts the same log collection configuration options as Autodiscovery log annotations, such as `source`, `service`, `tags`, `type`, `path`, and `log_processing_rules`. Each log entry also requires `containerName`, which must match the pod container name.
 
 ### Service targets
 
@@ -178,10 +178,10 @@ To configure an [endpoint check][6], set `targetRef` to a `Service`. Service tar
 
 - Datadog schedules one endpoint check for each endpoint of the Service.
 - `%%host%%` resolves to the endpoint IP.
-- If an endpoint is backed by a Kubernetes Pod, Datadog adds the Pod and container tags collected for that Pod.
+- If an endpoint is backed by a Kubernetes Pod, Datadog adds the Pod tags collected for that Pod.
 - If an endpoint is not backed by a Pod, Datadog converts the check into a regular cluster check without Pod-specific tags.
 
-Service targets do not use `containerImage`; omit that field.
+Service targets do not use `containerName`; omit that field.
 
 Example: configure NGINX for endpoints behind a `Service` named `nginx`:
 
@@ -213,7 +213,7 @@ When more than one configuration source applies to a workload, Datadog resolves 
 2. `DatadogInstrumentation` resources
 3. Static configuration, such as auto-configuration or mounted files
 
-If a workload already has annotation-based Autodiscovery configuration for a check, your `DatadogInstrumentation` configuration does not override it.
+If a workload already has annotation-based Autodiscovery configuration for a check or log collection, your `DatadogInstrumentation` configuration does not override it.
 
 ## One resource per target
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -34,7 +34,11 @@ The configuration is reconciled by a controller in the [Datadog Cluster Agent][3
 ## Requirements
 
 - Datadog Agent and Cluster Agent v7.81 or later.
-- To install the CRD and enable the controller, Datadog Operator v1.28 or later, or Datadog Helm chart v2.223.0 or later.
+
+To install the CRD and enable the controller, use one of the following:
+
+- Datadog Operator v1.28 or later.
+- Datadog Helm chart v2.223.0 or later.
 
 ## Enable the controller
 
@@ -97,27 +101,23 @@ If you manage Datadog CRDs separately, install or upgrade the Datadog CRDs Helm 
 helm upgrade --install datadog-crds datadog/datadog-crds
 ```
 
-When the controller is enabled, it waits for the `DatadogInstrumentation` CRD to be installed in the cluster before it starts reconciling resources.
-
 ## Configure a workload check
 
 A `DatadogInstrumentation` resource has two main parts:
 
 - `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
-- `spec.config.checks`: a list of Autodiscovery check configurations to apply to the target workload's containers.
+- `spec.config.checks`: defines the Autodiscovery configurations applied to the target.
 
-For Autodiscovery, `targetRef` supports the following target kinds:
+You can target the following Kubernetes resources:
 
-| `apiVersion` | `kind` | Behavior |
-| --- | --- | --- |
-| `apps/v1` | `Deployment` | Targets Deployment pods. |
-| `apps/v1` | `DaemonSet` | Targets DaemonSet pods. |
-| `apps/v1` | `StatefulSet` | Targets StatefulSet pods. |
-| `batch/v1` | `CronJob` | Targets pods from CronJob Jobs. |
-| `batch/v1` | `Job` | Targets Job pods. |
-| `v1` | `Service` | Targets each Service endpoint. See [Service targets](#service-targets). |
+- Deployment
+- DaemonSet
+- StatefulSet
+- CronJob
+- Job
+- Service. Service targets schedule endpoint checks. See [Service targets](#service-targets).
 
-The following example configures the [Redis integration][4] for a `Deployment` named `redis`, including log collection. It mirrors the [annotation-based example][2], using the same [template variables][5] such as `%%host%%`:
+This example configures a [Redis integration][4] for a `Deployment` named `redis`, including log collection. It mirrors this [annotation-based example][2], using the same [template variables][5], including `%%host%%`:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -157,17 +157,10 @@ Check the resource status:
 kubectl describe datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE>
 ```
 
-The status conditions show the state of the check configuration, including whether Datadog resolved the target workload and applied the configuration. To view only the conditions:
-
-```shell
-kubectl get datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE> \
-  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-```
-
 Each entry in `checks` accepts the following fields. For workload targets, provide `instances`, `logs`, or both. If neither is provided, the resource is rejected.
 
 `integration`
-: Required. The name of the Datadog integration to run, such as `redisdb`.
+: Required. The name of the Datadog integration to run, for example `redisdb`.
 
 `containerImage`
 : Required for workload targets. Not used for Service targets. A list of container image identifiers to match against the target workload's containers.
@@ -176,7 +169,7 @@ Each entry in `checks` accepts the following fields. For workload targets, provi
 : Optional. The `init_config` section for the integration.
 
 `instances`
-: Optional. A list of instance configurations for the check. Each instance supports [Autodiscovery template variables][5], such as `%%host%%`.
+: Optional. Check instance settings. Each instance can use [Autodiscovery template variables][5], including `%%host%%`.
 
 `logs`
 : Optional. The log collection configuration for the matching containers.
@@ -226,7 +219,7 @@ If a workload already has annotation-based Autodiscovery configuration for a che
 
 ## One resource per target
 
-A workload or Service can be the target of only one `DatadogInstrumentation` resource within a namespace. A validating admission webhook rejects a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
+A workload or Service can be the target of only one `DatadogInstrumentation` resource within a namespace. A validation webhook will reject a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
 
 ## Check the status
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -63,7 +63,7 @@ Apply the change:
 kubectl apply -f datadog-agent.yaml
 ```
 
-The Operator sets the required environment variables and RBAC on the Cluster Agent automatically.
+The Operator sets the required Cluster Agent and Node Agent environment variables, and configures the required RBAC for the Cluster Agent automatically.
 
 {{% /tab %}}
 {{% tab "Helm" %}}
@@ -154,13 +154,13 @@ kubectl apply -f redis-instrumentation.yaml
 Check the resource status:
 
 ```shell
-kubectl describe datadoginstrumentation <YOUR_CR_NAME>
+kubectl describe datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE>
 ```
 
 The status conditions show the state of the check configuration, including whether Datadog resolved the target workload and applied the configuration. To view only the conditions:
 
 ```shell
-kubectl get datadoginstrumentation <YOUR_CR_NAME> \
+kubectl get datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE> \
   -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
 ```
 
@@ -188,7 +188,7 @@ To configure an [endpoint check][6], set `targetRef` to a `Service`. Service tar
 - Datadog schedules one endpoint check for each endpoint of the Service.
 - `%%host%%` resolves to the endpoint IP.
 - If an endpoint is backed by a Kubernetes Pod, Datadog adds the Pod and container tags collected for that Pod.
-- If an endpoint is not backed by a Pod, Datadog schedules a regular endpoint check without Pod-specific tags.
+- If an endpoint is not backed by a Pod, Datadog converts the check into a regular cluster check without Pod-specific tags.
 
 Service targets do not use `containerImage`; omit that field.
 
@@ -233,7 +233,7 @@ A workload or Service can be the target of only one `DatadogInstrumentation` res
 The controller reports the result of reconciling each resource through Kubernetes status conditions. Use the status to view the state of the check configuration, including target resolution and whether the configuration was applied:
 
 ```shell
-kubectl describe datadoginstrumentation <YOUR_CR_NAME>
+kubectl describe datadoginstrumentation <YOUR_CR_NAME> -n <YOUR_TARGETS_NAMESPACE>
 ```
 
 ## Further reading

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -25,10 +25,11 @@ The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscov
 Use the `DatadogInstrumentation` CR when you want to:
 
 - Configure Autodiscovery checks without modifying workload manifests or adding annotations.
+- Use a structured resource spec with validation instead of raw JSON in annotations.
 - Centrally manage per-workload check configuration as a dedicated, version-controlled Kubernetes resource.
 - Update or remove check configuration without restarting your application pods.
 
-The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent generates the corresponding check configurations and applies them to the matching workload's containers.
+The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent validates the target, reports resource status, and schedules checks against the targeted workload.
 
 ## Requirements
 
@@ -84,14 +85,37 @@ helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 {{% /tab %}}
 {{< /tabs >}}
 
+Make sure the `DatadogInstrumentation` CRD is installed before creating resources:
+
+```shell
+kubectl get crd datadoginstrumentations.datadoghq.com
+```
+
+If you manage Datadog CRDs separately, install or upgrade the Datadog CRDs Helm chart:
+
+```shell
+helm upgrade --install datadog-crds datadog/datadog-crds
+```
+
 When the controller is enabled, it waits for the `DatadogInstrumentation` CRD to be installed in the cluster before it starts reconciling resources.
 
-## Configure a check
+## Configure a workload check
 
 A `DatadogInstrumentation` resource has two main parts:
 
 - `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
 - `spec.config.checks`: a list of Autodiscovery check configurations to apply to the target workload's containers.
+
+For Autodiscovery, `targetRef` supports the following target kinds:
+
+| `apiVersion` | `kind` | Behavior |
+| --- | --- | --- |
+| `apps/v1` | `Deployment` | Targets Deployment pods. |
+| `apps/v1` | `DaemonSet` | Targets DaemonSet pods. |
+| `apps/v1` | `StatefulSet` | Targets StatefulSet pods. |
+| `batch/v1` | `CronJob` | Targets pods from CronJob Jobs. |
+| `batch/v1` | `Job` | Targets Job pods. |
+| `v1` | `Service` | Targets each Service endpoint. See [Service targets](#service-targets). |
 
 The following example configures the [Redis integration][4] for a `Deployment` named `redis`, including log collection. It mirrors the [annotation-based example][2], using the same [template variables][5] such as `%%host%%`:
 
@@ -99,8 +123,8 @@ The following example configures the [Redis integration][4] for a `Deployment` n
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogInstrumentation
 metadata:
-  name: redis-instrumentation
-  namespace: default
+  name: <YOUR_CR_NAME>
+  namespace: <YOUR_TARGETS_NAMESPACE>
 spec:
   targetRef:
     apiVersion: apps/v1
@@ -117,9 +141,7 @@ spec:
             port: "6379"
             password: "%%env_REDIS_PASSWORD%%"
         logs:
-          - type: file
-            path: /var/log/redis_6379.log
-            source: redis
+          - source: redis
             service: redis_service
 ```
 
@@ -129,33 +151,67 @@ Apply the resource:
 kubectl apply -f redis-instrumentation.yaml
 ```
 
-Each entry in `checks` accepts the following fields:
+Check the resource status:
+
+```shell
+kubectl describe datadoginstrumentation <YOUR_CR_NAME>
+```
+
+The status conditions show the state of the check configuration, including whether Datadog resolved the target workload and applied the configuration. To view only the conditions:
+
+```shell
+kubectl get datadoginstrumentation <YOUR_CR_NAME> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+```
+
+Each entry in `checks` accepts the following fields. For workload targets, provide `instances`, `logs`, or both. If neither is provided, the resource is rejected.
 
 `integration`
-: The name of the Datadog integration to run, such as `redisdb`.
+: Required. The name of the Datadog integration to run, such as `redisdb`.
 
 `containerImage`
-: A list of container image identifiers to match against the target workload's containers. The check is applied to containers whose image matches an entry in this list.
+: Required for workload targets. Not used for Service targets. A list of container image identifiers to match against the target workload's containers.
 
 `initConfig`
-: The `init_config` section for the integration. This section is usually empty (`{}`).
+: Optional. The `init_config` section for the integration.
 
 `instances`
-: A list of instance configurations for the check. Each instance supports [Autodiscovery template variables][5], such as `%%host%%`.
+: Optional. A list of instance configurations for the check. Each instance supports [Autodiscovery template variables][5], such as `%%host%%`.
 
 `logs`
-: The log collection configuration for the matching containers.
+: Optional. The log collection configuration for the matching containers.
 
-### Endpoint and cluster checks
+### Service targets
 
-To configure an [endpoint check][6], set `targetRef` to a `Service`:
+To configure an [endpoint check][6], set `targetRef` to a `Service`. Service targets behave the same way as endpoint checks configured with Kubernetes service annotations:
+
+- Datadog schedules one endpoint check for each endpoint of the Service.
+- `%%host%%` resolves to the endpoint IP.
+- If an endpoint is backed by a Kubernetes Pod, Datadog adds the Pod and container tags collected for that Pod.
+- If an endpoint is not backed by a Pod, Datadog schedules a regular endpoint check without Pod-specific tags.
+
+Service targets do not use `containerImage`; omit that field.
+
+Example: configure NGINX for endpoints behind a `Service` named `nginx`:
 
 ```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <YOUR_CR_NAME>
+  namespace: <YOUR_SERVICES_NAMESPACE>
 spec:
   targetRef:
     apiVersion: v1
     kind: Service
-    name: my-service
+    name: nginx
+  config:
+    checks:
+      - integration: nginx
+        initConfig: {}
+        instances:
+          - name: "My NGINX Service Endpoints"
+            nginx_status_url: "http://%%host%%:%%port%%/status/"
 ```
 
 ## Precedence
@@ -164,27 +220,21 @@ When more than one configuration source applies to a workload, Datadog resolves 
 
 1. Pod annotations
 2. `DatadogInstrumentation` resources
-3. Static configuration (such as auto-configuration or mounted files)
+3. Static configuration, such as auto-configuration or mounted files
 
-If a workload already has annotation-based Autodiscovery configuration for a check, the `DatadogInstrumentation` configuration does not override it.
+If a workload already has annotation-based Autodiscovery configuration for a check, your `DatadogInstrumentation` configuration will not override it.
 
-## One resource per workload
+## One resource per target
 
-A workload can be the target of only one `DatadogInstrumentation` resource within a namespace. A validating admission webhook rejects a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
+A workload or Service can be the target of only one `DatadogInstrumentation` resource within a namespace. A validating admission webhook rejects a resource whose `targetRef` already belongs to another resource, or whose `targetRef` points to an unsupported kind.
 
 ## Check the status
 
-The controller reports the result of reconciling each resource through Kubernetes status conditions. To view the status, including whether the configuration was applied and the resolved target workload:
+The controller reports the result of reconciling each resource through Kubernetes status conditions. Use the status to view the state of the check configuration, including target resolution and whether the configuration was applied:
 
 ```shell
-kubectl describe datadoginstrumentation redis-instrumentation
+kubectl describe datadoginstrumentation <YOUR_CR_NAME>
 ```
-
-## Limitations
-
-- This capability is in beta.
-- The `DatadogInstrumentation` CRD is served at `apiVersion: datadoghq.com/v1alpha1`.
-- This page covers Autodiscovery checks only. Configuring APM Single Step Instrumentation through the `DatadogInstrumentation` resource is tracked separately.
 
 ## Further reading
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -223,7 +223,7 @@ A workload or Service can be the target of only one `DatadogInstrumentation` res
 
 Resource status confirms that the configuration was accepted. To confirm that the resulting checks are scheduled, run `agent configcheck` in the Node Agent running on a node where the target workload is scheduled.
 
-Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider, and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis service:
+Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider, and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis workload:
 
 ```text
 > agent configcheck

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -16,8 +16,6 @@ further_reading:
   text: "Datadog Cluster Agent"
 ---
 
-<div class="alert alert-info">Configuring Autodiscovery with the <code>DatadogInstrumentation</code> custom resource is in beta.</div>
-
 ## Overview
 
 The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks for specific Kubernetes workloads through a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and roll back integration configurations without editing pod specs or triggering Agent or application rollouts.
@@ -47,7 +45,7 @@ The `DatadogInstrumentation` controller runs in the Cluster Agent and is disable
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-While the feature is in beta, opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.81.0 or later.
+Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.81.0 or later.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -36,16 +36,28 @@ The configuration is reconciled by a controller in the [Datadog Cluster Agent][3
 To install the CRD and enable the controller, use one of the following:
 
 - Datadog Operator v1.29 or later.
-- Datadog Helm chart v2.223.0 or later.
+- Datadog Helm chart v3.236.0 or later.
 
-## Enable the controller
+## Setup
 
 The `DatadogInstrumentation` controller runs in the Cluster Agent and is disabled by default. Enable it with the Datadog Operator or Helm.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
+1. Update your Helm repositories:
+
+```shell
+helm repo update
+```
+
+2. Upgrade the Datadog Operator:
+
+```shell
+helm upgrade datadog-operator datadog/datadog-operator
+```
+
+3. Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -59,7 +71,7 @@ spec:
     [...]
 ```
 
-Apply the change:
+4. Apply the change:
 
 ```shell
 kubectl apply -f datadog-agent.yaml
@@ -70,7 +82,13 @@ The Operator sets the required Cluster Agent and Node Agent environment variable
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-In your `datadog-values.yaml` file, enable the controller:
+1. Update your Helm repositories:
+
+```shell
+helm repo update
+```
+
+2. In your `datadog-values.yaml` file, enable the controller:
 
 ```yaml
 datadog:
@@ -78,7 +96,7 @@ datadog:
     enabled: true
 ```
 
-Upgrade your release:
+3. Upgrade your release:
 
 ```shell
 helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks and logs with a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and remove integration configurations without editing your Agent or application and triggering a rollout.
+The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks and logs with a single Kubernetes resource instead of [pod annotations][2]. With this approach, you can enable, update, and remove integration configurations without editing your Agent or application and triggering a rollout.
 
 Use the `DatadogInstrumentation` CR when you want to:
 
@@ -226,10 +226,10 @@ spec:
 
 ## Precedence
 
-When more than one configuration source applies to a workload, Datadog resolves them in the following order (highest precedence first):
+When more than one configuration source applies to a workload, the Datadog Agent resolves them in the following order (highest precedence first):
 
 1. Pod annotations
-2. `DatadogInstrumentation` resources
+2. `DatadogInstrumentation` custom resource
 3. Static configuration, such as auto-configuration or mounted files
 
 If a workload already has annotation-based Autodiscovery configuration for a check or log collection, your `DatadogInstrumentation` configuration does not override it.

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -114,9 +114,9 @@ You can target the following Kubernetes resources:
 - StatefulSet
 - CronJob
 - Job
-- Service. (See [Service targets](#service-targets))
+- Service (see the [Service targets](#service-targets) section)
 
-This example configures a [Redis integration][4] targeting a `Deplymend` named `redis` mirroring this [annotation-based example][2].
+This example configures a [Redis integration][4] for a `Deployment` named `redis`, mirroring the [annotation-based example][2].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -170,7 +170,7 @@ Each entry in `checks` accepts the following fields:
 `instances`
 : Optional. Check instance settings. Each instance can use [Autodiscovery template variables][5], including `%%host%%`.
 
-Each entry in `logs` accepts the same log collection configuration options as Autodiscovery log annotations, like `tags`, `type`, and `path`. Each log config requires a `containerName` matching a container in the pod.
+Each entry in `logs` accepts the same log collection options as Autodiscovery log annotations, such as `tags`, `type`, and `path`. Each entry requires a `containerName` matching a container in the pod.
 
 ### Service targets
 
@@ -223,7 +223,7 @@ A workload or Service can be the target of only one `DatadogInstrumentation` res
 
 The resource status shows whether the Cluster Agent accepted the configuration. To verify that the checks are scheduled, run `agent configcheck` on the Node Agent where the target workload runs.
 
-Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider, and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis workload:
+Checks configured through a `DatadogInstrumentation` resource list `instrumentation-checks` as the configuration provider and `datadoginstrumentation:<NAMESPACE>/<CR_NAME>` as the configuration source. The following example shows the output for a `redisdb` check scheduled from a resource that targets a Redis workload:
 
 ```text
 > agent configcheck
@@ -236,32 +236,11 @@ Config for instance ID: redisdb:d5dd267b580bc10e
 host: 10.244.0.7
 password: "********"
 port: 6379
-tags:
-  - container_id:86fd26bd7ee8c8cd1864103b2a575cdac0d23b1d0961085c000cb96d0f4a2cc9
-  - container_name:redis
-  - display_container_name:redis_redis-6b4c7b565b-6dhfh
-  - env:staging
-  - image_id:********@sha256:0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973
-  - image_name:redis
-  - image_tag:latest
-  - kube_container_name:redis
-  - kube_deployment:redis
-  - kube_namespace:cache
-  - kube_ownerref_kind:replicaset
-  - kube_ownerref_name:redis-6b4c7b565b
-  - kube_qos:BestEffort
-  - kube_replica_set:redis-6b4c7b565b
-  - kube_service:redis
-  - pod_name:redis-6b4c7b565b-6dhfh
-  - pod_phase:running
-  - service:redis
-  - short_image:redis
-~
 Init Config:
 {}
 Log Config:
-- service: redis
-  source: redis
+- tags:
+  - env:demo
 Auto-discovery IDs:
 * redis
 ```

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Configure Autodiscovery with the DatadogInstrumentation CRD
+title: Configure Autodiscovery with DatadogInstrumentation CRD
 description: Configure Autodiscovery checks and logs for Kubernetes workloads through the DatadogInstrumentation custom resource instead of pod annotations.
 further_reading:
 - link: "/containers/kubernetes/integrations/"
@@ -101,7 +101,7 @@ helm upgrade --install datadog-crds datadog/datadog-crds
 
 ## Configure a workload
 
-A `DatadogInstrumentation` resource has three main parts:
+`DatadogInstrumentation` for Autodiscovery has three parts:
 
 - `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
 - `spec.config.checks`: defines integration checks to run against your workload.
@@ -114,9 +114,9 @@ You can target the following Kubernetes resources:
 - StatefulSet
 - CronJob
 - Job
-- Service. Service targets schedule endpoint checks. See [Service targets](#service-targets).
+- Service. (See [Service targets](#service-targets))
 
-This example configures a [Redis integration][4] for a `Deployment` named `redis`, including log collection. It mirrors this [annotation-based example][2], using the same [template variables][5], including `%%host%%`:
+This example configures a [Redis integration][4] targeting a `Deplymend` named `redis` mirroring this [annotation-based example][2].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -162,7 +162,7 @@ Each entry in `checks` accepts the following fields:
 : Required. The name of the Datadog integration to run, for example `redisdb`.
 
 `containerName`
-: Optional. For workload targets, use the pod container name to apply the check to a specific container. Not used for Service targets.
+: Required for workload targets. The value must match a container name in the pod. Omit this field for Service targets.
 
 `initConfig`
 : Optional. The `init_config` section for the integration.
@@ -170,11 +170,11 @@ Each entry in `checks` accepts the following fields:
 `instances`
 : Optional. Check instance settings. Each instance can use [Autodiscovery template variables][5], including `%%host%%`.
 
-Each entry in `logs` accepts the same log collection configuration options as Autodiscovery log annotations, such as `source`, `service`, `tags`, `type`, `path`, and `log_processing_rules`. Each log entry also requires `containerName`, which must match the pod container name.
+Each entry in `logs` accepts the same log collection configuration options as Autodiscovery log annotations, like `tags`, `type`, and `path`. Each log config requires a `containerName` matching a container in the pod.
 
 ### Service targets
 
-To configure an [endpoint check][6], set `targetRef` to a `Service`. Service targets behave the same way as endpoint checks configured with Kubernetes service annotations:
+Targeting a `Service` configures an [endpoint check][6] similar to an annotation on the Kubernetes service.
 
 - Datadog schedules one endpoint check for each endpoint of the Service.
 - `%%host%%` resolves to the endpoint IP.

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -18,25 +18,22 @@ further_reading:
 
 ## Overview
 
-The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks and logs for specific Kubernetes workloads through a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and roll back integration configurations without editing pod specs or triggering Agent or application rollouts.
+The `DatadogInstrumentation` custom resource (CR) lets you configure [Autodiscovery][1] checks and logs with a single Kubernetes resource, instead of [pod annotations][2]. With this approach, you can enable, update, and remove integration configurations without editing your Agent or application and triggering a rollout.
 
 Use the `DatadogInstrumentation` CR when you want to:
 
-- Configure Autodiscovery checks and logs without modifying workload manifests or adding annotations.
+- Configure checks and logs without modifying workload manifests or adding annotations.
 - Use a structured resource spec with validation instead of raw JSON in annotations.
 - Centrally manage per-workload Autodiscovery configuration as a dedicated, version-controlled Kubernetes resource.
 - Update or remove Autodiscovery configuration without restarting your application pods.
 
-The configuration is reconciled by a controller in the [Datadog Cluster Agent][3]. When you create or update a `DatadogInstrumentation` resource, the Cluster Agent validates the target, reports resource status, and applies the Autodiscovery configuration to the targeted workload.
+When you create or update a `DatadogInstrumentation` resource, the [Datadog Cluster Agent][3] validates the target, reports resource status, and applies the Autodiscovery configuration to the targeted workload.
 
 ## Requirements
 
-- Datadog Agent and Cluster Agent v7.82 or later.
-
-To install the CRD and enable the controller, use one of the following:
-
-- Datadog Operator v1.29 or later.
-- Datadog Helm chart v3.236.0 or later.
+Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `DatadogInstrumentation` CRD with one of the following:
+- Datadog Operator **v1.29** or later.
+- Datadog Helm chart **v3.236.0** or later.
 
 ## Setup
 
@@ -57,7 +54,7 @@ helm repo update
 helm upgrade datadog-operator datadog/datadog-operator
 ```
 
-3. Opt in by adding the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
+3. Add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -117,11 +114,11 @@ If you manage Datadog CRDs separately, install or upgrade the Datadog CRDs Helm 
 helm upgrade --install datadog-crds datadog/datadog-crds
 ```
 
-## Configure a workload
+## Target workloads
 
-`DatadogInstrumentation` for Autodiscovery has three parts:
+`DatadogInstrumentation` (DDI) for Autodiscovery has three parts:
 
-- `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. The resource and the target workload must be in the same namespace.
+- `spec.targetRef`: identifies the workload to configure, by `apiVersion`, `kind`, and `name`. Your custom resource and target workload must be in the same namespace.
 - `spec.config.checks`: defines integration checks to run against your workload.
 - `spec.config.logs`: defines logs to collect from your workload.
 
@@ -134,7 +131,7 @@ You can target the following Kubernetes resources:
 - Job
 - Service (see the [Service targets](#service-targets) section)
 
-This example configures a [Redis integration][4] for a `Deployment` named `redis`, mirroring the [annotation-based example][2].
+This example configures a [Redis integration][4] for a `StatefulSet` named `redis`, mirroring this [annotation-based example][2].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -145,7 +142,7 @@ metadata:
 spec:
   targetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: redis
   config:
     checks:
@@ -190,18 +187,22 @@ Each entry in `checks` accepts the following fields:
 
 Each entry in `logs` accepts the same log collection options as Autodiscovery log annotations, such as `tags`, `type`, and `path`. Each entry requires a `containerName` matching a container in the pod.
 
-### Service targets
+### Target Services
 
-Targeting a `Service` configures an [endpoint check][6] similar to an annotation on the Kubernetes service.
+Targeting a `Service` configures an [endpoint check][6] similar to an annotation on a Kubernetes service.
 
 - Datadog schedules one endpoint check for each endpoint of the Service.
 - `%%host%%` resolves to the endpoint IP.
 - If an endpoint is backed by a Kubernetes Pod, Datadog adds the Pod tags collected for that Pod.
 - If an endpoint is not backed by a Pod, Datadog converts the check into a regular cluster check without Pod-specific tags.
 
+<div class="alert alert-info">
+
 Service targets do not use `containerName`; omit that field.
 
-Example: configure NGINX for endpoints behind a `Service` named `nginx`:
+</div>
+
+Below is an example configuring a nginx check against a Kubernetes `Service`:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -352,8 +352,6 @@ See [Cluster Checks][3] for more context.
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-<div class="alert alert-info">Configuring Autodiscovery with the <code>DatadogInstrumentation</code> custom resource is in beta.</div>
-
 You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
 
 ```yaml

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -368,14 +368,14 @@ spec:
   config:
     checks:
       - integration: <INTEGRATION_NAME>
-        containerImage:
-          - <CONTAINER_IMAGE>
+        containerName: <CONTAINER_NAME>
         initConfig:
           <INIT_CONFIG>
         instances:
           - <INSTANCES_CONFIG>
-        logs:
-          - <LOGS_CONFIG>
+    logs:
+      - containerName: <CONTAINER_NAME>
+        <LOGS_CONFIG>
 ```
 
 For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with the DatadogInstrumentation CRD][29].

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -52,7 +52,7 @@ Some commonly-used integrations come with default configuration for Autodiscover
 
 Otherwise:
 
-1. Choose a configuration method (Kubernetes pod annotations, a local file, a ConfigMap, a key-value store, a Datadog Operator manifest, or a Helm chart) that suits your use case.
+1. Choose a configuration method (Kubernetes pod annotations, a local file, a ConfigMap, a key-value store, a Datadog Operator manifest, a Helm chart, or the `DatadogInstrumentation` custom resource) that suits your use case.
 2. Reference the template format for your chosen method. Each format contains placeholders, such as `<CONTAINER_NAME>`.
 3. [Supply values](#placeholder-values) for these placeholders.
 
@@ -349,6 +349,40 @@ See [Cluster Checks][3] for more context.
 [1]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L315-L330
 [2]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L680-L689
 [3]: /agent/cluster_agent/clusterchecks
+{{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+<div class="alert alert-info">Configuring Autodiscovery with the <code>DatadogInstrumentation</code> custom resource is in beta.</div>
+
+You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <NAME>
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: <INTEGRATION_NAME>
+        containerImage:
+          - <CONTAINER_IMAGE>
+        initConfig:
+          <INIT_CONFIG>
+        instances:
+          - <INSTANCES_CONFIG>
+        logs:
+          - <LOGS_CONFIG>
+```
+
+For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with the DatadogInstrumentation CRD][29].
+
+[29]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -354,13 +354,13 @@ See [Cluster Checks][3] for more context.
 
 <div class="alert alert-info">Configuring Autodiscovery with the <code>DatadogInstrumentation</code> custom resource is in beta.</div>
 
-You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods.
+You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogInstrumentation
 metadata:
-  name: <NAME>
+  name: <CR_NAME>
   namespace: default
 spec:
   targetRef:
@@ -446,7 +446,7 @@ For more information about tag cardinality, see [Per-check tag configuration][27
 
 The Datadog Agent automatically recognizes and supplies basic configuration for some common technologies. For a complete list, see [Autodiscovery auto-configuration][20].
 
-Configurations set with Kubernetes annotations take precedence over auto-configuration, but auto-configuration takes precedence over configurations set with Datadog Operator or Helm. To use Datadog Operator or Helm to configure an integration in the [Autodiscovery auto-configuration][20] list, you must [disable auto-configuration][22].
+Configurations set with Kubernetes annotations take precedence over `DatadogInstrumentation` resources and auto-configuration. `DatadogInstrumentation` resources take precedence over static configuration, including auto-configuration and configurations set with Datadog Operator or Helm. To use Datadog Operator or Helm to configure an integration in the [Autodiscovery auto-configuration][20] list, you must [disable auto-configuration][22].
 
 ## Integrations security
 

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -110,7 +110,7 @@ If you define pods indirectly (with deployments, ReplicaSets, or ReplicationCont
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
+You can configure Autodiscovery checks and log collection for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove Autodiscovery configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -108,6 +108,38 @@ spec:
 If you define pods indirectly (with deployments, ReplicaSets, or ReplicationControllers) add pod annotations under `spec.template.metadata`.
 
 {{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: <INTEGRATION_NAME>
+        containerName: <CONTAINER_NAME>
+        initConfig:
+          <INIT_CONFIG>
+        instances:
+          - <INSTANCES_CONFIG>
+    logs:
+      - containerName: <CONTAINER_NAME>
+        <LOGS_CONFIG>
+```
+
+For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with DatadogInstrumentation CRD][29].
+
+[29]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
+{{% /tab %}}
 {{% tab "Local file" %}}
 
 You can store Autodiscovery templates as local files inside the mounted `conf.d` directory (`/etc/datadog-agent/conf.d`). You must restart your Agent containers each time you change, add, or remove templates.
@@ -349,38 +381,6 @@ See [Cluster Checks][3] for more context.
 [1]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L315-L330
 [2]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L680-L689
 [3]: /agent/cluster_agent/clusterchecks
-{{% /tab %}}
-{{% tab "DatadogInstrumentation CRD" %}}
-
-You can configure Autodiscovery checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. This lets you update or remove check configuration without editing pod specs or restarting your application pods. You can also target a Kubernetes `Service` to schedule endpoint checks for each endpoint of that Service.
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: <CR_NAME>
-  namespace: default
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: <WORKLOAD_NAME>
-  config:
-    checks:
-      - integration: <INTEGRATION_NAME>
-        containerName: <CONTAINER_NAME>
-        initConfig:
-          <INIT_CONFIG>
-        instances:
-          - <INSTANCES_CONFIG>
-    logs:
-      - containerName: <CONTAINER_NAME>
-        <LOGS_CONFIG>
-```
-
-For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with DatadogInstrumentation CRD][29].
-
-[29]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/hugo/content/en/containers/kubernetes/integrations.md
+++ b/hugo/content/en/containers/kubernetes/integrations.md
@@ -378,7 +378,7 @@ spec:
         <LOGS_CONFIG>
 ```
 
-For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with the DatadogInstrumentation CRD][29].
+For setup steps, the full resource schema, and precedence rules, see [Configure Autodiscovery with DatadogInstrumentation CRD][29].
 
 [29]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
 {{% /tab %}}

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -186,12 +186,7 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 
-### Autodiscovery log configuration
-
-With Autodiscovery, configure log collection with pod annotations or a `DatadogInstrumentation` custom resource.
-
-{{< tabs >}}
-{{% tab "Annotations" %}}
+### Autodiscovery annotations
 
 The Agent searches Pod annotations for integration templates. To apply a specific configuration to a container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration.
 
@@ -218,36 +213,6 @@ spec:
     - name: '<CONTAINER_NAME>'
 # (...)
 ```
-
-{{% /tab %}}
-{{% tab "DatadogInstrumentation CRD" %}}
-
-Use a [`DatadogInstrumentation` custom resource][23] to configure the same Autodiscovery log configuration shown in annotation examples, without modifying pod annotations.
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: <CR_NAME>
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: <WORKLOAD_NAME>
-  config:
-    checks:
-      - integration: <INTEGRATION_NAME>
-        containerImage:
-          - <CONTAINER_IMAGE>
-        logs:
-          - <LOG_CONFIG>
-```
-
-For more details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
-
-{{% /tab %}}
-{{< /tabs >}}
 
 #### Example log Autodiscovery annotations
 
@@ -276,31 +241,6 @@ spec:
           image: owner/example-image:latest
 ```
 
-You can apply the same log configuration with a `DatadogInstrumentation` custom resource:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: example-logs
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: example
-  config:
-    checks:
-      - integration: <INTEGRATION_NAME>
-        containerImage:
-          - owner/example-image
-        logs:
-          - source: java
-            service: example-app
-            tags:
-              - foo:bar
-```
-
 #### Configure two different containers
 To apply two different integration templates to two different containers within your Pod, `<CONTAINER_NAME_1>` and `<CONTAINER_NAME_2>`, add the following annotations to your Pod:
 
@@ -320,6 +260,35 @@ spec:
     # (...)
     - name: '<CONTAINER_NAME_2>'
 # (...)
+```
+
+### Autodiscovery with DatadogInstrumentation CRD
+
+Use a [`DatadogInstrumentation` custom resource][23] to configure Autodiscovery log collection without modifying pod annotations. For more details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+
+The following example configures log collection for the `example` Deployment. It sets logs from the `app` container with the tags `source:java`, `service:example-app`, and `foo:bar`.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: example-logs
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example
+  config:
+    checks:
+      - integration: logs
+        containerImage:
+          - owner/example-image
+        logs:
+          - source: java
+            service: example-app
+            tags:
+              - foo:bar
 ```
 
 ### Autodiscovery configuration files

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -253,8 +253,6 @@ For more details, see [Configure Autodiscovery with the DatadogInstrumentation C
 
 The following Pod annotation defines the integration template for an example container. It is defined within the Pod template's annotations, rather than on the Deployment itself. This log configuration sets all the logs from the `app` container with the tags `source:java`, `service:example-app`, and the extra tag `foo:bar`.
 
-You can apply the same log configuration with a `DatadogInstrumentation` custom resource.
-
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -276,6 +274,31 @@ spec:
       containers:
         - name: app
           image: owner/example-image:latest
+```
+
+You can apply the same log configuration with a `DatadogInstrumentation` custom resource:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: example-logs
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example
+  config:
+    checks:
+      - integration: <INTEGRATION_NAME>
+        containerImage:
+          - owner/example-image
+        logs:
+          - source: java
+            service: example-app
+            tags:
+              - foo:bar
 ```
 
 #### Configure two different containers

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -179,17 +179,18 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 
 ## Integration logs
 
-[Autodiscovery][10] enables you to use templates to configure log collection and other capabilities on containers. Use one of the following methods to configure log collection:
+[Autodiscovery][10] enables you to use templates to configure log collection (and other capabilities) on containers. This can be used to enable log collection, customize tagging, and add advanced collection rules. To configure log collection for an integration with Autodiscovery you can either:
 
-- [Autodiscovery annotations](#autodiscovery-annotations)
-- [Autodiscovery with DatadogInstrumentation CRD](#autodiscovery-with-datadoginstrumentation-crd)
-- [Autodiscovery configuration files](#autodiscovery-configuration-files)
+- Specify a log configuration as Autodiscovery Annotations on a given Pod, to configure the rules for a given container *(Recommended)*
+- Specify a log configuration as a configuration file, to configure the rules for each matching container by image
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 
 ### Autodiscovery annotations
 
-The Agent searches Pod annotations for integration templates. To apply a specific configuration to a container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration.
+With Autodiscovery, the Agent automatically searches all Pod annotations for integration templates.
+
+To apply a specific configuration to a given container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration. 
 
 **Note**: Autodiscovery annotations identify containers by name, **not** image. It tries to match `<CONTAINER_NAME>` to the `.spec.containers[i].name`, not `.spec.containers[i].image`.
 
@@ -198,7 +199,8 @@ If you define your Kubernetes Pods <i>directly</i> (with <code>kind:Pod</code>),
 <br/><br/>
 If you define your Kubernetes Pods <i>indirectly</i> (with replication controllers, ReplicaSets, or Deployments), add Pod annotations to the Pod template under <code>.spec.template.metadata</code>.</div>
 
-To configure log collection for a single container, add the following annotations to your Pod:
+#### Configure a single container
+To configure log collection for a given container within your Pod, add the following annotations to your Pod:
 
 ```yaml
 apiVersion: v1
@@ -261,35 +263,6 @@ spec:
     # (...)
     - name: '<CONTAINER_NAME_2>'
 # (...)
-```
-
-### Autodiscovery with DatadogInstrumentation CRD
-
-Use a [`DatadogInstrumentation` custom resource][23] to configure Autodiscovery log collection without modifying pod annotations. For more details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
-
-The following example configures log collection for the `example` Deployment. It sets logs from the `app` container with the tags `source:java`, `service:example-app`, and `foo:bar`.
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: example-logs
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: example
-  config:
-    checks:
-      - integration: logs
-        containerImage:
-          - owner/example-image
-        logs:
-          - source: java
-            service: example-app
-            tags:
-              - foo:bar
 ```
 
 ### Autodiscovery configuration files
@@ -522,4 +495,3 @@ For troubleshooting steps, see [Container Log Collection Troubleshooting][21].
 [20]: /containers/kubernetes/log/?tab=helm#autodiscovery-configuration-files
 [21]: /containers/troubleshooting/log-collection/?tab=datadogoperator
 [22]: /containers/guide/ad_identifiers/
-[23]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -186,11 +186,14 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 
-### Autodiscovery annotations
+### Autodiscovery log configuration
 
-With Autodiscovery, the Agent automatically searches all Pod annotations for integration templates.
+With Autodiscovery, configure log collection with pod annotations or a `DatadogInstrumentation` custom resource.
 
-To apply a specific configuration to a given container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration. 
+{{< tabs >}}
+{{% tab "Annotations" %}}
+
+The Agent searches Pod annotations for integration templates. To apply a specific configuration to a container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration.
 
 **Note**: Autodiscovery annotations identify containers by name, **not** image. It tries to match `<CONTAINER_NAME>` to the `.spec.containers[i].name`, not `.spec.containers[i].image`.
 
@@ -199,8 +202,7 @@ If you define your Kubernetes Pods <i>directly</i> (with <code>kind:Pod</code>),
 <br/><br/>
 If you define your Kubernetes Pods <i>indirectly</i> (with replication controllers, ReplicaSets, or Deployments), add Pod annotations to the Pod template under <code>.spec.template.metadata</code>.</div>
 
-#### Configure a single container
-To configure log collection for a given container within your Pod, add the following annotations to your Pod:
+To configure log collection for a single container, add the following annotations to your Pod:
 
 ```yaml
 apiVersion: v1
@@ -217,9 +219,41 @@ spec:
 # (...)
 ```
 
+{{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+Use a [`DatadogInstrumentation` custom resource][23] to configure the same Autodiscovery log configuration shown in annotation examples, without modifying pod annotations.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: <INTEGRATION_NAME>
+        containerImage:
+          - <CONTAINER_IMAGE>
+        logs:
+          - <LOG_CONFIG>
+```
+
+For more details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+
+{{% /tab %}}
+{{< /tabs >}}
+
 #### Example log Autodiscovery annotations
 
 The following Pod annotation defines the integration template for an example container. It is defined within the Pod template's annotations, rather than on the Deployment itself. This log configuration sets all the logs from the `app` container with the tags `source:java`, `service:example-app`, and the extra tag `foo:bar`.
+
+You can apply the same log configuration with a `DatadogInstrumentation` custom resource.
 
 ```yaml
 apiVersion: apps/v1
@@ -495,3 +529,4 @@ For troubleshooting steps, see [Container Log Collection Troubleshooting][21].
 [20]: /containers/kubernetes/log/?tab=helm#autodiscovery-configuration-files
 [21]: /containers/troubleshooting/log-collection/?tab=datadogoperator
 [22]: /containers/guide/ad_identifiers/
+[23]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -179,10 +179,11 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 
 ## Integration logs
 
-[Autodiscovery][10] enables you to use templates to configure log collection (and other capabilities) on containers. This can be used to enable log collection, customize tagging, and add advanced collection rules. To configure log collection for an integration with Autodiscovery you can either:
+[Autodiscovery][10] enables you to use templates to configure log collection and other capabilities on containers. Use one of the following methods to configure log collection:
 
-- Specify a log configuration as Autodiscovery Annotations on a given Pod, to configure the rules for a given container *(Recommended)*
-- Specify a log configuration as a configuration file, to configure the rules for each matching container by image
+- [Autodiscovery annotations](#autodiscovery-annotations)
+- [Autodiscovery with DatadogInstrumentation CRD](#autodiscovery-with-datadoginstrumentation-crd)
+- [Autodiscovery configuration files](#autodiscovery-configuration-files)
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -268,7 +268,7 @@ spec:
 
 ### DatadogInstrumentation CRD
 
-You can configure log collection with a [`DatadogInstrumentation` custom resource][23], using `containerName` to select the container to collect logs from.
+Use `spec.config.logs` in a [`DatadogInstrumentation` custom resource][23] to configure log collection. Set `containerName` in each entry to the container name in the workload's Pod template.
 
 The following example configures log collection for the `app` container in the `example` Deployment:
 

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -182,7 +182,7 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 [Autodiscovery][10] enables you to use templates to configure log collection and other capabilities on containers. Use one of the following methods to configure log collection:
 
 - [Autodiscovery annotations](#autodiscovery-annotations) (recommended)
-- [`DatadogInstrumentation` CRD](#datadoginstrumentation-crd)
+- [`DatadogInstrumentation` CRD](#datadoginstrumentation-crd) (new)
 - [Autodiscovery configuration files](#autodiscovery-configuration-files)
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
@@ -268,9 +268,7 @@ spec:
 
 ### DatadogInstrumentation CRD
 
-Use `spec.config.logs` in a [`DatadogInstrumentation` custom resource][23] to configure log collection. Set `containerName` in each entry to the container name in the workload's Pod template.
-
-The following example configures log collection for the `app` container in the `example` Deployment:
+Instead of annotating your pods or deployments, you can use a [`DatadogInstrumentation` custom resource][23] to configure log collection. The following examples is for the `app` container part of the `example` Deployment:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -334,7 +332,6 @@ datadog:
     <INTEGRATION_NAME>.yaml: |-
       ad_identifiers:
       - <CONTAINER_IMAGE>
-
       logs:
       - source: example-source
         service: example-service

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -163,9 +163,9 @@ The Datadog Agent in Kubernetes is deployed by a DaemonSet (managed by the Datad
 
 When "Container Collect All" is enabled you can configure which containers you want to collect logs from. This can be useful to prevent the collection of the Datadog Agent logs, if desired. You can do this by passing configurations to the Datadog Agent to control what it pulls, or by passing configurations to the Kubernetes Pod to exclude certain logs more explicitly.
 
-When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent ignores log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations][19] or [Autodiscovery configuration files][20].
+When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent ignores log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations][19], the [`DatadogInstrumentation` CRD][23], or [Autodiscovery configuration files][20].
 
-When "Container Collect All" is disabled (default) you don't need to add any filtering because everything is excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations][19] or [Autodiscovery configuration files][20] for the desired pods.
+When "Container Collect All" is disabled (default) you don't need to add any filtering because everything is excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations][19], the [`DatadogInstrumentation` CRD][23], or [Autodiscovery configuration files][20] for the desired pods.
 
 See [Container Discovery Management][8] to learn more about filtering.
 
@@ -179,10 +179,11 @@ The `source` tag can be important for your logs, as the [out of box log pipeline
 
 ## Integration logs
 
-[Autodiscovery][10] enables you to use templates to configure log collection (and other capabilities) on containers. This can be used to enable log collection, customize tagging, and add advanced collection rules. To configure log collection for an integration with Autodiscovery you can either:
+[Autodiscovery][10] enables you to use templates to configure log collection and other capabilities on containers. Use one of the following methods to configure log collection:
 
-- Specify a log configuration as Autodiscovery Annotations on a given Pod, to configure the rules for a given container *(Recommended)*
-- Specify a log configuration as a configuration file, to configure the rules for each matching container by image
+- [Autodiscovery annotations](#autodiscovery-annotations) (recommended)
+- [`DatadogInstrumentation` CRD](#datadoginstrumentation-crd)
+- [Autodiscovery configuration files](#autodiscovery-configuration-files)
 
 Setting a `source` and `service` tag on these log configurations is strongly recommended. Match the `source` tag to one of Datadog's [out-of-the-box log pipelines][15] so your logs are automatically enriched; you can also find a [library of pipelines in Datadog][16]. The `service` tag powers [Unified Service Tagging][4], linking your logs with metrics and traces from the same service. If `source` and `service` are omitted, the Agent falls back to the `service` tag from Unified Service Tagging (when set), and otherwise to the container's short image name.
 
@@ -263,6 +264,34 @@ spec:
     # (...)
     - name: '<CONTAINER_NAME_2>'
 # (...)
+```
+
+### DatadogInstrumentation CRD
+
+You can configure log collection for a supported workload with `spec.config.logs` in a [`DatadogInstrumentation` custom resource][23], instead of adding Pod annotations.
+
+Use `containerName` to select the container in the workload's Pod template. Each log entry supports the same log configuration fields used in Autodiscovery annotations, including `source`, `service`, `tags`, `type`, `path`, and `log_processing_rules`. For setup steps and supported targets, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+
+The following example configures log collection for the `app` container in the `example` Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: example-logs
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example
+  config:
+    logs:
+      - containerName: app
+        source: java
+        service: example-app
+        tags:
+          - foo:bar
 ```
 
 ### Autodiscovery configuration files
@@ -495,3 +524,4 @@ For troubleshooting steps, see [Container Log Collection Troubleshooting][21].
 [20]: /containers/kubernetes/log/?tab=helm#autodiscovery-configuration-files
 [21]: /containers/troubleshooting/log-collection/?tab=datadogoperator
 [22]: /containers/guide/ad_identifiers/
+[23]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/kubernetes/log.md
+++ b/hugo/content/en/containers/kubernetes/log.md
@@ -191,7 +191,7 @@ Setting a `source` and `service` tag on these log configurations is strongly rec
 
 With Autodiscovery, the Agent automatically searches all Pod annotations for integration templates.
 
-To apply a specific configuration to a given container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration. 
+To apply a specific configuration to a given container, add the annotation `ad.datadoghq.com/<CONTAINER_NAME>.logs` to your Pod with the JSON formatted log configuration.
 
 **Note**: Autodiscovery annotations identify containers by name, **not** image. It tries to match `<CONTAINER_NAME>` to the `.spec.containers[i].name`, not `.spec.containers[i].image`.
 
@@ -268,9 +268,7 @@ spec:
 
 ### DatadogInstrumentation CRD
 
-You can configure log collection for a supported workload with `spec.config.logs` in a [`DatadogInstrumentation` custom resource][23], instead of adding Pod annotations.
-
-Use `containerName` to select the container in the workload's Pod template. Each log entry supports the same log configuration fields used in Autodiscovery annotations, including `source`, `service`, `tags`, `type`, `path`, and `log_processing_rules`. For setup steps and supported targets, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+You can configure log collection with a [`DatadogInstrumentation` custom resource][23], using `containerName` to select the container to collect logs from.
 
 The following example configures log collection for the `app` container in the `example` Deployment:
 
@@ -315,7 +313,7 @@ spec:
           <INTEGRATION_NAME>.yaml: |-
             ad_identifiers:
             - <CONTAINER_IMAGE>
-        
+
             logs:
             - source: example-source
               service: example-service
@@ -336,7 +334,7 @@ datadog:
     <INTEGRATION_NAME>.yaml: |-
       ad_identifiers:
       - <CONTAINER_IMAGE>
-      
+
       logs:
       - source: example-source
         service: example-service

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -128,7 +128,6 @@ spec:
     checks:
       - integration: openmetrics
         containerName: <CONTAINER_NAME>
-        initConfig: {}
         instances:
           - openmetrics_endpoint: "http://%%host%%:%%port%%/<PROMETHEUS_ENDPOINT>"
             namespace: "<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>"
@@ -254,7 +253,6 @@ For a full list of available parameters for instances, including `namespace` and
        checks:
          - integration: openmetrics
            containerName: prometheus-example
-           initConfig: {}
            instances:
              - openmetrics_endpoint: "http://%%host%%:%%port%%/metrics"
                namespace: "documentation_example_kubernetes"

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -111,7 +111,7 @@ spec:
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-Use the [`DatadogInstrumentation` custom resource][17] to configure an OpenMetrics check for a supported Kubernetes workload or Service without changing pod annotations. This example targets a Deployment; for Service targets, omit `containerImage`.
+Use the [`DatadogInstrumentation` custom resource][17] to configure an OpenMetrics check for a supported Kubernetes workload without changing pod annotations. For more information, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -144,7 +144,8 @@ With the following configuration placeholder values:
 
 | Placeholder                              | Description                                                                                        |
 |------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `<YOUR_CR_NAME>`                         | Name of your `DatadogInstrumentation` resource.                                                    |
+| `<CR_NAME>`                              | Name of your `DatadogInstrumentation` resource.                                                    |
+| `<WORKLOAD_NAMESPACE>`                   | Namespace that contains the target workload and the `DatadogInstrumentation` resource.             |
 | `<WORKLOAD_NAME>`                        | Name of the workload targeted by the `DatadogInstrumentation` resource.                            |
 | `<CONTAINER_NAME>`                       | Matches the name of the container that exposes the metrics.                                        |
 | `<CONTAINER_IMAGE>`                      | Matches the image of the container that exposes the metrics.                                       |

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -54,8 +54,6 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or `DatadogInstrumentation` custom resources.
 
-If you use the Prometheus Operator, `DatadogInstrumentation` provides a similar CRD-based workflow for Datadog Autodiscovery. See [Configure Autodiscovery with DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 {{< tabs >}}
 {{% tab "Annotations (AD v2)" %}}
 
@@ -113,7 +111,7 @@ spec:
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-Use a `DatadogInstrumentation` custom resource to configure an OpenMetrics check without adding pod annotations. For more information, see [Configure Autodiscovery with DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+Use a `DatadogInstrumentation` custom resource to configure an OpenMetrics check without adding pod annotations. For more information, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -137,6 +135,8 @@ spec:
             metrics:
               - "<METRIC_TO_FETCH>": "<NEW_METRIC_NAME>"
 ```
+
+[17]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -235,9 +235,9 @@ For a full list of available parameters for instances, including `namespace` and
    {{% /tab %}}
    {{% tab "DatadogInstrumentation CRD" %}}
 
-   **Note:** Configuring checks with the `DatadogInstrumentation` custom resource requires Datadog Agent and Cluster Agent version 7.82 or higher.
+   **Note:** This configuration requires Datadog Agent and Cluster Agent v7.82 or later. Enable the controller with Datadog Operator v1.29 or later, or Datadog Helm chart v2.223.0 or later. For setup instructions, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
 
-   The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation before applying this resource, because annotations take precedence over `DatadogInstrumentation` resources.
+   The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation because annotations take precedence over `DatadogInstrumentation` resources. Save the following resource as `prometheus-instrumentation.yaml`:
 
    ```yaml
    apiVersion: datadoghq.com/v1alpha1
@@ -264,6 +264,8 @@ For a full list of available parameters for instances, including `namespace` and
                  - "go_memory.*"
    ```
 
+   [17]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/
+
    {{% /tab %}}
    {{< /tabs >}}
 
@@ -271,6 +273,12 @@ For a full list of available parameters for instances, including `namespace` and
 
     ```shell
     kubectl create -f prometheus.yaml
+    ```
+
+   If you use a `DatadogInstrumentation` resource, apply it after creating the Deployment:
+
+    ```shell
+    kubectl apply -f prometheus-instrumentation.yaml
     ```
 
 3. Go into your [Fleet Automation][16] page and filter for the `openmetrics` integration to view detailed information about the status of your checks.

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -129,8 +129,7 @@ spec:
   config:
     checks:
       - integration: openmetrics
-        containerImage:
-          - <CONTAINER_IMAGE>
+        containerName: <CONTAINER_NAME>
         initConfig: {}
         instances:
           - openmetrics_endpoint: "http://%%host%%:%%port%%/<PROMETHEUS_ENDPOINT>"
@@ -149,7 +148,6 @@ With the following configuration placeholder values:
 | `<WORKLOAD_NAMESPACE>`                   | Namespace that contains the target workload and the `DatadogInstrumentation` resource.             |
 | `<WORKLOAD_NAME>`                        | Name of the workload targeted by the `DatadogInstrumentation` resource.                            |
 | `<CONTAINER_NAME>`                       | Matches the name of the container that exposes the metrics.                                        |
-| `<CONTAINER_IMAGE>`                      | Matches the image of the container that exposes the metrics.                                       |
 | `<PROMETHEUS_ENDPOINT>`                  | URL path for the metrics served by the container, in Prometheus format.                            |
 | `<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>` | Set namespace to be prefixed to every metric when viewed in Datadog.                               |
 | `<METRIC_TO_FETCH>`                      | Prometheus metrics key to be fetched from the Prometheus endpoint.                                 |
@@ -237,7 +235,7 @@ For a full list of available parameters for instances, including `namespace` and
    {{% /tab %}}
    {{% tab "DatadogInstrumentation CRD" %}}
 
-   **Note:** Configuring checks with the `DatadogInstrumentation` custom resource requires Datadog Agent version 7.81 or higher.
+   **Note:** Configuring checks with the `DatadogInstrumentation` custom resource requires Datadog Agent and Cluster Agent version 7.82 or higher.
 
    The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation before applying this resource, because annotations take precedence over `DatadogInstrumentation` resources.
 
@@ -255,8 +253,7 @@ For a full list of available parameters for instances, including `namespace` and
      config:
        checks:
          - integration: openmetrics
-           containerImage:
-             - prometheus # the image short name
+           containerName: prometheus-example
            initConfig: {}
            instances:
              - openmetrics_endpoint: "http://%%host%%:%%port%%/metrics"

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -235,7 +235,7 @@ For a full list of available parameters for instances, including `namespace` and
    {{% /tab %}}
    {{% tab "DatadogInstrumentation CRD" %}}
 
-   **Note:** This configuration requires Datadog Agent and Cluster Agent v7.82 or later. Enable the controller with Datadog Operator v1.29 or later, or Datadog Helm chart v2.223.0 or later. For setup instructions, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
+   **Note:** This configuration requires Datadog Agent and Cluster Agent v7.82 or later. Enable the controller with Datadog Operator v1.29 or later, or Datadog Helm chart v3.236.0 or later. For setup instructions, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
 
    The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation because annotations take precedence over `DatadogInstrumentation` resources. Save the following resource as `prometheus-instrumentation.yaml`:
 

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -54,7 +54,7 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or `DatadogInstrumentation` custom resources.
 
-If you use the Prometheus Operator, `DatadogInstrumentation` provides a similar CRD-based workflow for Datadog Autodiscovery. See [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+If you use the Prometheus Operator, `DatadogInstrumentation` provides a similar CRD-based workflow for Datadog Autodiscovery. See [Configure Autodiscovery with DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 {{< tabs >}}
 {{% tab "Annotations (AD v2)" %}}
@@ -113,7 +113,7 @@ spec:
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-Use a `DatadogInstrumentation` custom resource to configure an OpenMetrics check for a supported Kubernetes workload without changing pod annotations. For more information, see [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+Use a `DatadogInstrumentation` custom resource to configure an OpenMetrics check without adding pod annotations. For more information, see [Configure Autodiscovery with DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -54,7 +54,7 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or `DatadogInstrumentation` custom resources.
 
-If you're coming from the Prometheus Operator, `DatadogInstrumentation` is the CRD-based equivalent: target a workload as you would with a `PodMonitor`, or a `Service` as you would with a `ServiceMonitor`. See [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+If you use the Prometheus Operator, `DatadogInstrumentation` provides a similar CRD-based workflow for Datadog Autodiscovery. See [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 {{< tabs >}}
 {{% tab "Annotations (AD v2)" %}}

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -234,9 +234,13 @@ For a full list of available parameters for instances, including `namespace` and
    {{% /tab %}}
    {{% tab "DatadogInstrumentation CRD" %}}
 
-   **Note:** This configuration requires Datadog Agent and Cluster Agent v7.82 or later. Enable the controller with Datadog Operator v1.29 or later, or Datadog Helm chart v3.236.0 or later. For setup instructions, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
+   <div class="alert alert-info">
 
-   The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation because annotations take precedence over `DatadogInstrumentation` resources. Save the following resource as `prometheus-instrumentation.yaml`:
+   This configuration requires Datadog Agent and Cluster Agent v7.82 or later. Enable the controller with Datadog Operator v1.29+, or Datadog Helm chart v3.236.0+. For setup instructions, see [Configure Autodiscovery with DatadogInstrumentation CRD][17].
+
+   </div>
+
+  The example `prometheus.yaml` file defines the same check as a pod annotation. Remove that annotation because annotations take precedence over `DatadogInstrumentation` resources. Save the following resource as `prometheus-instrumentation.yaml`:
 
    ```yaml
    apiVersion: datadoghq.com/v1alpha1

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -52,10 +52,10 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 ### Configuration
 
-Configure your OpenMetrics or Prometheus check using Autodiscovery, by applying the following `annotations` to your **pod** exposing the OpenMetrics/Prometheus metrics:
+Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or the `DatadogInstrumentation` custom resource.
 
 {{< tabs >}}
-{{% tab "Kubernetes (AD v2)" %}}
+{{% tab "Annotations (AD v2)" %}}
 
 **Note:** AD Annotations v2 was introduced in Datadog Agent version 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
 
@@ -84,7 +84,7 @@ spec:
 ```
 
 {{% /tab %}}
-{{% tab "Kubernetes (AD v1)" %}}
+{{% tab "Annotations (AD v1)" %}}
 
 ```yaml
 # (...)
@@ -109,13 +109,45 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "DatadogInstrumentation CRD" %}}
+
+Use the [`DatadogInstrumentation` custom resource][17] to configure an OpenMetrics check for a supported Kubernetes workload or Service without changing pod annotations. This example targets a Deployment; for Service targets, omit `containerImage`.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: openmetrics
+        containerImage:
+          - <CONTAINER_IMAGE>
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:%%port%%/<PROMETHEUS_ENDPOINT> "
+            namespace: "<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>"
+            metrics:
+              - "<METRIC_TO_FETCH>": "<NEW_METRIC_NAME>"
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 With the following configuration placeholder values:
 
 | Placeholder                              | Description                                                                                        |
 |------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `<CONTAINER_NAME>`                 | Matches the name of the container that exposes the metrics. |
+| `<YOUR_CR_NAME>`                         | Name of your `DatadogInstrumentation` resource.                                                    |
+| `<WORKLOAD_NAME>`                        | Name of the workload targeted by the `DatadogInstrumentation` resource.                            |
+| `<CONTAINER_NAME>`                       | Matches the name of the container that exposes the metrics.                                        |
+| `<CONTAINER_IMAGE>`                      | Matches the image of the container that exposes the metrics.                                       |
 | `<PROMETHEUS_ENDPOINT>`                  | URL path for the metrics served by the container, in Prometheus format.                            |
 | `<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>` | Set namespace to be prefixed to every metric when viewed in Datadog.                               |
 | `<METRIC_TO_FETCH>`                      | Prometheus metrics key to be fetched from the Prometheus endpoint.                                 |
@@ -442,3 +474,4 @@ Official integrations have their own dedicated directories. There's a default in
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
 [15]: https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/common/types/prometheus.go#L57-L123
 [16]: https://app.datadoghq.com/fleet?query=integration:openmetrics
+[17]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -235,6 +235,39 @@ For a full list of available parameters for instances, including `namespace` and
    ```
 
    {{% /tab %}}
+   {{% tab "DatadogInstrumentation CRD" %}}
+
+   **Note:** Configuring checks with the `DatadogInstrumentation` custom resource requires Datadog Agent version 7.81 or higher.
+
+   The example `prometheus.yaml` defines the same check as a pod annotation. Remove that annotation before applying this resource, because annotations take precedence over `DatadogInstrumentation` resources.
+
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogInstrumentation
+   metadata:
+     name: prometheus-example
+     namespace: <WORKLOAD_NAMESPACE>
+   spec:
+     targetRef:
+       apiVersion: apps/v1
+       kind: Deployment
+       name: prometheus-example
+     config:
+       checks:
+         - integration: openmetrics
+           containerImage:
+             - prometheus # the image short name
+           initConfig: {}
+           instances:
+             - openmetrics_endpoint: "http://%%host%%:%%port%%/metrics"
+               namespace: "documentation_example_kubernetes"
+               metrics:
+                 - promhttp_metric_handler_requests: "handler.requests"
+                 - promhttp_metric_handler_requests_in_flight: "handler.requests.in_flight"
+                 - "go_memory.*"
+   ```
+
+   {{% /tab %}}
    {{< /tabs >}}
 
      Command to create the Prometheus Deployment:

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -54,6 +54,8 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or `DatadogInstrumentation` custom resources.
 
+If you're coming from the Prometheus Operator, `DatadogInstrumentation` is the CRD-based equivalent: target a workload as you would with a `PodMonitor`, or a `Service` as you would with a `ServiceMonitor`. See [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 {{< tabs >}}
 {{% tab "Annotations (AD v2)" %}}
 
@@ -131,7 +133,7 @@ spec:
           - <CONTAINER_IMAGE>
         initConfig: {}
         instances:
-          - openmetrics_endpoint: "http://%%host%%:%%port%%/<PROMETHEUS_ENDPOINT> "
+          - openmetrics_endpoint: "http://%%host%%:%%port%%/<PROMETHEUS_ENDPOINT>"
             namespace: "<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>"
             metrics:
               - "<METRIC_TO_FETCH>": "<NEW_METRIC_NAME>"

--- a/hugo/content/en/containers/kubernetes/prometheus.md
+++ b/hugo/content/en/containers/kubernetes/prometheus.md
@@ -52,7 +52,7 @@ This page explains the basic usage of these checks, which enable you to scrape c
 
 ### Configuration
 
-Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or the `DatadogInstrumentation` custom resource.
+Configure your OpenMetrics or Prometheus check using Autodiscovery. Use pod annotations or `DatadogInstrumentation` custom resources.
 
 {{< tabs >}}
 {{% tab "Annotations (AD v2)" %}}
@@ -111,13 +111,13 @@ spec:
 {{% /tab %}}
 {{% tab "DatadogInstrumentation CRD" %}}
 
-Use the [`DatadogInstrumentation` custom resource][17] to configure an OpenMetrics check for a supported Kubernetes workload without changing pod annotations. For more information, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+Use a `DatadogInstrumentation` custom resource to configure an OpenMetrics check for a supported Kubernetes workload without changing pod annotations. For more information, see [Configure Autodiscovery with the DatadogInstrumentation CRD](/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogInstrumentation
 metadata:
-  name: <CR_NAME>
+  name: example-cr
   namespace: <WORKLOAD_NAMESPACE>
 spec:
   targetRef:
@@ -144,7 +144,6 @@ With the following configuration placeholder values:
 
 | Placeholder                              | Description                                                                                        |
 |------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `<CR_NAME>`                              | Name of your `DatadogInstrumentation` resource.                                                    |
 | `<WORKLOAD_NAMESPACE>`                   | Namespace that contains the target workload and the `DatadogInstrumentation` resource.             |
 | `<WORKLOAD_NAME>`                        | Name of the workload targeted by the `DatadogInstrumentation` resource.                            |
 | `<CONTAINER_NAME>`                       | Matches the name of the container that exposes the metrics.                                        |
@@ -475,4 +474,3 @@ Official integrations have their own dedicated directories. There's a default in
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
 [15]: https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/common/types/prometheus.go#L57-L123
 [16]: https://app.datadoghq.com/fleet?query=integration:openmetrics
-[17]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/getting_started/containers/autodiscovery.md
+++ b/hugo/content/en/getting_started/containers/autodiscovery.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "/agent/kubernetes/integrations/"
   tag: "Documentation"
   text: "Create and load an Autodiscovery Integration Template"
+- link: "/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/"
+  tag: "Documentation"
+  text: "Configure Autodiscovery with the DatadogInstrumentation CRD"
 - link: "/agent/guide/ad_identifiers/"
   tag: "Documentation"
   text: "Match a container with the corresponding Integration Template"
@@ -140,6 +143,8 @@ Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodisc
 
 You can define an integration template in multiple forms: as Kubernetes pod annotations, Docker labels, a configuration file mounted within the Agent, a ConfigMap, and key-value stores. See the [Autodiscovery Integration Templates][4] documentation for further details.
 
+On Kubernetes, you can also configure checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. See [Configure Autodiscovery with the DatadogInstrumentation CRD][5] (beta).
+
 ### Notes
 
 If you are using Autodiscovery and an application is deployed on a new node, you may experience some delay in seeing metrics appear in Datadog. When you switch to a new node, it takes time for the Datadog Agent to collect metadata from your application.
@@ -152,3 +157,4 @@ If you are using Autodiscovery and an application is deployed on a new node, you
 [2]: /agent/faq/template_variables/
 [3]: /agent/faq/auto_conf/
 [4]: /agent/kubernetes/integrations/
+[5]: /containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/hugo/content/en/getting_started/containers/autodiscovery.md
+++ b/hugo/content/en/getting_started/containers/autodiscovery.md
@@ -143,7 +143,7 @@ Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodisc
 
 You can define an integration template in multiple forms: as Kubernetes pod annotations, Docker labels, a configuration file mounted within the Agent, a ConfigMap, and key-value stores. See the [Autodiscovery Integration Templates][4] documentation for further details.
 
-On Kubernetes, you can also configure checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. See [Configure Autodiscovery with the DatadogInstrumentation CRD][5] (beta).
+On Kubernetes, you can also configure checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. See [Configure Autodiscovery with the DatadogInstrumentation CRD][5].
 
 ### Notes
 

--- a/hugo/content/en/getting_started/containers/autodiscovery.md
+++ b/hugo/content/en/getting_started/containers/autodiscovery.md
@@ -11,7 +11,7 @@ further_reading:
   text: "Create and load an Autodiscovery Integration Template"
 - link: "/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/"
   tag: "Documentation"
-  text: "Configure Autodiscovery with the DatadogInstrumentation CRD"
+  text: "Configure Autodiscovery with DatadogInstrumentation CRD"
 - link: "/agent/guide/ad_identifiers/"
   tag: "Documentation"
   text: "Match a container with the corresponding Integration Template"
@@ -143,7 +143,7 @@ Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodisc
 
 You can define an integration template in multiple forms: as Kubernetes pod annotations, Docker labels, a configuration file mounted within the Agent, a ConfigMap, and key-value stores. See the [Autodiscovery Integration Templates][4] documentation for further details.
 
-On Kubernetes, you can also configure checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. See [Configure Autodiscovery with the DatadogInstrumentation CRD][5].
+On Kubernetes, you can also configure checks for a specific workload through the `DatadogInstrumentation` custom resource, instead of pod annotations. See [Configure Autodiscovery with DatadogInstrumentation CRD][5].
 
 ### Notes
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Datadog now lets users configure Autodiscovery for Kubernetes workloads through the `DatadogInstrumentation` custom resource, instead of pod annotations. This PR documents that capability.

Pod annotations require editing workload specs, are error-prone (raw JSON), and can't be centrally managed or rolled back without touching the workload. The custom resource gives users a structured, validated, version-controllable way to configure checks per workload — and it's a familiar model for teams coming from the Prometheus Operator's `PodMonitor`/`ServiceMonitor`.

Annotations remain the default path for most users. These docs surface the CRD as an alternative *wherever* annotation-based configuration already appears, so users discover it when it's relevant without disrupting the existing flow.

**What's included:**
- A new guide covering setup, the resource schema, precedence rules, and verification.
- Brief, consistent pointers from the existing Autodiscovery pages (Kubernetes integrations, logs, Prometheus/OpenMetrics, endpoint checks, JMX, and auto-configuration) and the Getting Started guide.

Epic context: [CONTP-1453](https://datadoghq.atlassian.net/browse/CONTP-1453)
Platform RFC: https://datadoghq.atlassian.net/wiki/x/J8FIhwE
Autodiscovery RFC: https://datadoghq.atlassian.net/wiki/x/mgAsiAE

### Merge instructions

Merge readiness:
- [ ] Ready for merge
- [ ] Wait for 7.82 agent release

[CONTP-1453]: https://datadoghq.atlassian.net/browse/CONTP-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ