### PR TITLE
[DOCS-14700, DOCS-14701] Add OCI and vSphere support to Cloudcraft in Datadog

### DIFF
--- a/content/en/datadog_cloudcraft/_index.md
+++ b/content/en/datadog_cloudcraft/_index.md
@@ -118,7 +118,7 @@ Enabling resource collection can impact your AWS CloudWatch costs. To avoid thes
 {{% tab "vSphere" %}}
 
 - To access Cloudcraft in Datadog, you need the `cloudcraft_read` [permission](#permissions).
-- The Datadog Agent must be installed in your vSphere environment. The vSphere check is included in the Agent package.
+- The Datadog Agent must be installed in your vSphere environment. The vSphere check is included in the Datadog Agent package.
 - The [vSphere integration][22] must be enabled and configured.
 
 **Note**: Only the Infrastructure and Monitors overlays are available for vSphere accounts.

--- a/content/en/datadog_cloudcraft/_index.md
+++ b/content/en/datadog_cloudcraft/_index.md
@@ -138,7 +138,13 @@ To get started using Cloudcraft, use the following steps:
 
 {{< img src="datadog_cloudcraft/getting_started_3.png" alt="Getting started in Cloudcraft, displaying a list of resources for the selected account and region" style="width:100%;" >}}
 
-<div class="alert alert-tip">The account name in the {{< ui >}}Account{{< /ui >}} dropdown comes from your AWS account tags in the AWS integration tile. For Azure, the {{< ui >}}Subscription{{< /ui >}} name comes from the subscription name in your Azure integration tile's list of managed subscriptions. For GCP, the {{< ui >}}Project{{< /ui >}} dropdown lists your GCP project IDs from the Google Cloud integration tile. For OCI, the {{< ui >}}Tenancy{{< /ui >}} name comes from your tenancy in the Oracle Cloud Infrastructure integration tile.
+<div class="alert alert-tip">Provider account names in the dropdowns come from their respective integration tiles:
+<ul>
+<li><strong>AWS</strong>: The {{< ui >}}Account{{< /ui >}} name comes from your AWS account tags in the AWS integration tile.</li>
+<li><strong>Azure</strong>: The {{< ui >}}Subscription{{< /ui >}} name comes from the subscription name in your Azure integration tile's list of managed subscriptions.</li>
+<li><strong>GCP</strong>: The {{< ui >}}Project{{< /ui >}} dropdown lists your GCP project IDs from the Google Cloud integration tile.</li>
+<li><strong>OCI</strong>: The {{< ui >}}Tenancy{{< /ui >}} name comes from your tenancy in the Oracle Cloud Infrastructure integration tile.</li>
+</ul>
 </div>
 
 ### Group By

--- a/content/en/datadog_cloudcraft/_index.md
+++ b/content/en/datadog_cloudcraft/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Cloudcraft in Datadog
-description: "Visualize and analyze AWS, Azure, and GCP cloud infrastructure with live Cloudcraft diagrams in Datadog for troubleshooting, security analysis, and cost optimization."
+description: "Visualize and analyze AWS, Azure, GCP, OCI, and vSphere infrastructure with live Cloudcraft diagrams in Datadog for troubleshooting, security analysis, and cost optimization."
 further_reading:
 - link: "https://www.datadoghq.com/blog/cloud-architecture-diagrams-cost-compliance-cloudcraft-datadog/"
   tag: "Blog"
@@ -19,7 +19,7 @@ Cloudcraft offers a powerful, live read-only visualization tool for cloud archit
 
 <div class="alert alert-info">This documentation applies to the Cloudcraft <em>in Datadog</em> product. For information on the standalone Cloudcraft product, please refer to the <a href="/cloudcraft">Cloudcraft (Standalone)</a> documentation.</div>
 
-Cloudcraft's core functionality is its ability to generate detailed architecture diagrams. These diagrams visually represent AWS, Azure, and GCP cloud resources, allowing you to explore and analyze your environments. Cloudcraft's diagrams are optimized for clarity and performance, providing an intuitive interface for navigating large-scale deployments. This helps teams to:
+Cloudcraft's core functionality is its ability to generate detailed architecture diagrams. These diagrams visually represent AWS, Azure, GCP, OCI, and vSphere resources, allowing you to explore and analyze your environments. Cloudcraft's diagrams are optimized for clarity and performance, providing an intuitive interface for navigating large-scale deployments. This helps teams to:
 
 - Trace incidents back to their root causes through infrastructure dependencies.
 - Determine if infrastructure is the cause of an incident, such as cross-region traffic causing latency or increased costs. 
@@ -101,6 +101,31 @@ Enabling resource collection can impact your AWS CloudWatch costs. To avoid thes
 [19]: /datadog_cloudcraft/overlays#observability
 
 {{% /tab %}}
+{{% tab "OCI" %}}
+
+- To access Cloudcraft in Datadog, you need the `cloudcraft_read` [permission](#permissions).
+- Add your OCI tenancy to the [Oracle Cloud Infrastructure integration][20] and enable [resource collection][21].
+
+- Viewing content on the [Security overlay][10] requires additional products to be enabled:
+  - To view security misconfigurations and identity risks, [Cloud Security][3] must be enabled.
+
+[3]: /security/cloud_security_management
+[10]: /datadog_cloudcraft/overlays#security
+[20]: /integrations/oracle_cloud_infrastructure/
+[21]: /integrations/oracle_cloud_infrastructure/#resource-collection
+
+{{% /tab %}}
+{{% tab "vSphere" %}}
+
+- To access Cloudcraft in Datadog, you need the `cloudcraft_read` [permission](#permissions).
+- The Datadog Agent must be installed in your vSphere environment. The vSphere check is included in the Agent package.
+- The [vSphere integration][22] must be enabled and configured.
+
+**Note**: Only the Infrastructure and Monitors overlays are available for vSphere accounts.
+
+[22]: /integrations/vsphere/
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Getting started
@@ -113,7 +138,7 @@ To get started using Cloudcraft, use the following steps:
 
 {{< img src="datadog_cloudcraft/getting_started_3.png" alt="Getting started in Cloudcraft, displaying a list of resources for the selected account and region" style="width:100%;" >}}
 
-<div class="alert alert-tip">The account name in the {{< ui >}}Account{{< /ui >}} dropdown comes from your AWS account tags in the AWS integration tile. For Azure, the {{< ui >}}Subscription{{< /ui >}} name comes from the subscription name in your Azure integration tile's list of managed subscriptions. For GCP, the {{< ui >}}Project{{< /ui >}} dropdown lists your GCP project IDs from the Google Cloud integration tile.
+<div class="alert alert-tip">The account name in the {{< ui >}}Account{{< /ui >}} dropdown comes from your AWS account tags in the AWS integration tile. For Azure, the {{< ui >}}Subscription{{< /ui >}} name comes from the subscription name in your Azure integration tile's list of managed subscriptions. For GCP, the {{< ui >}}Project{{< /ui >}} dropdown lists your GCP project IDs from the Google Cloud integration tile. For OCI, the {{< ui >}}Tenancy{{< /ui >}} name comes from your tenancy in the Oracle Cloud Infrastructure integration tile.
 </div>
 
 ### Group By
@@ -128,7 +153,7 @@ Enable the {{< ui >}}Show All Controls{{< /ui >}} toggle to display the availabl
 
 You can group resources by AWS and Azure tags, such as app, service, team, or cost center, to organize your view by team or workload. When grouping by tags, color-coded labels are displayed on each group. When grouping by the `service` tag, a raised block is displayed to visually indicate the service grouping.
 
-**Note**: Grouping by tags is supported for AWS tags, Azure tags, and GCP labels (for example, `Project`). Tags from the Datadog Agent (for example, locally configured `env` or `team` tags) are not supported.
+**Note**: Grouping by tags is supported for AWS tags, Azure tags, GCP labels, OCI tags, and vSphere tags. Tags from the Datadog Agent (for example, locally configured `env` or `team` tags) are not supported.
 
 {{< img src="datadog_cloudcraft/cloudcraft_group_by_with_team_tags_2.png" alt="Cloudcraft landing page with Group by highlighted, and grouping by Team" >}}
 

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -20,7 +20,8 @@ further_reading:
 
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 
-**Note**: The Cost view is not available for GCP accounts. The Recommendations view is supported for GCP.
+<!-- TODO (DOCS-14700): Confirm with PM whether OCI supports both Cost and Recommendations views, or Recommendations only (like GCP). -->
+**Note**: The Cost view is not available for GCP accounts. The Recommendations view is supported for GCP. The Cloud Cost Management overlay is not available for vSphere accounts.
 
 ## Cost view
 

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -16,12 +16,14 @@ further_reading:
   text: "Cloud Cost Management"
 ---
 
+<div class="alert alert-info">The Cloud Cost Management overlay is not available for vSphere accounts.</div>
+
 ## Overview
 
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 
 <!-- TODO (DOCS-14700): Confirm with PM whether OCI supports both Cost and Recommendations views, or Recommendations only (like GCP). -->
-**Note**: The Cost view is not available for GCP accounts. The Recommendations view is supported for GCP. The Cloud Cost Management overlay is not available for vSphere accounts.
+**Note**: The Cost view is not available for GCP accounts; GCP accounts support the Recommendations view only.
 
 ## Cost view
 

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -16,9 +16,9 @@ further_reading:
   text: "Cloud Cost Management"
 ---
 
-<div class="alert alert-info">The Cloud Cost Management overlay is not available for vSphere accounts.</div>
-
 ## Overview
+
+<div class="alert alert-info">The Cloud Cost Management overlay is not available for vSphere accounts.</div>
 
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -22,7 +22,7 @@ further_reading:
 
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 
-**Note**: For GCP accounts, only the Recommendations view is available.
+**Note**: For GCP and OCI accounts, only the Recommendations view is available.
 
 ## Cost view
 

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -22,7 +22,6 @@ further_reading:
 
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 
-<!-- TODO (DOCS-14700): Confirm with PM whether OCI supports both Cost and Recommendations views, or Recommendations only (like GCP). -->
 **Note**: For GCP accounts, only the Recommendations view is available.
 
 ## Cost view

--- a/content/en/datadog_cloudcraft/overlays/ccm.md
+++ b/content/en/datadog_cloudcraft/overlays/ccm.md
@@ -23,7 +23,7 @@ further_reading:
 The Cloud Cost overlay helps you visualize resource-level costs and identify savings opportunities within your cloud architecture diagrams. This overlay provides two views: [{{< ui >}}Cost{{< /ui >}}](#cost-view) and [{{< ui >}}Recommendations{{< /ui >}}](#recommendations-view).
 
 <!-- TODO (DOCS-14700): Confirm with PM whether OCI supports both Cost and Recommendations views, or Recommendations only (like GCP). -->
-**Note**: The Cost view is not available for GCP accounts; GCP accounts support the Recommendations view only.
+**Note**: For GCP accounts, only the Recommendations view is available.
 
 ## Cost view
 

--- a/content/en/datadog_cloudcraft/overlays/infrastructure.md
+++ b/content/en/datadog_cloudcraft/overlays/infrastructure.md
@@ -30,17 +30,7 @@ The Infrastructure overlay is ideal for:
 
 ## Resource grouping
 
-Resources are organized in a hierarchical structure. The default Group By hierarchy varies by provider:
-
-| Provider | Default Group By hierarchy |
-|----------|---------------------------|
-| AWS | Account > Region > VPC > Service > Security Group Subnet |
-| Azure | Subscription > Resource Group > Security Group \| VNet > Service > Subnet |
-| GCP | Project > Firewall > VPC > Region > Service > Subnet |
-| OCI | Tenancy > Compartment > Region > VCN > Service > Security Group Subnet |
-| vSphere | vCenter > Datacenter > Cluster > Service |
-
-This hierarchy helps you understand how resources are distributed across your cloud infrastructure.
+Resources are grouped by a provider-specific hierarchy. Use the **Group by** controls at the top of the diagram to customize the grouping.
 
 ## Interact with resources
 

--- a/content/en/datadog_cloudcraft/overlays/infrastructure.md
+++ b/content/en/datadog_cloudcraft/overlays/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 title: Infrastructure
-description: "Use the Infrastructure overlay in Cloudcraft to view resources grouped by Account, Region, and VPC for architecture diagrams and troubleshooting."
+description: "Use the Infrastructure overlay in Cloudcraft to view resources grouped by a provider-specific hierarchy for architecture diagrams and troubleshooting."
 further_reading:
 - link: "/datadog_cloudcraft/overlays/observability/"
   tag: "Documentation"
@@ -15,7 +15,7 @@ further_reading:
 
 ## Overview
 
-The Infrastructure overlay provides a broad overview of your cloud environment by grouping resources into Account, Region, and VPC. This is the default view when opening a Cloudcraft diagram.
+The Infrastructure overlay provides a broad overview of your cloud environment by grouping resources into a provider-specific hierarchy. This is the default view when opening a Cloudcraft diagram.
 
 {{< img src="datadog_cloudcraft/infra_overlay_5.png" alt="Infrastructure overlay in Cloudcraft." style="width:100%;" >}}
 
@@ -32,11 +32,12 @@ The Infrastructure overlay is ideal for:
 
 Resources are organized in a hierarchical structure. The grouping labels vary by provider:
 
-| Level | AWS | Azure | GCP |
-|-------|-----|-------|-----|
-| Top-level | Account | Subscription | Project |
-| Geographic | Region | Region | Region |
-| Network | VPC | Virtual Network | VPC |
+| Level | AWS | Azure | GCP | OCI | vSphere |
+|-------|-----|-------|-----|-----|---------|
+| Top-level | Account | Subscription | Project | Tenancy | vCenter |
+| Second | — | — | — | Compartment | Datacenter |
+| Geographic | Region | Region | Region | Region | — |
+| Network | VPC | Virtual Network | VPC | VCN | Cluster |
 
 This hierarchy helps you understand how resources are distributed across your cloud infrastructure.
 

--- a/content/en/datadog_cloudcraft/overlays/infrastructure.md
+++ b/content/en/datadog_cloudcraft/overlays/infrastructure.md
@@ -35,7 +35,7 @@ Resources are organized in a hierarchical structure. The grouping labels vary by
 | Level | AWS | Azure | GCP | OCI | vSphere |
 |-------|-----|-------|-----|-----|---------|
 | Top-level | Account | Subscription | Project | Tenancy | vCenter |
-| Second | — | — | — | Compartment | Datacenter |
+| Second | — | Resource Group | — | Compartment | Datacenter |
 | Geographic | Region | Region | Region | Region | — |
 | Network | VPC | Virtual Network | VPC | VCN | Cluster |
 

--- a/content/en/datadog_cloudcraft/overlays/infrastructure.md
+++ b/content/en/datadog_cloudcraft/overlays/infrastructure.md
@@ -30,14 +30,15 @@ The Infrastructure overlay is ideal for:
 
 ## Resource grouping
 
-Resources are organized in a hierarchical structure. The grouping labels vary by provider:
+Resources are organized in a hierarchical structure. The default Group By hierarchy varies by provider:
 
-| Level | AWS | Azure | GCP | OCI | vSphere |
-|-------|-----|-------|-----|-----|---------|
-| Top-level | Account | Subscription | Project | Tenancy | vCenter |
-| Second | — | Resource Group | — | Compartment | Datacenter |
-| Geographic | Region | Region | Region | Region | — |
-| Network | VPC | Virtual Network | VPC | VCN | Cluster |
+| Provider | Default Group By hierarchy |
+|----------|---------------------------|
+| AWS | Account > Region > VPC > Service > Security Group Subnet |
+| Azure | Subscription > Resource Group > Security Group \| Vnet > Service > Subnet |
+| GCP | Project > Firewall > VPC > Region > Service > Subnet |
+| OCI | Tenancy > Compartment > Region > VCN > Service > Security Group Subnet |
+| vSphere | vCenter > Datacenter > Cluster > Service |
 
 This hierarchy helps you understand how resources are distributed across your cloud infrastructure.
 

--- a/content/en/datadog_cloudcraft/overlays/infrastructure.md
+++ b/content/en/datadog_cloudcraft/overlays/infrastructure.md
@@ -35,7 +35,7 @@ Resources are organized in a hierarchical structure. The default Group By hierar
 | Provider | Default Group By hierarchy |
 |----------|---------------------------|
 | AWS | Account > Region > VPC > Service > Security Group Subnet |
-| Azure | Subscription > Resource Group > Security Group \| Vnet > Service > Subnet |
+| Azure | Subscription > Resource Group > Security Group \| VNet > Service > Subnet |
 | GCP | Project > Firewall > VPC > Region > Service > Subnet |
 | OCI | Tenancy > Compartment > Region > VCN > Service > Security Group Subnet |
 | vSphere | vCenter > Datacenter > Cluster > Service |

--- a/content/en/datadog_cloudcraft/overlays/monitors.md
+++ b/content/en/datadog_cloudcraft/overlays/monitors.md
@@ -14,7 +14,7 @@ The Monitors overlay is in Preview.
 
 ## Overview
 
-The Monitors overlay shows monitors associated with your AWS and Azure resources and services, along with their current state (`Alert`, `Warn`, or `OK`). Use this overlay to identify and investigate production issues directly in your infrastructure diagram.
+The Monitors overlay shows monitors associated with your cloud resources and services, along with their current state (`Alert`, `Warn`, or `OK`). Use this overlay to identify and investigate production issues directly in your infrastructure diagram.
 
 ## View monitor status
 

--- a/content/en/datadog_cloudcraft/overlays/observability.md
+++ b/content/en/datadog_cloudcraft/overlays/observability.md
@@ -18,6 +18,8 @@ further_reading:
 
 ## Overview
 
+**Note**: The Observability overlay is not available for vSphere accounts.
+
 The Observability overlay shows where the Datadog Agent is installed and what features are enabled per host, such as Application Performance Monitoring (APM), Cloud Network Monitoring (CNM), Log Management, and more. This helps you to assess visibility gaps across your environment.
 
 ## Take action on resources

--- a/content/en/datadog_cloudcraft/overlays/observability.md
+++ b/content/en/datadog_cloudcraft/overlays/observability.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-**Note**: The Observability overlay is not available for vSphere accounts.
+<div class="alert alert-info">The Observability overlay is not available for vSphere accounts.</div>
 
 The Observability overlay shows where the Datadog Agent is installed and what features are enabled per host, such as Application Performance Monitoring (APM), Cloud Network Monitoring (CNM), Log Management, and more. This helps you to assess visibility gaps across your environment.
 

--- a/content/en/datadog_cloudcraft/overlays/security.md
+++ b/content/en/datadog_cloudcraft/overlays/security.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-**Note**: The Security overlay is not available for vSphere accounts.
+<div class="alert alert-info">The Security overlay is not available for vSphere accounts.</div>
 
 The Security overlay highlights potential security exposures in your architecture, grouping resources by Region, VPC, and Security Group. It displays security findings detected by Cloud Security, helping you:
 

--- a/content/en/datadog_cloudcraft/overlays/security.md
+++ b/content/en/datadog_cloudcraft/overlays/security.md
@@ -18,6 +18,8 @@ further_reading:
 
 ## Overview
 
+**Note**: The Security overlay is not available for vSphere accounts.
+
 The Security overlay highlights potential security exposures in your architecture, grouping resources by Region, VPC, and Security Group. It displays security findings detected by Cloud Security, helping you:
 
 - Identify security issues directly in infrastructure diagrams


### PR DESCRIPTION
## What does this PR do?

Adds OCI and vSphere as supported cloud providers to the Cloudcraft in Datadog documentation. Previously the docs covered AWS, Azure, and GCP only.

**DOCS-14700** — OCI support (Infrastructure, Monitors, Observability, Cloud Cost, Security overlays)
**DOCS-14701** — vSphere support (Infrastructure and Monitors overlays only)

**Note**: I have [one open question](https://github.com/DataDog/documentation/pull/37573/changes#r3423829715) for the PM, but any changed needed will be small. This is ready for review otherwise. 

DO NOT MERGE - will merge when these support for these cloud providers is GA

🤖 Generated with [Claude Code](https://claude.com/claude-code)