### PR TITLE
[DET-62] Add manual trigger option to Data Observability monitor docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,25 +7,5 @@
         "editor.defaultFormatter": "stripe.markdoc-language-support",
         "editor.formatOnSave": false,
         "editor.tabSize": 2
-    },
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#7b3acb",
-        "activityBar.background": "#7b3acb",
-        "activityBar.foreground": "#e7e7e7",
-        "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#d0894e",
-        "activityBarBadge.foreground": "#15202b",
-        "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#7b3acb",
-        "statusBar.background": "#632ca6",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#7b3acb",
-        "statusBarItem.remoteBackground": "#632ca6",
-        "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#632ca6",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#632ca699",
-        "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.color": "#632CA6"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,25 @@
         "editor.defaultFormatter": "stripe.markdoc-language-support",
         "editor.formatOnSave": false,
         "editor.tabSize": 2
-    }
+    },
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#7b3acb",
+        "activityBar.background": "#7b3acb",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#d0894e",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#7b3acb",
+        "statusBar.background": "#632ca6",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#7b3acb",
+        "statusBarItem.remoteBackground": "#632ca6",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#632ca6",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#632ca699",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#632CA6"
 }

--- a/content/en/monitors/types/data_observability.md
+++ b/content/en/monitors/types/data_observability.md
@@ -196,7 +196,7 @@ Set how often the monitor evaluates your data:
 
 - **Hourly**: The monitor runs every hour.
 - **Daily**: The monitor runs once per day.
-- **Manual**: The monitor runs only when triggered programmatically. Trigger these monitors using the [Data Observability API][10].
+- **Manual**: The monitor runs only when triggered programmatically. Trigger these monitors using the [Data Observability API][10] on a schedule so enough historical data can accumulate for modeling to be useful. Currently, the UI does not support default metrics like row counts and freshness, so this workflow only applies to custom or column-level metrics.
 
 ### Set alert conditions
 

--- a/content/en/monitors/types/data_observability.md
+++ b/content/en/monitors/types/data_observability.md
@@ -196,7 +196,7 @@ Set how often the monitor evaluates your data:
 
 - **Hourly**: The monitor runs every hour.
 - **Daily**: The monitor runs once per day.
-- **Manual**: The monitor only runs when triggered programmatically. You can triggers these monitors using the APIs found [here](https://docs.datadoghq.com/api/latest/data-observability/).
+- **Manual**: The monitor only runs when triggered programmatically. Trigger these monitors using the [Data Observability API][10].
 
 ### Set alert conditions
 
@@ -299,3 +299,4 @@ On a monitor's status page, click **Annotate Bounds**, select a time range on th
 [7]: https://app.datadoghq.com/data-obs/monitors
 [8]: /monitors/configuration/?tab=thresholdalert#thresholds
 [9]: /help/
+[10]: /api/latest/data-observability/

--- a/content/en/monitors/types/data_observability.md
+++ b/content/en/monitors/types/data_observability.md
@@ -196,6 +196,7 @@ Set how often the monitor evaluates your data:
 
 - **Hourly**: The monitor runs every hour.
 - **Daily**: The monitor runs once per day.
+- **Manual**: The monitor only runs when triggered programmatically. You can triggers these monitors using the APIs found [here](https://docs.datadoghq.com/api/latest/data-observability/).
 
 ### Set alert conditions
 

--- a/content/en/monitors/types/data_observability.md
+++ b/content/en/monitors/types/data_observability.md
@@ -196,7 +196,7 @@ Set how often the monitor evaluates your data:
 
 - **Hourly**: The monitor runs every hour.
 - **Daily**: The monitor runs once per day.
-- **Manual**: The monitor only runs when triggered programmatically. Trigger these monitors using the [Data Observability API][10].
+- **Manual**: The monitor runs only when triggered programmatically. Trigger these monitors using the [Data Observability API][10].
 
 ### Set alert conditions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DET-62

Updates the Data Observability monitor documentation to include the **Manual** scheduling option, which allows monitors to run only when triggered programmatically via the Data Observability APIs.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Claude Code (pi) to create the PR.