### PR TITLE
Clarify that unknown deployment_type means the value was not set

### DIFF
--- a/content/en/opentelemetry/integrations/datadog_extension.md
+++ b/content/en/opentelemetry/integrations/datadog_extension.md
@@ -271,7 +271,7 @@ The DaemonSet forwards to `monitoring/otelcol-gateway-l2`, the Layer-2 gateway f
 | `hostname` | Custom hostname for the Collector. | Auto-detected |
 | `http.endpoint` | Local HTTP server endpoint. | `localhost:9875` |
 | `http.path` | HTTP server path for metadata. | `/metadata` |
-| `deployment_type` | Identifies how the Collector is deployed. This value appears in [Fleet Automation][7] and is required for [gateway topology](#5-optional-configure-gateway-topology-preview). One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
+| `deployment_type` | Identifies how the Collector is deployed. This value appears in [Fleet Automation][7] and is required for [gateway topology](#5-optional-configure-gateway-topology-preview). One of: `gateway`, `daemonset`, or `unknown`. The default `unknown` means the deployment type was not set. | `unknown` |
 | `installation_method` | How the Collector was installed. One of: `kubernetes`, `bare-metal`, `docker`, `ecs-fargate`, `eks-fargate`, or unset. Available in Collector v0.148.0 and later. | unset |
 | `gateway_service` | Set on **gateway** Collectors only. The Kubernetes Service fronting the gateway Collector pods. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |
 | `gateway_destination` | Set on any Collector that forwards telemetry to a downstream gateway. The Kubernetes Service that this Collector forwards telemetry to. Must match `gateway_service` on the receiving gateway Collector. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #37339. Adds a sentence to the `deployment_type` description in the Datadog Extension configuration options table clarifying that the default value `unknown` means the deployment type was not set.

This addresses reader feedback that `unknown` can read as "Datadog could not identify the Collector" rather than "the value was not specified."

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes