### PR TITLE
[SVLS-9268] Document dropped logs risk for in-container Cloud Run on cold starts

### DIFF
--- a/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
@@ -84,7 +84,7 @@ logger.LogInformation("Hello World!");
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/go.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/go.md
@@ -79,7 +79,7 @@ go get github.com/DataDog/dd-trace-go/contrib/net/http/v2
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/java.md
@@ -96,7 +96,7 @@ logger.info("Hello World!");
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
@@ -147,7 +147,7 @@ gcloud pubsub subscriptions update \
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/php.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/php.md
@@ -63,7 +63,7 @@ apk add libgcc
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -96,7 +96,7 @@ logger.info("Hello world!")
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/ruby.md
@@ -66,7 +66,7 @@ logger.info "Hello world!"
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
 
 ## Further reading
 

--- a/layouts/shortcodes/serverless-init-troubleshooting.en.md
+++ b/layouts/shortcodes/serverless-init-troubleshooting.en.md
@@ -8,4 +8,8 @@ To have your {{ .Get "productNames" }} appear in the [software catalog][2001], y
 
 {{ if eq (.Get "sidecar") "true" }}If you are missing logs or traces during container shutdown, specify a container start up order to make your main container depend on the sidecar container.
 {{ end }}
+
+{{ if eq (.Get "in_container") "true" }}
+If you are using [request-based billing](https://docs.cloud.google.com/run/docs/container-contract#cpu) for a Google Cloud Run application instrumented in-container, very short requests may lead to dropped logs during the post-request CPU throttling. You can control the speed at which logs are sent to Datadog using the [`DD_LOGS_CONFIG_BATCH_WAIT`](https://docs.datadoghq.com/agent/logs/log_transport/?tab=https#configure-the-batch-wait-time) environment variable. Set `DD_LOGS_CONFIG_BATCH_WAIT` to a value shorter than your typical request duration to avoid dropped logs. Sidecar instrumentation also prevents this issue, as the sidecar is not affected by request-based CPU throttling.
+{{ end }}
 [2001]: /internal_developer_portal/software_catalog/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a troubleshooting note to the serverless-init shortcode for users running in-container instrumentation on Google Cloud Run with request-based billing. The note explains the mechanism and recommends two mitigations: lowering `DD_LOGS_CONFIG_BATCH_WAIT` to flush before the response is returned, or switching to sidecar instrumentation (which is unaffected by CPU throttling).

### Additional notes

Part of [SVLS-9268](https://datadoghq.atlassian.net/browse/SVLS-9268)

[SVLS-9268]: https://datadoghq.atlassian.net/browse/SVLS-9268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ