### PR TITLE
Fix link reference in OSS setup documentation

### DIFF
--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -223,7 +223,9 @@ For cloud-specific environments, add the appropriate resource detection detector
 - **Google Cloud**: `detectors: [gcp, env, system]`
 - **Azure**: `detectors: [azure, env, system]`
 
-See the [full configuration files][5] for an optional config to gather additional metadata about the system.
+See the [full configuration files][500] for an optional config to gather additional metadata about the system.
+
+[500]: https://github.com/DataDog/opentelemetry-examples/tree/experimental-oss-config/configurations/opentelemetry-collector
 
 {{% /tab %}}
 


### PR DESCRIPTION
Updated link reference for full configuration files.

<img width="1496" height="436" alt="image" src="https://github.com/user-attachments/assets/0c432204-a523-4ba2-86b3-2053840af736" />
