### PR TITLE
Remove preview banner from Fleet Automation integration configuration

### DIFF
--- a/content/en/agent/fleet_automation/configure_integrations.md
+++ b/content/en/agent/fleet_automation/configure_integrations.md
@@ -14,10 +14,6 @@ further_reading:
 site-support-id: fleet-automation-standard-features  
 ---
 
-{{< callout btn_hidden="true" header="Join the Preview!" >}}
-Remote integration configuration is in Preview.
-{{< /callout >}}
-
 Fleet Automation can deploy, update, and remove [integration][1] configuration files (`conf.d`) on your Agents remotely. Select target Agents by host or tag, choose an integration, and Fleet Automation pushes the configuration change across your fleet.
 
 ## Prerequisites


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Configuring Agent integrations via Fleet Automation is now GA, so removing the preview banner.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

### AI assistance

None

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
