### PR TITLE
Update inconsistencies in AI SAST documentation

### DIFF
--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -77,11 +77,13 @@ AI-native SAST uses a two-phase approach:
 
 ### Supported languages
 
-| Language | Status      |
-| -------- | ----------- |
-| Java     | Available   |
-| Python   | Available   |
-| Go       | Available   |
+| Language   | Status      |
+| ---------- | ----------- |
+| Java       | Available   |
+| Python     | Available   |
+| Go         | Available   |
+| C#         | Available   |
+| JavaScript | Available   |
 
 ### Detected vulnerability types
 
@@ -102,7 +104,7 @@ AI-native SAST detects the following vulnerability types:
 - [CWE-94: Code Injection](https://cwe.mitre.org/data/definitions/94.html)
 - [CWE-501: Trust Boundary Violation](https://cwe.mitre.org/data/definitions/501.html)
 - [CWE-284: Broken Access Control (IDOR)](https://cwe.mitre.org/data/definitions/284.html)
-- [CWE-1427: Server-Side Template Injection](https://cwe.mitre.org/data/definitions/1427.html)
+- [CWE-1427: Prompt Injection](https://cwe.mitre.org/data/definitions/1427.html)
   {{% /collapse-content %}}
 
 <!-- ## AI-powered detection


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the AI-Enhanced Static Code Analysis page to correct two inaccuracies in the AI-native SAST section:
1. **Fixes CWE-1427 label**: The supported CWEs list incorrectly labeled CWE-1427 as "Server-Side Template Injection". CWE-1427 is "Prompt Injection (Improper Neutralization of Input Used for LLM Prompting)". SSTI is a subcase of CWE-94 (Code Injection), which is already listed separately.

2. **Adds C# and JavaScript to supported languages**: The supported languages table listed only Java, Python, and Go. C# and JavaScript are also supported with full coverage across all detected vulnerability types.

### Merge readiness

- [x] Ready for merge