### PR TITLE
[DO] Add AWS account prerequisite to Redshift and Glue Data Observability docs

### DIFF
--- a/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
+++ b/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
@@ -23,6 +23,7 @@ Before you begin, make sure you have:
 
 - An AWS account with Glue Iceberg tables you want to monitor.
 - An [AWS account connected in Datadog][1].
+  - Log forwarding is not required for Data Observability.
 - IAM permissions to modify the Datadog role's policies.
 - (Optional) AWS Lake Formation access if you use it to manage table permissions.
 

--- a/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
+++ b/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
@@ -22,7 +22,7 @@ If you're [using the Iceberg framework in AWS Glue][5], you can see metadata fro
 Before you begin, make sure you have:
 
 - An AWS account with Glue Iceberg tables you want to monitor.
-- The [Datadog AWS integration][1] configured for the account.
+- An [AWS account connected in Datadog][1].
 - IAM permissions to modify the Datadog role's policies.
 - (Optional) AWS Lake Formation access if you use it to manage table permissions.
 

--- a/content/en/data_observability/quality_monitoring/data_warehouses/redshift.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/redshift.md
@@ -20,6 +20,7 @@ Datadog supports both provisioned Redshift clusters and Redshift Serverless work
 
 Before you begin, make sure you have:
 
+- An [AWS account connected in Datadog][3].
 - A Redshift superuser or database user with the ability to create roles and grant privileges.
 - If your Redshift cluster or workgroup restricts network access by IP, add Datadog webhook IPs to your VPC security group inbound rules. For the list of IPs, see the `webhooks` section of the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
 
@@ -184,3 +185,4 @@ After the initial sync completes, create a [Data Observability monitor][2] to st
 
 [1]: https://app.datadoghq.com/datasets/settings/integrations
 [2]: /monitors/types/data_observability/
+[3]: /integrations/amazon-web-services/

--- a/content/en/data_observability/quality_monitoring/data_warehouses/redshift.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/redshift.md
@@ -21,6 +21,7 @@ Datadog supports both provisioned Redshift clusters and Redshift Serverless work
 Before you begin, make sure you have:
 
 - An [AWS account connected in Datadog][3].
+  - Log forwarding is not required for Data Observability.
 - A Redshift superuser or database user with the ability to create roles and grant privileges.
 - If your Redshift cluster or workgroup restricts network access by IP, add Datadog webhook IPs to your VPC security group inbound rules. For the list of IPs, see the `webhooks` section of the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
 


### PR DESCRIPTION
Adds an "An AWS account connected in Datadog" prerequisite to the Redshift and AWS Glue Data Observability quality monitoring guides, linking to the AWS integration setup docs.