### PR TITLE
[SYNTHETICS WORKER] docs: 📝 release windows-pl 1.69.1

### DIFF
--- a/data/synthetics_worker_versions.json
+++ b/data/synthetics_worker_versions.json
@@ -1,6 +1,6 @@
 [
     {
         "client": "synthetics-windows-pl",
-        "version": "1.69.0"
+        "version": "1.69.1"
     }
 ]


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Bumps the `synthetics-windows-pl` worker version in `data/synthetics_worker_versions.json` from `1.69.0` to `1.69.1` for the Private Location (PL) `1.69.1` release.

No customer-facing PL worker command option or environment variable shipped in `1.69.1` (Chrome/Edge 149 bump, TRACE HTTP method for API tests, and an XHR Browser-test fix), so `content/en/synthetics/platform/private_locations/configuration.md` is intentionally left unchanged.

Modeled on the previous version-bump PR: DataDog/documentation#26756.

### Merge readiness

- [ ] Ready for merge

**Merge these before this one** (release in this order):

1. web-ui — DataDog/web-ui#322914
2. helm-charts — DataDog/helm-charts#2754
3. dd-source — DataDog/dd-source#479821

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to apply the version bump and open this PR; the single-line change was reviewed against the reference PR (#26756).

### Additional notes

Single-line version bump only, matching the reference PR.
