### PR TITLE
Document PAT and SAT as alternatives to API + application key authentication

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -9,6 +9,18 @@ algolia:
   tags: ['api key']
 ---
 
+## Credential types overview
+
+Datadog supports three credential types for API authentication:
+
+| Credential type | Authentication | Requires pairing | Linked to |
+|---|---|---|---|
+| API key + application key | `DD-API-KEY` + `DD-APPLICATION-KEY` headers | Yes | Individual user or service account |
+| [Personal Access Token (PAT)][22] | `Authorization: Bearer <token>` header | No | Individual user |
+| [Service Access Token (SAT)][23] | `Authorization: Bearer <token>` header | No | Service account |
+
+PATs and SATs are scoped by default and do not require pairing with an API key. Use them for programmatic API calls when you want tighter credential control. Reserve API keys for telemetry intake (Agent, logs, metrics).
+
 ## API keys
 
 API keys are unique to your organization. An [API key][1] is required by the Datadog Agent to submit metrics and events to Datadog.
@@ -60,7 +72,7 @@ In order to use application keys with these APIs, you must enable Actions API ac
 
 {{< img src="account_management/click-enable-actions-api-access.png" alt="Click Enable for Actions API Access" style="width:80%;" >}}
 
-**Note**: The {{< ui >}}Last used{{< /ui >}} section only shows if [Audit Trail is enabled][22] in the account and you have [`Audit Trail Read`][23] permission.
+**Note**: The {{< ui >}}Last used{{< /ui >}} section only shows if [Audit Trail is enabled][24] in the account and you have [`Audit Trail Read`][25] permission.
 
 ## Client tokens
 
@@ -196,5 +208,7 @@ Need help? Contact [Datadog support][19].
 [19]: /help/
 [20]: /account_management/org_settings/service_accounts/
 [21]: /api/latest/action-connection/#register-a-new-app-key
-[22]: /account_management/audit_trail/#setup
-[23]: /account_management/rbac/permissions/#compliance
+[22]: /account_management/personal-access-tokens/
+[23]: /account_management/service-access-tokens/
+[24]: /account_management/audit_trail/#setup
+[25]: /account_management/rbac/permissions/#compliance

--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -13,13 +13,13 @@ algolia:
 
 Datadog supports three credential types for API authentication:
 
-| Credential type | Authentication | Requires pairing | Linked to |
-|---|---|---|---|
-| API key + application key | `DD-API-KEY` + `DD-APPLICATION-KEY` headers | Yes | Individual user or service account |
-| [Personal Access Token (PAT)][22] | `Authorization: Bearer <token>` header | No | Individual user |
-| [Service Access Token (SAT)][23] | `Authorization: Bearer <token>` header | No | Service account |
+| Credential type | Authentication | Requires pairing | Linked to | Recommended |
+|---|---|---|---|---|
+| [Personal Access Token (PAT)][22] | `Authorization: Bearer <token>` header | No | Individual user | Yes |
+| [Service Access Token (SAT)][23] | `Authorization: Bearer <token>` header | No | Service account | Yes |
+| API key + application key | `DD-API-KEY` + `DD-APPLICATION-KEY` headers | Yes | Individual user or service account | - |
 
-PATs and SATs are scoped by default and do not require pairing with an API key. Use them for programmatic API calls when you want tighter credential control. Reserve API keys for telemetry intake (Agent, logs, metrics).
+Datadog recommends PATs and SATs for programmatic API calls. They are scoped by default and do not require pairing credentials. Reserve API keys for telemetry intake (Agent, logs, metrics).
 
 ## API keys
 

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -71,7 +71,7 @@ curl -X POST \
 - Replace `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` with the corresponding [API and application keys][1] for your organization.
 - Replace `<YOUR_DD_SITE>` with {{< region-param key="dd_site" code="true" >}}
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][3] or [Service Access Token (SAT)][4] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][3] or [Service Access Token (SAT)][4] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 [1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -71,6 +71,8 @@ curl -X POST \
 - Replace `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` with the corresponding [API and application keys][1] for your organization.
 - Replace `<YOUR_DD_SITE>` with {{< region-param key="dd_site" code="true" >}}
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][3] or [Service Access Token (SAT)][4] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 [1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
@@ -610,3 +612,5 @@ curl -X POST \
 
 [1]: /account_management/saml/mapping
 [2]: /api/v2/roles/#list-roles
+[3]: /account_management/personal-access-tokens/
+[4]: /account_management/service-access-tokens/

--- a/content/en/account_management/guide/secure-configuration.md
+++ b/content/en/account_management/guide/secure-configuration.md
@@ -203,6 +203,8 @@ curl -X GET "https://api.datadoghq.com/api/v2/roles" \
  -H "DD-APPLICATION-KEY: <app_key>"
 {{< /code-block >}}
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 This endpoint allows organizations to:
 - Audit the Datadog Admin Role
 - Inspect assigned permissions
@@ -293,3 +295,6 @@ Typically, administrators manage these controls within the Datadog organization 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /account_management/personal-access-tokens/
+[2]: /account_management/service-access-tokens/

--- a/content/en/account_management/guide/secure-configuration.md
+++ b/content/en/account_management/guide/secure-configuration.md
@@ -203,7 +203,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/roles" \
  -H "DD-APPLICATION-KEY: <app_key>"
 {{< /code-block >}}
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 This endpoint allows organizations to:
 - Audit the Datadog Admin Role

--- a/content/en/account_management/org_settings/cross_org_visibility_api.md
+++ b/content/en/account_management/org_settings/cross_org_visibility_api.md
@@ -30,7 +30,7 @@ curl -X get "https://{datadog_site}/api/v2/org_connections/" \
   -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
 {{< /code-block >}}
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ## Create a connection
 

--- a/content/en/account_management/org_settings/cross_org_visibility_api.md
+++ b/content/en/account_management/org_settings/cross_org_visibility_api.md
@@ -30,6 +30,8 @@ curl -X get "https://{datadog_site}/api/v2/org_connections/" \
   -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
 {{< /code-block >}}
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ## Create a connection
 
 Creates a connection from this organization to the destination organization. You must perform this operation in the to-be-source organization. Creating connections requires the _Org Connections Write_ permission.
@@ -121,3 +123,5 @@ curl -X DELETE "https://{datadog_site}/api/v2/org_connections/{connection_id}" \
 [1]: /account_management/org_settings/cross_org_visibility
 [2]: /account_management/rbac/permissions/#access-management
 [3]: /api/latest/organizations/#list-your-managed-organizations
+[4]: /account_management/personal-access-tokens/
+[5]: /account_management/service-access-tokens/

--- a/content/en/account_management/org_settings/domain_allowlist_api.md
+++ b/content/en/account_management/org_settings/domain_allowlist_api.md
@@ -36,7 +36,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/domain_allowlist" \
 -H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ### Response
 

--- a/content/en/account_management/org_settings/domain_allowlist_api.md
+++ b/content/en/account_management/org_settings/domain_allowlist_api.md
@@ -36,6 +36,8 @@ curl -X GET "https://api.datadoghq.com/api/v2/domain_allowlist" \
 -H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ### Response
 
 {{< tabs >}}
@@ -219,3 +221,5 @@ Too many requests
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/org_settings/domain_allowlist
+[2]: /account_management/personal-access-tokens/
+[3]: /account_management/service-access-tokens/

--- a/content/en/account_management/workload_identity_federation.md
+++ b/content/en/account_management/workload_identity_federation.md
@@ -116,6 +116,8 @@ curl -X POST "{{< region-param key=dd_api code="true" >}}/api/v2/cloud_auth/aws/
 }'
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ##### Map an AWS ARN to a Datadog service account
 For `account_identifier`, you can use either:
 - The service account's **UUID**: Go to {{< ui >}}Organization settings{{< /ui >}} > {{< ui >}}Service accounts{{< /ui >}}, click the service account you want to map, and copy the `service_account_id` from the URL. For example, if the URL ends in `/organization-settings/service-accounts?service_account_id=3fa85f64-5717-4562-b3fc-2c963f66afa6`, then use `3fa85f64-5717-4562-b3fc-2c963f66afa6`.
@@ -435,3 +437,5 @@ delegated_auth:
 [4]: https://app.datadoghq.com/integrations/amazon-web-services
 [5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html
 [6]: https://app.datadoghq.com/organization-settings/workload-identity-federation
+[7]: /account_management/personal-access-tokens/
+[8]: /account_management/service-access-tokens/

--- a/content/en/account_management/workload_identity_federation.md
+++ b/content/en/account_management/workload_identity_federation.md
@@ -116,7 +116,7 @@ curl -X POST "{{< region-param key=dd_api code="true" >}}/api/v2/cloud_auth/aws/
 }'
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ##### Map an AWS ARN to a Datadog service account
 For `account_identifier`, you can use either:

--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -238,7 +238,7 @@ curl -X POST \
   https://api.datadoghq.com/api/v2/workflows/32866005-d275-4553-be86-9f1b13066d84/instances
 {{< /code-block >}}
 
-   **Note**: You can also authenticate with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+   **Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
    If the workflow includes input parameters, include them in the request payload. The following example uses two input parameters, `example_input1` and `example_input2`:
 

--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -238,6 +238,8 @@ curl -X POST \
   https://api.datadoghq.com/api/v2/workflows/32866005-d275-4553-be86-9f1b13066d84/instances
 {{< /code-block >}}
 
+   **Note**: You can also authenticate with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
    If the workflow includes input parameters, include them in the request payload. The following example uses two input parameters, `example_input1` and `example_input2`:
 
    {{< code-block lang="shell" >}}
@@ -304,3 +306,5 @@ After you trigger a workflow, the workflow page switches to the workflow's {{< u
 [14]: https://app.datadoghq.com/software
 [15]: /incident_response/incident_management/setup_and_configuration/automations
 [16]: /incident_response/incident_management/setup_and_configuration/notification_rules/
+[17]: /account_management/personal-access-tokens/
+[18]: /account_management/service-access-tokens/

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -325,7 +325,7 @@ curl -X POST "https://api.datadoghq.com/api/v1/dashboard" \
 -d @DatadogAgentVersionCheck.json
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 **Note**: The Datadog Agent Version Check dashboard does not show older versions of the Datadog Agent (v5), because those versions are not vulnerable.
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -325,6 +325,8 @@ curl -X POST "https://api.datadoghq.com/api/v1/dashboard" \
 -d @DatadogAgentVersionCheck.json
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 **Note**: The Datadog Agent Version Check dashboard does not show older versions of the Datadog Agent (v5), because those versions are not vulnerable.
 
 ### With the CLI
@@ -341,3 +343,5 @@ You can also check specific Agent version information with the Agent CLI `versio
 [4]: /dashboards/#copy-import-or-export-dashboard-json
 [5]: /resources/json/agent-version-dashboard.json
 [6]: /agent/configuration/agent-commands/?tab=agentv6v7#other-commands
+[7]: /account_management/personal-access-tokens/
+[8]: /account_management/service-access-tokens/

--- a/content/en/agent/guide/datadog-disaster-recovery.md
+++ b/content/en/agent/guide/datadog-disaster-recovery.md
@@ -88,6 +88,8 @@ curl -v -H "Content-Type: application/json" -H \
 "dd-application-key:${PRIMARY_DD_APP_KEY}" --data "${CONNECTION}" --request POST ${PRIMARY_DD_API_URL}/api/v2/hamr
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][18] or [Service Access Token (SAT)][19] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 After linking your orgs, only the failover org displays this banner:
 
 {{< img src="agent/guide/ddr/ddr-banner.png" alt="The DDR banner in the DDR org" >}}
@@ -313,3 +315,5 @@ During testing, integration telemetry is spread over both organizations. If you 
 [15]: https://www.datadoghq.com/support/
 [16]: https://app.datadoghq.com/signup
 [17]: /getting_started/site#access-the-datadog-site
+[18]: /account_management/personal-access-tokens/
+[19]: /account_management/service-access-tokens/

--- a/content/en/agent/guide/datadog-disaster-recovery.md
+++ b/content/en/agent/guide/datadog-disaster-recovery.md
@@ -88,7 +88,7 @@ curl -v -H "Content-Type: application/json" -H \
 "dd-application-key:${PRIMARY_DD_APP_KEY}" --data "${CONNECTION}" --request POST ${PRIMARY_DD_API_URL}/api/v2/hamr
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][18] or [Service Access Token (SAT)][19] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][18] or [Service Access Token (SAT)][19] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 After linking your orgs, only the failover org displays this banner:
 

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -29,22 +29,20 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 ### Getting started
 
-You can authenticate to the Datadog API with one of the following credential types:
+Datadog recommends authenticating API calls with a [Personal Access Token (PAT)][8] or [Service Access Token (SAT)][9]. Pass the token as a Bearer credential in the `Authorization` header - no API key pairing required:
 
-- **API key and application key**: Pass your [API key][1] in the `DD-API-KEY` header and your [application key][2] in the `DD-APPLICATION-KEY` header.
+```bash
+curl -X GET "https://api.datadoghq.com/api/v2/users" \
+  -H "Authorization: Bearer <YOUR_PAT_OR_SAT>"
+```
 
-  ```bash
-  curl -X GET "https://api.datadoghq.com/api/v2/users" \
-    -H "DD-API-KEY: ${DD_API_KEY}" \
-    -H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
-  ```
+You can also authenticate with an [API key][1] and [application key][2] pair using the `DD-API-KEY` and `DD-APPLICATION-KEY` headers:
 
-- **Personal Access Token (PAT) or Service Access Token (SAT)**: Pass the token as a Bearer credential in the `Authorization` header. PATs and SATs authenticate without an API key. See [Personal Access Tokens][8] and [Service Access Tokens][9].
-
-  ```bash
-  curl -X GET "https://api.datadoghq.com/api/v2/users" \
-    -H "Authorization: Bearer <YOUR_PAT_OR_SAT>"
-  ```
+```bash
+curl -X GET "https://api.datadoghq.com/api/v2/users" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
+```
 
 To try out the API [![Run in Postman][3]](https://god.gw.postman.com/run-collection/20651290-809b13c1-4ada-46c1-af65-ab276c434068?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D20651290-809b13c1-4ada-46c1-af65-ab276c434068%26entityType%3Dcollection%26workspaceId%3Dbf049f54-c695-4e91-b879-0cad1854bafa)
 

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -29,7 +29,22 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 ### Getting started
 
-Authenticate to the API with an [API key][1] using the header `DD-API-KEY`. For some endpoints, you also need an [Application key][2], which uses the header `DD-APPLICATION-KEY`.
+You can authenticate to the Datadog API with one of the following credential types:
+
+- **API key and application key**: Pass your [API key][1] in the `DD-API-KEY` header and your [application key][2] in the `DD-APPLICATION-KEY` header.
+
+  ```bash
+  curl -X GET "https://api.datadoghq.com/api/v2/users" \
+    -H "DD-API-KEY: ${DD_API_KEY}" \
+    -H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
+  ```
+
+- **Personal Access Token (PAT) or Service Access Token (SAT)**: Pass the token as a Bearer credential in the `Authorization` header. PATs and SATs authenticate without an API key. See [Personal Access Tokens][8] and [Service Access Tokens][9].
+
+  ```bash
+  curl -X GET "https://api.datadoghq.com/api/v2/users" \
+    -H "Authorization: Bearer <YOUR_PAT_OR_SAT>"
+  ```
 
 To try out the API [![Run in Postman][3]](https://god.gw.postman.com/run-collection/20651290-809b13c1-4ada-46c1-af65-ab276c434068?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D20651290-809b13c1-4ada-46c1-af65-ab276c434068%26entityType%3Dcollection%26workspaceId%3Dbf049f54-c695-4e91-b879-0cad1854bafa)
 
@@ -260,3 +275,5 @@ Trying to get started with the application instead? Check out Datadog's general 
 [5]: https://brew.sh
 [6]: https://docs.datadoghq.com/extend/community/libraries/
 [7]: /getting_started/application/
+[8]: /account_management/personal-access-tokens/
+[9]: /account_management/service-access-tokens/

--- a/content/en/byoc-logs/configure/pipelines.md
+++ b/content/en/byoc-logs/configure/pipelines.md
@@ -34,6 +34,8 @@ You can configure log processing pipelines using a JSON file that adheres to the
     -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" > pipelines-config.json
    ```
 
+   **Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 This JSON file can be used directly with BYOC Logs.
 
 2. To set the configuration in the Helm Chart, provide the path to your JSON configuration file using the `pipelinesConfig` parameter in the BYOC Logs Helm chart:
@@ -138,3 +140,5 @@ Ignored processors appear as a warning in the indexer logs.
 [1]: /logs/log_configuration/pipelines/?tab=source
 [2]: /api/latest/logs-pipelines/#get-all-pipelines
 [3]: /logs/log_configuration/processors/
+[4]: /account_management/personal-access-tokens/
+[5]: /account_management/service-access-tokens/

--- a/content/en/byoc-logs/configure/pipelines.md
+++ b/content/en/byoc-logs/configure/pipelines.md
@@ -34,7 +34,7 @@ You can configure log processing pipelines using a JSON file that adheres to the
     -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" > pipelines-config.json
    ```
 
-   **Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+   **Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 This JSON file can be used directly with BYOC Logs.
 

--- a/content/en/byoc-logs/guides/send_otel_logs_observability_pipelines.md
+++ b/content/en/byoc-logs/guides/send_otel_logs_observability_pipelines.md
@@ -113,6 +113,8 @@ curl -s -X POST "https://api.${DD_SITE}/api/v2/obs-pipelines/pipelines" \
   }' | jq -r '.data.id'
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 This command returns the `pipeline_id`. Save it for the next step.
 
 **Note**: The custom processor adds a `ddtags` field with custom tags to all logs through the `remaps` configuration.
@@ -231,4 +233,6 @@ docker rm byoc-logs opw
 [4]: https://docs.docker.com/get-docker/
 [5]: https://app.datadoghq.com/logs
 [6]: /observability_pipelines/
+[7]: /account_management/personal-access-tokens/
+[8]: /account_management/service-access-tokens/
 

--- a/content/en/byoc-logs/guides/send_otel_logs_observability_pipelines.md
+++ b/content/en/byoc-logs/guides/send_otel_logs_observability_pipelines.md
@@ -113,7 +113,7 @@ curl -s -X POST "https://api.${DD_SITE}/api/v2/obs-pipelines/pipelines" \
   }' | jq -r '.data.id'
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][7] or [Service Access Token (SAT)][8] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 This command returns the `pipeline_id`. Save it for the next step.
 

--- a/content/en/cloud_cost_management/setup/custom.md
+++ b/content/en/cloud_cost_management/setup/custom.md
@@ -253,6 +253,8 @@ curl -L -X PUT "{{< region-param key="custom_costs_endpoint" >}}" \
 -F "file=${file};type=text/json"
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 To send the content of the file programmatically, use the `PUT api/v2/cost/custom_costs` endpoint.
 
 For example, using cURL:
@@ -303,3 +305,5 @@ You can view custom costs data on the [**Cloud Cost Explorer** page][6], the [Cl
 [8]: /dashboards
 [9]: /notebooks
 [10]: /monitors/types/cloud_cost/
+[11]: /account_management/personal-access-tokens/
+[12]: /account_management/service-access-tokens/

--- a/content/en/cloud_cost_management/setup/custom.md
+++ b/content/en/cloud_cost_management/setup/custom.md
@@ -253,7 +253,7 @@ curl -L -X PUT "{{< region-param key="custom_costs_endpoint" >}}" \
 -F "file=${file};type=text/json"
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 To send the content of the file programmatically, use the `PUT api/v2/cost/custom_costs` endpoint.
 

--- a/content/en/dashboards/sharing/secure_embedded_dashboards.md
+++ b/content/en/dashboards/sharing/secure_embedded_dashboards.md
@@ -398,7 +398,7 @@ def manage_tenant(tenant_id: str):
         delete_tenant_credentials(tenant_id)
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ### Generate the iFrame URL
 

--- a/content/en/dashboards/sharing/secure_embedded_dashboards.md
+++ b/content/en/dashboards/sharing/secure_embedded_dashboards.md
@@ -398,6 +398,8 @@ def manage_tenant(tenant_id: str):
         delete_tenant_credentials(tenant_id)
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ### Generate the iFrame URL
 
 The iFrame URL generation follows the same pattern as single-tenant setups. The difference is that your backend looks up the correct credential and base URL for the requesting user's tenant.
@@ -445,3 +447,5 @@ If you are using client-side rendering and see CORS errors when your frontend fe
 [3]: https://app.datadoghq.com/organization-settings/public-sharing/settings
 [4]: https://app.datadoghq.com/organization-settings/roles
 [5]: /api/latest/dashboard-secure-embed/
+[6]: /account_management/personal-access-tokens/
+[7]: /account_management/service-access-tokens/

--- a/content/en/database_monitoring/guide/build_apps_with_dbm_api.md
+++ b/content/en/database_monitoring/guide/build_apps_with_dbm_api.md
@@ -90,6 +90,8 @@ curl -X POST "https://api.${DD_SITE}/api/v2/query/scalar" \
   }'
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 | Field | Description |
 |-------|-------------|
 | `data.type` | Must be `scalar_request` |
@@ -502,3 +504,5 @@ python identify_sequential_scans.py
 [2]: /database_monitoring/setup_postgres/
 [3]: /getting_started/site/
 [4]: https://app.datadoghq.com/databases/samples
+[5]: /account_management/personal-access-tokens/
+[6]: /account_management/service-access-tokens/

--- a/content/en/database_monitoring/guide/build_apps_with_dbm_api.md
+++ b/content/en/database_monitoring/guide/build_apps_with_dbm_api.md
@@ -90,7 +90,7 @@ curl -X POST "https://api.${DD_SITE}/api/v2/query/scalar" \
   }'
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 | Field | Description |
 |-------|-------------|

--- a/content/en/dd_e2e/cdocs/components/code_block.mdoc.md
+++ b/content/en/dd_e2e/cdocs/components/code_block.mdoc.md
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     print(data)
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ### Copy disabled
 

--- a/content/en/dd_e2e/cdocs/components/code_block.mdoc.md
+++ b/content/en/dd_e2e/cdocs/components/code_block.mdoc.md
@@ -37,6 +37,8 @@ if __name__ == "__main__":
     print(data)
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][1] or [Service Access Token (SAT)][2] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ### Copy disabled
 
 ```bash {% filename="dangerous_command.sh" collapsible=false disable_copy=true wrap=false %}
@@ -91,3 +93,6 @@ statsd = Datadog::Statsd.new('localhost', 8125)
 statsd.increment('example.counter')
 statsd.gauge('example.gauge', 42)
 ```
+
+[1]: /account_management/personal-access-tokens/
+[2]: /account_management/service-access-tokens/

--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -451,9 +451,13 @@ The script has the following characteristics:
 
 This is a general behavior, and you should change it based on your personal use case and preferences. The script uses `curl` (to perform the request) and `jq` (to process the returned JSON). If those commands are not available, install them at the beginning of the script (for example, by adding `apk add --no-cache curl jq`).
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 [1]: /getting_started/site/
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://app.datadoghq.com/organization-settings/application-keys
+[4]: /account_management/personal-access-tokens/
+[5]: /account_management/service-access-tokens/
 
 {{% /tab %}}
 {{% tab "Direct API calls" %}}

--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -451,7 +451,7 @@ The script has the following characteristics:
 
 This is a general behavior, and you should change it based on your personal use case and preferences. The script uses `curl` (to perform the request) and `jq` (to process the returned JSON). If those commands are not available, install them at the beginning of the script (for example, by adding `apk add --no-cache curl jq`).
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 [1]: /getting_started/site/
 [2]: https://app.datadoghq.com/organization-settings/api-keys

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -248,7 +248,7 @@ curl -X PUT "https://api.${DD_SITE}/api/v2/cloudinventoryservice/syncconfigs" \
   }'
 ```
 
-**Note**: You can also authenticate with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 To use the example above:
 - Replace `<AWS_ACCOUNT_ID>` with the 12-digit AWS account ID that owns the destination bucket.

--- a/content/en/infrastructure/storage_management/amazon_s3.md
+++ b/content/en/infrastructure/storage_management/amazon_s3.md
@@ -248,6 +248,8 @@ curl -X PUT "https://api.${DD_SITE}/api/v2/cloudinventoryservice/syncconfigs" \
   }'
 ```
 
+**Note**: You can also authenticate with a [Personal Access Token (PAT)][11] or [Service Access Token (SAT)][12] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 To use the example above:
 - Replace `<AWS_ACCOUNT_ID>` with the 12-digit AWS account ID that owns the destination bucket.
 - Replace `<DESTINATION_BUCKET_NAME>` with the name of the destination bucket holding inventory reports.
@@ -355,3 +357,5 @@ Seeing recommendations has the following prerequisites:
 [8]: https://app.datadoghq.com/dash/integration/32296/storage-management-for-amazon-s3
 [9]: https://app.datadoghq.com/storage-management/settings
 [10]: https://docs.datadoghq.com/bits_ai/bits_ai_dev_agent/
+[11]: /account_management/personal-access-tokens/
+[12]: /account_management/service-access-tokens/

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -204,6 +204,8 @@ curl -G "https://api.datadoghq.com/api/v2/llm-obs/v1/spans/events" \
   --data-urlencode "filter[trace_id]=<TRACE_ID>"
 {{< /code-block >}}
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][15] or [Service Access Token (SAT)][16] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 **By session ID**:
 
 {{< code-block lang="bash" >}}
@@ -386,3 +388,5 @@ Build benchmark datasets with human-verified labels for regression testing and c
 [12]: /api/latest/llm-observability/#get-annotated-queue-interactions
 [13]: /api/latest/llm-observability/#get-annotation-queue-label-schema
 [14]: /api/latest/llm-observability/#update-annotation-queue-label-schema
+[15]: /account_management/personal-access-tokens/
+[16]: /account_management/service-access-tokens/

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -204,7 +204,7 @@ curl -G "https://api.datadoghq.com/api/v2/llm-obs/v1/spans/events" \
   --data-urlencode "filter[trace_id]=<TRACE_ID>"
 {{< /code-block >}}
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][15] or [Service Access Token (SAT)][16] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][15] or [Service Access Token (SAT)][16] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 **By session ID**:
 

--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -91,7 +91,7 @@ EOF
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ## List spans
 

--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -91,6 +91,8 @@ EOF
 {{% /tab %}}
 {{< /tabs >}}
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ## List spans
 
 Use this endpoint to retrieve a list of Agent Observability spans.
@@ -425,3 +427,5 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 
 
 [1]: https://jsonapi.org/format/#fetching-pagination
+[2]: /account_management/personal-access-tokens/
+[3]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -54,7 +54,7 @@ curl -L -X POST "https://api.{{< region-param key="dd_site" code="true" >}}/api/
 
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 **Response:**
 

--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -54,6 +54,8 @@ curl -L -X POST "https://api.{{< region-param key="dd_site" code="true" >}}/api/
 
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 **Response:**
 
 The result dataset is comprised of the `data` object, as depicted in the following example response.
@@ -542,3 +544,5 @@ In the response, the next two results, `joe` with 500 `pageviews` and `chris` wi
 [3]: /account_management/api-app-keys/#application-keys
 [4]: https://curl.haxx.se/download.html
 [5]: /logs/explorer/search_syntax/
+[6]: /account_management/personal-access-tokens/
+[7]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -70,7 +70,7 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
 }'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 **Response:**
 

--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -70,6 +70,8 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
 }'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 **Response:**
 
 The result dataset comprises the `buckets` object as shown in the following sample response. In this example, `c0` represents the total `count`.
@@ -868,3 +870,5 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
 [1]: https://docs.datadoghq.com/api/v2/logs/
 [2]: /account_management/api-app-keys/#api-keys
 [3]: /account_management/api-app-keys/#application-keys
+[4]: /account_management/personal-access-tokens/
+[5]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/collect-multiple-logs-with-pagination.md
+++ b/content/en/logs/guide/collect-multiple-logs-with-pagination.md
@@ -47,6 +47,8 @@ curl -X POST "https://api.<DATADOG_SITE>/api/v1/logs-queries/list" \
     }'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 Example result:
 
 ```json
@@ -196,3 +198,5 @@ Which returns these results:
 *Logging without Limits is a trademark of Datadog, Inc.
 
 [1]: /api/v1/logs/#get-a-list-of-logs
+[2]: /account_management/personal-access-tokens/
+[3]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/collect-multiple-logs-with-pagination.md
+++ b/content/en/logs/guide/collect-multiple-logs-with-pagination.md
@@ -47,7 +47,7 @@ curl -X POST "https://api.<DATADOG_SITE>/api/v1/logs-queries/list" \
     }'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 Example result:
 

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -288,6 +288,7 @@ curl -X POST \
             }'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
 
 [1]: /api/v2/roles/#list-roles
 [2]: /api/v2/roles/#list-permissions
@@ -367,3 +368,5 @@ curl -X POST \
 [14]: /account_management/rbac/permissions/#access-management
 [15]: /api/v2/logs-restriction-queries/
 [16]: /logs/explorer/live_tail/
+[17]: /account_management/personal-access-tokens/
+[18]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -288,7 +288,7 @@ curl -X POST \
             }'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][17] or [Service Access Token (SAT)][18] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 [1]: /api/v2/roles/#list-roles
 [2]: /api/v2/roles/#list-permissions

--- a/content/en/logs/guide/logs-rbac.md
+++ b/content/en/logs/guide/logs-rbac.md
@@ -74,6 +74,8 @@ If you plan to use the Datadog API, use the [Permissions API][11] to get all exi
 curl -X GET "https://app.datadoghq.com/api/v2/permissions" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>"
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][22] or [Service Access Token (SAT)][23] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ## Setting up roles
 
 This section guides you through creating two roles, `ACME Admin` and `ACME User`, granting them basic log permissions, and assigning users to these roles.
@@ -231,3 +233,5 @@ Create one or multiple [archives][17] for `team:acme` logs. Assign the [Read Arc
 [19]: /account_management/rbac/permissions?tab=ui#logs_write_historical_view
 [20]: /logs/archives#datadog-permissions
 [21]: /account_management/rbac/permissions?tab=ui#logs_read_index_data
+[22]: /account_management/personal-access-tokens/
+[23]: /account_management/service-access-tokens/

--- a/content/en/logs/guide/logs-rbac.md
+++ b/content/en/logs/guide/logs-rbac.md
@@ -74,7 +74,7 @@ If you plan to use the Datadog API, use the [Permissions API][11] to get all exi
 curl -X GET "https://app.datadoghq.com/api/v2/permissions" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>"
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][22] or [Service Access Token (SAT)][23] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][22] or [Service Access Token (SAT)][23] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ## Setting up roles
 

--- a/content/en/monitors/downtimes/examples.md
+++ b/content/en/monitors/downtimes/examples.md
@@ -49,7 +49,7 @@ curl -X POST "https://api.<DATADOG_SITE>/api/v2/downtime" \
 -d '{"data":{"type":"downtime","attributes":{"monitor_identifier":{"monitor_tags":["*"]},"scope":"env:prod","display_timezone":"Europe/Berlin","message":"","mute_first_recovery_notification":false,"notify_end_types":["expired","canceled"],"notify_end_states":["alert","warn","no data"],"schedule":{"timezone":"Europe/Berlin","recurrences":[{"start":"2023-09-16T00:00","duration":"24h","rrule":"FREQ=WEEKLY;INTERVAL=1;BYDAY=SA,SU"}]}}}'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 Optionally, add a `message` to your Downtime to let others know the reason and purpose of the Downtime you are creating. For instance, `Muting all monitors in production environment over the weekend`.
 

--- a/content/en/monitors/downtimes/examples.md
+++ b/content/en/monitors/downtimes/examples.md
@@ -49,6 +49,8 @@ curl -X POST "https://api.<DATADOG_SITE>/api/v2/downtime" \
 -d '{"data":{"type":"downtime","attributes":{"monitor_identifier":{"monitor_tags":["*"]},"scope":"env:prod","display_timezone":"Europe/Berlin","message":"","mute_first_recovery_notification":false,"notify_end_types":["expired","canceled"],"notify_end_states":["alert","warn","no data"],"schedule":{"timezone":"Europe/Berlin","recurrences":[{"start":"2023-09-16T00:00","duration":"24h","rrule":"FREQ=WEEKLY;INTERVAL=1;BYDAY=SA,SU"}]}}}'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][6] or [Service Access Token (SAT)][7] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 Optionally, add a `message` to your Downtime to let others know the reason and purpose of the Downtime you are creating. For instance, `Muting all monitors in production environment over the weekend`.
 
 Replace the placeholder value `<DATADOG_SITE>` with the site parameter of your Datadog account, see the [Datadog Sites][1] documentation. Replace the `start` and `end` parameter to match your wanted schedule. For example:
@@ -345,3 +347,5 @@ Open the [Manage Downtime page][1] and add a new downtime. Select `recurring` an
 [3]: https://docs.datadoghq.com/monitors/downtimes/
 [4]: https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html
 [5]: https://icalendar.org/rrule-tool.html
+[6]: /account_management/personal-access-tokens/
+[7]: /account_management/service-access-tokens/

--- a/content/en/monitors/guide/clean_up_monitor_clutter.md
+++ b/content/en/monitors/guide/clean_up_monitor_clutter.md
@@ -61,7 +61,7 @@ curl -s -X GET "{{< region-param key=dd_api >}}/api/v1/monitor/search" \
   | @csv' > monitors_muted.csv
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][12] or [Service Access Token (SAT)][13] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][12] or [Service Access Token (SAT)][13] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 This gives you the details of your monitors in a CSV file for readability. You can refine the query to your specific use case.
 

--- a/content/en/monitors/guide/clean_up_monitor_clutter.md
+++ b/content/en/monitors/guide/clean_up_monitor_clutter.md
@@ -61,6 +61,8 @@ curl -s -X GET "{{< region-param key=dd_api >}}/api/v1/monitor/search" \
   | @csv' > monitors_muted.csv
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][12] or [Service Access Token (SAT)][13] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 This gives you the details of your monitors in a CSV file for readability. You can refine the query to your specific use case.
 
 ### 3. Delete the monitors
@@ -1415,3 +1417,5 @@ To help you get started, import the following JSON dashboard definition directly
 [9]: https://app.datadoghq.com/dashboard/lists
 [10]: /account_management/rbac/permissions/#monitors
 [11]: /monitors/types/composite/
+[12]: /account_management/personal-access-tokens/
+[13]: /account_management/service-access-tokens/

--- a/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
+++ b/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
@@ -49,6 +49,8 @@ curl --request GET 'https://api.datadoghq.com/api/v2/roles' \
 --header 'DD-APPLICATION-KEY: <DD-APPLICATION-KEY>'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 ```bash
 {
     "meta": {
@@ -147,3 +149,5 @@ All monitors also display the role restriction option regardless of the underlyi
 [2]: /account_management/rbac/?tab=datadogapplication#datadog-default-roles
 [3]: /api/latest/monitors/#edit-a-monitor
 [4]: /api/latest/restriction-policies/
+[5]: /account_management/personal-access-tokens/
+[6]: /account_management/service-access-tokens/

--- a/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
+++ b/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
@@ -49,7 +49,7 @@ curl --request GET 'https://api.datadoghq.com/api/v2/roles' \
 --header 'DD-APPLICATION-KEY: <DD-APPLICATION-KEY>'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][5] or [Service Access Token (SAT)][6] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 ```bash
 {

--- a/content/en/security/ai_guard/setup/http_api.md
+++ b/content/en/security/ai_guard/setup/http_api.md
@@ -61,6 +61,8 @@ curl -s -XPOST \
   https://app.datadoghq.com/api/v2/ai-guard/evaluate
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 #### Response {#api-example-generic-response}
 
 ```json
@@ -175,3 +177,5 @@ As a best practice, evaluate a tool call before running the tool. However, you c
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://platform.openai.com/docs/api-reference/chat/object
+[2]: /account_management/personal-access-tokens/
+[3]: /account_management/service-access-tokens/

--- a/content/en/security/ai_guard/setup/http_api.md
+++ b/content/en/security/ai_guard/setup/http_api.md
@@ -61,7 +61,7 @@ curl -s -XPOST \
   https://app.datadoghq.com/api/v2/ai-guard/evaluate
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][2] or [Service Access Token (SAT)][3] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 #### Response {#api-example-generic-response}
 

--- a/content/en/security/cloud_siem/guide/customize-which-logs-cloud-siem-analyzes.md
+++ b/content/en/security/cloud_siem/guide/customize-which-logs-cloud-siem-analyzes.md
@@ -164,7 +164,7 @@ curl -L -X POST 'https://api.{{< region-param key="dd_site" code="true" >}}/api/
 }'
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][10] or [Service Access Token (SAT)][11] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][10] or [Service Access Token (SAT)][11] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 Example response:
 

--- a/content/en/security/cloud_siem/guide/customize-which-logs-cloud-siem-analyzes.md
+++ b/content/en/security/cloud_siem/guide/customize-which-logs-cloud-siem-analyzes.md
@@ -164,6 +164,8 @@ curl -L -X POST 'https://api.{{< region-param key="dd_site" code="true" >}}/api/
 }'
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][10] or [Service Access Token (SAT)][11] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 Example response:
 
 ```json
@@ -377,3 +379,5 @@ If you restrict analysis to specific categories of logs, take care not to exclud
 [7]: /security/cloud_siem/ingest_and_enrich/content_packs
 [8]: /logs/log_configuration/pipelines/
 [9]: /security/cloud_siem/ingest_and_enrich/threat_intelligence/
+[10]: /account_management/personal-access-tokens/
+[11]: /account_management/service-access-tokens/

--- a/content/en/synthetics/guide/version_history.md
+++ b/content/en/synthetics/guide/version_history.md
@@ -91,7 +91,7 @@ Content-Type: application/json
 }
 ```
 
-**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+**Note**: Datadog recommends authenticating these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header. API key and application key authentication is also supported.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/synthetics/guide/version_history.md
+++ b/content/en/synthetics/guide/version_history.md
@@ -91,6 +91,8 @@ Content-Type: application/json
 }
 ```
 
+**Note**: You can also authenticate these API calls with a [Personal Access Token (PAT)][4] or [Service Access Token (SAT)][5] using the `Authorization: Bearer <token>` header, without pairing an API key with an application key.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -112,3 +114,5 @@ Content-Type: application/json
 [1]: /account_management/audit_trail/
 [2]: https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-synthetics#run-tests-command
 [3]: /api/latest/synthetics/#trigger-tests-from-cicd-pipelines
+[4]: /account_management/personal-access-tokens/
+[5]: /account_management/service-access-tokens/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

PATs and SATs are now supported as standalone authentication credentials for the Datadog API, replacing the requirement to pair an API key with an application key. This PR updates the API reference overview and all English guide pages that previously implied API + application key was the only way to authenticate programmatic API calls.

Changes:
- `api/latest/_index.md` - Rewrites the "Getting started" auth section to present all three credential types (API+App key, PAT, SAT) with curl examples for each
- `account_management/api-app-keys.md` - Adds a credential types comparison table at the top of the page
- 29 guide pages across logs, monitors, security, LLM observability, actions, agent, and other product areas - Each gets a note after the first qualifying curl block pointing to PAT/SAT as an alternative using `Authorization: Bearer <token>`

Note: a Jira ticket number should be added to this PR title before merging.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Telemetry intake endpoints (metrics submission, log ingestion, Agent) were intentionally excluded - PATs/SATs do not apply to those paths.