### PR TITLE
[DOCS-4707] Fix ACL and logrotate guidance for rotating logs

### DIFF
--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -23,7 +23,7 @@ To allow read-only access for the `dd-agent` user, create [access control lists 
 
 ### Verifying ACLs are enabled on your system
 
-[ACLs needs to be enabled][2] on your file system to set permissions using the methods outlined in this article. Verify ACLs are enabled by using the`getfacl` and `setfacl` commands to set permissions for the `datadog-agent` user on a test directory, for example:
+[ACLs needs to be enabled][2] on your file system to set permissions using the methods outlined in this article. Verify ACLs are enabled by using the`getfacl` and `setfacl` commands to set permissions for the `dd-agent` user on a test directory, for example:
 
 ```shell
 mkdir /var/log/test-dir
@@ -32,7 +32,7 @@ setfacl -m u:dd-agent:rx /var/log/test-dir
 getfacl /var/log/test-dir/
 ```
 
-The permissions set for `datadog-agent` appears in the output of getfacl if ACLs are enabled.
+The permissions set for `dd-agent` appears in the output of getfacl if ACLs are enabled.
 
 {{< img src="logs/faq/setting_file_permission.png" alt="Setting file permission" >}}
 
@@ -56,9 +56,9 @@ A default ACL applies to files created in the directory afterward, including tho
 
 ### Setting permissions for log file rotation
 
-If you set a default ACL with the `-d` flag in the previous section, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. A default ACL does not cover every rotation scheme, however. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
+If you set a default ACL with the `-d` flag in the previous section, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. However, a default ACL does not cover every rotation scheme. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
 
-When a default ACL does not apply to your setup, add a rule to logrotate to reset the ACL after each rotation. Avoid defining a rule for log files that another logrotate configuration already manages, because logrotate reports a `duplicate log entry` error when two configurations match the same file. Instead, add a `postrotate` script to the service's existing configuration, or create a separate file for paths that are not already managed:
+When a default ACL does not apply to your setup, add a rule to logrotate to reset the ACL after each rotation. Avoid defining a rule for log files that another logrotate configuration already manages, because logrotate reports an `error: duplicate log entry for <FILE>` message when two configurations match the same file. Instead, add a `postrotate` script to the service's existing configuration, or create a separate file for paths that are not already managed:
 
 ```shell
 sudo touch /etc/logrotate.d/dd-agent_ACLs
@@ -124,4 +124,4 @@ Each common off-the-shelf application will follow a similar nomenclature. The ad
 
 [1]: https://help.ubuntu.com/community/FilePermissionsACLs
 [2]: https://www.tecmint.com/secure-files-using-acls-in-linux
-[3]: http://xmodulo.com/configure-access-control-lists-acls-linux.html
+[3]: https://www.xmodulo.com/configure-access-control-lists-acls-linux.html

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -23,7 +23,7 @@ To allow read-only access for the `dd-agent` user, create [access control lists 
 
 ### Verifying ACLs are enabled on your system
 
-[ACLs needs to be enabled][2] on your file system to set permissions using the methods outlined in this article. Verify ACLs are enabled by using the`getfacl` and `setfacl` commands to set permissions for the `dd-agent` user on a test directory, for example:
+[ACLs need to be enabled][2] on your file system to set permissions using the methods outlined in this article. Verify ACLs are enabled by using the`getfacl` and `setfacl` commands to set permissions for the `dd-agent` user on a test directory, for example:
 
 ```shell
 mkdir /var/log/test-dir
@@ -44,7 +44,7 @@ After you verify ACLs are enabled, grant read and execute permissions for the `d
 setfacl -R -m u:dd-agent:rx /var/log/apache
 ```
 
-To make new log files inherit this access automatically, set a *default* ACL on the directory with the `-d` flag:
+To make new log files inherit this access automatically, set a default ACL on the directory with the `-d` flag:
 
 ```shell
 setfacl -R -d -m u:dd-agent:rx /var/log/apache

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -19,7 +19,7 @@ The Datadog Agent runs under the `dd-agent` user and `dd-agent` group. This prev
 
 ## Setting permissions using ACLs
 
-To allow read-only access for the `dd-agent` user, create [access control lists (ACLs)][1] and modify logrotate to persist the permission changes, as described in the following sections.
+To allow read-only access for the `dd-agent` user, create [access control lists (ACLs)][1] and modify logrotate to persist the permission changes.
 
 ### Verifying ACLs are enabled on your system
 
@@ -50,13 +50,13 @@ To make new log files inherit this access automatically, set a default ACL on th
 setfacl -R -d -m u:dd-agent:rx /var/log/apache
 ```
 
-A default ACL applies to files created in the directory afterward, including those that log rotation creates. This reduces the need for the logrotate rule described in the next section. Files that already exist when you set the default ACL are unaffected, so run both commands above.
+A default ACL applies to files created in the directory afterward, including those that log rotation creates. This reduces the need for a separate logrotate rule. Files that already exist when you set the default ACL are unaffected, so run both commands above.
 
 [Learn more about how to configure ACLs on Linux][3]
 
 ### Setting permissions for log file rotation
 
-If you set a default ACL with the `-d` flag in the previous section, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. However, a default ACL does not cover every rotation scheme. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
+If you set a default ACL with the `-d` flag, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. However, a default ACL does not cover every rotation scheme. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
 
 When a default ACL does not apply to your setup, add a rule to logrotate to reset the ACL after each rotation. Avoid defining a rule for log files that another logrotate configuration already manages, because logrotate reports an `error: duplicate log entry for <FILE>` message when two configurations match the same file. Instead, add a `postrotate` script to the service's existing configuration, or create a separate file for paths that are not already managed:
 

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -44,19 +44,19 @@ After you verify ACLs are enabled, grant read and execute permissions for the `d
 setfacl -R -m u:dd-agent:rx /var/log/apache
 ```
 
-To make new log files inherit this access automatically, set a default ACL on the directory with the `-d` flag:
+To have new log files inherit this access automatically, set a default ACL on the directory with the `-d` flag:
 
 ```shell
 setfacl -R -d -m u:dd-agent:rx /var/log/apache
 ```
 
-A default ACL applies to files created in the directory afterward, including those that log rotation creates. This reduces the need for a separate logrotate rule. Files that already exist when you set the default ACL are unaffected, so run both commands above.
+A default ACL only applies to files created in the directory after the default has been set, including those that log rotation creates. This reduces the need for a separate logrotate rule. Files that already exist when you set the default ACL are unaffected, so run both commands above.
 
 [Learn more about how to configure ACLs on Linux][3]
 
 ### Setting permissions for log file rotation
 
-If you set a default ACL with the `-d` flag, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. However, a default ACL does not cover every rotation scheme. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
+If you set a default ACL with the `-d` flag, log files created by a rotation inherit `dd-agent` access automatically, and no further configuration is required. However, a default ACL does not cover every rotation scheme. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
 
 When a default ACL does not apply to your setup, add a rule to logrotate to reset the ACL after each rotation. Avoid defining a rule for log files that another logrotate configuration already manages, because logrotate reports an `error: duplicate log entry for <FILE>` message when two configurations match the same file. Instead, add a `postrotate` script to the service's existing configuration, or create a separate file for paths that are not already managed:
 

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -19,7 +19,7 @@ The Datadog Agent runs under the `dd-agent` user and `dd-agent` group. This prev
 
 ## Setting permissions using ACLs
 
-In order to allow read-only access for `datadog-agent` only, [create ACLs and modify logrotate to persist the permissions changes][1].
+To allow read-only access for the `dd-agent` user, create [access control lists (ACLs)][1] and modify logrotate to persist the permission changes, as described in the following sections.
 
 ### Verifying ACLs are enabled on your system
 
@@ -38,17 +38,27 @@ The permissions set for `datadog-agent` appears in the output of getfacl if ACLs
 
 ### Granting dd-agent read and execute permissions on log directories
 
-Once you have verified ACLs are enabled, grant read and execute permissions for the `datadog-agent` user on the appropriate directories for log collection. For example, to grant access to `/var/log/apache` , run:
+After you verify ACLs are enabled, grant read and execute permissions for the `dd-agent` user on the appropriate directories for log collection. A plain `setfacl -m` command applies the ACL only to the directory itself, not to the log files already inside it. Use the `-R` (recursive) flag to also grant access to existing files. For example, to grant access to `/var/log/apache`, run:
 
 ```shell
-setfacl -m u:dd-agent:rx /var/log/apache
+setfacl -R -m u:dd-agent:rx /var/log/apache
 ```
 
-[Learn more about how to configure ACLs on linux][3]
+To make new log files inherit this access automatically, set a *default* ACL on the directory with the `-d` flag:
+
+```shell
+setfacl -R -d -m u:dd-agent:rx /var/log/apache
+```
+
+A default ACL applies to files created in the directory afterward, including those that log rotation creates. This reduces the need for the logrotate rule described in the next section. Files that already exist when you set the default ACL are unaffected, so run both commands above.
+
+[Learn more about how to configure ACLs on Linux][3]
 
 ### Setting permissions for log file rotation
 
-Setting the permissions once will not persist for rotating logs, as logrotate does not re-apply the ACL setting. For a more permanent solution add a rule to logrotate to reset the ACL in a new file:
+If you set a default ACL with the `-d` flag in the previous section, log files that rotation creates inherit `dd-agent` access automatically, and no further configuration is required. A default ACL does not cover every rotation scheme, however. For example, a configuration that uses `copytruncate` keeps the original file (and its ACL) in place rather than creating a new file.
+
+When a default ACL does not apply to your setup, add a rule to logrotate to reset the ACL after each rotation. Avoid defining a rule for log files that another logrotate configuration already manages, because logrotate reports a `duplicate log entry` error when two configurations match the same file. Instead, add a `postrotate` script to the service's existing configuration, or create a separate file for paths that are not already managed:
 
 ```shell
 sudo touch /etc/logrotate.d/dd-agent_ACLs
@@ -59,8 +69,8 @@ Example file:
 ```text
 /var/log/apache/*.log {
  postrotate
- /usr/bin/setfacl -m g:dd-agent:rx /var/log/apache/access.log
- /usr/bin/setfacl -m g:dd-agent:rx /var/log/apache/error.log
+ /usr/bin/setfacl -m u:dd-agent:rx /var/log/apache/access.log
+ /usr/bin/setfacl -m u:dd-agent:rx /var/log/apache/error.log
  endscript
 }
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-4707

Updates the "Setting file permissions for rotating logs (Linux)" guide to fix inaccurate ACL guidance reported through user feedback:

- Uses recursive `setfacl -R` so existing log files in a directory get access, not just the directory itself.
- Documents default ACLs (`setfacl -d`) so newly rotated log files inherit `dd-agent` access automatically, reducing the need for a separate logrotate rule.
- Explains the `error: duplicate log entry` failure that occurs when a custom logrotate rule overlaps with a service's existing rule, and recommends adding a `postrotate` script to the existing config instead.
- Standardizes on the `dd-agent` username throughout, fixes a misleading link description, fixes subject-verb agreement, and upgrades an external reference link to HTTPS.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to verify the reported ACL behavior, draft the content changes, and run an editorial review pass.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
