### PR TITLE
[SYNTHETICS WORKER] docs: 📝 release windows-pl 1.69.0

### DIFF
--- a/data/synthetics_worker_versions.json
+++ b/data/synthetics_worker_versions.json
@@ -1,6 +1,6 @@
 [
     {
         "client": "synthetics-windows-pl",
-        "version": "1.68.0"
+        "version": "1.69.0"
     }
 ]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Monthly Private Location worker release: bumps `synthetics-windows-pl` from `1.68.0` to `1.69.0` in `data/synthetics_worker_versions.json`.

This is a manual version bump, mirroring the previous release PR DataDog/documentation#26756 (which bumped the same `synthetics-windows-pl` key) since the automated [bump_synthetics_worker_version](https://github.com/DataDog/documentation/actions/workflows/bump_synthetics_worker_version.yml) workflow does not reliably run.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used an AI coding assistant to locate the version entry and apply the single-line version bump; the change was reviewed against reference PR #26756.

### Additional notes

Diff is limited to the single version value in `data/synthetics_worker_versions.json` (`1.68.0` → `1.69.0`).

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


## Prerequisites — merge these before this one

This is the final step of the monthly PL 1.69.0 release; the other three must be merged/released first:

- web-ui: https://github.com/DataDog/web-ui/pull/322217
- helm-charts: https://github.com/DataDog/helm-charts/pull/2750
- dd-source: https://github.com/DataDog/dd-source/pull/477287
