### PR TITLE
Remove Purchase category from CCM recommendations page

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -607,7 +607,6 @@ Below are the available cloud cost recommendation categories and their descripti
 | Terminate | Resources with signals that the resource is unused or very low utilization signals. Consider terminating or deleting these resources to reduce your costs. |
 | Migrate | Resources with moderately low utilization signals or other inefficiencies. Consider adjusting the instance type or other parameters. |
 | Downsize | Resources that are under-utilized or over-provisioned. Consider adjusting the size or other parameters to reduce costs. |
-| Purchase | Resources with on-demand charges and extended uptime. Purchasing a reservation or Savings Plan can reduce the amortized cost of the resource. |
 | Configure | Resources with configuration options that can be adjusted to reduce costs without changing capacity or terminating the resource. |
 
 ## Prerequisites

--- a/content/en/cloud_cost_management/setup/saas_costs.md
+++ b/content/en/cloud_cost_management/setup/saas_costs.md
@@ -181,6 +181,8 @@ Begin by getting an [Admin API key](https://docs.anthropic.com/en/api/administra
 
 After you save your configuration, Datadog begins polling Anthropic usage and cost endpoints using this key, and populates metrics in your environment.
 
+**Note**: To track costs for both Anthropic Enterprise and platform accounts, add a separate account entry for each API key type. Use the platform Admin API key for standard platform usage, and the enterprise Analytics API key for Anthropic Enterprise usage.
+
 {{% /tab %}}
 
 {{% tab "GitHub" %}}
@@ -554,6 +556,7 @@ The following table contains a non-exhaustive list of out-of-the-box tags associ
 | `org_id` | The unique identifier of the Anthropic organization. |
 | `org_name` | A tag-normalized version of the Anthropic organization's name. |
 | `display_org_name` | The unaltered name of the organization. |
+| `org_type` | The type of Anthropic account (for example, `enterprise`). Displays `N/A` for non-enterprise accounts. |
 | `model_id` | The canonical Anthropic model identifier (for example, `claude-3-opus-20240229`). |
 | `model` | An alias for `model_id`, provided for compatibility and consistency with usage and metrics. |
 | `model_name` | The friendly name of the model (for example, `Claude 3 Opus`). |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the Purchase row from the Recommendation categories table on the Cloud Cost Management recommendations page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes