### PR TITLE
Bits Code: add GitLab support

### DIFF
--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with [source code platforms](#supported-source-code-platforms) to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
+Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with [source code providers](#supported-source-code-providers) to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
 
 {{< img src="bits_ai/dev_agent/sessions_overview.png" alt="A tab titled 'Sessions' shows a text field with suggestions underneath" style="width:100%;" >}}
 
@@ -24,14 +24,14 @@ To get started with Bits Code, [set up the GitHub or GitLab integration][6] and 
 
 Learn how your Bits Code usage is billed on [AI Credits][27].
 
-## Supported source code platforms
+## Supported source code providers
 
-Bits Code supports the following source code platforms:
+Bits Code supports the following source code providers:
 
 - **GitHub**: GitHub.com and GitHub Enterprise Cloud
 - **GitLab**: GitLab.com and GitLab Dedicated
 
-Self-hosted platforms, such as GitHub Enterprise Server and GitLab Self-Managed, are not supported.
+Self-hosted providers, such as GitHub Enterprise Server and GitLab Self-Managed, are not supported.
 
 ## Sessions
 A session captures a segment of work with Bits Code, including its analysis and code changes. Start, view, and manage your sessions at **Bits AI** > **Bits Code** > [**Sessions**][7].
@@ -89,7 +89,7 @@ You can build automations from triggers (a product finding, a custom prompt, a s
 
 ### Pull request collaboration
 
-Bits Code integrates with [source code providers](#supported-source-code-platforms) to:
+Bits Code integrates with [source code providers](#supported-source-code-providers) to:
 - Create pull requests, generating titles and descriptions based on your repository's pull request template
 - Iterate on pull requests in response to comments; mention `@Datadog` in a comment to prompt Bits for updates
 - Monitor CI logs and fix failures

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with [source code providers](#supported-source-code-providers) to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
+Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with [source code providers](#supported-source-code-providers) to create production-ready pull/merge requests, then iterates on changes using CI logs and developer feedback.
 
 {{< img src="bits_ai/dev_agent/sessions_overview.png" alt="A tab titled 'Sessions' shows a text field with suggestions underneath" style="width:100%;" >}}
 
@@ -47,7 +47,7 @@ After [completing setup][6], do one of the following to start a Bits Code sessio
 A session can also be created when another Bits AI agent (like [Bits Chat][16] or [Bits Investigation][17]) hands off a coding task to Bits Code.
 
 ### View and manage sessions
-On **[Sessions][7]**, view your past sessions in the **My Sessions** panel. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR.
+On **[Sessions][7]**, view your past sessions in the **My Sessions** panel. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR/MR.
 
 Click a session to view its details and continue working with Bits Code. To remove a session from your **My Sessions** list, click <i class="icon-archive-wui"></i> (**Archive for everyone**) or <i class="icon-eye-slashed-wui"></i> (**Unwatch session**).
 
@@ -83,18 +83,18 @@ Use the freeform prompt field at [**Sessions**][7] to work with Bits Code on gen
 
 ### Automations
 
-[Automations][28] run Bits Code sessions automatically, on a schedule or in response to signals from Datadog products like Error Tracking, APM, or Code Security. After a session completes, Bits Code delivers the results as a pull request, a draft PR, or a Slack notification.
+[Automations][28] run Bits Code sessions automatically, on a schedule or in response to signals from Datadog products like Error Tracking, APM, or Code Security. After a session completes, Bits Code delivers the results as a pull/merge request, a draft PR/MR, or a Slack notification.
 
 You can build automations from triggers (a product finding, a custom prompt, a schedule, or a combination) and configure one or more outputs. Datadog-provided templates are also available to help you get started. Create and manage automations at **Bits AI** > **Bits Code** > [**Automations**][29].
 
-### Pull request collaboration
+### Pull/merge request collaboration
 
 Bits Code integrates with [source code providers](#supported-source-code-providers) to:
-- Create pull requests, generating titles and descriptions based on your repository's pull request template
-- Iterate on pull requests in response to comments; mention `@Datadog` in a comment to prompt Bits for updates
+- Create pull/merge requests, generating titles and descriptions based on your repository's pull/merge request template
+- Iterate on pull/merge requests in response to comments; mention `@Datadog` in a comment to prompt Bits for updates
 - Monitor CI logs and fix failures
 
-Bits Code never auto-merges PRs. See all the PRs that Bits Code is working on in **Bits AI** > **Bits Code** > **[Sessions][7]**.
+Bits Code never auto-merges PR/MRs. See all the PR/MRs that Bits Code is working on in **Bits AI** > **Bits Code** > **[Sessions][7]**.
 
 ## Limitations
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -14,13 +14,13 @@ further_reading:
 
 ## Overview
 
-Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with GitHub to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
+Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with GitHub and GitLab to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
 
 {{< img src="bits_ai/dev_agent/sessions_overview.png" alt="A tab titled 'Sessions' shows a text field with suggestions underneath" style="width:100%;" >}}
 
 Each time Bits Code investigates an issue or generates a fix, it creates a [session](#sessions), which captures the agent's analysis, actions, and any resulting code changes across supported Datadog products. Set up [automations][28] to have Bits Code run sessions on a schedule or in response to signals from other Datadog products, such as a new APM Recommendation or flaky test.
 
-To get started with Bits Code, [set up the GitHub integration][6] and complete any additional configuration. Then, [start your first session](#start-a-session).
+To get started with Bits Code, [set up the GitHub or GitLab integration][6] and complete any additional configuration. Then, [start your first session](#start-a-session).
 
 Learn how your Bits Code usage is billed on [AI Credits][27].
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -29,7 +29,7 @@ Learn how your Bits Code usage is billed on [AI Credits][27].
 Bits Code supports the following source code platforms:
 
 - **GitHub**: GitHub.com and GitHub Enterprise Cloud
-- **GitLab**: GitLab.com
+- **GitLab**: GitLab.com and GitLab Dedicated
 
 Self-hosted platforms, such as GitHub Enterprise Server and GitLab Self-Managed, are not supported.
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with GitHub and GitLab to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
+Bits Code is a generative AI coding assistant that uses Datadog observability data to automatically diagnose and fix issues in your code. It integrates with [source code platforms](#supported-source-code-platforms) to create production-ready pull requests, then iterates on changes using CI logs and developer feedback.
 
 {{< img src="bits_ai/dev_agent/sessions_overview.png" alt="A tab titled 'Sessions' shows a text field with suggestions underneath" style="width:100%;" >}}
 
@@ -23,6 +23,15 @@ Each time Bits Code investigates an issue or generates a fix, it creates a [sess
 To get started with Bits Code, [set up the GitHub or GitLab integration][6] and complete any additional configuration. Then, [start your first session](#start-a-session).
 
 Learn how your Bits Code usage is billed on [AI Credits][27].
+
+## Supported source code platforms
+
+Bits Code supports the following source code platforms:
+
+- **GitHub**: GitHub.com and GitHub Enterprise Cloud
+- **GitLab**: GitLab.com
+
+Self-hosted platforms, such as GitHub Enterprise Server and GitLab Self-Managed or Dedicated, are not yet supported.
 
 ## Sessions
 A session captures a segment of work with Bits Code, including its analysis and code changes. Start, view, and manage your sessions at **Bits AI** > **Bits Code** > [**Sessions**][7].

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -20,7 +20,7 @@ Bits Code is a generative AI coding assistant that uses Datadog observability da
 
 Each time Bits Code investigates an issue or generates a fix, it creates a [session](#sessions), which captures the agent's analysis, actions, and any resulting code changes across supported Datadog products. Set up [automations][28] to have Bits Code run sessions on a schedule or in response to signals from other Datadog products, such as a new APM Recommendation or flaky test.
 
-To get started with Bits Code, [set up the GitHub or GitLab integration][6] and complete any additional configuration. Then, [start your first session](#start-a-session).
+To get started with Bits Code, [set up a source code integration][6] and complete any additional configuration. Then, [start your first session](#start-a-session).
 
 Learn how your Bits Code usage is billed on [AI Credits][27].
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -116,7 +116,6 @@ Bits Code never auto-merges PRs. See all the PRs that Bits Code is working on in
 [10]: /profiler/automated_analysis/
 [12]: /containers/
 [13]: /containers/bits_ai_kubernetes_remediation
-[14]: https://app.datadoghq.com/code/settings
 [15]: /security/code_security/static_analysis/ai_enhanced_sast/#remediation
 [16]: /bits_ai/bits_chat/
 [17]: /bits_ai/bits_ai_sre/

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -89,7 +89,7 @@ You can build automations from triggers (a product finding, a custom prompt, a s
 
 ### Pull request collaboration
 
-Bits Code integrates with GitHub to:
+Bits Code integrates with [source code providers](#supported-source-code-platforms) to:
 - Create pull requests, generating titles and descriptions based on your repository's pull request template
 - Iterate on pull requests in response to comments; mention `@Datadog` in a comment to prompt Bits for updates
 - Monitor CI logs and fix failures

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -94,7 +94,7 @@ Bits Code integrates with [source code providers](#supported-source-code-provide
 - Iterate on pull/merge requests in response to comments; mention `@Datadog` in a comment to prompt Bits for updates
 - Monitor CI logs and fix failures
 
-Bits Code never auto-merges PR/MRs. See all the PR/MRs that Bits Code is working on in **Bits AI** > **Bits Code** > **[Sessions][7]**.
+Bits Code never auto-merges PRs/MRs. See all the PRs/MRs that Bits Code is working on in **Bits AI** > **Bits Code** > **[Sessions][7]**.
 
 ## Limitations
 

--- a/content/en/bits_ai/bits_ai_dev_agent/_index.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/_index.md
@@ -31,7 +31,7 @@ Bits Code supports the following source code platforms:
 - **GitHub**: GitHub.com and GitHub Enterprise Cloud
 - **GitLab**: GitLab.com
 
-Self-hosted platforms, such as GitHub Enterprise Server and GitLab Self-Managed or Dedicated, are not yet supported.
+Self-hosted platforms, such as GitHub Enterprise Server and GitLab Self-Managed, are not supported.
 
 ## Sessions
 A session captures a segment of work with Bits Code, including its analysis and code changes. Start, view, and manage your sessions at **Bits AI** > **Bits Code** > [**Sessions**][7].

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -63,7 +63,7 @@ You can also configure service-to-repository mapping manually in Bits Code setti
 
 ### Enable auto-push
 
-Auto-push allows Bits Code to create branches, push code, and open PR/MRs when it detects something it can help you with. Auto-push only opens PR/MRs and pushes changes; it never merges code. When auto-push is disabled, you must review code in Datadog before it gets pushed.
+Auto-push allows Bits Code to create branches, push code, and open PRs/MRs when it detects something it can help you with. Auto-push only opens PRs/MRs and pushes changes; it never merges code. When auto-push is disabled, you must review code in Datadog before it gets pushed.
 
 To enable auto-push, navigate to **Bits Code** > **Settings** > [**General**][6].
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -42,7 +42,7 @@ Set up Bits Code for one of the [supported source code platforms][11].
 {{% tab "GitLab" %}}
 
 1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
-1. Configure the following permissions for Bits Code:
+1. Configure the [service account][16] in GitLab:
    - The service account must have the [`Developer` role][12] on the project. This role can be inherited from a [group][13].
    - The service account's personal access token must have the following [scopes][15]: `api`, `write_repository`, and `read_user`.
 
@@ -152,3 +152,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes
 [14]: https://app.datadoghq.com/code/settings
+[16]: https://docs.gitlab.com/user/profile/service_accounts/

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -43,7 +43,7 @@ Set up Bits Code for one of the [supported source code platforms][11].
 
 1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
 1. Configure the following permissions for Bits Code:
-   - The service account must have the `Developer` role on the project. This role can be inherited from the group.
+   - The service account must have the [`Developer` role][12] on the project. This role can be inherited from [a group][13].
    - The service account's token must have the `api`, `write_repository`, and `read_user` scopes.
 
 {{% /tab %}}
@@ -148,3 +148,5 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [9]: https://app.datadoghq.com/integrations/gitlab-source-code
 [10]: /integrations/gitlab-source-code/
 [11]: /bits_ai/bits_ai_dev_agent/#supported-source-code-platforms
+[12]: https://docs.gitlab.com/user/permissions/#default-roles
+[13]: https://docs.gitlab.com/user/permissions/#groups

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -72,7 +72,7 @@ To enable auto-push, navigate to **Bits Code** > **Settings** > [**General**][6]
 
 Allowing any AI-based tool to read untrusted data can let attackers influence its output. Auto-push behavior depends on the type of data Bits Code works with: code-only workflows operate on source code the Agent can inspect directly, while telemetry-based workflows (such as errors or traces) may include untrusted runtime inputs.
 
-To balance safety and automation, you can configure auto-push behavior in [Datadog][14] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
+To balance safety and automation, you can configure auto-push behavior in [Datadog][6] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
 
 ### Configure custom instructions
 
@@ -152,4 +152,3 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes
 [16]: https://docs.gitlab.com/user/profile/service_accounts/
-[14]: https://app.datadoghq.com/code/settings

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -5,7 +5,7 @@ disable_toc: false
 
 ## Overview
 
-[Bits Code][8] integrates with GitHub and GitLab to open, update, and iterate on pull requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
+[Bits Code][8] integrates with GitHub and GitLab to open, update, and iterate on pull/merge requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
 
 ## Prerequisites
 
@@ -63,7 +63,7 @@ You can also configure service-to-repository mapping manually in Bits Code setti
 
 ### Enable auto-push
 
-Auto-push allows Bits Code to create branches, push code, and open PRs when it detects something it can help you with. Auto-push only opens PRs and pushes changes; it never merges code. When auto-push is disabled, you must review code in Datadog before it gets pushed.
+Auto-push allows Bits Code to create branches, push code, and open PR/MRs when it detects something it can help you with. Auto-push only opens PR/MRs and pushes changes; it never merges code. When auto-push is disabled, you must review code in Datadog before it gets pushed.
 
 To enable auto-push, navigate to **Bits Code** > **Settings** > [**General**][6].
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -44,7 +44,7 @@ Set up Bits Code for one of the [supported source code platforms][11].
 1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
 1. Configure the following permissions for Bits Code:
    - The service account must have the [`Developer` role][12] on the project. This role can be inherited from a [group][13].
-   - The service account's token must have the `api`, `write_repository`, and `read_user` scopes.
+   - The service account's personal access token must have the following [scopes][15]: `api`, `write_repository`, and `read_user`.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -150,3 +150,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [11]: /bits_ai/bits_ai_dev_agent/#supported-source-code-platforms
 [12]: https://docs.gitlab.com/user/permissions/#default-roles
 [13]: https://docs.gitlab.com/user/permissions/#groups
+[15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -5,7 +5,7 @@ disable_toc: false
 
 ## Overview
 
-[Bits Code][8] integrates with GitHub to open, update, and iterate on pull requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
+[Bits Code][8] integrates with GitHub and GitLab to open, update, and iterate on pull requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
 
 ## Prerequisites
 
@@ -14,6 +14,9 @@ To set up Bits Code, you need the **Bits Code Write** (`bits_dev_write`) permiss
 If your organization uses custom roles, an admin must add this permission manually. For details, see [Access Control][1].
 
 ## Setup
+
+{{< tabs >}}
+{{% tab "GitHub" %}}
 
 1. Install the [GitHub integration][2]. For full installation and configuration steps, see the [GitHub integration guide][3].
 1. In your GitHub account, navigate to {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Apps{{< /ui >}} > {{< ui >}}Datadog{{< /ui >}} to configure GitHub permissions.
@@ -32,6 +35,17 @@ If your organization uses custom roles, an admin must add this permission manual
          - Check suite  
          - Issue comment  
          - Status
+
+{{% /tab %}}
+{{% tab "GitLab" %}}
+
+1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
+1. Configure the following permissions for Bits Code:
+   - The service account must have the `Developer` role on the project. This role can be inherited from the group.
+   - The service account's token must have the `api`, `write_repository`, and `read_user` scopes.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Additional configuration  
 
@@ -129,3 +143,5 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [6]: https://app.datadoghq.com/code/settings
 [7]: /bits_ai/bits_ai_dev_agent/#start-a-session
 [8]: /bits_ai/bits_ai_dev_agent/
+[9]: https://app.datadoghq.com/integrations/gitlab-source-code
+[10]: /integrations/gitlab-source-code/

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -131,9 +131,9 @@ Bits Code runs the setup command at startup and can use any tools installed in y
 
 ## Troubleshooting
 
-### Creation of PRs fails unexpectedly
+### Creation of GitHub PRs fails unexpectedly
 
-In some cases, especially in repositories with many branches, GitHub does not run the permission check when creating a branch for the session. If you use a custom GitHub App, you can work around this issue by adding the `workflows:write` permission to your app in [Source Code Integration][2].
+In some cases, especially in repositories with many branches, GitHub does not run the permission check when creating a branch for the session. If you use a custom GitHub App, you can work around this issue by adding the `workflows:write` permission to your app in [GitHub Source Code Integration][2].
 
 **Note**: This permission allows Bits AI to create workflows in your repository and has security implications.
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -72,7 +72,7 @@ To enable auto-push, navigate to **Bits Code** > **Settings** > [**General**][6]
 
 Allowing any AI-based tool to read untrusted data can let attackers influence its output. Auto-push behavior depends on the type of data Bits Code works with: code-only workflows operate on source code the Agent can inspect directly, while telemetry-based workflows (such as errors or traces) may include untrusted runtime inputs.
 
-To balance safety and automation, you can configure auto-push behavior in [Datadog][6] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
+To balance safety and automation, you can configure auto-push behavior in [Datadog][14] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
 
 ### Configure custom instructions
 
@@ -152,3 +152,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes
 [16]: https://docs.gitlab.com/user/profile/service_accounts/
+[14]: https://app.datadoghq.com/code/settings

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -43,7 +43,7 @@ Set up Bits Code for one of the [supported source code platforms][11].
 
 1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
 1. Configure the following permissions for Bits Code:
-   - The service account must have the [`Developer` role][12] on the project. This role can be inherited from [a group][13].
+   - The service account must have the [`Developer` role][12] on the project. This role can be inherited from a [group][13].
    - The service account's token must have the `api`, `write_repository`, and `read_user` scopes.
 
 {{% /tab %}}

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -151,3 +151,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [12]: https://docs.gitlab.com/user/permissions/#default-roles
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes
+[14]: https://app.datadoghq.com/code/settings

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -15,7 +15,7 @@ If your organization uses custom roles, an admin must add this permission manual
 
 ## Setup
 
-Set up Bits Code for one of the [supported source code platforms][11].
+Set up Bits Code for one of the [supported source code providers][11].
 
 {{< tabs >}}
 {{% tab "GitHub" %}}
@@ -147,7 +147,7 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [8]: /bits_ai/bits_ai_dev_agent/
 [9]: https://app.datadoghq.com/integrations/gitlab-source-code
 [10]: /integrations/gitlab-source-code/
-[11]: /bits_ai/bits_ai_dev_agent/#supported-source-code-platforms
+[11]: /bits_ai/bits_ai_dev_agent/#supported-source-code-providers
 [12]: https://docs.gitlab.com/user/permissions/#default-roles
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -72,7 +72,7 @@ To enable auto-push, navigate to **Bits Code** > **Settings** > [**General**][6]
 
 Allowing any AI-based tool to read untrusted data can let attackers influence its output. Auto-push behavior depends on the type of data Bits Code works with: code-only workflows operate on source code the Agent can inspect directly, while telemetry-based workflows (such as errors or traces) may include untrusted runtime inputs.
 
-To balance safety and automation, you can configure auto-push behavior in [Datadog][14] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
+To balance safety and automation, you can configure auto-push behavior in [Datadog][6] (for example, limiting auto-push to code-only workflows or requiring review when telemetry is involved). Datadog scans all Agent-generated code before pushing changes, but these safeguards are not foolproof.
 
 ### Configure custom instructions
 
@@ -151,5 +151,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [12]: https://docs.gitlab.com/user/permissions/#default-roles
 [13]: https://docs.gitlab.com/user/permissions/#groups
 [15]: https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes
-[14]: https://app.datadoghq.com/code/settings
 [16]: https://docs.gitlab.com/user/profile/service_accounts/

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -5,7 +5,7 @@ disable_toc: false
 
 ## Overview
 
-[Bits Code][8] integrates with GitHub and GitLab to open, update, and iterate on pull/merge requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
+[Bits Code][8] integrates with [source code providers][11] to open, update, and iterate on pull/merge requests based on issues detected in Datadog. After completing setup, you can [start using Bits Code][7].
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ Set up Bits Code for one of the [supported source code providers][11].
 {{% tab "GitLab" %}}
 
 1. Install the [GitLab Source Code integration][9]. For full installation and configuration steps, see the [GitLab Source Code integration guide][10].
-1. Configure the [service account][16] in GitLab:
+1. Ensure the GitLab [service account][16] has the following configurations:
    - The service account must have the [`Developer` role][12] on the project. This role can be inherited from a [group][13].
    - The service account's personal access token must have the following [scopes][15]: `api`, `write_repository`, and `read_user`.
 

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -15,6 +15,8 @@ If your organization uses custom roles, an admin must add this permission manual
 
 ## Setup
 
+Set up Bits Code for one of the [supported source code platforms][11].
+
 {{< tabs >}}
 {{% tab "GitHub" %}}
 
@@ -145,3 +147,4 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [8]: /bits_ai/bits_ai_dev_agent/
 [9]: https://app.datadoghq.com/integrations/gitlab-source-code
 [10]: /integrations/gitlab-source-code/
+[11]: /bits_ai/bits_ai_dev_agent/#supported-source-code-platforms


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4f08bbad-6d4d-47ab-93ca-ef1351b09016","source":"chat","resourceId":"40b5012f-65ee-4c34-a841-eb332a91b797","workflowId":"23da624a-b183-4244-ab43-aa83ed933b0f","codeChangeId":"23da624a-b183-4244-ab43-aa83ed933b0f","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

- adds GitLab setup instructions alongside the existing GitHub instructions (in tabs)
- documents the supported source code providers on the overview page 
- rewords provider-neutral sections so they no longer imply GitHub is the only supported provider

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Drafted by Bits Code (Datadog's AI coding agent), based on input from the Bits Code engineering team and aligned with existing documentation patterns. Iterated on with Cara. Pending human review.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/40b5012f-65ee-4c34-a841-eb332a91b797)

Comment @datadog to request changes