### PR TITLE
Document Datadog Apps agent skill

### DIFF
--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -79,7 +79,7 @@ npx skills add datadog-labs/agent-skills \
   --full-depth -y
 ```
 
-Restart Claude Code after installing for the skill to appear.
+The `skills` CLI supports Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and other coding agents. To target a specific agent, see the [skills CLI documentation][22]. If the skill does not appear after installation, restart your coding agent.
 
 ### Example prompts
 
@@ -303,3 +303,4 @@ The scaffolding tool requires Node.js 20.12.0 or later. If you see errors even o
 [19]: https://nodejs.org
 [20]: https://github.com/datadog-labs/agent-skills/tree/main/dd-apps/datadog-app
 [21]: https://github.com/datadog-labs/agent-skills/blob/main/README.md
+[22]: https://github.com/antfu/skills-cli

--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -88,7 +88,6 @@ The `skills` CLI supports Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and 
 - `Upload and publish this Datadog App.`
 - `Set up CI/CD for this Datadog App.`
 - `Troubleshoot this Datadog Apps authentication error.`
-- `Query app data with DDSQL or the Action Catalog.`
 
 ## Develop your app locally
 

--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -87,7 +87,7 @@ The `skills` CLI supports Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and 
 - `Run this Datadog App locally.`
 - `Upload and publish this Datadog App.`
 - `Set up CI/CD for this Datadog App.`
-- `Troubleshoot this Datadog Apps authentication error.`
+- `Troubleshoot this Datadog App authentication error.`
 
 ## Develop your app locally
 

--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -67,6 +67,29 @@ The scaffolded project includes:
 | `vite.config.ts` | Build configuration with [`@datadog/vite-plugin`][9] pre-configured |
 | `package.json` | Dependencies and scripts (`dev`, `build`, `upload`) |
 
+## Use the `datadog-app` skill
+
+The [`datadog-app` agent skill][20] gives AI coding agents Datadog Apps workflow guidance for scaffolding, local development, uploads, publishing, CI/CD, troubleshooting, DDSQL, and Action Catalog usage. The skill is available in the [agent-skills GitHub repository][21].
+
+### Install
+
+```shell
+npx skills add datadog-labs/agent-skills \
+  --skill datadog-app \
+  --full-depth -y
+```
+
+Restart Claude Code after installing for the skill to appear.
+
+### Example prompts
+
+- `Scaffold a Datadog App called my-app.`
+- `Run this Datadog App locally.`
+- `Upload and publish this Datadog App.`
+- `Set up CI/CD for this Datadog App.`
+- `Troubleshoot this Datadog Apps authentication error.`
+- `Query app data with DDSQL or the Action Catalog.`
+
 ## Develop your app locally
 
 1. Start the development server:
@@ -278,3 +301,5 @@ The scaffolding tool requires Node.js 20.12.0 or later. If you see errors even o
 [17]: https://volta.sh
 [18]: https://github.com/Schniz/fnm
 [19]: https://nodejs.org
+[20]: https://github.com/datadog-labs/agent-skills/tree/main/dd-apps/datadog-app
+[21]: https://github.com/datadog-labs/agent-skills/blob/main/README.md

--- a/content/en/actions/datadog_apps.md
+++ b/content/en/actions/datadog_apps.md
@@ -69,7 +69,7 @@ The scaffolded project includes:
 
 ## Use the `datadog-app` skill
 
-The [`datadog-app` agent skill][20] gives AI coding agents Datadog Apps workflow guidance for scaffolding, local development, uploads, publishing, CI/CD, troubleshooting, DDSQL, and Action Catalog usage. The skill is available in the [agent-skills GitHub repository][21].
+The [`datadog-app` agent skill][20] gives AI coding agents guidance on Datadog Apps workflows, including scaffolding, local development, uploads, publishing, CI/CD, troubleshooting, DDSQL, and Action Catalog usage. The skill is available in the [agent-skills GitHub repository][21].
 
 ### Install
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds documentation for installing the Datadog Apps `datadog-app` agent skill and gives example prompts for common Apps workflows.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Validated with Vale and `git diff --check`.
