### PR TITLE
Add data-observability toolset to MCP Server docs

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -677,6 +677,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `cases`: Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues
 - `cost`: Tools for [Cloud Cost Management][63], including listing cost-saving recommendations ranked by estimated potential daily savings
 - `dashboards`: Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation
+- `data-observability`: Tools for [Data Observability][69], including searching data entities, navigating data lineage, monitoring data quality, analyzing Spark and Databricks jobs, and managing entity metadata
 - `dbm`: Tools for interacting with [Database Monitoring][33]
 - `ddsql`: Tools for querying Datadog data using [DDSQL][44], a SQL dialect with support for infrastructure resources, logs, metrics, RUM, spans, and other Datadog data sources
 - `error-tracking`: Tools for interacting with Datadog [Error Tracking][32]
@@ -939,3 +940,4 @@ Local authentication is recommended for Cline and when remote authentication is 
 [66]: /account_management/personal-access-tokens/
 [67]: /account_management/service-access-tokens/
 [68]: /account_management/org_settings/ip_allowlist/
+[69]: /data_observability/

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -576,7 +576,7 @@ Fetches full details and attributes for one or more data entities by their entit
 ### `get_data_entity_hierarchy`
 *Toolset: **data-observability***\
 *Permissions Required: `Monitors Read` or `APM Read`*\
-Fetches the containment hierarchy (ancestors and descendants) for one or more entities. Use this for containment navigation—for example, finding which schema and database a table belongs to, or listing the columns in a table. Not for data lineage (use `get_data_entity_lineage` for that).
+Fetches the containment hierarchy (ancestors and descendants) for one or more entities. Use this for containment navigation, such as finding which schema and database a table belongs to, or listing the columns in a table. This tool is for containment, not data lineage (use `get_data_entity_lineage` for lineage).
 
 - What schema and database does this table belong to?
 - List all columns in the `orders` table.
@@ -594,7 +594,7 @@ Fetches the live reachable lineage subgraph from one or more anchor entities. Re
 ### `summarize_data_entity_lineage`
 *Toolset: **data-observability***\
 *Permissions Required: `Monitors Read` or `APM Read`*\
-Gets aggregate statistics about the lineage graph reachable from anchor entities—counts and breakdowns by node type, depth, and attributes—without returning the full node and edge payload. Use this before `get_data_entity_lineage` when working with large or unknown graphs.
+Gets aggregate statistics about the lineage graph reachable from anchor entities, such as counts and breakdowns by node type, depth, and attributes, without returning the full node and edge payload. Use this before `get_data_entity_lineage` when working with large or unknown graphs.
 
 - How many tables does `fct_revenue` depend on upstream?
 - What types of entities are downstream from this Spark job?
@@ -620,7 +620,7 @@ Retrieves data quality metrics timeseries data for a given data observability mo
 ### `get_spark_job_health`
 *Toolset: **data-observability***\
 *Permissions Required: `APM Read`*\
-Retrieves detailed health metrics for a single Spark or Databricks job run, including duration, CPU time, executor allocation, memory usage, shuffle read, spill, and skew. Can look up a run by trace ID or search by job name.
+Retrieves detailed health metrics for a single Spark or Databricks job run, including duration, CPU time, executor allocation, memory usage, shuffle read, spill, and skew. Accepts either a trace ID or a job name to identify the run.
 
 - Show me the health metrics for the latest run of the `process_orders` Spark job.
 - What were the worst-performing stages in Spark job trace `abc123`?

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -560,7 +560,7 @@ Searches for data entities in the data catalog. Supports filtering by name (with
 ### `get_data_catalog_schema`
 *Toolset: **data-observability***\
 *Permissions Required: `Monitors Read` or `APM Read`*\
-Returns the entity type schema for every platform the organization has data in. Discovers active platforms (Snowflake, BigQuery, Databricks, dbt, and so on), their entity types, the containment hierarchy, and the filterable attribute names. Call this at the start of a data catalog conversation to learn which platforms, entity types, and filters are available.
+Returns the entity type schema for every platform the organization has data in. Discovers active platforms (Snowflake, BigQuery, Databricks, dbt, and so on), their entity types, the containment hierarchy, the filterable attribute names, and the default metrics available for each entity type (such as `dataset.freshness`). Call this at the start of a data catalog conversation to learn which platforms, entity types, and filters are available.
 
 - What platforms and entity types are in my data catalog?
 - Which attributes can I filter on when searching for Snowflake tables?
@@ -570,7 +570,7 @@ Returns the entity type schema for every platform the organization has data in. 
 *Permissions Required: `Monitors Read` or `APM Read`*\
 Fetches full details and attributes for one or more data entities by their entity IDs. Returns owner, tags, display name, platform, schema, database, account, and all other attributes. Use `search_data_entities` first to find entity IDs.
 
-- Get full details for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`.
+- Get full details for entity `<entity_id>`.
 - Show me the owner and tags for this Snowflake table.
 
 ### `get_data_entity_hierarchy`
@@ -603,7 +603,7 @@ Gets aggregate statistics about the lineage graph reachable from anchor entities
 ### `rank_data_entities_by_lineage_degree`
 *Toolset: **data-observability***\
 *Permissions Required: `Monitors Read` or `APM Read`*\
-Ranks entities by their transitive lineage connectivity using a pre-built snapshot. Returns parent-level entities ranked by how many other entities they connect to (downstream or upstream). Useful for identifying the most critical or widely consumed tables.
+Ranks entities by their transitive lineage connectivity using a pre-built snapshot. Returns entities such as tables, dashboards, and jobs ranked by how many other entities they connect to (downstream or upstream). Useful for identifying the most critical or widely consumed tables.
 
 - Which tables have the most downstream consumers?
 - Rank tables by upstream dependency count to find raw ingestion points.
@@ -659,7 +659,7 @@ Ranks database tables by query activity, broken out by user type (human analysts
 Gets the custom user-defined descriptions for data entities by their IDs. Returns a map of entity ID to description with created and updated timestamps.
 
 - Show me the custom descriptions for these three tables.
-- What description has been set for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`?
+- What description has been set for entity `<entity_id>`?
 
 ### `update_entity_description`
 *Toolset: **data-observability***\
@@ -667,7 +667,7 @@ Gets the custom user-defined descriptions for data entities by their IDs. Return
 Sets or updates the custom user-defined description for a data entity.
 
 - Set the description of the `orders` table to "Contains all customer orders."
-- Update the description for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`.
+- Update the description for entity `<entity_id>`.
 
 ### `get_entity_tags`
 *Toolset: **data-observability***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -544,6 +544,147 @@ Ask a Datadog widget expert a question about widget configuration, schemas, quer
 - Help me debug why this widget is showing fractional values when it should be a count.
 - How do I configure a timeseries to show both bars and lines?
 
+## Data Observability
+
+Tools for [Data Observability][70], including searching data entities in the catalog, navigating data lineage, monitoring data quality, analyzing Spark and Databricks jobs, and managing entity metadata.
+
+### `search_data_entities`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Searches for data entities in the data catalog. Supports filtering by name (with wildcards), entity type, platform, schema, database, and account. Entity types include tables, columns, schemas, databases, dbt models, BI dashboards, Spark jobs, S3 buckets, and more. Use `get_data_catalog_schema` to discover available platforms and entity types.
+
+- Find tables named `orders` in the Snowflake platform.
+- Search for dbt models starting with `stg_` in the analytics database.
+- List all schemas in the `analytics` Snowflake database.
+
+### `get_data_catalog_schema`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Returns the entity type schema for every platform the organization has data in. Discovers active platforms (Snowflake, BigQuery, Databricks, dbt, and so on), their entity types, the containment hierarchy, and the filterable attribute names. Call this at the start of a data catalog conversation to learn which platforms, entity types, and filters are available.
+
+- What platforms and entity types are in my data catalog?
+- Which attributes can I filter on when searching for Snowflake tables?
+
+### `get_data_entity_details`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Fetches full details and attributes for one or more data entities by their entity IDs. Returns owner, tags, display name, platform, schema, database, account, and all other attributes. Use `search_data_entities` first to find entity IDs.
+
+- Get full details for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`.
+- Show me the owner and tags for this Snowflake table.
+
+### `get_data_entity_hierarchy`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Fetches the containment hierarchy (ancestors and descendants) for one or more entities. Use this for containment navigation—for example, finding which schema and database a table belongs to, or listing the columns in a table. Not for data lineage (use `get_data_entity_lineage` for that).
+
+- What schema and database does this table belong to?
+- List all columns in the `orders` table.
+- What tables are in the `landing` schema?
+
+### `get_data_entity_lineage`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Fetches the live reachable lineage subgraph from one or more anchor entities. Returns upstream or downstream data-flow relationships (nodes and edges) up to a configurable depth. For large or unknown graphs, use `summarize_data_entity_lineage` first.
+
+- Show me what downstream tables depend on the `raw_orders` table.
+- What data sources feed into the `fct_revenue` table?
+- Trace lineage from `stg_orders` downstream with a depth of 3.
+
+### `summarize_data_entity_lineage`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Gets aggregate statistics about the lineage graph reachable from anchor entities—counts and breakdowns by node type, depth, and attributes—without returning the full node and edge payload. Use this before `get_data_entity_lineage` when working with large or unknown graphs.
+
+- How many tables does `fct_revenue` depend on upstream?
+- What types of entities are downstream from this Spark job?
+- Give me a summary of the lineage graph from `raw_orders`.
+
+### `rank_data_entities_by_lineage_degree`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Ranks entities by their transitive lineage connectivity using a pre-built snapshot. Returns parent-level entities ranked by how many other entities they connect to (downstream or upstream). Useful for identifying the most critical or widely consumed tables.
+
+- Which tables have the most downstream consumers?
+- Rank tables by upstream dependency count to find raw ingestion points.
+- Find the most widely consumed entities in the data catalog.
+
+### `get_data_observability_monitor`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read`, `Timeseries`, and `APM Read`*\
+Retrieves data quality metrics timeseries data for a given data observability monitor ID. For anomaly monitors, the response includes upper and lower bounds that define the expected normal range.
+
+- Get the row count timeseries for monitor `12345` on the `orders` table.
+- Show me the anomaly bounds for monitor `67890` over the last 24 hours.
+
+### `get_spark_job_health`
+*Toolset: **data-observability***\
+*Permissions Required: `APM Read`*\
+Retrieves detailed health metrics for a single Spark or Databricks job run, including duration, CPU time, executor allocation, memory usage, shuffle read, spill, and skew. Can look up a run by trace ID or search by job name.
+
+- Show me the health metrics for the latest run of the `process_orders` Spark job.
+- What were the worst-performing stages in Spark job trace `abc123`?
+- Find Databricks job runs for `nightly_aggregation` in the last 7 days.
+
+### `get_spark_sql_plan`
+*Toolset: **data-observability***\
+*Permissions Required: `APM Read`*\
+Retrieves the Spark SQL physical execution plan from a `spark.stage` span. Shows node types (Exchange, SortMergeJoin, HashAggregate, and so on), join strategies, shuffle and partitioning information, and child node relationships. Use `get_spark_job_health` to find stage span IDs.
+
+- Show me the SQL execution plan for stage span `def456` in trace `abc123`.
+- What join strategy is used in this Spark stage?
+- Inspect the physical plan for the slowest stage in this job.
+
+### `get_warehouse_query_history`
+*Toolset: **data-observability***\
+*Permissions Required: `Logs Read Data` and `Logs Read Index Data`*\
+Fetches recent queries that touched one or more data entities, in reverse chronological order. Supports filtering by access type (read or write) and time range. Use `search_data_entities` to find entity IDs first.
+
+- Who has been querying the `orders` table in the last 7 days?
+- Show me write operations on the `fct_revenue` table from yesterday.
+- What SQL queries have touched this entity recently?
+
+### `get_popular_warehouse_tables_by_query_frequency`
+*Toolset: **data-observability***\
+*Permissions Required: `Logs Read Data`, `Logs Read Index Data`, and `APM Read`*\
+Ranks database tables by query activity, broken out by user type (human analysts, BI tools, orchestrators, ETL tools, and internal apps). Useful for identifying business-critical tables and prioritizing monitoring coverage.
+
+- Which tables are most queried by human analysts in Snowflake?
+- What are the top tables powering BI dashboards?
+- Show me the most frequently queried tables by orchestration tools like dbt and Airflow.
+
+### `get_entity_descriptions`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Gets the custom user-defined descriptions for data entities by their IDs. Returns a map of entity ID to description with created and updated timestamps.
+
+- Show me the custom descriptions for these three tables.
+- What description has been set for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`?
+
+### `update_entity_description`
+*Toolset: **data-observability***\
+*Permissions Required: `Data Observability Catalog Write`*\
+Sets or updates the custom user-defined description for a data entity.
+
+- Set the description of the `orders` table to "Contains all customer orders."
+- Update the description for entity `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`.
+
+### `get_entity_tags`
+*Toolset: **data-observability***\
+*Permissions Required: `Monitors Read` or `APM Read`*\
+Gets the custom user-defined tags for data entities. Returns entity IDs with their associated key:value tags. These are custom tags distinct from built-in entity attributes.
+
+- Show me the custom tags on the `orders` table.
+- What tags have been applied to these entities?
+
+### `update_entity_tags`
+*Toolset: **data-observability***\
+*Permissions Required: `Data Observability Catalog Write`*\
+Adds or removes custom user-defined tags on data entities. Tags are key:value strings.
+
+- Add the tag `team:data-eng` to the `orders` table entity.
+- Remove the `env:staging` tag from these entities.
+
 ## Database Monitoring
 
 Tools for interacting with [Database Monitoring][26].
@@ -2033,3 +2174,4 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [67]: /security/cloud_siem/triage_and_investigate/ioc_explorer/
 [68]: /product_analytics/
 [69]: /session_replay/
+[70]: /data_observability/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds the `data-observability` toolset to the MCP Server documentation.

Updates:
- `setup.md`: Adds `data-observability` to the Available toolsets list
- `tools.md`: Adds a full Data Observability section documenting all 16 tools in the toolset

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes