### PR TITLE
[DOCS-14870] Remove TODO comments from serverless OTLP ingest page

### DIFF
--- a/content/en/opentelemetry/setup/otlp_ingest/serverless.md
+++ b/content/en/opentelemetry/setup/otlp_ingest/serverless.md
@@ -79,8 +79,6 @@ The ADOT layer handles resource attribute detection automatically. If you are no
 export OTEL_RESOURCE_ATTRIBUTES="cloud.provider=aws,faas.id=arn:aws:lambda:us-east-1:123456789012:function:my-function"
 ```
 
-<!-- TODO: Eng to confirm whether backend accepts cloud.resource_id (faas.id is deprecated in OTel semconv). -->
-
 | Attribute | Required | Description |
 |---|---|---|
 | `cloud.provider` | Yes | Set to `aws` |
@@ -165,8 +163,6 @@ export OTEL_RESOURCE_ATTRIBUTES="cloud.provider=azure,cloud.platform=azure.funct
 ```
 
 ### Resource attributes reference
-
-<!-- TODO: Confirm whether Azure Functions cloud.resource_id should identify the specific function, not just the function app. -->
 
 | Platform | `cloud.provider` | `cloud.platform` | `cloud.resource_id` |
 |---|---|---|---|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #37395. Removes two `<!-- TODO -->` HTML comments from the serverless OTLP ingest page so they don't ship in the public repo source. The open questions they tracked (backend `cloud.resource_id` acceptance, and whether the Azure Functions `cloud.resource_id` should identify the specific function) remain tracked as engineering follow-ups.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes