### PR TITLE
Add copy button to hard-coded API docs

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -12,6 +12,11 @@ $ddpurple: #632ca6;
         font-size: 16px;
         text-decoration: none;
         border-bottom: none;
+
+        &:hover {
+            text-decoration: none;
+            border-bottom: none;
+        }
     }
 
     .copy-btn-icon-wrapper {

--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -42,6 +42,12 @@ $ddpurple: #632ca6;
     margin-bottom: 0.75rem;
 }
 
+// Hardcoded Overview pages (Using the API, Authorization Scopes, Rate Limits, API Reference):
+// the copy button sits on its own line, flush right, above the page content.
+.api-hardcoded-header {
+    margin-bottom: -1rem;
+}
+
 .announcement.api {
     .main-api {
         h2 {

--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -42,12 +42,6 @@ $ddpurple: #632ca6;
     margin-bottom: 0.75rem;
 }
 
-// Hardcoded Overview pages (Using the API, Authorization Scopes, Rate Limits, API Reference):
-// the copy button sits on its own line, flush right, above the page content.
-.api-hardcoded-header {
-    margin-bottom: -1rem;
-}
-
 .announcement.api {
     .main-api {
         h2 {

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -23,7 +23,7 @@ algolia:
   tags: ['api']
 ---
 
-{{< h2 >}}API Reference{{< /h2 >}}
+{{< h2-with-copy-btn >}}API Reference{{< /h2-with-copy-btn >}}
 
 The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call the API, uses status codes to indicate the success or failure of requests, returns JSON from all requests, and uses standard HTTP response codes. Use the Datadog API to access the Datadog platform programmatically.
 

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -3,7 +3,7 @@ title: Rate Limits
 type: api
 ---
 
-{{< h2 >}}Rate Limits{{< /h2 >}}
+{{< h2-with-copy-btn >}}Rate Limits{{< /h2-with-copy-btn >}}
 
 Many API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 

--- a/content/en/api/latest/scopes/_index.md
+++ b/content/en/api/latest/scopes/_index.md
@@ -3,7 +3,7 @@ title: Authorization Scopes
 type: api
 disable_sidebar: true
 ---
-## Authorization scopes for OAuth clients
+{{< h2-with-copy-btn >}}Authorization scopes for OAuth clients{{< /h2-with-copy-btn >}}
 
 Scopes are an authorization mechanism that allow you to limit and define the specific access applications have to an organization's Datadog data. When authorized to access data on behalf of a user or service account, applications can only access the information explicitly permitted by their assigned scopes.
 

--- a/content/en/api/latest/using-the-api/_index.md
+++ b/content/en/api/latest/using-the-api/_index.md
@@ -3,7 +3,7 @@ title: Using the API
 type: api
 ---
 
-{{< h2 >}}Using the API{{< /h2 >}}
+{{< h2-with-copy-btn >}}Using the API{{< /h2-with-copy-btn >}}
 
 Use the Datadog HTTP API to access the Datadog platform programmatically. You can use the API to send data to Datadog, build data visualizations, and manage your account.
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -4,10 +4,22 @@
 
     {{ with .Content}}
        <div class="col-12 {{if ne $dot.RelPermalink "/api/latest/scopes/"}}col-lg-9{{ end }} ps-0">
-        <div class="api-hardcoded-header d-flex justify-content-end">
-          {{ partial "api/api-copy-btn.html" $dot }}
-        </div>
-        {{ . }}
+        <!-- Hardcoded Overview pages bake their heading into the content; lift the first
+             heading out so the copy button can sit beside it, matching generated pages. -->
+        {{ $re := `(?s)<h2[^>]*>.*?</h2>` }}
+        {{ $heading := index (findRE $re . 1) 0 }}
+        {{ with $heading }}
+          <div class="api-intro-header d-flex flex-wrap align-items-start justify-content-between">
+            {{ . | safeHTML }}
+            {{ partial "api/api-copy-btn.html" $dot }}
+          </div>
+          {{ replaceRE $re "" $dot.Content 1 | safeHTML }}
+        {{ else }}
+          <div class="d-flex justify-content-end">
+            {{ partial "api/api-copy-btn.html" $dot }}
+          </div>
+          {{ . }}
+        {{ end }}
        </div>
     {{ end }}
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -4,22 +4,7 @@
 
     {{ with .Content}}
        <div class="col-12 {{if ne $dot.RelPermalink "/api/latest/scopes/"}}col-lg-9{{ end }} ps-0">
-        <!-- Hardcoded Overview pages bake their heading into the content; lift the first
-             heading out so the copy button can sit beside it, matching generated pages. -->
-        {{ $re := `(?s)<h2[^>]*>.*?</h2>` }}
-        {{ $heading := index (findRE $re . 1) 0 }}
-        {{ with $heading }}
-          <div class="api-intro-header d-flex flex-wrap align-items-start justify-content-between">
-            {{ . | safeHTML }}
-            {{ partial "api/api-copy-btn.html" $dot }}
-          </div>
-          {{ replaceRE $re "" $dot.Content 1 | safeHTML }}
-        {{ else }}
-          <div class="d-flex justify-content-end">
-            {{ partial "api/api-copy-btn.html" $dot }}
-          </div>
-          {{ . }}
-        {{ end }}
+        {{ . }}
        </div>
     {{ end }}
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -4,6 +4,9 @@
 
     {{ with .Content}}
        <div class="col-12 {{if ne $dot.RelPermalink "/api/latest/scopes/"}}col-lg-9{{ end }} ps-0">
+        <div class="api-hardcoded-header d-flex justify-content-end">
+          {{ partial "api/api-copy-btn.html" $dot }}
+        </div>
         {{ . }}
        </div>
     {{ end }}

--- a/layouts/shortcodes/h2-with-copy-btn.html
+++ b/layouts/shortcodes/h2-with-copy-btn.html
@@ -1,0 +1,16 @@
+{{- /*
+  Page-title heading for hardcoded API Overview pages (Using the API,
+  Authorization Scopes, Rate Limits, API Reference). Renders the same anchored
+  <h2> as the h2 shortcode, paired with the page Copy button so the two sit
+  together — mirroring the layout of the generated API pages.
+
+  Use once per page, for the top heading only: it emits the #page-copy-btn
+  element, so a second use would duplicate that id.
+*/ -}}
+{{ $anchorized := anchorize .Inner }}
+<div class="api-intro-header d-flex flex-wrap align-items-start justify-content-between">
+  <h2 id="{{ $anchorized }}">
+    <a href="#{{ $anchorized }}">{{ .Inner }}</a>
+  </h2>
+  {{ partial "api/api-copy-btn.html" .Page }}
+</div>

--- a/layouts/shortcodes/h2-with-copy-btn.html
+++ b/layouts/shortcodes/h2-with-copy-btn.html
@@ -1,6 +1,5 @@
 {{- /*
-  Page-title heading for hardcoded API Overview pages (Using the API,
-  Authorization Scopes, Rate Limits, API Reference). Renders the same anchored
+  Page-title heading for hardcoded API Overview pages. Renders the same anchored
   <h2> as the h2 shortcode, paired with the page Copy button so the two sit
   together — mirroring the layout of the generated API pages.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

Adds a button to the hard-coded (non-generated) API docs. There are only four pages like this, all in the Overview section ([example](https://docs-staging.datadoghq.com/jen.gilbert/hardcoded-api-docs-copy/api/latest/using-the-api/)).

Note that CORS errors are expected in staging, since there is no staging plaintext build, so the Copy button fails over to the HTML scrape. But you can see that the URL of the failed request does exist (for example, `https://docs.datadoghq.com/api/latest.md`), so it would work fine in prod, where the request would be coming from the same origin (`docs.datadoghq.com`).

Also removes an unwanted underline on hover, the CSS just wasn't fleshed out enough on the original button.

If you're the docs reviewer, not much for you to do here, feel free to stamp it. I can seek CorpWeb approval myself, don't worry about escalating it for me.

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
