### PR TITLE
[FFL-2544] Add Flag Migration CLI guide

### DIFF
--- a/content/en/feature_flags/guide/_index.md
+++ b/content/en/feature_flags/guide/_index.md
@@ -12,7 +12,7 @@ cascade:
 
 {{< whatsnext desc="Feature Flags Guides:" >}}
     {{< nextlink href="/getting_started/feature_flags" >}}Getting started with Feature Flags{{< /nextlink >}}
-    {{< nextlink href="/feature_flags/guide/migrate_flags_with_cli" >}}Migrating Flags with the Flag Migration CLI{{< /nextlink >}}
+    {{< nextlink href="/feature_flags/guide/migrate_flags_with_cli" >}}Migrate Flags with the Flag Migration CLI{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/migrate_from_launchdarkly" >}}Migrate Your Feature Flags from LaunchDarkly{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/migrate_from_statsig" >}}Migrate Your Feature Flags from Statsig{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/headless_cms" >}}Integrate Feature Flags with a Headless CMS{{< /nextlink >}}

--- a/content/en/feature_flags/guide/_index.md
+++ b/content/en/feature_flags/guide/_index.md
@@ -12,6 +12,7 @@ cascade:
 
 {{< whatsnext desc="Feature Flags Guides:" >}}
     {{< nextlink href="/getting_started/feature_flags" >}}Getting started with Feature Flags{{< /nextlink >}}
+    {{< nextlink href="/feature_flags/guide/migrate_flags_with_cli" >}}Migrating Flags with the Flag Migration CLI{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/migrate_from_launchdarkly" >}}Migrate Your Feature Flags from LaunchDarkly{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/migrate_from_statsig" >}}Migrate Your Feature Flags from Statsig{{< /nextlink >}}
     {{< nextlink href="/feature_flags/guide/headless_cms" >}}Integrate Feature Flags with a Headless CMS{{< /nextlink >}}

--- a/content/en/feature_flags/guide/migrate_flags_with_cli.md
+++ b/content/en/feature_flags/guide/migrate_flags_with_cli.md
@@ -18,8 +18,8 @@ The [Datadog Flag Migration CLI][1] is a command-line tool that helps you migrat
 
 Before running the CLI, make sure your Datadog organization is set up:
 
-- **Users and Teams**: Datadog organization should be provisioned with the users and teams needed to manage flags.
-- **Feature Flag Environments**: Create the [feature flag environments][3] you plan to migrate into before running the CLI. The CLI does not create environments for you.
+- **Users and Teams**: Your Datadog organization should be provisioned with the users and teams needed to manage flags. The CLI does not create users or teams for you.
+- **Feature Flag Environments**: The [feature flag environments][3] you plan to migrate into should be created before running the CLI. The CLI does not create environments for you.
 
 For details on how the migration works and the providers it supports, see the [GitHub repository][1].
 

--- a/content/en/feature_flags/guide/migrate_flags_with_cli.md
+++ b/content/en/feature_flags/guide/migrate_flags_with_cli.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating Flags with the Flag Migration CLI
+title: Migrate Flags with the Flag Migration CLI
 description: Learn how to use the Datadog Flag Migration CLI to migrate feature flags from other providers to Datadog Feature Flags.
 further_reading:
 - link: "/feature_flags/"

--- a/content/en/feature_flags/guide/migrate_flags_with_cli.md
+++ b/content/en/feature_flags/guide/migrate_flags_with_cli.md
@@ -1,0 +1,42 @@
+---
+title: Migrating Flags with the Flag Migration CLI
+description: Learn how to use the Datadog Flag Migration CLI to migrate feature flags from other providers to Datadog Feature Flags.
+further_reading:
+- link: "/feature_flags/"
+  tag: "Documentation"
+  text: "Feature Flags Overview"
+- link: "/feature_flags/guide/migrate_from_launchdarkly"
+  tag: "Guide"
+  text: "Migrate Your Feature Flags from LaunchDarkly"
+---
+
+## Overview
+
+The [Datadog Flag Migration CLI][1] is a command-line tool that helps you migrate feature flags from other providers to [Datadog Feature Flags][2]. The CLI reads flag definitions from a source provider and recreates them in Datadog, preserving targeting rules, variations, and rollout configurations where possible.
+
+## Prerequisites
+
+Before running the CLI, make sure your Datadog organization is set up:
+
+- **Users and Teams**: Datadog organization should be provisioned with the users and teams needed to manage flags.
+- **Feature Flag Environments**: Create the [feature flag environments][3] you plan to migrate into before running the CLI. The CLI does not create environments for you.
+
+For details on how the migration works and the providers it supports, see the [GitHub repository][1].
+
+## Run the CLI
+
+Run the migration with `npx`:
+
+```bash
+npx @datadog/dd-flag-migration migrate
+```
+
+For full configuration options, supported source providers, authentication setup, and troubleshooting, see the [`dd-flag-migration` README on GitHub][1].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dd-flag-migration
+[2]: /feature_flags/
+[3]: /feature_flags/concepts/environments/

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -779,6 +779,14 @@ end
 
 <div class="alert alert-info">Datadog can help with migrating flags. Contact <a href="https://docs.datadoghq.com/help/">Support</a> for assistance.</div>
 
+You can recreate critical flags either manually or with the Datadog Flag Migration CLI.
+
+#### Option 1: Use the Flag Migration CLI
+
+The [Datadog Flag Migration CLI][13] automates the migration of flag definitions, targeting rules, and variations from LaunchDarkly to Datadog. See the [Migrating Flags with the Flag Migration CLI][14] guide to get started, or read the [`dd-flag-migration` README on GitHub][13] for full details.
+
+#### Option 2: Recreate flags manually
+
 1. In the Datadog UI, recreate the critical flags from LaunchDarkly by navigating to {{< ui >}}Software Delivery{{< /ui >}} > {{< ui >}}Feature Flags{{< /ui >}}.
 2. Ensure that the flag configurations - such as rollout percentages, targeting rules, and variations - are accurately replicated in the new service.
 3. For complex targeting rules, use the evaluation context attributes to implement equivalent logic.
@@ -804,3 +812,5 @@ end
 [10]: /feature_flags/client/react/
 [11]: /feature_flags/client/android/
 [12]: /feature_flags/client/ios/
+[13]: https://github.com/DataDog/dd-flag-migration
+[14]: /feature_flags/guide/migrate_flags_with_cli/

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -783,7 +783,7 @@ You can recreate critical flags either manually or with the Datadog Flag Migrati
 
 #### Option 1: Use the Flag Migration CLI
 
-The [Datadog Flag Migration CLI][13] automates the migration of flag definitions, targeting rules, and variations from LaunchDarkly to Datadog. See the [Migrating Flags with the Flag Migration CLI][14] guide to get started, or read the [`dd-flag-migration` README on GitHub][13] for full details.
+The [Datadog Flag Migration CLI][13] automates the migration of flag definitions, targeting rules, and variations from LaunchDarkly to Datadog. See [Migrate Flags with the Flag Migration CLI][14] to get started.
 
 #### Option 2: Recreate flags manually
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-FFL-2544

Adds a new lightweight guide, *Migrating Flags with the Flag Migration CLI*, under `/feature_flags/guide/`. The guide covers prerequisites (Users/Teams provisioning and Feature Flag Environments) and the `npx @datadog/dd-flag-migration migrate` command, and links out to the [dd-flag-migration GitHub repository](https://github.com/DataDog/dd-flag-migration) for full details.

Also updates the *Migrate Your Feature Flags from LaunchDarkly* guide to reference the new CLI as an option for recreating flags in Datadog.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes