### PR TITLE
[DBM Doc] Document new `agent diagnose` support for Postgres DBM setup

### DIFF
--- a/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -213,6 +213,8 @@ For tuning options, see [Advanced Configuration][16].
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
 
+**Note**: After installing and configuring the Agent, you can also run `datadog-agent diagnose` to automatically validate your Postgres DBM setup, including connection, version support, required GUCs, role membership, and per-database schema/function prerequisites. The diagnostics report actionable remediation hints for common configuration issues.
+
 {{< tabs >}}
 {{% tab "Postgres ≥ 10" %}}
 


### PR DESCRIPTION
## Confidence: DISCUSSION

**Source PR:** https://github.com/DataDog/integrations-core/pull/23433

**What changed:**
The Postgres integration now surfaces common DBM setup issues via `datadog-agent diagnose`. The new diagnostic framework validates:
- Connection and authentication
- Postgres version support
- Server GUCs: `shared_preload_libraries`, `track_activity_query_size`, `track_io_timing`, `pg_stat_statements.max`
- `pg_monitor` role membership
- Access to `pg_stat_activity`, `pg_stat_database`, `pg_stat_statements`
- Per-database `datadog` schema, `pg_stat_statements` extension, and `datadog.explain_statement` function

Diagnostics are gated on the DBM subfeatures that require each dependency (e.g., query_metrics checks `shared_preload_libraries`, query_samples validates the explain function) and cascade-suppress so a single root cause yields one actionable diagnostic.

**Why document this:**
Users can now run `datadog-agent diagnose` to validate their Postgres DBM setup and get actionable remediation hints for common configuration issues. The self-hosted setup guide should mention this diagnostic capability so users know they can validate their configuration after completing the setup steps.

**Uncertainty:**
The PR does not explicitly state a minimum Agent version for the new diagnostics, though the code changes are in integrations-core only. The placement and wording of the diagnostic callout in the setup flow is open to discussion — should it go near "Verify database permissions" or as a separate troubleshooting step?