### PR TITLE
Add PR coverage summary and per-file coverage tools to MCP server docs

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1370,7 +1370,7 @@ Fetches aggregated code coverage summary metrics for a repository commit, includ
 ### `get_datadog_code_coverage_pr_summary`
 *Toolset: **software-delivery***\
 *Permissions Required: `Code Coverage read`*\
-Fetches aggregated code coverage summary metrics for a pull request, including total coverage, patch coverage, and service/codeowner breakdowns.
+Fetches aggregated code coverage summary metrics for a pull request, including total coverage, patch coverage, and service or codeowner breakdowns.
 
 - Show me the code coverage for PR #123 in `github.com/my-org/my-repo`.
 - What's the patch coverage for pull request #456 in `github.com/my-org/my-repo`?
@@ -1382,7 +1382,7 @@ Fetches per-file code coverage line data for a repository commit, branch, or pul
 
 - Show me per-file coverage for PR #123 in `github.com/my-org/my-repo`.
 - Get changed-file coverage for commit `abc123abc123abc123abc123abc123abc123abcd` in `github.com/my-org/my-repo`.
-- Show coverage details filtered by codeowner `@my-org/my-team` for the `main` branch of `github.com/my-org/my-repo`.
+- Show coverage for the `main` branch of `github.com/my-org/my-repo`, filtered by codeowner `@my-org/my-team`.`
 
 ### `get_datadog_test_optimization_settings`
 *Toolset: **software-delivery***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1367,6 +1367,23 @@ Fetches aggregated code coverage summary metrics for a repository commit, includ
 - Show me the code coverage for commit `abc123abc123abc123abc123abc123abc123abcd` in `github.com/my-org/my-repo`.
 - What's the patch coverage for the latest commit on my branch?
 
+### `get_datadog_code_coverage_pr_summary`
+*Toolset: **software-delivery***\
+*Permissions Required: `Code Coverage read`*\
+Fetches aggregated code coverage summary metrics for a pull request, including total coverage, patch coverage, and service/codeowner breakdowns.
+
+- Show me the code coverage for PR #123 in `github.com/my-org/my-repo`.
+- What's the patch coverage for pull request #456 in `github.com/my-org/my-repo`?
+
+### `get_datadog_code_coverage_files`
+*Toolset: **software-delivery***\
+*Permissions Required: `Code Coverage read`*\
+Fetches per-file code coverage line data for a repository commit, branch, or pull request. Returns executable lines, covered lines, and added lines for each file. Exactly one of `commit_sha`, `branch`, or `pr_number` must be provided. At most one of `service`, `codeowner`, or `flag` may be provided to filter results.
+
+- Show me per-file coverage for PR #123 in `github.com/my-org/my-repo`.
+- Get changed-file coverage for commit `abc123abc123abc123abc123abc123abc123abcd` in `github.com/my-org/my-repo`.
+- Show coverage details filtered by codeowner `@my-org/my-team` for the `main` branch of `github.com/my-org/my-repo`.
+
 ### `get_datadog_test_optimization_settings`
 *Toolset: **software-delivery***\
 *Permissions Required: `Test Optimization Read`*\


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents two new Code Coverage MCP tools in the Software Delivery section of the MCP Server Tools reference page:

- `get_datadog_code_coverage_pr_summary`: Fetches aggregated coverage summary metrics (total coverage, patch coverage, service/codeowner breakdowns) for a pull request.
- `get_datadog_code_coverage_files`: Fetches per-file coverage line data (executable lines, covered lines, added lines) for a commit, branch, or pull request, with optional filtering by service, codeowner, or flag.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes