### PR TITLE
Add OpenLineage integration to AWS Glue Jobs Monitoring docs

### DIFF
--- a/content/en/data_observability/jobs_monitoring/glue.md
+++ b/content/en/data_observability/jobs_monitoring/glue.md
@@ -108,13 +108,13 @@ This helps ensure the logs are searchable and available under the {{< ui >}}Glue
 Enable the [Glue Integration][4] tile for Glue metrics collection.
 Metrics should be available under the {{< ui >}}Glue{{< /ui >}} job tab in **Data Observability: Jobs Monitoring**.
 
-## (Optional) Enable OpenLineage for dataset lineage
+## (Optional) Enable dataset lineage
 
 Glue jobs that run with the Spark engine can emit OpenLineage events directly to Datadog. This provides dataset-level lineage, showing which datasets your job reads and writes.
 
 **Note**: AWS Glue includes the Spark OpenLineage connector in its default class path. To use a more recent version, add the connector JAR manually through the `--extra-jars` Glue job parameter and set `--user-jars-first=true` to override the bundled version.
 
-### Configure Spark
+### Configure the SparkSession
 
 In your Glue job script, configure the `SparkSession` with the following settings:
 

--- a/content/en/data_observability/jobs_monitoring/glue.md
+++ b/content/en/data_observability/jobs_monitoring/glue.md
@@ -108,6 +108,34 @@ This helps ensure the logs are searchable and available under the {{< ui >}}Glue
 Enable the [Glue Integration][4] tile for Glue metrics collection.
 Metrics should be available under the {{< ui >}}Glue{{< /ui >}} job tab in **Data Observability: Jobs Monitoring**.
 
+## (Optional) Enable OpenLineage for dataset lineage
+
+Glue jobs that run with the Spark engine can emit OpenLineage events directly to Datadog. This provides dataset-level lineage, showing which datasets your job reads and writes.
+
+**Note**: AWS Glue includes the Spark OpenLineage connector in its default class path. To use a more recent version, add the connector JAR manually through the `--extra-jars` Glue job parameter and set `--user-jars-first=true` to override the bundled version.
+
+### Configure Spark
+
+In your Glue job script, configure the `SparkSession` with the following settings:
+
+```python
+spark = SparkSession.builder \
+    .config("spark.extraListeners", "io.openlineage.spark.agent.OpenLineageSparkListener") \
+    .config("spark.openlineage.transport.type", "http") \
+    .config("spark.openlineage.transport.url", "https://data-obs-intake.datadoghq.com") \
+    .config("spark.openlineage.transport.auth.type", "api_key") \
+    .config("spark.openlineage.transport.auth.apiKey", "<DATADOG_API_KEY>") \
+    .config("spark.redaction.regex", "(?i)secret|password|token|access[.]key|apikey") \
+    .config("spark.openlineage.capturedProperties", "spark.glue.JOB_RUN_ID") \
+    .getOrCreate()
+```
+
+Replace `<DATADOG_API_KEY>` with your Datadog API key.
+
+### Validate
+
+After enabling OpenLineage, open a job run in [Data Observability: Jobs Monitoring][6]. In the flame graph, additional spans such as `spark.application` or `spark.sql_job` should appear. The payloads of these spans should be helpful when debugging dataset extraction.
+
 ## Next steps
 
 The crawler runs every few minutes.

--- a/content/en/data_observability/jobs_monitoring/glue.md
+++ b/content/en/data_observability/jobs_monitoring/glue.md
@@ -122,7 +122,7 @@ In your Glue job script, configure the `SparkSession` with the following setting
 spark = SparkSession.builder \
     .config("spark.extraListeners", "io.openlineage.spark.agent.OpenLineageSparkListener") \
     .config("spark.openlineage.transport.type", "http") \
-    .config("spark.openlineage.transport.url", "https://data-obs-intake.datadoghq.com") \
+    .config("spark.openlineage.transport.url", "<DD_DATA_OBSERVABILITY_INTAKE>") \
     .config("spark.openlineage.transport.auth.type", "api_key") \
     .config("spark.openlineage.transport.auth.apiKey", "<DATADOG_API_KEY>") \
     .config("spark.redaction.regex", "(?i)secret|password|token|access[.]key|apikey") \
@@ -130,7 +130,7 @@ spark = SparkSession.builder \
     .getOrCreate()
 ```
 
-Replace `<DATADOG_API_KEY>` with your Datadog API key.
+Replace `<DD_DATA_OBSERVABILITY_INTAKE>` with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}. Replace `<DATADOG_API_KEY>` with your Datadog API key.
 
 ### Validate
 

--- a/content/en/data_observability/jobs_monitoring/glue.md
+++ b/content/en/data_observability/jobs_monitoring/glue.md
@@ -112,7 +112,7 @@ Metrics should be available under the {{< ui >}}Glue{{< /ui >}} job tab in **Dat
 
 Glue jobs that run with the Spark engine can emit OpenLineage events directly to Datadog. This provides dataset-level lineage, showing which datasets your job reads and writes.
 
-**Note**: AWS Glue includes the Spark OpenLineage connector in its default class path. To use a more recent version, add the connector JAR manually through the `--extra-jars` Glue job parameter and set `--user-jars-first=true` to override the bundled version.
+**Note**: AWS Glue includes the Spark OpenLineage connector in its default class path. To use a more recent version, add the connector JAR manually through the `--extra-jars` Glue job parameter and set `--user-jars-first=true` to override the bundled version. For example: `--extra-jars s3://<YOUR_BUCKET>/openlineage-spark-<VERSION>.jar` and `--user-jars-first true`.
 
 ### Configure the SparkSession
 
@@ -130,7 +130,7 @@ spark = SparkSession.builder \
     .getOrCreate()
 ```
 
-Replace `<DD_DATA_OBSERVABILITY_INTAKE>` with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}. Replace `<DATADOG_API_KEY>` with your Datadog API key.
+Replace `<DD_DATA_OBSERVABILITY_INTAKE>` with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}. Replace `<DATADOG_API_KEY>` with your Datadog API key. `spark.glue.JOB_RUN_ID` is the Spark configuration property automatically set by AWS Glue with the current job run ID — use it verbatim.
 
 ### Validate
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds an optional section to the AWS Glue Jobs Monitoring page documenting how to enable OpenLineage event emission from Spark-based Glue jobs to Datadog.

The new section covers:
- Spark `SparkSession` configuration required to emit OpenLineage events
- A note that the OpenLineage connector is bundled in Glue's default class path, with instructions for overriding it with a newer version via `--extra-jars` and `--user-jars-first=true`
- Validation steps: checking for `spark.application` / `spark.sql_job` spans in the Data Jobs flame graph

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes