### PR TITLE
[Auto] DOCS-14686: Fixed the triple-'l' typo in 'folllowing' → 'following' in the internal pathway_type description.

### DIFF
--- a/content/en/data_streams/metrics_and_tags.md
+++ b/content/en/data_streams/metrics_and_tags.md
@@ -28,7 +28,7 @@ This metric measures latency between two points in the pipeline. The value can r
   - `partial_edge`: latency between a service and a queue, if the producer or consumer is not known (that is, not instrumented with Data Streams Monitoring)
      - `start` tag: the upstream producer service/queue
      - `end` tag: the downstream consumer service/queue
-  - `internal`: latency within the service. Measures time between _consume_ and the folllowing _produce_ operation.
+  - `internal`: latency within the service. Measures time between _consume_ and the following _produce_ operation.
 
 `start`
 : The name of the node where Data Streams Monitoring first detects the payload. This node can be a service (the original producer) or a queue (the original producer is not known to Data Streams Monitoring).


### PR DESCRIPTION
## [DOCS-14686] Spelling typo in Metrics and Tags doc

**Jira:** [DOCS-14686](https://datadoghq.atlassian.net//browse/DOCS-14686)

**Changes:** Fixed the triple-'l' typo in 'folllowing' → 'following' in the internal pathway_type description.

[DOCS-14686]: https://datadoghq.atlassian.net/browse/DOCS-14686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14686]: https://datadoghq.atlassian.net/browse/DOCS-14686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ