### PR TITLE
Remove APM Rust preview callouts

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/rust.md
+++ b/content/en/tracing/trace_collection/compatibility/rust.md
@@ -13,10 +13,6 @@ further_reading:
       text: 'dd-trace-rs repository'
 ---
 
-{{< callout header="false" btn_hidden="true"  >}}
-  The Datadog Rust SDK is in Preview.
-{{< /callout >}} 
-
 The Datadog Rust SDK is open source. For more information, see the [`dd-trace-rs` repository][1] or the [`datadog-opentelemetry` crate][4].
 
 ## Language and library support

--- a/content/en/tracing/trace_collection/dd_libraries/rust.md
+++ b/content/en/tracing/trace_collection/dd_libraries/rust.md
@@ -15,10 +15,6 @@ further_reading:
   text: "Custom Instrumentation"
 ---
 
-{{< callout header="false" btn_hidden="true"  >}}
-    The Datadog Rust SDK is in Preview.
-{{< /callout >}}
-
 <div class="alert alert-info">
 The Rust SDK does not provide automatic instrumentation. Tracing is achieved by manually instrumenting your application using the OpenTelemetry API.
 </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The APM Rust tracer has moved from preview status so the callouts mentioning that have been removed.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
