### PR TITLE
Document LLMObs trace sampling controls for Python and Node.js SDKs

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -90,7 +90,7 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 
 `DD_LLMOBS_SAMPLE_RATE`
 : optional - _float_ - **default**: `1.0`
-<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans, so a trace is always kept or dropped as a whole. The decision is also propagated to downstream services, keeping distributed traces intact. This client-side sampling happens before ingestion and is independent of in-app controls such as [automation rules][2]. It does not affect [APM trace sampling][3], and APM sampling does not drop Agent Observability data.
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). This sampling is independent of in-app controls such as [automation rules][2] and [APM trace sampling][3].
 
 `DD_API_KEY`
 : optional - _string_
@@ -132,7 +132,7 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> NODE_OPTIONS="--import dd-trace/initialize.m
 
 `DD_LLMOBS_SAMPLE_RATE`
 : optional - _float_ - **default**: `1.0`
-<br />The proportion of traces to sample for Agent Observability, between `0.0` (drop everything) and `1.0` (keep everything). The sampling decision is computed once on the root span, inherited by all of its child spans, and propagated to downstream services, so a distributed trace is kept or dropped as a whole. Spans are always sent to Datadog, and the sampling decision is applied during ingestion. This is independent of in-app controls such as [automation rules][2], and does not affect [APM trace sampling][3].
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). This sampling is independent of in-app controls such as [automation rules][2] and [APM trace sampling][3].
 
 `DD_API_KEY`
 : optional - _string_
@@ -222,7 +222,7 @@ LLMObs.enable(
 
 `sample_rate`
 : optional - _float_
-<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans, so a trace is always kept or dropped as a whole. Values outside the `[0.0, 1.0]` range are ignored. This takes precedence over `DD_LLMOBS_SAMPLE_RATE`; if not provided, this defaults to the value of that environment variable (`1.0` if unset).
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). If unset, this defaults to `DD_LLMOBS_SAMPLE_RATE`, but otherwise takes precedence over the environment variable.
 
 `site`
 : optional - _string_
@@ -276,7 +276,7 @@ const llmobs = tracer.llmobs;
 
 `sampleRate`
 : optional - _number_
-<br />The proportion of traces to sample for Agent Observability, between `0` and `1` (inclusive). The sampling decision is computed once on the root span, inherited by all of its child spans, and propagated to downstream services, so a distributed trace is kept or dropped as a whole. This takes precedence over `DD_LLMOBS_SAMPLE_RATE`; if not provided, it defaults to the value of that environment variable (`1` if unset).
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). If unset, this defaults to `DD_LLMOBS_SAMPLE_RATE`, but otherwise takes precedence over the environment variable.
 
 **Options for general tracer configuration**:
 

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -88,11 +88,17 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
+`DD_LLMOBS_SAMPLE_RATE`
+: optional - _float_ - **default**: `1.0`
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans, so a trace is always kept or dropped as a whole. The decision is also propagated to downstream services, keeping distributed traces intact. This client-side sampling happens before ingestion and is independent of in-app controls such as [automation rules][2]. It does not affect [APM trace sampling][3], and APM sampling does not drop Agent Observability data.
+
 `DD_API_KEY`
 : optional - _string_
 <br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 [1]: /getting_started/tagging/unified_service_tagging?tab=kubernetes#non-containerized-environment
+[2]: /llm_observability/monitoring/automation_rules/
+[3]: /tracing/trace_pipeline/ingestion_mechanisms/
 {{% /tab %}}
 
 {{% tab "Node.js" %}}
@@ -207,6 +213,10 @@ LLMObs.enable(
 `agentless_enabled`
 : optional - _boolean_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
+
+`sample_rate`
+: optional - _float_
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans, so a trace is always kept or dropped as a whole. Values outside the `[0.0, 1.0]` range are ignored. This takes precedence over `DD_LLMOBS_SAMPLE_RATE`; if not provided, this defaults to the value of that environment variable (`1.0` if unset).
 
 `site`
 : optional - _string_

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -130,11 +130,17 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> NODE_OPTIONS="--import dd-trace/initialize.m
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
+`DD_LLMOBS_SAMPLE_RATE`
+: optional - _float_ - **default**: `1.0`
+<br />The proportion of traces to sample for Agent Observability, between `0.0` (drop everything) and `1.0` (keep everything). The sampling decision is computed once on the root span, inherited by all of its child spans, and propagated to downstream services, so a distributed trace is kept or dropped as a whole. Spans are always sent to Datadog, and the sampling decision is applied during ingestion. This is independent of in-app controls such as [automation rules][2], and does not affect [APM trace sampling][3].
+
 `DD_API_KEY`
 : optional - _string_
 <br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 [1]: /getting_started/tagging/unified_service_tagging?tab=kubernetes#non-containerized-environment
+[2]: /llm_observability/monitoring/automation_rules/
+[3]: /tracing/trace_pipeline/ingestion_mechanisms/
 {{% /tab %}}
 {{% tab "Java" %}}
 
@@ -267,6 +273,10 @@ const llmobs = tracer.llmobs;
 `agentlessEnabled`
 : optional - _boolean_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `true`. This configures the `dd-trace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
+
+`sampleRate`
+: optional - _number_
+<br />The proportion of traces to sample for Agent Observability, between `0` and `1` (inclusive). The sampling decision is computed once on the root span, inherited by all of its child spans, and propagated to downstream services, so a distributed trace is kept or dropped as a whole. This takes precedence over `DD_LLMOBS_SAMPLE_RATE`; if not provided, it defaults to the value of that environment variable (`1` if unset).
 
 **Options for general tracer configuration**:
 


### PR DESCRIPTION
## What

Documents Python and Node.js LLM Observability (Agent Observability) trace sampling controls in the SDK reference (`instrumentation/sdk.md`):

**Python:**
- **`DD_LLMOBS_SAMPLE_RATE`** environment variable — added to the Python *command-line setup* env-var list (float `0.0`–`1.0`, default `1.0`).
- **`sample_rate`** parameter on `LLMObs.enable()` — added to the Python *in-code setup* parameters, following [dd-trace-py#18607](https://github.com/DataDog/dd-trace-py/pull/18607). Documents precedence (`sample_rate` arg > `DD_LLMOBS_SAMPLE_RATE` > default `1.0`) and that out-of-range values are ignored.

**Node.js** (assumes [dd-trace-js#9030](https://github.com/DataDog/dd-trace-js/pull/9030) merges):
- **`DD_LLMOBS_SAMPLE_RATE`** environment variable — added to the Node.js *command-line setup* env-var list (float, default `1.0`).
- **`sampleRate`** parameter under `llmobs` in `tracer.init({ llmobs: { sampleRate } })` — added to the Node.js *in-code setup* parameters. Documents precedence (`sampleRate` > `DD_LLMOBS_SAMPLE_RATE` > default `1`).

In the Node.js SDK the keep/drop decision is computed once on the root span, inherited by descendants, and propagated across services via `x-datadog-tags`; spans are always shipped and the decision is applied during ingestion.

## Why

Neither control was documented anywhere in `content/en/llm_observability/`. The existing docs only cover server-side/UI sampling (automation rules, annotation queues, datasets, custom judges), so there was no reference for client-side, pre-ingestion trace sampling in the SDK.

## Scope notes

- **Python and Node.js.** Java does not expose these controls, so its tabs are intentionally untouched.
- No retention/limits content added — this PR is scoped to sampling mechanisms only.
- Cross-links to automation rules and APM ingestion mechanisms; both targets verified to exist.

Claude session: \`8bc9e12c-8440-4689-a2dc-e2f1f1ad66ae\`
Resume: \`claude --resume 8bc9e12c-8440-4689-a2dc-e2f1f1ad66ae\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
