### PR TITLE
Add Python/pytest support to Test Parallelization docs

### DIFF
--- a/content/en/tests/test_parallelization/_index.md
+++ b/content/en/tests/test_parallelization/_index.md
@@ -23,14 +23,10 @@ Before setting up Test Parallelization, set up [Test Optimization][2]. Optionall
 
 Test Parallelization is supported for the following language and frameworks:
 
-| Language | Frameworks |
-| -------- | ---------- |
-| Ruby     | RSpec, Minitest |
-| Python   | pytest |
-
-Ruby projects require the `datadog-ci` gem version `1.31.0` or later.
-
-Python projects require the `ddtrace` package version `4.10.3` or later and `pytest`.
+| Language | Frameworks | Minimum library version |
+| -------- | ---------- | ----------------------- |
+| Ruby     | RSpec, Minitest | `datadog-ci` gem `1.31.0` or later |
+| Python   | pytest | `ddtrace` package `4.10.3` or later |
 
 ## How it works
 

--- a/content/en/tests/test_parallelization/_index.md
+++ b/content/en/tests/test_parallelization/_index.md
@@ -26,8 +26,11 @@ Test Parallelization is supported for the following language and frameworks:
 | Language | Frameworks |
 | -------- | ---------- |
 | Ruby     | RSpec, Minitest |
+| Python   | pytest |
 
 Ruby projects require the `datadog-ci` gem version `1.31.0` or later.
+
+Python projects require the `ddtrace` package version `4.10.3` or later and `pytest`.
 
 ## How it works
 

--- a/content/en/tests/test_parallelization/_index.md
+++ b/content/en/tests/test_parallelization/_index.md
@@ -26,7 +26,7 @@ Test Parallelization is supported for the following language and frameworks:
 | Language | Frameworks | Minimum library version |
 | -------- | ---------- | ----------------------- |
 | Ruby     | RSpec, Minitest | `datadog-ci` gem `1.31.0` or later |
-| Python   | pytest | `ddtrace` package `4.10.3` or later |
+| Python   | pytest | `ddtrace` package `4.11.0` or later |
 
 ## How it works
 

--- a/content/en/tests/test_parallelization/best_practices.md
+++ b/content/en/tests/test_parallelization/best_practices.md
@@ -1,6 +1,6 @@
 ---
 title: Test Parallelization Best Practices
-description: Optimize Test Parallelization planning and test discovery for Ruby and Rails test suites.
+description: Optimize Test Parallelization planning and test discovery for Ruby, Rails, and Python test suites.
 further_reading:
   - link: "/tests/test_parallelization/setup/"
     tag: "Documentation"
@@ -19,7 +19,7 @@ Test Parallelization is in Preview. Complete the form to request access.
 
 ## Optimize the planning step
 
-Test Parallelization adds a planning step that discovers tests before execution. For example, RSpec projects use dry-run discovery. Keep this step lightweight so the time saved by parallel execution is not offset by planning overhead.
+Test Parallelization adds a planning step that discovers tests before execution. For example, RSpec projects use dry-run discovery and pytest projects use collection. Keep this step lightweight so the time saved by parallel execution is not offset by planning overhead.
 
 ### Preinstall system dependencies with Docker
 
@@ -42,6 +42,15 @@ Use your CI provider dependency cache. For example, GitHub Actions can cache Bun
   with:
     ruby-version: 3.3
     bundler-cache: true
+{{< /code-block >}}
+
+For Python projects, use `actions/setup-python` with pip caching:
+
+{{< code-block lang="yaml" >}}
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.12"
+    cache: pip
 {{< /code-block >}}
 
 ### Skip database setup during discovery
@@ -71,6 +80,14 @@ end
 {{< /code-block >}}
 
 After these changes, test discovery can run faster and avoid failures when the database is unavailable during planning.
+
+## Configure pytest
+
+`ddtest` runs pytest as `python -m pytest` and appends the selected test files. It appends `--ddtrace` to `PYTEST_ADDOPTS`, preserving any existing value, so the `ddtrace` pytest plugin loads without changing your pytest config.
+
+For test discovery, `ddtest` reads `testpaths` and `python_files` from `pytest.ini`, `pyproject.toml`, `tox.ini`, or `setup.cfg`. If no pytest config defines those settings, `ddtest` uses `**/{test_*,*_test}.py`.
+
+During discovery, `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED` is set to `1`. Use this variable to skip expensive setup code during planning, similar to [skipping database setup during discovery](#skip-database-setup-during-discovery).
 
 ## Configure Minitest in non-Rails projects
 

--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -25,16 +25,16 @@ Most `ddtest` settings can be passed as a CLI flag or as an environment variable
 : Programming language.<br/>
 **CLI flag:** `--platform`<br/>
 **Default:** `ruby`<br/>
-**Example:** `ruby`
+**Supported values:** `ruby`, `python`
 
 `DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK`
 : Test framework.<br/>
 **CLI flag:** `--framework`<br/>
 **Default:** `rspec`<br/>
-**Example:** `rspec`, `minitest`
+**Supported values:** `rspec`, `minitest`, `pytest`
 
 `DD_TEST_OPTIMIZATION_RUNNER_COMMAND`
-: Overrides the default test command. `ddtest` appends selected test files and framework-specific flags to the command. For more information, see [Custom test commands](#custom-test-commands).<br/>
+: Overrides the default test command for Ruby frameworks. `ddtest` appends selected test files and framework-specific flags to the command. For pytest, use `PYTEST_ADDOPTS` instead. For more information, see [Custom test commands](#custom-test-commands).<br/>
 **CLI flag:** `--command`<br/>
 **Default:** Empty<br/>
 **Example:** `bundle exec rspec --profile`
@@ -76,10 +76,10 @@ Most `ddtest` settings can be passed as a CLI flag or as an environment variable
 **Example:** `DB_NAME=testdb{{nodeIndex}}_{{workerIndex}};FIXTURE=fixture{{nodeIndex}}`
 
 `DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION`
-: Glob pattern used to discover test files. Defaults to `spec/**/*_spec.rb` for RSpec and `test/**/*_test.rb` for Minitest.<br/>
+: Glob pattern used to discover test files. Defaults to `spec/**/*_spec.rb` for RSpec, `test/**/*_test.rb` for Minitest, and pytest configuration (`testpaths` and `python_files`) or `**/{test_*,*_test}.py` for pytest.<br/>
 **CLI flag:** `--tests-location`<br/>
 **Default:** Framework default<br/>
-**Example:** `custom/spec/**/*_spec.rb`
+**Example:** `custom/spec/**/*_spec.rb`, `tests/**/*_test.py`
 
 `DD_TEST_OPTIMIZATION_RUNNER_RUNTIME_TAGS`
 : JSON string that overrides runtime tags used to fetch skippable tests. Use this when `ddtest` runs outside the CI environment used to calculate skippable tests.<br/>
@@ -111,7 +111,7 @@ Increase `--ci-job-overhead` to use fewer CI nodes. Decrease it to prefer faster
 
 ## Custom test commands
 
-Use `--command` to override the default test command:
+For Ruby frameworks, use `--command` to override the default test command:
 
 {{< code-block lang="bash" >}}
 bin/ddtest run --platform ruby --framework rspec --command "bin/integration-tests"
@@ -120,6 +120,18 @@ bin/ddtest run --platform ruby --framework rspec --command "bin/integration-test
 When using `--command`, do not include test files in the command. `ddtest` appends test files and framework-specific flags to the command.
 
 Do not include the `--` separator in `--command`. If the command contains `--`, `ddtest` emits a warning and removes the separator and everything after it.
+
+For pytest, `ddtest` runs `python -m pytest` and appends selected test files. Use `PYTEST_ADDOPTS` to pass additional pytest flags. `ddtest` appends `--ddtrace` to `PYTEST_ADDOPTS` automatically so the `ddtrace` pytest plugin loads without changing your pytest config.
+
+## Pytest test discovery
+
+For pytest, `ddtest` discovers test files using this priority:
+
+1. `--tests-location` when set.
+2. Pytest configuration from `pytest.ini`, `pyproject.toml`, `tox.ini`, or `setup.cfg`, using `testpaths` and `python_files`.
+3. The built-in pattern `**/{test_*,*_test}.py`.
+
+Pytest does not have an equivalent to RSpec's pattern flag, so `ddtest` resolves the pattern to explicit file paths before invoking `python -m pytest`.
 
 ## Worker environment variables
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -146,8 +146,7 @@ For a list of available environment variables, defaults, and examples, see [Conf
 
 Use the following examples as starting points for GitHub Actions and CircleCI.
 
-{{< tabs >}}
-{{% tab "Ruby" %}}
+{{< collapse-content title="Ruby" level="h3" >}}
 
 {{< tabs >}}
 {{% tab "GitHub Actions" %}}
@@ -334,8 +333,9 @@ workflows:
 {{% /tab %}}
 {{< /tabs >}}
 
-{{% /tab %}}
-{{% tab "Python" %}}
+{{< /collapse-content >}}
+
+{{< collapse-content title="Python" level="h3" >}}
 
 {{< tabs >}}
 {{% tab "GitHub Actions" %}}
@@ -530,8 +530,7 @@ workflows:
 {{% /tab %}}
 {{< /tabs >}}
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /collapse-content >}}
 
 ## Use third-party test runners
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -147,7 +147,10 @@ For a list of available environment variables, defaults, and examples, see [Conf
 Use the following examples as starting points for GitHub Actions and CircleCI.
 
 {{< tabs >}}
-{{% tab "GitHub Actions (Ruby)" %}}
+{{% tab "Ruby" %}}
+
+{{< tabs >}}
+{{% tab "GitHub Actions" %}}
 
 The plan job chooses the CI node count and emits a matrix. The test job downloads the `.testoptimization/` artifact and runs only the files assigned to its matrix node.
 
@@ -231,97 +234,7 @@ jobs:
 {{< /code-block >}}
 
 {{% /tab %}}
-{{% tab "GitHub Actions (Python)" %}}
-
-The plan job chooses the CI node count and emits a matrix. The test job downloads the `.testoptimization/` artifact and runs only the files assigned to its matrix node.
-
-{{< code-block lang="yaml" >}}
-name: CI with Test Parallelization
-
-on: [push]
-
-env:
-  DD_TEST_OPTIMIZATION_RUNNER_PLATFORM: python
-  DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK: pytest
-  DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM: 1
-  DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
-
-jobs:
-  dd_plan:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.dd_plan.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download ddtest binary
-        run: |
-          mkdir -p bin
-          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
-          mv bin/ddtest-linux-amd64 bin/ddtest
-          chmod +x bin/ddtest
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
-      - name: Configure Datadog Test Optimization
-        uses: datadog/test-visibility-github-action@v2
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: datadoghq.com
-      - id: dd_plan
-        name: Plan test execution
-        run: bin/ddtest plan
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dd-artifacts
-          path: .testoptimization
-          include-hidden-files: true
-
-  dd_test:
-    runs-on: ubuntu-latest
-    needs: [dd_plan]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.dd_plan.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download ddtest binary
-        run: |
-          mkdir -p bin
-          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
-          mv bin/ddtest-linux-amd64 bin/ddtest
-          chmod +x bin/ddtest
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - uses: actions/download-artifact@v4
-        with:
-          name: dd-artifacts
-          path: .testoptimization
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
-      - name: Configure Datadog Test Optimization
-        uses: datadog/test-visibility-github-action@v2
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: datadoghq.com
-      - name: Run tests
-        run: bin/ddtest run --ci-node ${{ matrix.ci_node_index }}
-{{< /code-block >}}
-
-{{% /tab %}}
-{{% tab "CircleCI (Ruby)" %}}
+{{% tab "CircleCI" %}}
 
 The setup workflow runs `ddtest plan`, stores `.testoptimization/`, and continues into a test workflow with the selected CI node count.
 
@@ -419,7 +332,103 @@ workflows:
 {{< /code-block >}}
 
 {{% /tab %}}
-{{% tab "CircleCI (Python)" %}}
+{{< /tabs >}}
+
+{{% /tab %}}
+{{% tab "Python" %}}
+
+{{< tabs >}}
+{{% tab "GitHub Actions" %}}
+
+The plan job chooses the CI node count and emits a matrix. The test job downloads the `.testoptimization/` artifact and runs only the files assigned to its matrix node.
+
+{{< code-block lang="yaml" >}}
+name: CI with Test Parallelization
+
+on: [push]
+
+env:
+  DD_TEST_OPTIMIZATION_RUNNER_PLATFORM: python
+  DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK: pytest
+  DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM: 1
+  DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
+
+jobs:
+  dd_plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dd_plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ddtest binary
+        run: |
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mv bin/ddtest-linux-amd64 bin/ddtest
+          chmod +x bin/ddtest
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: datadoghq.com
+      - id: dd_plan
+        name: Plan test execution
+        run: bin/ddtest plan
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dd-artifacts
+          path: .testoptimization
+          include-hidden-files: true
+
+  dd_test:
+    runs-on: ubuntu-latest
+    needs: [dd_plan]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.dd_plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ddtest binary
+        run: |
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mv bin/ddtest-linux-amd64 bin/ddtest
+          chmod +x bin/ddtest
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: dd-artifacts
+          path: .testoptimization
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: datadoghq.com
+      - name: Run tests
+        run: bin/ddtest run --ci-node ${{ matrix.ci_node_index }}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "CircleCI" %}}
 
 The setup workflow runs `ddtest plan`, stores `.testoptimization/`, and continues into a test workflow with the selected CI node count.
 
@@ -517,6 +526,9 @@ workflows:
     jobs:
       - test
 {{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -25,7 +25,8 @@ Test Parallelization is in Preview. Complete the form to request access.
 Before setting up Test Parallelization:
 
 - Set up [Test Optimization][1].
-- Use the `datadog-ci` gem version `1.31.0` or later.
+- For Ruby: use the `datadog-ci` gem version `1.31.0` or later.
+- For Python: use the `ddtrace` package version `4.10.3` or later and `pytest`.
 - Enable [Test Impact Analysis][2] for the test service when you want Test Parallelization to split only the tests affected by a code change.
 
 ## Concepts
@@ -79,15 +80,31 @@ chmod +x bin/ddtest
 
 If you run your tests on a single CI node, run `ddtest run`:
 
+{{< tabs >}}
+{{% tab "Ruby" %}}
+
 {{< code-block lang="bash" >}}
 bin/ddtest run --platform ruby --framework rspec
 {{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Python" %}}
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform python --framework pytest
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
 
 By default, `ddtest` can start one worker for each physical CPU core available on the node.
 
 ## Run across multiple CI nodes
 
 For multiple CI nodes, run `ddtest plan` once, share the `.testoptimization/` directory with every CI node, and pass each node its zero-indexed CI node number:
+
+{{< tabs >}}
+{{% tab "Ruby" %}}
 
 {{< code-block lang="bash" >}}
 bin/ddtest plan \
@@ -102,6 +119,25 @@ bin/ddtest run \
   --ci-node <CI_NODE_INDEX>
 {{< /code-block >}}
 
+{{% /tab %}}
+{{% tab "Python" %}}
+
+{{< code-block lang="bash" >}}
+bin/ddtest plan \
+  --platform python \
+  --framework pytest \
+  --min-parallelism 1 \
+  --max-parallelism 8
+
+bin/ddtest run \
+  --platform python \
+  --framework pytest \
+  --ci-node <CI_NODE_INDEX>
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
 In CI-node mode, `ddtest` uses one local worker by default. To start multiple workers in each CI node, set `--ci-node-workers` to a positive integer or `ncpu`.
 
 For a list of available environment variables, defaults, and examples, see [Configuration][4].
@@ -111,7 +147,7 @@ For a list of available environment variables, defaults, and examples, see [Conf
 Use the following examples as starting points for GitHub Actions and CircleCI.
 
 {{< tabs >}}
-{{% tab "GitHub Actions" %}}
+{{% tab "GitHub Actions (Ruby)" %}}
 
 The plan job chooses the CI node count and emits a matrix. The test job downloads the `.testoptimization/` artifact and runs only the files assigned to its matrix node.
 
@@ -195,7 +231,97 @@ jobs:
 {{< /code-block >}}
 
 {{% /tab %}}
-{{% tab "CircleCI" %}}
+{{% tab "GitHub Actions (Python)" %}}
+
+The plan job chooses the CI node count and emits a matrix. The test job downloads the `.testoptimization/` artifact and runs only the files assigned to its matrix node.
+
+{{< code-block lang="yaml" >}}
+name: CI with Test Parallelization
+
+on: [push]
+
+env:
+  DD_TEST_OPTIMIZATION_RUNNER_PLATFORM: python
+  DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK: pytest
+  DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM: 1
+  DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
+
+jobs:
+  dd_plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dd_plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ddtest binary
+        run: |
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mv bin/ddtest-linux-amd64 bin/ddtest
+          chmod +x bin/ddtest
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: datadoghq.com
+      - id: dd_plan
+        name: Plan test execution
+        run: bin/ddtest plan
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dd-artifacts
+          path: .testoptimization
+          include-hidden-files: true
+
+  dd_test:
+    runs-on: ubuntu-latest
+    needs: [dd_plan]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.dd_plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ddtest binary
+        run: |
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mv bin/ddtest-linux-amd64 bin/ddtest
+          chmod +x bin/ddtest
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: dd-artifacts
+          path: .testoptimization
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: datadoghq.com
+      - name: Run tests
+        run: bin/ddtest run --ci-node ${{ matrix.ci_node_index }}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "CircleCI (Ruby)" %}}
 
 The setup workflow runs `ddtest plan`, stores `.testoptimization/`, and continues into a test workflow with the selected CI node count.
 
@@ -293,6 +419,106 @@ workflows:
 {{< /code-block >}}
 
 {{% /tab %}}
+{{% tab "CircleCI (Python)" %}}
+
+The setup workflow runs `ddtest plan`, stores `.testoptimization/`, and continues into a test workflow with the selected CI node count.
+
+In `.circleci/config.yml`:
+
+{{< code-block lang="yaml" >}}
+version: "2.1"
+setup: true
+
+orbs:
+  test-optimization-circleci-orb: datadog/test-optimization-circleci-orb@1
+  continuation: circleci/continuation@0.2.0
+
+jobs:
+  plan:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: Install Python dependencies
+          command: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - test-optimization-circleci-orb/autoinstrument:
+          languages: python
+          site: datadoghq.com
+      - run:
+          name: Download ddtest
+          command: |
+            mkdir -p bin
+            curl -fsSL https://github.com/DataDog/ddtest/releases/latest/download/ddtest-linux-amd64 -o bin/ddtest
+            chmod +x bin/ddtest
+      - run:
+          name: Plan tests
+          command: bin/ddtest plan --platform python --framework pytest
+          environment:
+            DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM: 1
+            DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
+      - save_cache:
+          key: ddtest-plan-{{ .Revision }}
+          paths:
+            - .testoptimization
+            - bin/ddtest
+      - run:
+          name: Continue with selected parallelism
+          command: |
+            desired=$(cat .testoptimization/runner/parallel-runners.txt 2>/dev/null || echo 1)
+            printf '{"parallelism": %s}\n' "${desired}" > pipeline-parameters.json
+      - continuation/continue:
+          configuration_path: .circleci/test.yml
+          parameters: pipeline-parameters.json
+
+workflows:
+  plan:
+    jobs:
+      - plan
+{{< /code-block >}}
+
+In `.circleci/test.yml`:
+
+{{< code-block lang="yaml" >}}
+version: "2.1"
+
+parameters:
+  parallelism:
+    type: integer
+    default: 1
+
+orbs:
+  test-optimization-circleci-orb: datadog/test-optimization-circleci-orb@1
+
+jobs:
+  test:
+    parallelism: << pipeline.parameters.parallelism >>
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - ddtest-plan-{{ .Revision }}
+      - run:
+          name: Install Python dependencies
+          command: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+      - test-optimization-circleci-orb/autoinstrument:
+          languages: python
+          site: datadoghq.com
+      - run:
+          name: Run tests
+          command: |
+            export DD_TEST_SESSION_NAME="python-tests-${CIRCLE_NODE_INDEX:-0}"
+            bin/ddtest run --platform python --framework pytest --ci-node "${CIRCLE_NODE_INDEX:-0}"
+
+workflows:
+  test:
+    jobs:
+      - test
+{{< /code-block >}}
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Use third-party test runners
@@ -310,6 +536,15 @@ For example, use `.testoptimization/runner/test-files.txt` with Knapsack Pro:
 
 {{< code-block lang="bash" >}}
 KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.testoptimization/runner/test-files.txt bundle exec rake knapsack_pro:queue:rspec
+{{< /code-block >}}
+
+For pytest, enable the `ddtrace` plugin with `PYTEST_ADDOPTS` and pass the file list to `python -m pytest`:
+
+{{< code-block lang="bash" >}}
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:+$PYTEST_ADDOPTS }--ddtrace"
+if [ -s .testoptimization/runner/test-files.txt ]; then
+  xargs python -m pytest < .testoptimization/runner/test-files.txt
+fi
 {{< /code-block >}}
 
 ## Further reading

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -26,7 +26,7 @@ Before setting up Test Parallelization:
 
 - Set up [Test Optimization][1].
 - For Ruby: use the `datadog-ci` gem version `1.31.0` or later.
-- For Python: use the `ddtrace` package version `4.10.3` or later and `pytest`.
+- For Python: use the `ddtrace` package version `4.11.0` or later and `pytest`.
 - Enable [Test Impact Analysis][2] for the test service when you want Test Parallelization to split only the tests affected by a code change.
 
 ## Concepts
@@ -374,7 +374,7 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+        run: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@v2
         with:
@@ -416,7 +416,7 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install Python dependencies
-        run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+        run: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@v2
         with:
@@ -450,7 +450,7 @@ jobs:
       - checkout
       - run:
           name: Install Python dependencies
-          command: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+          command: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
       - test-optimization-circleci-orb/autoinstrument:
           languages: python
           site: datadoghq.com
@@ -511,7 +511,7 @@ jobs:
             - ddtest-plan-{{ .Revision }}
       - run:
           name: Install Python dependencies
-          command: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+          command: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
       - test-optimization-circleci-orb/autoinstrument:
           languages: python
           site: datadoghq.com


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Test Parallelization documentation to reflect that `ddtest` now supports Python/pytest (added in DataDog/ddtest#96).

Changes across all four pages in `/tests/test_parallelization/`:

- **Overview (`_index.md`)**: Added Python/pytest to the compatibility table; added `ddtrace >= 4.11.0` requirement.
- **Setup (`setup.md`)**: Added Python prerequisites; added Ruby/Python tabs for single-node and multi-node run commands; added full GitHub Actions (Python) and CircleCI (Python) workflow examples; added pytest third-party runner example using `PYTEST_ADDOPTS`.
- **Configuration (`configuration.md`)**: Updated `--platform`, `--framework`, `--command`, and `--tests-location` descriptions to include Python/pytest; added "Pytest test discovery" section documenting config file lookup order and default pattern.
- **Best Practices (`best_practices.md`)**: Updated description; added pip caching example alongside Bundler; added "Configure pytest" section covering `PYTEST_ADDOPTS`, discovery behavior, and `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes