### PR TITLE
docs(tracing): document B3 propagation support in the Rust SDK

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -630,7 +630,7 @@ void SetHeaderValues(MessageHeaders headers, string name, string value)
 
 The Datadog Rust SDK is built on the OpenTelemetry (OTel) SDK.
 
-Trace context propagation is handled by the OTel SDK, which is configured by `datadog-opentelemetry` to support both `datadog` and `tracecontext` (W3C) formats.
+Trace context propagation is handled by the OTel SDK, which is configured by `datadog-opentelemetry` to support `datadog`, `tracecontext` (W3C), and B3 formats.
 
 ### Supported formats
 
@@ -638,6 +638,8 @@ Trace context propagation is handled by the OTel SDK, which is configured by `da
 |---|---|
 | [Datadog][1] | `datadog` |
 | [W3C Trace Context][2] | `tracecontext` |
+| [B3 Single][3] | `b3` |
+| [B3 Multi][4] | `b3multi` |
 
 ### Configuration
 
@@ -646,8 +648,8 @@ You can control which propagation formats are used by setting the `DD_TRACE_PROP
 For example:
 
 ```bash
-# To support both W3C and Datadog
-export DD_TRACE_PROPAGATION_STYLE="tracecontext,datadog"
+# To support W3C, Datadog, and B3
+export DD_TRACE_PROPAGATION_STYLE="tracecontext,datadog,b3multi,b3"
 ```
 
 ### Manual injection and extraction
@@ -751,6 +753,8 @@ async fn hyper_handler(req: Request<Incoming>) -> Response<Full<Bytes>> {
 
 [1]: #datadog-format
 [2]: https://www.w3.org/TR/trace-context/
+[3]: https://github.com/openzipkin/b3-propagation#single-header
+[4]: https://github.com/openzipkin/b3-propagation#multiple-headers
 
 {{% /tab %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds B3 Single (`b3`) and B3 Multi (`b3multi`) as supported propagation formats in the Rust tab of `trace_context_propagation/_index.md`. The Rust SDK gains B3 support in the upcoming `datadog-opentelemetry` release, matching the format coverage of the other Datadog tracers.

Specifically:
- Adds two rows to the "Supported formats" table (`b3`, `b3multi`).
- Updates the intro paragraph and `DD_TRACE_PROPAGATION_STYLE` example to reflect the four supported formats.
- Adds the `[3]` / `[4]` link references inside the Rust tab so the table links resolve.

### Merge readiness

- [ ] Ready for merge

Depends on the B3 propagator changes landing in `DataDog/dd-trace-rs` first: **DataDog/dd-trace-rs#262** (single combined PR; supersedes the earlier #253–#260 split). Please hold this PR until that merges and a release that includes it ships.

## For Datadog employees:

### AI assistance

AI-assisted, manually reviewed.

### Additional notes

The note "**`baggage` is not supported in Rust**" earlier in the document is unchanged and remains accurate; this PR only adds B3.
