### PR TITLE
Removed legacy app launch metric

### DIFF
--- a/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -29,7 +29,8 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 
 | Metric Name | Description | Dimensions | Platform |
 |-------------|-------------|------------|----------|
-| `rum.measure.app.startup_time` | App startup time | Default, Percentiles breakdown | Mobile only |
+| `rum.measure.app.startup_to_full_display` | Time to full display during application launch | Default, Percentiles breakdown | Mobile only |
+| `rum.measure.app.startup_to_initial_display` | Time to initial display during application launch | Default, Percentiles breakdown | Mobile only |
 | `rum.measure.error` | Count of errors | Default, Is Crash, View Name | Mobile & Browser |
 | `rum.measure.error.anr` | Count of ANRs (an Android freeze) | Default, Is Crash, View Name | Mobile only |
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Replace legacy application launch metric with new time to initial display and time to full display metrics.


### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
