### PR TITLE
Document Ruby OpenFeature runtime recommendation

### DIFF
--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -35,7 +35,7 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Service and environment configured** - Feature flags are targeted by service and environment
 - **Supported operating system** - Production support is limited to [Linux operating systems][2]. macOS and Windows are not natively supported production targets, but Dockerized Linux environments running on those operating systems are. For local development on macOS, you can use a compatible prebuilt native artifact when one is available.
 
-<div class="alert alert-info">The Datadog Ruby tracer supports older Ruby runtimes for APM. For Datadog Feature Flags through OpenFeature, use Ruby 3.1 or later because the OpenFeature Ruby SDK versions that expose the provider hook surface required for complete Feature Flags telemetry require Ruby 3.1 or later.</div>
+<div class="alert alert-info">The Datadog Ruby tracer supports older Ruby runtimes for APM. Applications on older Ruby versions, including Ruby 2.5, can continue to use Datadog APM, but cannot use Datadog Feature Flags through OpenFeature until they upgrade to Ruby 3.1 or later. The OpenFeature Ruby SDK versions that expose the provider hook surface required for complete Feature Flags telemetry require Ruby 3.1 or later.</div>
 
 ## Installing and initializing
 

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -30,10 +30,12 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Datadog Agent** version 7.55 or later with [Remote Configuration][1] enabled
 - **Datadog [API key][4]** configured on the Agent
 - **Datadog Ruby SDK** `datadog` version 2.24.0 or later
-- **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later if you need flag evaluation metrics support
+- **Ruby runtime** version 3.1 or later to use the full Datadog Feature Flags OpenFeature integration
+- **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later for provider hooks, exposure logging, and flag evaluation metrics support
 - **Service and environment configured** - Feature flags are targeted by service and environment
 - **Supported operating system** - Production support is limited to [Linux operating systems][2]. macOS and Windows are not natively supported production targets, but Dockerized Linux environments running on those operating systems are. For local development on macOS, you can use a compatible prebuilt native artifact when one is available.
 
+<div class="alert alert-info">The Datadog Ruby tracer supports older Ruby runtimes for APM. For Datadog Feature Flags through OpenFeature, use Ruby 3.1 or later because the OpenFeature Ruby SDK versions that expose the provider hook surface required for complete Feature Flags telemetry require Ruby 3.1 or later.</div>
 
 ## Installing and initializing
 


### PR DESCRIPTION
## Motivation
Customers need a clear Ruby runtime floor for the full Datadog Feature Flags OpenFeature integration, distinct from general APM tracer support. Without that distinction, teams on older Ruby versions can assume tracing support means provider hooks, exposure logging, and evaluation telemetry are fully covered.

## Changes
- Update the Ruby Feature Flags prerequisites to recommend Ruby 3.1 or later for the full OpenFeature integration.
- Clarify that `openfeature-sdk` 0.5.1 or later is needed for provider hooks, exposure logging, and flag evaluation metrics support.
- Add an info note explaining that older Ruby runtime support remains available for APM tracing, while full Feature Flags telemetry through OpenFeature requires Ruby 3.1 or later.

## Decisions
- Document Ruby 3.1 as the minimum recommendation because the OpenFeature Ruby SDK versions with the needed provider hook surface require Ruby >= 3.1.
- Keep this guidance on the Ruby Feature Flags server setup page rather than the generic Ruby tracer support page because the constraint is specific to the Feature Flags/OpenFeature integration.

## Related PRs
- Ruby implementation: https://github.com/DataDog/dd-trace-rb/pull/5896
- Ruby OpenFeature system-tests surface: https://github.com/DataDog/system-tests/pull/7199
- Ruby OpenFeature runtime documentation: https://github.com/DataDog/documentation/pull/37674
