### PR TITLE
[DBM][Oracle] Note reported_hostname requirement on RDS setup page

### DIFF
--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -117,6 +117,14 @@ instances:
       - 'env:<CUSTOM_ENV>'
 ```
 
+**Note:** When the Agent runs on a host whose system hostname does not match the RDS endpoint (for example, an EC2 instance), set the `reported_hostname` field on each instance to the RDS endpoint. Without it, the database may appear in Datadog under an internal hostname (such as `ip-10-0-0-12`) rather than the RDS endpoint, making it harder to correlate with the AWS RDS integration. See [Troubleshooting][12] for details.
+
+```yaml
+  - server: '<RDS_INSTANCE_ENDPOINT_1>:<PORT>'
+    reported_hostname: '<RDS_INSTANCE_ENDPOINT_1>'
+    # ... other options
+```
+
 Once all Agent configuration is complete, [restart the Datadog Agent][2].
 
 ### Validate the setup
@@ -140,6 +148,7 @@ Database Monitoring supports custom queries for Oracle databases. See the [conf.
 [9]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
 [10]: /database_monitoring/architecture/
 [11]: /integrations/guide/oracle-check-upgrade-7.50.1/
+[12]: /database_monitoring/setup_oracle/troubleshooting/#no-oracle-db-hostname-reported
 
 ## Further reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a `Note` to `content/en/database_monitoring/setup_oracle/rds.md`, immediately after the Agent configuration YAML example, explaining when `reported_hostname` is required for RDS Oracle setups and giving a minimal config snippet. Links to the existing troubleshooting entry on the same topic.

Motivation: when the Agent runs on a host whose system hostname does not match the RDS endpoint (typically an EC2 instance), the database surfaces in Datadog under an internal hostname (such as `ip-10-0-0-12`) instead of the RDS endpoint, breaking correlation with the AWS RDS integration. The fix is documented in `setup_oracle/troubleshooting.md` but customers only find it after the wrong hostname shows up — repeatedly opening support tickets covering the same setup gap. Surfacing this in the setup flow lets readers configure it correctly on the first pass.

Files touched:

- `content/en/database_monitoring/setup_oracle/rds.md` — adds a Note + minimal YAML example after the `Configure the Agent` section.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Translated copies (`.es.md`, `.ja.md`, `.fr.md`, `.ko.md`) are not updated by the author — the localization pipeline handles them.

Docs preview: https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/