### PR TITLE
Update OTLP trace intake docs for broad availability

### DIFF
--- a/content/en/opentelemetry/setup/_index.md
+++ b/content/en/opentelemetry/setup/_index.md
@@ -53,7 +53,7 @@ Alternative methods are available for specific use cases, such as maintaining a 
     Best for: Users on platforms other than Kubernetes Linux, or those who prefer a minimal configuration without managing Collector pipelines.
     {{< /nextlink >}}
     {{< nextlink href="/opentelemetry/setup/agentless" >}}
-    <h3>Direct OTLP Ingest (Preview)</h3>
+    <h3>Direct OTLP Ingest</h3>
     Best for: Situations requiring direct data transmission to Datadog's intake endpoint without any intermediary components.
     {{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -28,6 +28,8 @@ Send traces, metrics, and logs to Datadog using the [OpenTelemetry Collector Con
 
 <div class="alert alert-info">To see which Datadog features are supported with this setup, see the <a href="/opentelemetry/compatibility/">feature compatibility table</a> under <b>OTel SDK + OSS Collector</b>.</div>
 
+<div class="alert alert-info">This setup supports bare metal, VMs, and Kubernetes, including managed distributions such as Amazon EKS and Google GKE. Standard EKS has been tested; EKS auto mode has not. This setup does not support serverless or task-based container runtimes such as ECS Fargate or AWS Lambda.</div>
+
 ## Prerequisites
 
 - [OpenTelemetry Collector Contrib][1] v0.152.0 or later

--- a/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
+++ b/content/en/opentelemetry/setup/collector_exporter/oss_setup.md
@@ -26,11 +26,9 @@ Send traces, metrics, and logs to Datadog using the [OpenTelemetry Collector Con
 
 <div class="alert alert-warning">This setup is in Preview. Some Datadog features may behave differently compared to the Datadog Exporter setup. For example, the <a href="/infrastructure/list/">Infrastructure List</a> may show less host metadata until host metadata ingestion support is finalized and the Kubernetes Explorer related views may be empty.</div>
 
-<div class="alert alert-info">To see which Datadog features are supported with this setup, see the <a href="/opentelemetry/compatibility/">feature compatibility table</a> under <b>OTel SDK + OSS Collector</b>.</div>
-
-<div class="alert alert-info">This setup supports bare metal, VMs, and Kubernetes, including managed distributions such as Amazon EKS and Google GKE. Standard EKS has been tested; EKS auto mode has not. This setup does not support serverless or task-based container runtimes such as ECS Fargate or AWS Lambda.</div>
-
 ## Prerequisites
+
+This setup supports bare metal, VMs, and Kubernetes, including managed distributions such as Amazon EKS and Google GKE. Standard EKS is tested; EKS auto mode is not. This setup does not support serverless or task-based container runtimes such as ECS Fargate or AWS Lambda. To see which Datadog features this setup supports, see the [feature compatibility table][7] under **OTel SDK + OSS Collector**.
 
 - [OpenTelemetry Collector Contrib][1] v0.152.0 or later
 - A [Datadog API key][2]
@@ -813,4 +811,5 @@ The configuration sends the Collector's own metrics back to its local OTLP recei
 [4]: /getting_started/tagging/unified_service_tagging/
 [5]: https://github.com/DataDog/opentelemetry-examples/tree/experimental-oss-config/configurations/opentelemetry-collector
 [6]: /opentelemetry/guide/otlp_delta_temporality/
+[7]: /opentelemetry/compatibility/
 [100]: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest

--- a/content/en/opentelemetry/setup/otlp_ingest/_index.md
+++ b/content/en/opentelemetry/setup/otlp_ingest/_index.md
@@ -27,7 +27,7 @@ Your setup depends on where your telemetry is coming from. Check the [Managed pl
 |---|---|
 | A managed platform (Cloudflare, Vercel, Heroku, Netlify, Modal, and [others][6]) | [Managed platforms][6] |
 | A serverless environment sending traces (Lambda, ECS Fargate, Azure Functions, Cloud Run, GKE Autopilot) | [Serverless][7] |
-| Your own app, host, or container | [Logs][3], [Metrics][4], or Traces (in Preview; contact your Customer Success Manager) |
+| Your own app, host, or container | [Logs][3], [Metrics][4], or [Traces][8] |
 
 See also: [Instrumenting for Agent Observability][5].
 
@@ -42,3 +42,4 @@ See also: [Instrumenting for Agent Observability][5].
 [5]: /llm_observability/instrumentation/otel_instrumentation/?tab=python#setup
 [6]: /opentelemetry/setup/otlp_ingest/managed_platforms/
 [7]: /opentelemetry/setup/otlp_ingest/serverless/
+[8]: /opentelemetry/setup/otlp_ingest/traces/

--- a/content/en/opentelemetry/setup/otlp_ingest/managed_platforms.md
+++ b/content/en/opentelemetry/setup/otlp_ingest/managed_platforms.md
@@ -66,7 +66,7 @@ All endpoints follow the pattern `https://{subdomain}.integrations.otlp.{{< regi
 | Heroku | `heroku` | [Heroku telemetry][13] |
 | IBM | `ibm` | — |
 | LangSmith | `langsmith` | — |
-| LiveCloudKit | `livecloudkit` | — |
+| LiveCloudKit | `livekit` | — |
 | Modal | `modal` | [Modal OpenTelemetry][14] |
 | MuleSoft | `mulesoft` | [MuleSoft Telemetry Exporter][15] |
 | Netlify | `netlify` | — |

--- a/content/en/opentelemetry/setup/otlp_ingest/serverless.md
+++ b/content/en/opentelemetry/setup/otlp_ingest/serverless.md
@@ -10,10 +10,6 @@ further_reading:
     text: "Datadog Serverless Monitoring"
 ---
 
-{{< callout header="false" btn_hidden="true">}}
-Serverless traces use the OTLP traces intake endpoint, which is in Preview. To send serverless traces, you must have access to the OTLP traces endpoint.
-{{< /callout >}}
-
 ## Overview
 
 Send traces from serverless workloads directly to Datadog over HTTP/protobuf, without requiring a [Datadog Agent][1] or OpenTelemetry Collector. If your platform appears in the [Managed platforms][5] table, use its dedicated endpoint instead.

--- a/content/en/opentelemetry/setup/otlp_ingest/traces.md
+++ b/content/en/opentelemetry/setup/otlp_ingest/traces.md
@@ -4,7 +4,6 @@ aliases:
   - /opentelemetry/otlp_endpoint
   - /opentelemetry/setup/intake_endpoint/otlp_traces
   - /opentelemetry/setup/agentless/traces
-private: true
 further_reading:
   - link: "https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/"
     tag: "External Site"
@@ -16,9 +15,6 @@ further_reading:
     tag: "External Site"
     text: "OpenTelemetry Protocol Exporter"
 ---
-{{< callout header="false" btn_hidden="true">}}
-  The Datadog OTLP traces intake endpoint is in Preview. To request access, contact your Customer Success Manager.
-{{< /callout >}}
 
 ## Overview
 
@@ -26,8 +22,9 @@ Datadog's OpenTelemetry protocol (OTLP) intake API endpoint allows you to send t
 
 You might prefer this option if you're looking for a straightforward setup and want to send traces directly to Datadog without using the Datadog Agent or OpenTelemetry Collector.
 
+For serverless workloads, see [OTLP Intake for Serverless][8]. For managed platforms such as Cloudflare, Vercel, and Heroku, see [OTLP Intake for Managed Platforms][9].
 
-<div class="alert alert-info">The OTLP trace intake endpoint only supports <code>http/protobuf</code> encoding. <code>http/json</code> and <code>grpc</code> are not supported at this time.</div>
+<div class="alert alert-info">The OTLP trace intake endpoint supports <code>http/protobuf</code> and <code>http/json</code> encoding. <code>grpc</code> is not supported.</div>
 
 ## Configuration
 
@@ -173,30 +170,7 @@ For example:
 ```
 ## OpenTelemetry Collector
 
-If you are using the OpenTelemetry Collector and don't want to use the Datadog Exporter, you can configure [`otlphttpexporter`][4] to export traces to the Datadog OTLP traces intake endpoint.
-
-For example, configure your `config.yaml` like this:
-
-```yaml
-...
-
-exporters:
-  otlphttp:
-    traces_endpoint: {{< region-param key="otlp_trace_endpoint" >}}
-    headers:
-      dd-api-key: ${env:DD_API_KEY}
-      dd-otel-span-mapping: "{span_name_as_resource_name: false}"
-      dd-otlp-source: "${YOUR_SITE}" # Replace with the specific value provided by Datadog for your organization
-      compute_stats: "true"
-...
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlphttp]
-```
+If you are using an OpenTelemetry Collector and don't want to use the Datadog Exporter, you need a specific configuration to get the best product experience. To get set up, see [OpenTelemetry Native Instrumentation][10].
 
 ## Troubleshooting
 
@@ -270,7 +244,9 @@ This ensures that the span operation names are consistent across the Datadog OTL
 [1]: /opentelemetry/collector_exporter/
 [2]: /opentelemetry/otlp_ingest_in_the_agent/
 [3]: https://opentelemetry.io/docs/specs/otel/glossary/#automatic-instrumentation
-[4]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter
 [5]: https://github.com/open-telemetry/opentelemetry-go/issues/3706
 [6]: https://github.com/open-telemetry/opentelemetry-specification/issues/3203
 [7]: /tracing/metrics/
+[8]: /opentelemetry/setup/otlp_ingest/serverless/
+[9]: /opentelemetry/setup/otlp_ingest/managed_platforms/
+[10]: https://www.datadoghq.com/product-preview/otel-native-instrumentation/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the OpenTelemetry OTLP intake docs ahead of the OTLP trace intake becoming broadly available:

- Makes the **OTLP Traces Intake Endpoint** page public (removes `private: true`) and removes the Preview callout. Also removes the Preview callout from the **OTLP Intake for Serverless** page.
- Updates the supported-encoding note on the traces page: the endpoint supports both `http/protobuf` and `http/json`; only `grpc` is unsupported.
- Links the now-public Traces page from the OTLP intake section index, and links the Serverless and Managed Platforms pages from the Traces page.
- Replaces the OpenTelemetry Collector configuration example on the Traces page with a pointer to the OpenTelemetry Native Instrumentation setup.
- Corrects the LiveCloudKit managed platform subdomain to `livekit`.
- Adds a supported-environments note to the OSS Collector setup page (bare metal, VMs, and Kubernetes including EKS/GKE; not serverless or task-based runtimes), with a caveat that standard EKS is tested but EKS auto mode is not.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

