### PR TITLE
Rename Debug with Bits to Bits Live Debugger

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4697,9 +4697,9 @@ menu:
       identifier: live_debugger
       parent: tracing
       weight: 12
-    - name: Debug with Bits
-      url: tracing/live_debugger/debug-with-bits/
-      identifier: live_debugger_debug_with_bits
+    - name: Bits Live Debugger
+      url: tracing/live_debugger/bits-live-debugger/
+      identifier: live_debugger_bits_live_debugger
       parent: live_debugger
       weight: 1
     - name: Error Tracking

--- a/content/en/tracing/live_debugger/_index.md
+++ b/content/en/tracing/live_debugger/_index.md
@@ -148,9 +148,9 @@ Live Debugger data might contain sensitive information, especially when using th
 1. Use the built-in [sensitive data scrubbing][1] mechanisms.
 2. Use [Sensitive Data Scanner][17] to identify and redact sensitive information based on regular expressions.
 
-### Debug with Bits
+### Bits Live Debugger
 
-[Debug with Bits][23] lets you investigate a running service by describing the issue in plain language. Bits Code handles logpoint placement, captures variable snapshots, and helps interpret the results.
+[Bits Live Debugger][23] lets you investigate a running service by describing the issue in plain language. Bits Code handles logpoint placement, captures variable snapshots, and helps interpret the results.
 
 ## Impact on performance and billing
 
@@ -195,4 +195,4 @@ The following constraints apply to Live Debugger usage and configuration:
 [20]: /tracing/code_origin
 [21]: /account_management/rbac/permissions#apm
 [22]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/go
-[23]: /tracing/live_debugger/debug-with-bits/
+[23]: /tracing/live_debugger/bits-live-debugger/

--- a/content/en/tracing/live_debugger/bits-live-debugger.md
+++ b/content/en/tracing/live_debugger/bits-live-debugger.md
@@ -1,6 +1,8 @@
 ---
-title: Debug with Bits
+title: Bits Live Debugger
 description: Use Bits Code to create and manage Live Debugger sessions through a conversational interface.
+aliases:
+- /tracing/live_debugger/debug-with-bits/
 further_reading:
 - link: "/bits_ai/bits_ai_dev_agent/"
   tag: "Documentation"
@@ -14,22 +16,22 @@ further_reading:
 ---
 
 {{< beta-callout url="https://www.datadoghq.com/product-preview/debug-with-bits/" >}}
-Debug with Bits is in Preview. Request access to join the waiting list.
+Bits Live Debugger is in Preview. Request access to join the waiting list.
 {{< /beta-callout >}}
 
 ## Overview
 
-Debug with Bits brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate, and Bits places logpoints, retrieves variable snapshots, and interprets results. After Bits identifies a root cause, it can suggest code fixes.
+Bits Live Debugger brings a conversational interface to Live Debugger for investigating running services through natural language. Describe what you want to investigate, and Bits places logpoints, retrieves variable snapshots, and interprets results. After Bits identifies a root cause, it can suggest code fixes.
 
 All debugging activity runs through [Live Debugger][1], so the same [permissions][2], rate limits, auto-expiry behavior, and [sensitive data scrubbing][3] apply.
 
 <div class="alert alert-info">
-Debug with Bits uses <a href="/bits_ai/bits_ai_dev_agent/">Bits Code</a>, which may impact billing.
+Bits Live Debugger uses <a href="/bits_ai/bits_ai_dev_agent/">Bits Code</a>, which may impact billing.
 </div>
 
 ## Prerequisites
 
-Before using Debug with Bits:
+Before using Bits Live Debugger:
 
 - [Live Debugger][1] must be enabled for the target service. See [Requirements and setup][7] for details.
 - Your account must have the [permissions][2] required to use Live Debugger, including read, write, and variable-capture permissions for the target environment.
@@ -53,7 +55,7 @@ Logpoints created by Bits follow the same rules as manually created logpoints. T
 ## Start a debugging session
 
 1. Go to [Live Debugger][4] in Datadog.
-1. In the Debug with Bits chatbox, describe the issue you want to investigate. Select the target service and environment before submitting the prompt.
+1. In the Bits Live Debugger chatbox, describe the issue you want to investigate. Select the target service and environment before submitting the prompt.
 
    Bits then works through the investigation automatically:
    - It analyzes relevant code paths in the connected source code repository and may ask follow-up questions to form a hypothesis.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Renames the "Debug with Bits" feature to "Bits Live Debugger" across the Live Debugger documentation.

- Renames the page (`debug-with-bits.md` -> `bits-live-debugger.md`) and adds an alias from the old URL so existing links keep working.
- Updates the page title, navigation entry, section heading, and all in-page references.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

The external `datadoghq.com/product-preview/debug-with-bits/` marketing URL is left unchanged, since it is not controlled by this repository.
