### PR TITLE
[Auto] DOCS-14720: Cloud Security Vulnerabilities - Document saved views workaround on Findings page

### DIFF
--- a/content/en/security/cloud_security_management/vulnerabilities/_index.md
+++ b/content/en/security/cloud_security_management/vulnerabilities/_index.md
@@ -99,6 +99,8 @@ Focus on exploitable vulnerabilities first, using the Datadog Severity Score, co
 
 For vulnerabilities with available fixes, the Findings page provides guided remediation steps to assist Dev and Ops teams in resolving issues more quickly and effectively. You can also triage, mute, comment, and assign vulnerabilities to manage their lifecycle.
 
+<div class="alert alert-info">The Vulnerabilities Findings page does not include a <strong>Save as new view</strong> option. To reuse a filter configuration, bookmark the full page URL — your search query and facet selections are preserved in the URL.</div>
+
 {{< img src="security/vulnerabilities/csm-vm-explorer-actionability-2.png" alt="The Cloud Security Vulnerabilities Findings page displaying a vulnerability and the actions a user can take to remediate it" width="100%">}}
 
 In [Container Images][7], you can trace vulnerabilities found in an image to specific layers, so you can pinpoint and remediate your security risks faster.

--- a/content/en/security/cloud_security_management/vulnerabilities/_index.md
+++ b/content/en/security/cloud_security_management/vulnerabilities/_index.md
@@ -99,7 +99,7 @@ Focus on exploitable vulnerabilities first, using the Datadog Severity Score, co
 
 For vulnerabilities with available fixes, the Findings page provides guided remediation steps to assist Dev and Ops teams in resolving issues more quickly and effectively. You can also triage, mute, comment, and assign vulnerabilities to manage their lifecycle.
 
-<div class="alert alert-info">The Vulnerabilities Findings page does not include a <strong>Save as new view</strong> option. To reuse a filter configuration, bookmark the full page URL — your search query and facet selections are preserved in the URL.</div>
+<div class="alert alert-info">To reuse your explorer settings on the Vulnerabilities Findings page, bookmark the full page URL. Your search query and facet selections are preserved in the URL.</div>
 
 {{< img src="security/vulnerabilities/csm-vm-explorer-actionability-2.png" alt="The Cloud Security Vulnerabilities Findings page displaying a vulnerability and the actions a user can take to remediate it" width="100%">}}
 


### PR DESCRIPTION
## [DOCS-14720] Cloud Security Vulnerabilities - Document saved views workaround on Findings page

**Jira:** [DOCS-14720](https://datadoghq.atlassian.net//browse/DOCS-14720)

**Changes:** Added an info banner to the 'Continuously detect, prioritize, and remediate exploitable vulnerabilities' section of the Cloud Security Vulnerabilities page, documenting that the Findings page does not include a Save as new view option and providing the URL-bookmark workaround.

[DOCS-14720]: https://datadoghq.atlassian.net/browse/DOCS-14720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-14720]: https://datadoghq.atlassian.net/browse/DOCS-14720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ