### PR TITLE
Document create, update, and delete detection rule MCP tools

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1196,7 +1196,7 @@ Retrieves security detection rules. Supports two modes: provide `rule_id` to get
 ### `create_datadog_security_detection_rule`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Write`*\
-Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the payload grammar, then supply a complete rule payload. Automatically tags the created rule with `datadog_mcp:created`. On success, returns the full rule including its server-assigned ID.
+Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the payload grammar, then supply a complete rule payload. On success, returns the full rule including its server-assigned ID.
 
 - Create a threshold detection rule that fires when more than 10 failed logins occur from the same IP in 5 minutes.
 - Author a new log detection rule for CloudTrail that alerts on IAM privilege escalation.
@@ -1205,7 +1205,7 @@ Creates a new detection rule. Call `get_datadog_security_detection_rules_schema`
 ### `update_datadog_security_detection_rule`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Write`*\
-Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Automatically tags the updated rule with `datadog_mcp:updated`. Cannot update Datadog-shipped default rules.
+Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Cannot update Datadog-shipped default rules.
 
 - Update the threshold on my brute force detection rule from 10 to 20 failed logins.
 - Add a new case to detection rule `abc-123-def` that fires at critical severity.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1193,6 +1193,32 @@ Retrieves security detection rules. Supports two modes: provide `rule_id` to get
 - Get the full definition of detection rule `abc-123-def`.
 - What thresholds and group-by fields does this detection rule use?
 
+### `create_datadog_security_detection_rule`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Write`*\
+Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the payload grammar, then supply a complete rule payload. Automatically tags the created rule with `datadog_mcp:created`. On success, returns the full rule including its server-assigned ID.
+
+- Create a threshold detection rule that fires when more than 10 failed logins occur from the same IP in 5 minutes.
+- Author a new log detection rule for CloudTrail that alerts on IAM privilege escalation.
+- Create a detection rule for `source:nginx` that generates a signal when error rate exceeds 100 per minute.
+
+### `update_datadog_security_detection_rule`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Write`*\
+Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Automatically tags the updated rule with `datadog_mcp:updated`. Cannot update Datadog-shipped default rules.
+
+- Update the threshold on my brute force detection rule from 10 to 20 failed logins.
+- Add a new case to detection rule `abc-123-def` that fires at critical severity.
+- Change the group-by field on this rule from `@usr.ip` to `@network.client.ip`.
+
+### `delete_datadog_security_detection_rules`
+*Toolset: **security***\
+*Permissions Required: `Security Monitoring Rules Write`*\
+Deletes one or more custom detection rules by ID. Only custom (non-default) rules can be deleted — default rules return 403. Each rule is authorized individually; failures appear in `failed_rules` without aborting the batch.
+
+- Delete detection rule `abc-123-def`.
+- Remove these three test detection rules I created earlier.
+
 ### `get_datadog_security_suppressions`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Suppressions Read`*\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1205,7 +1205,7 @@ Creates a new detection rule. Call `get_datadog_security_detection_rules_schema`
 ### `update_datadog_security_detection_rule`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Write`*\
-Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Cannot update Datadog-shipped default rules.
+Updates an existing custom detection rule by replacing it entirely. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Cannot update Datadog-shipped default rules.
 
 - Enable detection rule `abc-123-def`.
 - Disable the brute force detection rule.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1207,6 +1207,8 @@ Creates a new detection rule. Call `get_datadog_security_detection_rules_schema`
 *Permissions Required: `Security Monitoring Rules Write`*\
 Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need, and submit the full updated object. Cannot update Datadog-shipped default rules.
 
+- Enable detection rule `abc-123-def`.
+- Disable the brute force detection rule.
 - Update the threshold on my brute force detection rule from 10 to 20 failed logins.
 - Add a new case to detection rule `abc-123-def` that fires at critical severity.
 - Change the group-by field on this rule from `@usr.ip` to `@network.client.ip`.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1216,7 +1216,7 @@ Updates an existing custom detection rule by replacing it entirely. Call `get_da
 ### `delete_datadog_security_detection_rules`
 *Toolset: **security***\
 *Permissions Required: `Security Monitoring Rules Write`*\
-Deletes one or more custom detection rules by ID. Only custom (non-default) rules can be deleted — default rules return 403. Each rule is authorized individually; failures appear in `failed_rules` without aborting the batch.
+Deletes one or more custom detection rules by ID. Only custom (non-default) rules can be deleted. Default rules return 403. Each rule is authorized individually; failures appear in `failed_rules` without aborting the batch.
 
 - Delete detection rule `abc-123-def`.
 - Remove these three test detection rules I created earlier.

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -131,7 +131,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `update_datadog_security_detection_rule`
-: Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
+: Updates an existing custom detection rule by replacing it wholesale. Use this to enable or disable a rule, change thresholds, add cases, and more. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `delete_datadog_security_detection_rules`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -127,11 +127,11 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Rules Read`*
 
 `create_datadog_security_detection_rule`
-: Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the required payload grammar, then supply a complete rule payload. Automatically tags the created rule with `datadog_mcp:created`. On success, returns the full rule including its server-assigned ID.
+: Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the required payload grammar, then supply a complete rule payload. On success, returns the full rule including its server-assigned ID.
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `update_datadog_security_detection_rule`
-: Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Automatically tags the updated rule with `datadog_mcp:updated`. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
+: Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `delete_datadog_security_detection_rules`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -131,7 +131,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `update_datadog_security_detection_rule`
-: Updates an existing custom detection rule by replacing it wholesale. Use this to enable or disable a rule, change thresholds, add cases, and more. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
+: Updates an existing custom detection rule by replacing it entirely. Use this to enable or disable a rule, change thresholds, add cases, and more. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
 : *Permissions required: `Security Monitoring Rules Write`*
 
 `delete_datadog_security_detection_rules`

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -40,7 +40,7 @@ You can use the `security` toolset to:
 - **Investigate specific findings**: Retrieve full details for a set of findings to understand scope, affected resources, and remediation context.
 - **Triage security findings**: Create Jira issues, ServiceNow tickets, or Case Management cases for findings. Assign findings to team members, or mute false positives and accepted risks.
 - **Correlate signals and findings**: Cross-reference active security signals with open findings to determine whether an alert is tied to a known posture issue.
-- **Inspect and manage detection rules**: List and retrieve detection rule definitions to understand what logic is generating signals.
+- **Inspect and manage detection rules**: List, retrieve, create, update, and delete detection rules to understand and manage the logic generating signals.
 - **Manage suppressions**: Create, update, and delete suppressions to silence noisy rules for specific conditions without disabling them entirely.
 - **Remediate vulnerabilities with an AI agent**: Pull library vulnerability findings, including code location and remediation guidance, and pass them to your AI agent to apply patches directly in your codebase.
 
@@ -125,6 +125,18 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 `get_datadog_security_detection_rules`
 : Retrieves security detection rules. Supports two modes: provide `rule_id` to get the full definition of a single rule by ID, or omit `rule_id` to list rules (optionally filtered with `query` and token-limited with `max_tokens`). The two modes are mutually exclusive.
 : *Permissions required: `Security Monitoring Rules Read`*
+
+`create_datadog_security_detection_rule`
+: Creates a new detection rule. Call `get_datadog_security_detection_rules_schema` first to fetch the required payload grammar, then supply a complete rule payload. Automatically tags the created rule with `datadog_mcp:created`. On success, returns the full rule including its server-assigned ID.
+: *Permissions required: `Security Monitoring Rules Write`*
+
+`update_datadog_security_detection_rule`
+: Updates an existing custom detection rule by replacing it wholesale. Call `get_datadog_security_detection_rules` first to fetch the current rule body, modify the fields you need to change, and submit the full updated object. Automatically tags the updated rule with `datadog_mcp:updated`. Cannot update Datadog-shipped default rules. On success, returns the full updated rule.
+: *Permissions required: `Security Monitoring Rules Write`*
+
+`delete_datadog_security_detection_rules`
+: Deletes one or more custom detection rules by ID. Only custom (non-default) rules can be deleted. Each rule is authorized individually; rules that cannot be deleted appear in `failed_rules` without aborting the batch. Returns `deleted_rules` and `failed_rules`.
+: *Permissions required: `Security Monitoring Rules Write`*
 
 ### Suppressions
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for three new write tools in the `security` MCP toolset that were previously undocumented:

- `create_datadog_security_detection_rule` — creates a new detection rule
- `update_datadog_security_detection_rule` — updates an existing custom detection rule (PUT, replaces wholesale)
- `delete_datadog_security_detection_rules` — deletes one or more custom detection rules by ID (batch)

Updated both `content/en/security/mcp_server.md` and `content/en/mcp_server/tools.md` to match the existing pattern established for the suppression write tools. Also updated the "Inspect and manage detection rules" use case bullet to reflect the new write capabilities.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Follows the same documentation pattern as Chelsea Xu's previous security MCP toolset PRs (#37077, #36453).