### PR TITLE
docs(security): document base date option for CVE-based due date rules

### DIFF
--- a/content/en/security/automation_pipelines/set_due_date.md
+++ b/content/en/security/automation_pipelines/set_due_date.md
@@ -39,7 +39,7 @@ Configure due date rules to ensure findings are addressed within your specified 
       - API Security
     - **Any of these tags or attributes**: The resource tags or attributes that must match for the rule to apply.
 1. Set a due date for each severity level that needs one.
-1. If the rule includes a CVE-based finding type (Library, Container Image, or Host vulnerability), select the **base date** for the SLA clock:
+1. If the rule includes a CVE-based finding type (Library, Container Image, or Host vulnerability), under **Calculate due dates from**, select the base date for the SLA clock:
    - **First Seen Date**: Starts the SLA clock when Datadog first detects the finding.
    - **Fix-Available Date**: Starts the SLA clock when a patch is published for the vulnerability. Useful when you don't want teams to breach SLA on advisories they can't yet remediate.
 

--- a/content/en/security/automation_pipelines/set_due_date.md
+++ b/content/en/security/automation_pipelines/set_due_date.md
@@ -38,7 +38,12 @@ Configure due date rules to ensure findings are addressed within your specified 
       - Identity Risk
       - API Security
     - **Any of these tags or attributes**: The resource tags or attributes that must match for the rule to apply.
-1. Set a due date for each severity level that needs one. The due date starts from when the matching finding was discovered, not when the rule was created.
+1. Set a due date for each severity level that needs one.
+1. If the rule includes a CVE-based finding type (Library, Container Image, or Host vulnerability), select the **base date** for the SLA clock:
+   - **First Seen Date**: Starts the SLA clock when Datadog first detects the finding.
+   - **Fix-Available Date**: Starts the SLA clock when a patch is published for the vulnerability. Useful when you don't want teams to breach SLA on advisories they can't yet remediate.
+
+   For all other finding types, First Seen Date is always used.
 1. Click **Save**. The rule applies to new findings immediately and starts checking existing findings within the next hour.
 
 ## Where due dates appear


### PR DESCRIPTION
## What does this PR do?

Updates the [Set Due Date Rules](https://docs.datadoghq.com/security/automation_pipelines/set_due_date/) documentation to explain the new base date option available when configuring due date rules that target CVE-based finding types.

## Motivation

A new UI toggle lets users choose between **First Seen Date** and **Fix-Available Date** as the SLA start point. This option only appears when the rule includes Library, Container Image, or Host vulnerability finding types. Without documentation, users may not understand what the toggle does or why it is sometimes absent.

## Changes

- Split step 4 of "Create a due date rule" into two steps: one for setting durations per severity, and one for selecting the base date.
- Describes both options (**First Seen Date** and **Fix-Available Date**) and when each is appropriate.
- Notes that the option only appears for CVE-based finding types, and that First Seen Date is always used for all other types.

## Reviewer notes

No structural changes — this is a pure content addition to a single markdown file.