### PR TITLE
Enhance troubleshooting section for Worker logs

### DIFF
--- a/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
+++ b/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
@@ -68,7 +68,7 @@ docker run -i -e DD_API_KEY=<DATADOG_API_KEY> \
 
 ### No Worker logs in Log Explorer
 
-If you do not see Worker logs in [Log Explorer][12], make sure they are not getting excluded in your log pipelines. Worker logs must be indexed in Log Management for optimal functionality. The logs provide deployment information, such as Worker status, version, and any errors, that is shown in the Observability Pipelines UI. The logs are also helpful for troubleshooting Worker or pipelines issues. If Worker logs are not indexed in Log Management, the Latest Deploy and Setup tab displays a perpetual loading state instead of the current worker status. All Worker logs have the tag `source:op_worker`.
+If you do not see Worker logs in [Log Explorer][12], make sure they are not getting excluded in your log pipelines. Worker logs must be indexed in Log Management for optimal functionality. The logs provide deployment information, such as Worker status, version, and any errors, that is shown in the Observability Pipelines UI. The logs are also helpful for troubleshooting Worker or pipelines issues. If Worker logs are not indexed in Log Management, the Latest Deploy and Setup tab displays a perpetual loading state instead of the current Worker status. All Worker logs have the tag `source:op_worker`.
 
 ### Duplicate Observability Pipelines logs
 

--- a/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
+++ b/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
@@ -68,7 +68,7 @@ docker run -i -e DD_API_KEY=<DATADOG_API_KEY> \
 
 ### No Worker logs in Log Explorer
 
-If you do not see Worker logs in [Log Explorer][12], make sure they are not getting excluded in your log pipelines. Worker logs must be indexed in Log Management for optimal functionality. The logs provide deployment information, such as Worker status, version, and any errors, that is shown in the Observability Pipelines UI. The logs are also helpful for troubleshooting Worker or pipelines issues. All Worker logs have the tag `source:op_worker`.
+If you do not see Worker logs in [Log Explorer][12], make sure they are not getting excluded in your log pipelines. Worker logs must be indexed in Log Management for optimal functionality. The logs provide deployment information, such as Worker status, version, and any errors, that is shown in the Observability Pipelines UI. The logs are also helpful for troubleshooting Worker or pipelines issues. If Worker logs are not indexed in Log Management, the Latest Deploy and Setup tab displays a perpetual loading state instead of the current worker status. All Worker logs have the tag `source:op_worker`.
 
 ### Duplicate Observability Pipelines logs
 


### PR DESCRIPTION
Added information on the impact of unindexed Worker logs on the Latest Deploy and Setup tab.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Based on this [escalation](https://datadoghq.atlassian.net/browse/LOGSS-10452?focusedCommentId=3374409), if customers worker logs aren't indexed, then the worker status will be in a perpetual loading state. Wanted to outline this in our docs as it wasn't clear that this is required. 
The motivation for this is this [ticket](https://datadog.zendesk.com/agent/tickets/2924757), want the docs to be clear on this as the current information indicates the logs need to be indexed for optimal functionality, however the worker status loading indicates that recent changes haven't been implemented.

### Merge readiness
Unsure of this
## For Datadog employees:

- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance
I used Claude code to improve the wording of my initial draft based on the escalation on the contribution style guide(https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md)

### Additional notes
NA