### PR TITLE
[DOCS-14911] Remove GovCloud site restriction for Network Path testing

### DIFF
--- a/content/en/synthetics/network_path_tests/_index.md
+++ b/content/en/synthetics/network_path_tests/_index.md
@@ -78,10 +78,6 @@ Running Network Path tests from managed locations lets you perform TCP, UDP, and
 
 ## Agent configuration
 
-{{% site-region region="gov,gov2" %}}
-<div class="alert alert-warning">Network Path testing with the Datadog Agent is not supported for this <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{% /site-region %}}
-
 ### Prerequisites
 
 Requires [Agent version][7] `7.72` or higher.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14911

Network Path testing with the Datadog Agent is now supported for GovCloud (gov) and gov2 sites. This removes the unsupported site warning block that was previously shown for those regions.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes