### PR TITLE
Add Code Coverage and DORA metrics links to Software Delivery docs

### DIFF
--- a/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-The [Datadog MCP Server][1] enables AI agents to access your Software Delivery data through the [Model Context Protocol (MCP)][2]. The `software-delivery` toolset provides tools for interacting with [CI Visibility][3] and [Test Optimization][4] directly from AI-powered clients like Cursor, Claude Code, or OpenAI Codex.
+The [Datadog MCP Server][1] enables AI agents to access your Software Delivery data through the [Model Context Protocol (MCP)][2]. The `software-delivery` toolset provides tools for interacting with [CI Visibility][3], [Test Optimization][4], [Code Coverage][8], and [DORA metrics][9] directly from AI-powered clients like Cursor, Claude Code, or OpenAI Codex.
 
 ## Use cases
 
@@ -170,3 +170,5 @@ For flaky failures, the skill chains into `triage-flaky-test` for a deeper inves
 [5]: /getting_started/site/
 [6]: https://github.com/datadog-labs/agent-skills
 [7]: https://github.com/DataDog/pup
+[8]: /code_coverage/
+[9]: /delivery_performance/dora_metrics/

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1329,7 +1329,7 @@ Assigns or unassigns security findings to a user. Assignment cascades to any lin
 
 ## Software Delivery
 
-Tools for interacting with Software Delivery ([CI Visibility][48] and [Test Optimization][24]).
+Tools for interacting with Software Delivery ([CI Visibility][48], [Test Optimization][24], [Code Coverage][65], and [DORA metrics][66]).
 
 ### `search_datadog_ci_pipeline_events`
 *Toolset: **software-delivery***\
@@ -1632,3 +1632,5 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [59]: /real_user_monitoring/rum_without_limits/
 [63]: /agent/guide/rshell/
 [64]: /cloud_cost_management/
+[65]: /code_coverage/
+[66]: /delivery_performance/dora_metrics/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR updates the Software Delivery toolset descriptions in both the MCP Server tools reference and the Software Delivery MCP tools getting started guide to include proper documentation links for Code Coverage and DORA metrics, matching the existing link format used for CI Visibility and Test Optimization.

Previously, the descriptions only mentioned CI Visibility and Test Optimization, despite the toolset including tools for Code Coverage and DORA metrics as well.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The changes are minimal and only add proper markdown links to existing text. Both Code Coverage (`/code_coverage/`) and DORA metrics (`/delivery_performance/dora_metrics/`) documentation pages exist and are linked appropriately.