### PR TITLE
(docs-dev) Update integration-finder to match by app-id and support publishing-platform

### DIFF
--- a/local/bin/py/integration-finder.py
+++ b/local/bin/py/integration-finder.py
@@ -4,6 +4,7 @@ import os
 from os.path import isdir
 import git
 import argparse
+import json
 
 def filter_out_dots(array):
     for dir in array:
@@ -11,17 +12,22 @@ def filter_out_dots(array):
             array.remove(dir)
     return array
 
+def normalize(s):
+    return s.strip().lower().replace('_', '-')
+
 # Hardcode integration data
 integrations_repos = {
-    'integrations-core': 'master',
-    'integrations-extras': 'master',
-    'integrations-internal-core': 'main',
-    'marketplace':'master'
+    'integrations-core':          {'branch': 'master', 'github': True},
+    'integrations-extras':        {'branch': 'master', 'github': True},
+    'integrations-internal-core': {'branch': 'main',   'github': True},
+    'marketplace':                {'branch': 'master', 'github': True},
+    'publishing-platform':        {'branch': 'main',   'github': False},
 }
 
 # Check if the repos are present locally. If not, clone them. If so, update them
 def update_repos(integrations_repos):
-    for repo, branch in integrations_repos.items():
+    for repo, cfg in integrations_repos.items():
+        branch = cfg['branch']
         local_repo_path = os.path.join('..', repo)
         if isdir(local_repo_path):
             try:
@@ -36,9 +42,9 @@ def update_repos(integrations_repos):
                 # Pull the latest changes from the remote repository
                 print(f'\tPulling latest changes from {repo} on branch {branch}')
                 local_repo.remotes.origin.pull(branch)
-            except: 
+            except:
                 print(f'\n\x1b[33mWARNING\x1b[0m:Failed to update {repo}' +
-                        '\nContinuing without updating the repo. ' + 
+                        '\nContinuing without updating the repo. ' +
                         f'To resolve, check {repo} for a dirty feature branch and commit, ' +
                         'stash, or reset any changes and try again.\n')
         else:
@@ -48,28 +54,43 @@ def update_repos(integrations_repos):
 # Find the given integration in the integrations repos
 def find_integration(integrations_repos, integration_name):
     found = []
-    for repo,branch in integrations_repos.items():
-        integration_list = []
+    target = normalize(integration_name)
+    for repo, cfg in integrations_repos.items():
+        branch = cfg['branch']
+        is_github = cfg['github']
         location = os.path.join('..', repo)
-        url = f'https://github.com/DataDog/{repo}/blob/{branch}/{integration_name}/README.md'
-        integration_list = [f.name for f in os.scandir(location) if f.is_dir()]
-        integration_list = filter_out_dots(integration_list)
-        if integration_name in integration_list:
-            readme_path = os.path.join(location, integration_name, 'README.md')
-            if os.path.exists(readme_path):
-                found.append(f'{location}/{integration_name}/README.md\n- {url}')
+        dirs = [f.name for f in os.scandir(location) if f.is_dir()]
+        dirs = filter_out_dots(dirs)
+        for dir_name in dirs:
+            manifest_path = os.path.join(location, dir_name, 'manifest.json')
+            if not os.path.exists(manifest_path):
+                continue
+            try:
+                with open(manifest_path) as fp:
+                    manifest = json.load(fp)
+            except Exception:
+                continue
+            app_id = manifest.get('app_id', '')
+            if not app_id or normalize(app_id) != target:
+                continue
+            readme_path = os.path.join(location, dir_name, 'README.md')
+            if is_github:
+                url = f'https://github.com/DataDog/{repo}/blob/{branch}/{dir_name}/README.md'
+                found.append(f'{readme_path}\n- {url}')
+            else:
+                found.append(f'{readme_path}\n- {app_id} is published through the publishing platform')
+            break  # short-circuit within this repo; continue to other repos
     if len(found) == 0:
         print(f'\nIntegration "{integration_name}" not found. Check the spelling and try again.')
     elif len(found) == 1:
         print(f'\nYou can find {integration_name} here:\n- {"".join(found)}')
     else:
-        
         print('\nMore than one integration with that name was found. Check the following:')
         for entry in found:
             print(f'{entry}\n')
 
 parser = argparse.ArgumentParser(description="Find an integration")
-parser.add_argument('integration', help="The name of the integration to search for", type=str)
+parser.add_argument('integration', help="The app-id of the integration to search for (for example, rapdev-box)", type=str)
 args = parser.parse_args()
 
 integrations = update_repos(integrations_repos)

--- a/local/bin/py/integration-finder.py
+++ b/local/bin/py/integration-finder.py
@@ -59,6 +59,8 @@ def find_integration(integrations_repos, integration_name):
         branch = cfg['branch']
         is_github = cfg['github']
         location = os.path.join('..', repo)
+        if not os.path.isdir(location):
+            continue
         dirs = [f.name for f in os.scandir(location) if f.is_dir()]
         dirs = filter_out_dots(dirs)
         for dir_name in dirs:
@@ -78,7 +80,7 @@ def find_integration(integrations_repos, integration_name):
                 url = f'https://github.com/DataDog/{repo}/blob/{branch}/{dir_name}/README.md'
                 found.append(f'{readme_path}\n- {url}')
             else:
-                found.append(f'{readme_path}\n- {app_id} is published through the publishing platform')
+                found.append(f'{readme_path}\n- {integration_name} is published through the publishing platform')
             break  # short-circuit within this repo; continue to other repos
     if len(found) == 0:
         print(f'\nIntegration "{integration_name}" not found. Check the spelling and try again.')
@@ -93,5 +95,5 @@ parser = argparse.ArgumentParser(description="Find an integration")
 parser.add_argument('integration', help="The app-id of the integration to search for (for example, rapdev-box)", type=str)
 args = parser.parse_args()
 
-integrations = update_repos(integrations_repos)
+update_repos(integrations_repos)
 find_integration(integrations_repos, args.integration)


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates `local/bin/py/integration-finder.py` to reflect how integration sources work today:

- **Match by app-id instead of directory name.** Integration URLs now map to an integration's `app_id` (e.g. `rapdev-box`), but directory names in source repos differ arbitrarily. For example: `rapdev_box`. The tool now reads each integration's `manifest.json` to match on `app_id`.
   - hyphen/underscore/case normalization so both `rapdev-box` and `rapdev_box` find the same result.
- **Add `publishing-platform` as a source.** The tool now surfaces integrations in the publishing platform and prints a "published through the publishing platform" message instead of the GitHub URL.
- **Remove dogweb.** This is no longer a source.
- **Robustness fix.** Added a directory existence check before scanning, so a silently failed repo clone skips gracefully instead of crashing.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Here are some tests you can try:
```
make find-int int=amazon-ec2-spot
make find-int int=ably
make find-int int=aruba-central
```