### PR TITLE
[NETPATH-894] Remove Preview Section for Network Path Monitors

### DIFF
--- a/content/en/monitors/types/network_path.md
+++ b/content/en/monitors/types/network_path.md
@@ -16,10 +16,6 @@ further_reading:
   text: "Network Path Overview"
 ---
 
-{{< callout url=# btn_hidden="true" header="Join the Preview!">}}
-The Network Path monitor is in Preview. To request access, contact your Datadog account team or reach out to <a href="https://docs.datadoghq.com/help/">Datadog Support.
-{{< /callout >}}
-
 ## Overview
 
 [Network Path][1] provides a visual representation of network traffic flow from its origin to its destination. After you enable Network Path for your organization, you can create a Network Path monitor to alert you when a Network Path metric crosses a set threshold. For example, you can monitor packet loss percentage between a specific source and destination and be alerted when this percentage breaches a configured threshold.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Network Path Monitors are going GA so we are removing the Preview portion of the related documentation.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

