### PR TITLE
[DOCS] Add Enterprise plan note to Dynamic by Metric allocation method

### DIFF
--- a/content/en/cloud_cost_management/allocation/custom_allocation_rules.md
+++ b/content/en/cloud_cost_management/allocation/custom_allocation_rules.md
@@ -91,6 +91,8 @@ You can also specify how cost proportions should be partitioned to ensure segmen
 
 {{% tab "Dynamic by metric" %}}
 
+<div class="alert alert-info">The Dynamic by Metric allocation method requires a CCM Enterprise plan.</div>
+
 {{< img src="cloud_cost/custom_allocation_rules/dynamic_diagram.png" alt="Diagram illustrating the dynamic by metric strategy" style="width:70%;" >}}
 
 Metrics-based allocation provides the ability to split up costs based on Datadog's [metrics queries][1]. By using performance metrics to allocate expenses, you can more accurately allocate costs based on application usage patterns.

--- a/content/en/cloud_cost_management/allocation/custom_allocation_rules.md
+++ b/content/en/cloud_cost_management/allocation/custom_allocation_rules.md
@@ -91,7 +91,7 @@ You can also specify how cost proportions should be partitioned to ensure segmen
 
 {{% tab "Dynamic by metric" %}}
 
-<div class="alert alert-info">The Dynamic by Metric allocation method requires a CCM Enterprise plan.</div>
+<div class="alert alert-info">The Dynamic by Metric allocation method requires a <a href="https://www.datadoghq.com/pricing/?product=cloud-cost-management#products">CCM Enterprise plan</a>.</div>
 
 {{< img src="cloud_cost/custom_allocation_rules/dynamic_diagram.png" alt="Diagram illustrating the dynamic by metric strategy" style="width:70%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a callout to the Dynamic by Metric tab in the Custom Allocation Rules page clarifying that this allocation method requires a CCM Enterprise plan.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
**Based on this conversation**

<img width="1732" height="1344" alt="image" src="https://github.com/user-attachments/assets/3c3db8e9-3cdc-4078-a490-bce636a3b454" />

**Preview:**
<img width="888" height="655" alt="image" src="https://github.com/user-attachments/assets/e1faf0b1-5c56-469b-b75d-d33216801d6f" />

