### PR TITLE
[codex] Add BYOC Logs v0.1.29 release note

### DIFF
--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -37,6 +37,19 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 ## Releases
 
+### v0.1.29 — 2026-06-05
+
+*Bundled in chart: `0.4.2`.*
+
+#### Changed
+- Faster execution for common log analysis queries, including 2x faster range queries, 1.6x faster cardinality aggregations, and up to 6x faster intersections with range queries.
+- Treats `field:*` filters as existence queries, and fixes sorting by percentile aggregations.
+- Reduced memory usage for Google Cloud Storage uploads to improve indexing stability.
+
+#### Helm chart changes
+- Enables BYOC service telemetry by default with `datadog.byocTelemetry.enabled`; this exports BYOC service logs and metrics only, not customer-ingested logs, metrics, or traces.
+- Deprecates and ignores `cloudprem.index.retention`, and no longer sets `CP_RETENTION_PERIOD`.
+
 ### v0.1.26 — 2026-05-05
 
 *Bundled in chart: `0.4.0`.*


### PR DESCRIPTION
## What changed

Adds the BYOC Logs v0.1.29 release note, including:

- benchmark-backed query performance improvements
- `field:*` existence-query behavior and percentile aggregation sorting fix
- GCS upload memory usage improvement
- Helm chart 0.4.2 changes for BYOC service telemetry and retention deprecation

## Why

Documents the public changes bundled with BYOC Logs v0.1.29 and Helm chart 0.4.2.

## Validation

- Ran `git diff --check` against the release note change.
- Compared the PR branch against `master`; only `content/en/byoc-logs/release_notes.md` is modified.