### PR TITLE
Fix(WEB-9465): emit partners.json on preview builds for search indexing

### DIFF
--- a/layouts/_default/list.partners.json
+++ b/layouts/_default/list.partners.json
@@ -1,4 +1,4 @@
-{{- if (or (eq hugo.Environment "live") (in (slice "typesense_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+{{- if (in (slice "live" "preview") hugo.Environment) -}}
     {{ $.Scratch.Add "partners_collection" slice }}
 
     {{- range where .Site.AllPages "Type" "=" "partners" -}}

--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -1,4 +1,4 @@
-{{- if (or (eq hugo.Environment "live") (eq hugo.Environment "preview") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+{{- if (in (slice "live" "preview") hugo.Environment) -}}
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
 Emit `partners.json` on preview builds so partner docs get indexed, and simplify the
   matching guard in `search.json`.
  => Production behavior unchanged.

Jira: WEB-8804

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
