### PR TITLE
Flaky Tests Management: document attempt-to-fix detection across batched commits

### DIFF
--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -251,7 +251,7 @@ To find your account name, go to the [Slack integration tile][5] and check the
 
 After you include the test key (for example, `DD_ABC123`) in a commit, Datadog scans the commit that triggered the test run and up to the 10 most recent commits before it. If the remediation flow does not start, check the following:
 
-- **The key is in an older commit.** Only the 10 most recent commits in the triggering commit's history are scanned. If you push more than 10 commits at once, include the key in the triggering commit or within its 10 most recent commits.
+- **The key is in an older commit.** Datadog scans only the triggering commit and the 10 most recent commits in its history. If you push more than 10 commits at once, include the key in the triggering commit or one of the 10 most recent commits.
 - **The fix was squash-merged.** A squash merge combines the original commits into a single commit, so Datadog reads only the squash commit's message; the individual pre-squash commits are no longer scanned. Most providers include the original commit messages in the squash commit, so a key in any of them is preserved. If your provider omits them, add the key to the squash commit message.
 - **The key does not match the expected format.** Use the exact key shown in the Flaky Tests Management UI (for example, `DD_ABC123`) in the commit title or message.
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -124,7 +124,7 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
 1. For the test you are fixing, click **Link commit to Flaky Test fix** in the Flaky Tests Management UI.
 1. Copy the unique flaky test key that is displayed (for example, `DD_ABC123`).
 1. Include the test key in your Git commit title or message for the fix (for example, `git commit -m "DD_ABC123"`).
-1. When Datadog detects the test key, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit: Datadog checks the commit that triggered the test run and scans up to the 10 most recent commits in its history, so the flow still triggers when you push several commits together or when your CI provider reports only the most recent commit. The remediation flow:
+1. When Datadog detects the test key, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit, because Datadog also checks the recent commits leading up to it, so the flow still triggers when you push several commits together or when your CI provider reports only the most recent commit. The remediation flow:
     - Retries any tests you're attempting to fix 20 times (or the number of retries you specified in your [Flaky Test Policies configuration](#configure-policies-to-automate-the-flaky-test-lifecycle)).
       - Tags every retry with `@test.test_management.is_attempt_to_fix:true` in test run events.
     - Runs tests even if they are marked as `Disabled`.
@@ -133,8 +133,6 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
       - Starts a 14-day [grace period](#grace-period-mechanism) to give time for the fix to propagate everywhere in the repository.
     - If any retry fails, keeps the test's current state (`Active`, `Quarantined`, or `Disabled`).
       - Tags the last test retry with `@test.test_management.attempt_to_fix_passed:false` in test run events.
-
-Datadog scans up to the 10 most recent commits, starting from the commit that triggered the test run. If you push more than 10 commits at once, include the test key within the 10 most recent commits. For squash merges, the original commits are combined into a single commit, so Datadog reads only the squash commit's message. Most providers include the original commit messages in the squash commit, so a key in any of them is preserved; if your provider omits them, add the key to the squash commit message.
 
 ### Track fixes that are in progress
 
@@ -248,6 +246,14 @@ If you are using `@slack-CHANNEL` (without the account name), the notification i
 
 To find your account name, go to the [Slack integration tile][5] and check the
 **Account Name** field for the workspace you want to use.
+
+### Attempt-to-fix remediation does not trigger after linking a fix
+
+After you include the test key (for example, `DD_ABC123`) in a commit, Datadog scans the commit that triggered the test run and up to the 10 most recent commits in its history. If the remediation flow does not start, check the following:
+
+- **The key is in an older commit.** Only the 10 most recent commits in the triggering commit's history are scanned. If you push more than 10 commits at once, include the key in the triggering commit or within its 10 most recent commits.
+- **The fix was squash-merged.** A squash merge combines the original commits into a single commit, so Datadog reads only the squash commit's message; the individual pre-squash commits are no longer scanned. Most providers include the original commit messages in the squash commit, so a key in any of them is preserved. If your provider omits them, add the key to the squash commit message.
+- **The key does not match the expected format.** Use the exact key shown in the Flaky Tests Management UI (for example, `DD_ABC123`) in the commit title or message.
 
 ## Further reading
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -124,7 +124,7 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
 1. For the test you are fixing, click **Link commit to Flaky Test fix** in the Flaky Tests Management UI.
 1. Copy the unique flaky test key that is displayed (for example, `DD_ABC123`).
 1. Include the test key in your Git commit title or message for the fix (for example, `git commit -m "DD_ABC123"`).
-1. When Datadog detects the test key in your commit, it automatically triggers the remediation flow for that test:
+1. When Datadog detects the test key in any of the commits included in your push, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit, so the flow still triggers when you push several commits together or squash them, or when your CI provider reports only the head commit. CI retries of the same push are handled correctly and the fix is not processed more than once. The remediation flow:
     - Retries any tests you're attempting to fix 20 times (or the number of retries you specified in your [Flaky Test Policies configuration](#configure-policies-to-automate-the-flaky-test-lifecycle)).
       - Tags every retry with `@test.test_management.is_attempt_to_fix:true` in test run events.
     - Runs tests even if they are marked as `Disabled`.

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -124,7 +124,7 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
 1. For the test you are fixing, click **Link commit to Flaky Test fix** in the Flaky Tests Management UI.
 1. Copy the unique flaky test key that is displayed (for example, `DD_ABC123`).
 1. Include the test key in your Git commit title or message for the fix (for example, `git commit -m "DD_ABC123"`).
-1. When Datadog detects the test key, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit, because Datadog also checks the recent commits leading up to it, so the flow still triggers when you push several commits together or when your CI provider reports only the most recent commit. The remediation flow:
+1. When Datadog detects the test key, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit. Datadog also checks recent preceding commits, so the flow still triggers when you push several commits together or when your CI provider reports only the most recent commit. The remediation flow:
     - Retries any tests you're attempting to fix 20 times (or the number of retries you specified in your [Flaky Test Policies configuration](#configure-policies-to-automate-the-flaky-test-lifecycle)).
       - Tags every retry with `@test.test_management.is_attempt_to_fix:true` in test run events.
     - Runs tests even if they are marked as `Disabled`.

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -124,7 +124,7 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
 1. For the test you are fixing, click **Link commit to Flaky Test fix** in the Flaky Tests Management UI.
 1. Copy the unique flaky test key that is displayed (for example, `DD_ABC123`).
 1. Include the test key in your Git commit title or message for the fix (for example, `git commit -m "DD_ABC123"`).
-1. When Datadog detects the test key in any of the commits included in your push, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit, so the flow still triggers when you push several commits together or squash them, or when your CI provider reports only the head commit. CI retries of the same push are handled correctly and the fix is not processed more than once. The remediation flow:
+1. When Datadog detects the test key, it automatically triggers the remediation flow for that test. The key does not need to be in the most recent commit: Datadog checks the commit that triggered the test run and scans up to the 10 most recent commits in its history, so the flow still triggers when you push several commits together or when your CI provider reports only the most recent commit. The remediation flow:
     - Retries any tests you're attempting to fix 20 times (or the number of retries you specified in your [Flaky Test Policies configuration](#configure-policies-to-automate-the-flaky-test-lifecycle)).
       - Tags every retry with `@test.test_management.is_attempt_to_fix:true` in test run events.
     - Runs tests even if they are marked as `Disabled`.
@@ -133,6 +133,8 @@ When you fix a flaky test, Test Optimization's remediation flow can confirm the 
       - Starts a 14-day [grace period](#grace-period-mechanism) to give time for the fix to propagate everywhere in the repository.
     - If any retry fails, keeps the test's current state (`Active`, `Quarantined`, or `Disabled`).
       - Tags the last test retry with `@test.test_management.attempt_to_fix_passed:false` in test run events.
+
+Datadog scans up to the 10 most recent commits, starting from the commit that triggered the test run. If you push more than 10 commits at once, include the test key within the 10 most recent commits. For squash merges, the original commits are combined into a single commit, so Datadog reads only the squash commit's message. Most providers include the original commit messages in the squash commit, so a key in any of them is preserved; if your provider omits them, add the key to the squash commit message.
 
 ### Track fixes that are in progress
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -249,7 +249,7 @@ To find your account name, go to the [Slack integration tile][5] and check the
 
 ### Attempt-to-fix remediation does not trigger after linking a fix
 
-After you include the test key (for example, `DD_ABC123`) in a commit, Datadog scans the commit that triggered the test run and up to the 10 most recent commits in its history. If the remediation flow does not start, check the following:
+After you include the test key (for example, `DD_ABC123`) in a commit, Datadog scans the commit that triggered the test run and up to the 10 most recent commits before it. If the remediation flow does not start, check the following:
 
 - **The key is in an older commit.** Only the 10 most recent commits in the triggering commit's history are scanned. If you push more than 10 commits at once, include the key in the triggering commit or within its 10 most recent commits.
 - **The fix was squash-merged.** A squash merge combines the original commits into a single commit, so Datadog reads only the squash commit's message; the individual pre-squash commits are no longer scanned. Most providers include the original commit messages in the squash commit, so a key in any of them is preserved. If your provider omits them, add the key to the squash commit message.


### PR DESCRIPTION
### What does this PR do?

Updates the **Flaky Tests Management** page to document an improvement to the attempt-to-fix remediation flow: Datadog now detects the unique test key (for example, `DD_ABC123`) in **any commit included in the triggering push**, not only the most recent commit.

**Do not merge immediately**

### Motivation

Previously the key was reliably detected only in the commit that triggered the test run (typically the head commit). When commits were pushed together or squashed — or when a CI provider reported only the head commit — the key could be missed if it lived in an earlier commit of the push. The flow now triggers regardless of which commit in the push carries the key, and CI retries of the same push are not double-processed. No user configuration is required.

### Scope

One-line content change in `content/en/tests/flaky_management/_index.md`, in the **Confirm fixes for flaky tests** section. User-facing wording only — no API or behavior contract changes.

Reference: SDCT-332