### PR TITLE
Fix(search Index): Include static `/API` guide pages  into the search Index

### DIFF
--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -2,16 +2,12 @@
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}
-    {{- /* TEMP: API guide page indexing is commented out to reset the shared preview Typesense baseline on this branch (avoids a ~400k phantom "update" diff caused by branch-namespaced URLs). Uncomment the block below and restore the original loop to re-enable -- same content diff. */ -}}
-    {{- /* Type=api pages are normally excluded (indexed via api-pages-full-index.json by spec tag). These specific API guide pages have real markdown content but no matching spec tag, so index them through the standard content loop.
+    {{- /* Type=api pages are normally excluded (indexed via api-pages-full-index.json by spec tag). These specific API guide pages have real markdown content but no matching spec tag, so index them through the standard content loop. */ -}}
     {{ $apiGuidePages := slice "/api/latest" "/api/latest/using-the-api" "/api/latest/scopes" "/api/latest/rate-limits" }}
     {{ $contentPages := where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api" }}
     {{ $apiGuidePageList := where .Site.AllPages ".Path" "in" $apiGuidePages }}
-    {{ range ($contentPages | append $apiGuidePageList) }}
-    */ -}}
-    {{ $apiPagesWithoutTypeAPI := slice "api/latest/" "api/latest/rate-limits/" "api/latest/scopes/" }}
 
-    {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") ".RelPermalink" "not in" $apiPagesWithoutTypeAPI) }}
+    {{ range ($contentPages | append $apiGuidePageList) }}
         {{ $page := . }}
         {{ if and ($page.IsDescendant $section) (ne $page.Params.type "partners") (ne $page.Params.private true) (not (in $page.RelPermalink "/faq")) (not $page.Draft) (not (isset .Params "external_redirect")) }}
             {{- /* Generate unique ID for each page. Use file path when available, fallback to RelPermalink for pages without files (e.g. virtual pages). This avoids duplicate IDs while preserving existing IDs for 300k+ items. */ -}}

--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -2,9 +2,12 @@
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}
-    {{ $apiPagesWithoutTypeAPI := slice "api/latest/" "api/latest/rate-limits/" "api/latest/scopes/" }}
+    {{- /* Type=api pages are normally excluded (indexed via api-pages-full-index.json by spec tag). These specific API guide pages have real markdown content but no matching spec tag, so index them through the standard content loop. */ -}}
+    {{ $apiGuidePages := slice "/api/latest" "/api/latest/using-the-api" "/api/latest/scopes" "/api/latest/rate-limits" }}
+    {{ $contentPages := where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api" }}
+    {{ $apiGuidePageList := where .Site.AllPages ".Path" "in" $apiGuidePages }}
 
-    {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") ".RelPermalink" "not in" $apiPagesWithoutTypeAPI) }}
+    {{ range ($contentPages | append $apiGuidePageList) }}
         {{ $page := . }}
         {{ if and ($page.IsDescendant $section) (ne $page.Params.type "partners") (ne $page.Params.private true) (not (in $page.RelPermalink "/faq")) (not $page.Draft) (not (isset .Params "external_redirect")) }}
             {{- /* Generate unique ID for each page. Use file path when available, fallback to RelPermalink for pages without files (e.g. virtual pages). This avoids duplicate IDs while preserving existing IDs for 300k+ items. */ -}}

--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -2,12 +2,16 @@
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}
-    {{- /* Type=api pages are normally excluded (indexed via api-pages-full-index.json by spec tag). These specific API guide pages have real markdown content but no matching spec tag, so index them through the standard content loop. */ -}}
+    {{- /* TEMP: API guide page indexing is commented out to reset the shared preview Typesense baseline on this branch (avoids a ~400k phantom "update" diff caused by branch-namespaced URLs). Uncomment the block below and restore the original loop to re-enable -- same content diff. */ -}}
+    {{- /* Type=api pages are normally excluded (indexed via api-pages-full-index.json by spec tag). These specific API guide pages have real markdown content but no matching spec tag, so index them through the standard content loop.
     {{ $apiGuidePages := slice "/api/latest" "/api/latest/using-the-api" "/api/latest/scopes" "/api/latest/rate-limits" }}
     {{ $contentPages := where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api" }}
     {{ $apiGuidePageList := where .Site.AllPages ".Path" "in" $apiGuidePages }}
-
     {{ range ($contentPages | append $apiGuidePageList) }}
+    */ -}}
+    {{ $apiPagesWithoutTypeAPI := slice "api/latest/" "api/latest/rate-limits/" "api/latest/scopes/" }}
+
+    {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") ".RelPermalink" "not in" $apiPagesWithoutTypeAPI) }}
         {{ $page := . }}
         {{ if and ($page.IsDescendant $section) (ne $page.Params.type "partners") (ne $page.Params.private true) (not (in $page.RelPermalink "/faq")) (not $page.Draft) (not (isset .Params "external_redirect")) }}
             {{- /* Generate unique ID for each page. Use file path when available, fallback to RelPermalink for pages without files (e.g. virtual pages). This avoids duplicate IDs while preserving existing IDs for 300k+ items. */ -}}


### PR DESCRIPTION
Adding static /api pages (non-endpoint pages) to the Index, including:
 `/api/latest`, `/api/latest/using-the-api`, `/api/latest/scopes`, and `/api/latest/rate-limits`.
 
 They were previously excluded entirely, since they have  `type=api`  but no matching API spec tag

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
