### PR TITLE
[CCT-1571] Add Customize anomaly detection section to CCM anomalies page

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -47,7 +47,7 @@ To customize anomaly detection:
 1. Adjust the following settings for the selected provider:
    - **Detection dimension**: The dimension that Datadog detects cost anomalies on (for example, service or charge description). This setting is required.
    - **Minimum daily cost**: The minimum daily cost a change must reach before it is flagged as an anomaly (at least 5, in your organization's currency). Increase this value to reduce noise from low-cost changes.
-   - **Breakdown tags**: Up to five additional tags used to break down detected anomalies, helping [Watchdog Explains][2] identify what's driving each anomaly. A set of default tags is always included and cannot be removed.
+   - **Breakdown tags**: Up to five additional tags used to break down detected anomalies, helping the [Cloud Cost skill in Bits Chat][5] identify what's driving each anomaly. A set of default tags is always included and cannot be removed.
 1. Click {{< ui >}}Save{{< /ui >}}. Changes apply to anomalies detected going forward.
 
 To return a provider to Datadog's default settings, select the provider, click {{< ui >}}Revert{{< /ui >}}, and then click {{< ui >}}Save{{< /ui >}}.
@@ -133,3 +133,4 @@ For more help, contact [Datadog Support][4].
 [2]: /dashboards/graph_insights/watchdog_explains
 [3]: /cloud_cost_management/setup/
 [4]: /help/
+[5]: /cloud_cost_management/cloud_cost_skill/

--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -34,6 +34,24 @@ To distinguish between true anomalies and expected fluctuations, Datadog's algor
 - Focuses on engineering usage (excludes taxes, credits, refunds, and Reserved Instance fees)
 - Filters out low-impact anomalies to reduce noise
 
+## Customize anomaly detection
+
+<div class="alert alert-danger">Custom anomaly detection is in Preview.</div>
+
+By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how anomalies are detected per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, and Oracle Cloud.
+
+To customize anomaly detection:
+
+1. On the [Anomalies tab][1], click {{< ui >}}Configure{{< /ui >}}.
+1. In the {{< ui >}}Configure Cost Anomalies{{< /ui >}} panel, select a provider. A checkmark indicates that the provider uses custom settings, and an empty circle indicates that it uses Datadog's default settings.
+1. Adjust the following settings for the selected provider:
+   - **Detection dimension**: The dimension that Datadog detects cost anomalies on (for example, service or charge description). This setting is required.
+   - **Minimum daily cost**: The minimum daily cost a change must reach before it is flagged as an anomaly (100 by default, with a minimum of 5, in your organization's currency). Increase this value to reduce noise from low-cost changes.
+   - **Breakdown tags**: Up to five additional tags used to break down detected anomalies, helping [Watchdog Explains][2] identify what's driving each anomaly. A set of default tags is always included and cannot be removed.
+1. Click {{< ui >}}Save{{< /ui >}}. Changes apply to anomalies detected going forward.
+
+To return a provider to Datadog's default settings, select the provider, click {{< ui >}}Revert{{< /ui >}}, and then save.
+
 ## View cost anomalies
 
 On the [Anomalies tab of the Cloud Cost page in Datadog][1], you can view and filter anomalies:

--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -46,7 +46,7 @@ To customize anomaly detection:
 1. In the {{< ui >}}Configure Cost Anomalies{{< /ui >}} panel, select a provider. A checkmark indicates that the provider uses custom settings, and an empty circle indicates that it uses Datadog's default settings.
 1. Adjust the following settings for the selected provider:
    - **Detection dimension**: The dimension that Datadog detects cost anomalies on (for example, service or charge description). This setting is required.
-   - **Minimum daily cost**: The minimum daily cost a change must reach before it is flagged as an anomaly (100 by default, with a minimum of 5, in your organization's currency). Increase this value to reduce noise from low-cost changes.
+   - **Minimum daily cost**: The minimum daily cost a change must reach before it is flagged as an anomaly (at least 5, in your organization's currency). Increase this value to reduce noise from low-cost changes.
    - **Breakdown tags**: Up to five additional tags used to break down detected anomalies, helping [Watchdog Explains][2] identify what's driving each anomaly. A set of default tags is always included and cannot be removed.
 1. Click {{< ui >}}Save{{< /ui >}}. Changes apply to anomalies detected going forward.
 

--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -38,11 +38,11 @@ To distinguish between true anomalies and expected fluctuations, Datadog's algor
 
 <div class="alert alert-danger">Custom anomaly detection is in Preview.</div>
 
-By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how anomalies are detected per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, and Oracle Cloud.
+By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, and Oracle Cloud.
 
 To customize anomaly detection:
 
-1. On the [Anomalies tab][1], click {{< ui >}}Configure{{< /ui >}}.
+1. On the [{{< ui >}}Anomalies{{< /ui >}} tab][1], click {{< ui >}}Configure{{< /ui >}}.
 1. In the {{< ui >}}Configure Cost Anomalies{{< /ui >}} panel, select a provider. A checkmark indicates that the provider uses custom settings, and an empty circle indicates that it uses Datadog's default settings.
 1. Adjust the following settings for the selected provider:
    - **Detection dimension**: The dimension that Datadog detects cost anomalies on (for example, service or charge description). This setting is required.
@@ -50,7 +50,7 @@ To customize anomaly detection:
    - **Breakdown tags**: Up to five additional tags used to break down detected anomalies, helping [Watchdog Explains][2] identify what's driving each anomaly. A set of default tags is always included and cannot be removed.
 1. Click {{< ui >}}Save{{< /ui >}}. Changes apply to anomalies detected going forward.
 
-To return a provider to Datadog's default settings, select the provider, click {{< ui >}}Revert{{< /ui >}}, and then save.
+To return a provider to Datadog's default settings, select the provider, click {{< ui >}}Revert{{< /ui >}}, and then click {{< ui >}}Save{{< /ui >}}.
 
 ## View cost anomalies
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
[CCT-1571](https://datadoghq.atlassian.net/browse/CCT-1571)
Documents the new **custom anomaly detection** capability (the **Configure Cost Anomalies** experience) on the Cloud Cost Management Anomalies page. The feature lets users with the `cloud_cost_management_write` permission customize, per cloud provider, the detection dimension, minimum daily cost threshold, and breakdown tags used to detect cost anomalies.

This adds a new `## Customize anomaly detection` section to `content/en/cloud_cost_management/cost_changes/anomalies.md`. The feature is currently in **Preview**, flagged using the existing `alert alert-danger` Preview convention used elsewhere in the CCM docs.

### Additional notes

Preview link (active after the build_preview check completes): https://docs-staging.datadoghq.com/bianca.catarau/ccm-custom-anomalies-docs/cloud_cost_management/cost_changes/anomalies/


[CCT-1571]: https://datadoghq.atlassian.net/browse/CCT-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ