### PR TITLE
Document GitHub retry permission

### DIFF
--- a/content/en/continuous_integration/pipelines/automatic_retries.md
+++ b/content/en/continuous_integration/pipelines/automatic_retries.md
@@ -36,6 +36,7 @@ When a job in your CI pipeline fails:
 
 To use automatic job retries:
 - CI Visibility must be enabled for your [GitHub Actions][1] or [GitLab][2] integration.
+- For GitHub Actions, the [Datadog GitHub App][8] must have the **Actions: Write** permission.
 - The [Datadog Source Code Integration][3] must be configured for the repositories where you'd like to use automatic retries.
 - Datadog must have indexed CI job logs for the repositories where you'd like to use automatic retries (see [Collect job logs for GitHub Actions][4] or [Collect job logs for GitLab][5]).
 - To enable this feature, you must have the **CI Provider Settings Write** permission in Datadog.
@@ -100,3 +101,4 @@ A failed job is not retried when:
 [5]: /continuous_integration/pipelines/gitlab/#collect-job-logs
 [6]: /continuous_integration/guides/use_ci_jobs_failure_analysis/
 [7]: https://app.datadoghq.com/ci/settings/ci-cd/repositories
+[8]: /continuous_integration/pipelines/github/#configure-a-github-app


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4faad733-3e63-4139-bd8f-f937c170677c","source":"chat","resourceId":"4d5c8a1d-94b2-4408-b709-ebbdea6b317e","workflowId":"97fe54df-28ab-4f97-b7c3-f0842c3b68a5","codeChangeId":"97fe54df-28ab-4f97-b7c3-f0842c3b68a5","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

Adds the GitHub Actions permission prerequisite for automatic job retries so the page clearly states that the Datadog GitHub App needs the **Actions: Write** permission.

Changes:
- Adds the GitHub Actions-specific prerequisite.
- Links the Datadog GitHub App mention to the GitHub app setup section.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to make a targeted documentation edit and validation checks.

### Additional notes
n/a

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4d5c8a1d-94b2-4408-b709-ebbdea6b317e)

Comment @datadog to request changes