### PR TITLE
[CASCL-1493] change autoscaling profile values and descriptions

### DIFF
--- a/content/en/containers/autoscaling/_index.md
+++ b/content/en/containers/autoscaling/_index.md
@@ -232,8 +232,8 @@ There are three ways to enable autoscaling for a workload. Pick the path that ma
 The fastest way to get started is the [Setup page][11] in the Datadog UI. The wizard walks you through five steps: select a cluster, verify Agent and permission requirements, choose an install method, pick a scaling template, and deploy. Templates available in the wizard:
 
 - **Optimize cost**: high CPU utilization target, aggressive scale-down, lowest replica floor. Best for stateless, cost-sensitive workloads.
-- **Optimize balance**: moderate utilization target, balanced scale-up and scale-down. Best for most stateless workloads.
-- **Optimize performance**: conservative utilization target, slow scale-down, higher replica floor. Best for stateful or critical services.
+- **Optimize balance**: moderate utilization target, fast scale-up, balanced scale-down. Best for most stateless workloads.
+- **Optimize performance**: conservative utilization target, fast scale-up, slow scale-down, higher replica floor. Best for stateful or critical services.
 - **Customize**: start from any of the above and tune CPU target, replicas, and stabilization windows yourself.
 
 The Setup wizard is best for trying autoscaling on a single workload, getting hands-on with a recommendation, or onboarding a small set of workloads. (Requires `Workload Scaling Write` and `Autoscaling Manage` permissions.)
@@ -282,7 +282,7 @@ spec:
                 - periodSeconds: 120
                   type: Percent
                   value: 50
-            stabilizationWindowSeconds: 300
+            stabilizationWindowSeconds: 190
         update:
             strategy: Auto
     constraints:
@@ -302,7 +302,7 @@ spec:
 {{% /tab %}}
 {{% tab "Optimize Balance" %}}
 
-Pick this template when you want savings without trading off availability. It's a sensible default for most stateless workloads. The defining setting is the moderate CPU utilization target (70%) paired with a conservative scale-down (20% every 20 minutes) and a two-replica minimum. The controller adds capacity rapidly but removes it slowly.
+Pick this template when you want savings without trading off availability. It's a sensible default for most stateless workloads. The defining setting is the moderate CPU utilization target (70%) paired with a conservative scale-down and a two-replica minimum. The controller adds capacity rapidly but removes it slowly.
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha2
@@ -330,7 +330,7 @@ spec:
                 - periodSeconds: 120
                   type: Percent
                   value: 50
-            stabilizationWindowSeconds: 600
+            stabilizationWindowSeconds: 130
         update:
             strategy: Auto
     constraints:
@@ -417,7 +417,7 @@ spec:
                 - periodSeconds: 120
                   type: Percent
                   value: 50
-            stabilizationWindowSeconds: 600
+            stabilizationWindowSeconds: 130
         # Vertical updates disabled — horizontal only
         update:
             strategy: Disabled
@@ -472,9 +472,9 @@ The Cluster Agent ships three built-in profiles and recreates them on startup, s
 
 | Profile | CPU target | Min replicas | Profile of behavior |
 |---|---|---|---|
-| `datadog-optimize-cost` | 85% | 1 | Stateless, cost-sensitive workloads. Fast scale-up and scale-down (5-minute stabilization windows, 50% step every 2 minutes). |
-| `datadog-optimize-balance` | 70% | 2 | Default for most stateless workloads. Balanced 10-minute stabilization windows, conservative scale-down (20% step every 20 minutes). |
-| `datadog-optimize-performance` | 60% | 3 | Stateful or latency-sensitive workloads. Very conservative scale-down (15-minute stabilization windows, 10% step every 30 minutes). |
+| `datadog-optimize-cost` | 85% | 1 | High CPU utilization target, aggressive scale-down, lowest replica floor. Best for stateless, cost-sensitive workloads. |
+| `datadog-optimize-balance` | 70% | 2 | Moderate utilization target, fast scale-up, balanced scale-down. Best for most stateless workloads. |
+| `datadog-optimize-performance` | 60% | 3 | Conservative utilization target, fast scale-up, slow scale-down, higher replica floor. Best for stateful or critical services. |
 
 To activate a profile on a single workload, add the label to the workload's `metadata.labels`:
 
@@ -515,7 +515,7 @@ spec:
     applyPolicy:
       mode: Apply
       scaleUp:
-        stabilizationWindowSeconds: 300
+        stabilizationWindowSeconds: 190
         rules:
           - type: Percent
             value: 50

--- a/content/en/containers/guide/manage-datadogpodautoscaler-with-argocd.md
+++ b/content/en/containers/guide/manage-datadogpodautoscaler-with-argocd.md
@@ -287,7 +287,7 @@ autoscaler:
       - type: Percent
         value: 50
         periodSeconds: 120
-    stabilizationWindowSeconds: 600
+    stabilizationWindowSeconds: 130
     strategy: Max
   scaleDown:
     rules:

--- a/content/en/containers/guide/manage-datdadogpodautoscaler-with-terraform.md
+++ b/content/en/containers/guide/manage-datdadogpodautoscaler-with-terraform.md
@@ -318,7 +318,7 @@ resource "kubernetes_manifest" "datadogpodautoscaler_nginx_dka_demo_nginx" {
               "value" = 50
             },
           ]
-          "stabilizationWindowSeconds" = 600
+          "stabilizationWindowSeconds" = 130
           "strategy" = "Max"
         }
         "update" = {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Update DPA preset scale-up stabilization window values and profile descriptions to match the new defaults that we agreed upon in this [document](https://datadoghq.atlassian.net/wiki/spaces/CAUT/pages/6858016173/Staabilization+Window+Change+Proposal+for+DPA+Presets+New+Scale-Up+Times).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
