### PR TITLE
[DOCS-14876] Remove `paperplane` from supported loggers

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
@@ -23,7 +23,7 @@ further_reading:
 
 ## Automatic injection
 
-Enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, and `winston` when structured application loggers are used. 
+Enables automatic trace ID injection for `bunyan`, `pino`, and `winston` when structured application loggers are used. 
 
 For older tracer versions injection can be enabled the environment variable `DD_LOGS_INJECTION=true` or by configuring the SDK directly:
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
@@ -41,7 +41,7 @@ experience for adding `env`, `service`, and `version` (see [Unified Service Tagg
 
 ### Example with Winston and Express
 
-Here's a simple example using Winston with Express:
+Here's an example using Winston with Express:
 
 ```javascript
 // init tracer first

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -31,9 +31,9 @@ When a release has changes that could go in multiple semver categories, the high
 
 _Maintenance mode_ is a period during which a release gets only security and bug fixes whenever possible, but not new features except on a case-by-case basis. Major versions of `dd-trace` enter maintenance mode upon the release of the subsequent major version of dd-trace. The maintenance mode period lasts for one year after the release date of that subsequent version.
 
-For example, if version 5.0.0 of `dd-trace` is released on May 4, 2023, the 4.x.x release line is supported on a maintenance mode basis until May 4, 2024. During this maintenance mode period, security and bug patches will be applied whenever possible.
+For example, if version 5.0.0 of `dd-trace` is released on May 4, 2023, the 4.x.x release line is supported on a maintenance mode basis until May 4, 2024. During this maintenance mode period, Datadog applies security and bug patches whenever possible.
 
-If you have any questions or concerns about our support for a particular version of `dd-trace-js`, [contact Support][3] to discuss.
+If you have any questions or concerns about Datadog's support for a particular version of `dd-trace-js`, [contact Support][3] to discuss.
 
 ### Node.js Version Support
 

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -212,7 +212,6 @@ Or, modify the `package.json` file if you typically start an application with np
 | Module           | Versions  | Support Type    |
 | ---------------- | --------- | --------------- |
 | [bunyan][55]     | `>=1`     | Fully supported |
-| [paperplane][56] | `>=2.3.2` | Fully supported |
 | [pino][57]       | `>=2`     | Fully supported |
 | [winston][58]    | `>=1`     | Fully supported |
 
@@ -301,7 +300,6 @@ For additional information or to discuss [leave a comment on this GitHub issue][
 [53]: https://github.com/kriskowal/q
 [54]: https://github.com/cujojs/when
 [55]: https://github.com/trentm/node-bunyan
-[56]: https://github.com/articulate/paperplane/blob/master/docs/API.md#logger
 [57]: http://getpino.io
 [58]: https://github.com/winstonjs/winston
 [59]: https://github.com/laverdet/node-fibers


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

`paperplane` does not support the version of Node.js that Datadog uses, so it is not compatible with our Log Management product as a logger.

### Merge readiness

- [X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

n/a

### Additional notes

- Engineering will update the compatibility tables to automatically update by ingesting the source in the future.
- I filed DOCS-14937 to add code examples for `bunyan` and `pino` to [Correlating Node.js Logs and Traces](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/) later.

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
