### PR TITLE
Add description front matter to all IDP docs

### DIFF
--- a/content/en/internal_developer_portal/_index.md
+++ b/content/en/internal_developer_portal/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Internal Developer Portal
+description: Datadog's Internal Developer Portal unifies live telemetry, metadata, and self-service workflows to standardize software delivery and optimize developer experience.
 disable_toc: false
 further_reading:
 - link: https://www.datadoghq.com/blog/datadog-forms

--- a/content/en/internal_developer_portal/campaigns/_index.md
+++ b/content/en/internal_developer_portal/campaigns/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Campaigns
+description: Coordinate time-bound engineering initiatives by grouping Scorecard rules under a shared goal and tracking adoption across entities and teams.
 further_reading:
 - link: "/internal_developer_portal/scorecards/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/catalog/_index.md
+++ b/content/en/internal_developer_portal/catalog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Catalog
+description: Catalog provides a centralized, dynamic view of your software ecosystem and infrastructure resources, integrating observability, security, and cost management tools.
 aliases:
   - /tracing/faq/software_catalog/
   - /tracing/services/services_list/

--- a/content/en/internal_developer_portal/catalog/endpoints/_index.md
+++ b/content/en/internal_developer_portal/catalog/endpoints/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Endpoint Observability
+description: Monitor and manage HTTP API endpoints with performance metrics, ownership tracking, alerting, and test coverage from a single view.
 further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-apis-datadog-api-catalog/"
   tag: "Blog"

--- a/content/en/internal_developer_portal/catalog/endpoints/explore_endpoints.md
+++ b/content/en/internal_developer_portal/catalog/endpoints/explore_endpoints.md
@@ -1,5 +1,6 @@
 ---
 title: Exploring Endpoints
+description: Browse, search, and filter HTTP endpoints in the Catalog's Endpoints list to view performance metrics, ownership, and dependency data.
 further_reading:
 - link: "/internal_developer_portal/catalog/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/catalog/endpoints/monitor_endpoints.md
+++ b/content/en/internal_developer_portal/catalog/endpoints/monitor_endpoints.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring Endpoints
+description: Create monitors and Synthetic API tests for endpoints to track health, detect performance issues, and maintain reliability standards.
 further_reading:
 - link: "/tracing/api_catalog/get_started/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/catalog/entity_model/_index.md
+++ b/content/en/internal_developer_portal/catalog/entity_model/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Entity Model
+description: Learn how Catalog uses YAML-based definition schemas to store and display metadata about services, systems, datastores, queues, and other entity types.
 aliases:
   - /software_catalog/service_definitions/
   - /software_catalog/adding_metadata

--- a/content/en/internal_developer_portal/catalog/entity_model/custom_entities.md
+++ b/content/en/internal_developer_portal/catalog/entity_model/custom_entities.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Entities
+description: Define custom entity types in Catalog to represent components unique to your organization, such as libraries, pipelines, or ML models.
 disable_toc: false
 aliases:
   - /internal_developer_portal/software_catalog/entity_model/custom_entities

--- a/content/en/internal_developer_portal/catalog/entity_model/native_entities.md
+++ b/content/en/internal_developer_portal/catalog/entity_model/native_entities.md
@@ -1,5 +1,6 @@
 ---
 title: Native Entities
+description: Learn about the native entity types in Catalog, including services, systems, APIs, datastores, queues, and frontends, and how to define them using schema v3.0.
 disable_toc: false
 aliases:
   - /internal_developer_portal/software_catalog/entity_model/entity_types

--- a/content/en/internal_developer_portal/catalog/set_up/_index.md
+++ b/content/en/internal_developer_portal/catalog/set_up/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Set Up Catalog
+description: Populate Catalog by discovering entities from Datadog telemetry, creating entity definitions manually, or importing from third-party sources like Backstage and ServiceNow.
 aliases:
   - /software_catalog/set_up
   - /tracing/software_catalog/guides/validating-service-definition  ## aliases for Validating Service Definition page

--- a/content/en/internal_developer_portal/catalog/set_up/create_entities.md
+++ b/content/en/internal_developer_portal/catalog/set_up/create_entities.md
@@ -1,5 +1,6 @@
 ---
 title: Create Entities
+description: Add entity definitions to Catalog through the Datadog UI or by automating imports with GitHub, Terraform, or the Datadog API.
 disable_toc: false
 aliases:
   - /software_catalog/set_up/new_to_datadog ## aliases for New to Datadog page

--- a/content/en/internal_developer_portal/catalog/set_up/discover_entities.md
+++ b/content/en/internal_developer_portal/catalog/set_up/discover_entities.md
@@ -1,5 +1,6 @@
 ---
 title: Discover Entities
+description: Learn how Catalog automatically discovers entities from APM, USM, and RUM, and how to import additional entities from infrastructure metrics and logs.
 disable_toc: false
 aliases:
   - /software_catalog/set_up/existing_datadog_user ## aliases for Existing Datadog User page

--- a/content/en/internal_developer_portal/catalog/set_up/import_entities.md
+++ b/content/en/internal_developer_portal/catalog/set_up/import_entities.md
@@ -1,5 +1,6 @@
 ---
 title: Import Entities
+description: Sync entities from Backstage or ServiceNow CMDB into Datadog Catalog using the Backstage plugin, API, Terraform, or the GitHub integration.
 disable_toc: false
 aliases:
   - /software_catalog/import_entries_integrations/     ## aliases for Import Entries from Backstage page 

--- a/content/en/internal_developer_portal/catalog/troubleshooting.md
+++ b/content/en/internal_developer_portal/catalog/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Catalog
+description: Diagnose and resolve common issues with Catalog, including missing services, SLOs, telemetry data, endpoints, and monitors.
 aliases:
   - /tracing/software_catalog/troubleshooting
   - /software_catalog/guides/troubleshooting

--- a/content/en/internal_developer_portal/eng_reports/_index.md
+++ b/content/en/internal_developer_portal/eng_reports/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Engineering Reports
+description: Access executive-level reports on reliability, DORA metrics, and Scorecard performance to identify gaps and drive improvements across engineering teams.
 further_reading:
 - link: "/service_level_objectives/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/eng_reports/custom_reports.md
+++ b/content/en/internal_developer_portal/eng_reports/custom_reports.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Reports
+description: Embed existing Datadog dashboards into the IDP Overview page to give all users access to key engineering insights in one place.
 further_reading:
 - link: "dashboards/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/eng_reports/custom_reports.md
+++ b/content/en/internal_developer_portal/eng_reports/custom_reports.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Reports
-description: Embed existing Datadog dashboards into the IDP Overview page to give all users access to key engineering insights in one place.
+description: Embed existing Datadog dashboards into the Internal Developer Portal Overview page to give all users access to key engineering insights in one place.
 further_reading:
 - link: "dashboards/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/eng_reports/dora_metrics.md
+++ b/content/en/internal_developer_portal/eng_reports/dora_metrics.md
@@ -1,5 +1,6 @@
 ---
 title: DORA Metrics
+description: View organization-wide software delivery velocity and stability metrics, broken down by service, team, and environment, with historical trends and scheduled reports.
 aliases:
 - /software_catalog/eng_reports/dora_metrics
 further_reading:

--- a/content/en/internal_developer_portal/eng_reports/reliability_overview.md
+++ b/content/en/internal_developer_portal/eng_reports/reliability_overview.md
@@ -1,5 +1,6 @@
 ---
 title: Reliability Overview
+description: View aggregated SLO and incident data across services and teams to assess your organization's reliability, with historical trends and a summary score for leadership.
 aliases:
 - /software_catalog/eng_reports/reliability_overview/
 further_reading:

--- a/content/en/internal_developer_portal/eng_reports/scorecards_performance.md
+++ b/content/en/internal_developer_portal/eng_reports/scorecards_performance.md
@@ -1,5 +1,6 @@
 ---
 title: Scorecards Performance
+description: Track organization-wide Scorecard compliance by team and rule, with historical trends and filters to identify top- and bottom-performing areas.
 aliases:
 - /software_catalog/eng_reports/scorecards_performance
 further_reading:

--- a/content/en/internal_developer_portal/external_provider_status.md
+++ b/content/en/internal_developer_portal/external_provider_status.md
@@ -1,5 +1,6 @@
 ---
 title: External Provider Status
+description: Monitor real-time operational status of third-party services such as payment gateways, cloud platforms, and APIs to detect provider disruptions early.
 further_reading:
 - link: "https://www.datadoghq.com/blog/watchdog-outage-detection/"
   tag: "Blog"

--- a/content/en/internal_developer_portal/homepage.md
+++ b/content/en/internal_developer_portal/homepage.md
@@ -1,5 +1,6 @@
 ---
 title: Homepage
+description: The IDP Homepage gives you a centralized view of your team's entities, GitHub pull requests, Jira tickets, and Datadog Cases in one place.
 aliases:  
 - /software_catalog/developer_homepage  
 - /internal_developer_portal/developer_homepage  

--- a/content/en/internal_developer_portal/homepage.md
+++ b/content/en/internal_developer_portal/homepage.md
@@ -1,6 +1,6 @@
 ---
 title: Homepage
-description: The IDP Homepage gives you a centralized view of your team's entities, GitHub pull requests, Jira tickets, and Datadog Cases in one place.
+description: The Internal Developer Portal Homepage gives you a centralized view of your team's entities, GitHub pull requests, Jira tickets, and Datadog Cases in one place.
 aliases:  
 - /software_catalog/developer_homepage  
 - /internal_developer_portal/developer_homepage  

--- a/content/en/internal_developer_portal/integrations.md
+++ b/content/en/internal_developer_portal/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+description: Connect IDP with third-party tools including PagerDuty, OpsGenie, GitHub, Jira, and CI/CD platforms to enrich Catalog metadata and automate actions.
 aliases:
   - /tracing/software_catalog/integrations
   - /tracing/service_catalog/integrations

--- a/content/en/internal_developer_portal/integrations.md
+++ b/content/en/internal_developer_portal/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-description: Connect IDP with third-party tools including PagerDuty, OpsGenie, GitHub, Jira, and CI/CD platforms to enrich Catalog metadata and automate actions.
+description: Connect Internal Developer Portal with third-party tools including PagerDuty, Opsgenie, GitHub, Jira, and CI/CD platforms to enrich Catalog metadata and automate actions.
 aliases:
   - /tracing/software_catalog/integrations
   - /tracing/service_catalog/integrations

--- a/content/en/internal_developer_portal/integrations.md
+++ b/content/en/internal_developer_portal/integrations.md
@@ -12,14 +12,14 @@ further_reading:
   text: "Learn about the Service Definition API"
 - link: "/integrations/opsgenie/"
   tag: "Documentation"
-  text: "Learn about the OpsGenie integration"
+  text: "Learn about the Opsgenie integration"
 - link: "/integrations/pagerduty/"
   tag: "Documentation"
   text: "Learn about the PagerDuty integration"
 ---
 {{% site-region region="gov,gov2" %}}
 <div class="alert alert-danger">
-PagerDuty and OpsGenie integrations for Internal Developer Portal are not supported in the {{< region-param key=dd_datacenter code="true" >}} site.
+PagerDuty and Opsgenie integrations for Internal Developer Portal are not supported in the {{< region-param key=dd_datacenter code="true" >}} site.
 </div>
 {{% /site-region %}}
   
@@ -35,7 +35,7 @@ When you configure a service account for a [Datadog integration][1], you can inc
 | Integration  | Description    | Example actions (Action Catalog) |
 |--------------|----------------|----------------------------------|
 | [PagerDuty][2] | Add PagerDuty metadata to a service so that the Catalog displays and links to information such as who is on-call and whether there are active PagerDuty incidents for the service. | `Get current on-call`, `Trigger incident` <br> [See all available actions.][32] |
-| [OpsGenie][3] | Add OpsGenie metadata to a service so that the Catalog displays and links to information such as who is on-call for the service. | `Acknowledge alert`, `Get current on call` <br> [See all available actions.][33] |
+| [Opsgenie][3] | Add Opsgenie metadata to a service so that the Catalog displays and links to information such as who is on-call for the service. | `Acknowledge alert`, `Get current on call` <br> [See all available actions.][33] |
 | [StatusPage][4] | Create, update, and retrieve details about incidents and components. | `Create an incident`, `Update component status` <br> [See all available actions.][34] |
 | [Freshservice][5] | Create, update, and query Freshservice tickets. | `List tickets`, `Update ticket` <br> [See all available actions.][35] |
 | [Slack][6] | Send incident alerts or updates to Slack channels, and perform channel management. | `Invite users to channel`, `Set channel topic` <br> [See all available actions.][36] |
@@ -66,18 +66,18 @@ You can connect any service in your [PagerDuty Service Directory][63]. You can m
 
 {{% /collapse-content %}}
 
-{{% collapse-content title="OpsGenie" level="h4" expanded=false id="opsgenie-setup" %}}
+{{% collapse-content title="Opsgenie" level="h4" expanded=false id="opsgenie-setup" %}}
 
-To add OpsGenie metadata to an entity definition: 
+To add Opsgenie metadata to an entity definition: 
 
-1. If you have not already done so, set up the [Datadog OpsGenie integration][3].
-1. Obtain your [OpsGenie API Access Key][62] and ensure it has **configuration access** and **read** permissions.
-3. At the bottom of the [integration tile][55], add an account, paste your OpsGenie API access key, and select the region for your OpsGenie account.
+1. If you have not already done so, set up the [Datadog Opsgenie integration][3].
+1. Obtain your [Opsgenie API Access Key][62] and ensure it has **configuration access** and **read** permissions.
+3. At the bottom of the [integration tile][55], add an account, paste your Opsgenie API access key, and select the region for your Opsgenie account.
 
-   {{< img src="tracing/software_catalog/create_account1.png" alt="The Create New Account workflow in the OpsGenie integration tile" style="width:80%;" >}}
-   {{< img src="tracing/software_catalog/create_account2.png" alt="The Create New Account workflow in the OpsGenie integration tile" style="width:80%;" >}}
+   {{< img src="tracing/software_catalog/create_account1.png" alt="The Create New Account workflow in the Opsgenie integration tile" style="width:80%;" >}}
+   {{< img src="tracing/software_catalog/create_account2.png" alt="The Create New Account workflow in the Opsgenie integration tile" style="width:80%;" >}}
 
-4. Update the [entity definition][82] with OpsGenie metadata. For example:
+4. Update the [entity definition][82] with Opsgenie metadata. For example:
 
    ```yaml
    "integrations": {
@@ -90,7 +90,7 @@ To add OpsGenie metadata to an entity definition:
 
 Once you've completed these steps, an **On Call** information box appears in the **Ownership** tab for services in Catalog.
 
-{{< img src="tracing/software_catalog/oncall_information.png" alt="On Call information box displaying information from OpsGenie in the Catalog" style="width:85%;" >}}
+{{< img src="tracing/software_catalog/oncall_information.png" alt="On Call information box displaying information from Opsgenie in the Catalog" style="width:85%;" >}}
 
 {{% /collapse-content %}}
 

--- a/content/en/internal_developer_portal/onboarding_guide.md
+++ b/content/en/internal_developer_portal/onboarding_guide.md
@@ -1,5 +1,6 @@
 ---
 title: Onboard with Internal Developer Portal
+description: A phased implementation guide for platform and engineering leaders setting up Datadog's Internal Developer Portal, from planning and data sources to golden paths.
 further_reading:
   - link: 'https://app.datadoghq.com/idp/get-started'
     tag: 'App'

--- a/content/en/internal_developer_portal/overview_pages.md
+++ b/content/en/internal_developer_portal/overview_pages.md
@@ -1,5 +1,6 @@
 ---
 title: Overview Pages
+description: IDP overview pages give developers a view of their action items and service health, and give engineering managers a high-level view of reliability and scorecard performance.
 aliases:
 - /software_catalog/overview_pages
 further_reading:

--- a/content/en/internal_developer_portal/overview_pages.md
+++ b/content/en/internal_developer_portal/overview_pages.md
@@ -1,6 +1,6 @@
 ---
 title: Overview Pages
-description: IDP overview pages give developers a view of their action items and service health, and give engineering managers a high-level view of reliability and scorecard performance.
+description: Internal Developer Portal overview pages give developers a view of their action items and service health, and give engineering managers a high-level view of reliability and scorecard performance.
 aliases:
 - /software_catalog/overview_pages
 further_reading:

--- a/content/en/internal_developer_portal/plugins.md
+++ b/content/en/internal_developer_portal/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+description: Build and deploy custom full-stack applications natively within Datadog using local development workflows, the Datadog CLI, React, and serverless backend functions.
 further_reading:
 - link: "/internal_developer_portal/catalog/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/plugins.md
+++ b/content/en/internal_developer_portal/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-description: Build and deploy custom full-stack applications natively within Datadog using local development workflows, the Datadog CLI, React, and serverless backend functions.
+description: Build, deploy, and manage fully custom applications natively within Datadog using local development workflows and the Datadog CLI.
 further_reading:
 - link: "/internal_developer_portal/catalog/"
   tag: "Documentation"

--- a/content/en/internal_developer_portal/scorecards/_index.md
+++ b/content/en/internal_developer_portal/scorecards/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Scorecards
+description: Automatically evaluate entities in your Catalog against defined criteria to measure software health and promote engineering best practices across teams.
 aliases:
   - /tracing/software_catalog/scorecards
   - /tracing/service_catalog/scorecards

--- a/content/en/internal_developer_portal/scorecards/custom_rules.md
+++ b/content/en/internal_developer_portal/scorecards/custom_rules.md
@@ -1,5 +1,6 @@
 ---
 title: Custom rules
+description: Create custom Scorecard rules through the Scorecards API or Workflow Automation to codify your organization's expectations for software components.
 aliases:
   - /tracing/software_catalog/scorecards/custom_rules
   - /tracing/service_catalog/scorecards/custom_rules

--- a/content/en/internal_developer_portal/scorecards/scorecard_configuration.md
+++ b/content/en/internal_developer_portal/scorecards/scorecard_configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Scorecard Configuration
+description: Configure out-of-the-box Scorecards for Production Readiness, Observability Best Practices, and Ownership and Documentation, and learn how scores are calculated.
 aliases:
   - /tracing/software_catalog/scorecards/scorecard_configuration
   - /tracing/service_catalog/scorecards/scorecard_configuration

--- a/content/en/internal_developer_portal/scorecards/using_scorecards.md
+++ b/content/en/internal_developer_portal/scorecards/using_scorecards.md
@@ -1,5 +1,6 @@
 ---
 title: Using Scorecards
+description: View entity-level Scorecard scores, track progress over time, and generate scheduled reports to keep teams informed about engineering standards compliance.
 aliases:
   - /tracing/software_catalog/scorecards/using_scorecards
   - /tracing/service_catalog/scorecards/using_scorecards

--- a/content/en/internal_developer_portal/self_service_actions/_index.md
+++ b/content/en/internal_developer_portal/self_service_actions/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Self-Service Actions
+description: Platform teams can define and share templates that let developers provision infrastructure, scaffold services, manage deployments, and automate tasks with one click.
 aliases:
   - /software_catalog/actions
   - /software_catalog/self-service

--- a/content/en/internal_developer_portal/self_service_actions/software_templates.md
+++ b/content/en/internal_developer_portal/self_service_actions/software_templates.md
@@ -1,5 +1,6 @@
 ---
 title: Software Templates
+description: Create reusable Software Templates in Catalog to help developers provision infrastructure and scaffold microservices that align with your organization's best practices.
 aliases:
   - /service_catalog/software_templates
   - /software_catalog/software_templates

--- a/content/en/internal_developer_portal/use_cases/_index.md
+++ b/content/en/internal_developer_portal/use_cases/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Use Cases
+description: Learn how teams use Datadog Internal Developer Portal to centralize knowledge, streamline processes, and improve operational efficiency.
 aliases:
   - /tracing/service_catalog/guides
   - /service_catalog/guides

--- a/content/en/internal_developer_portal/use_cases/api_management.md
+++ b/content/en/internal_developer_portal/use_cases/api_management.md
@@ -1,5 +1,6 @@
 ---
 title: Simplify API Management
+description: Use Catalog to centralize API discovery, ownership, and governance so developers can find, reuse, and maintain APIs across your organization.
 aliases:
   - /tracing/software_catalog/guides/api_management
   - /software_catalog/guides/api_management

--- a/content/en/internal_developer_portal/use_cases/appsec_management.md
+++ b/content/en/internal_developer_portal/use_cases/appsec_management.md
@@ -1,5 +1,6 @@
 ---
 title: Manage App and API Protection Posture Across Development Teams
+description: Use Catalog to surface security signals, track third-party dependencies, and enforce security standards across development teams and services.
 aliases:
   - /tracing/software_catalog/guides/appsec_management
   - /software_catalog/guides/appsec_management

--- a/content/en/internal_developer_portal/use_cases/cloud_cost_management.md
+++ b/content/en/internal_developer_portal/use_cases/cloud_cost_management.md
@@ -1,5 +1,6 @@
 ---
 title: Manage and Optimize Cloud Costs
+description: Monitor cost anomalies and enforce tagging compliance at the team level by combining Catalog, Scorecards, and Cloud Cost Management.
 aliases:
   - /tracing/software_catalog/guides/cloud_cost_management
   - /software_catalog/guides/cloud_cost_management

--- a/content/en/internal_developer_portal/use_cases/dependency_management.md
+++ b/content/en/internal_developer_portal/use_cases/dependency_management.md
@@ -1,5 +1,6 @@
 ---
 title: Manage and Map Dependencies
+description: Use Catalog to automatically discover and manually define upstream and downstream service dependencies for a complete view of your system architecture.
 aliases:
   - /tracing/software_catalog/guides/dependency_management
   - /software_catalog/guides/dependency_management

--- a/content/en/internal_developer_portal/use_cases/dev_onboarding.md
+++ b/content/en/internal_developer_portal/use_cases/dev_onboarding.md
@@ -1,6 +1,6 @@
 ---
 title: Accelerate Developer Onboarding
-description: Use Catalog and Software Templates to give new developers quick access to documentation, runbooks, and automated onboarding workflows that reduce time-to-first-commit.
+description: Use Catalog and Software Templates to give new developers access to documentation, runbooks, and automated onboarding workflows that reduce time-to-first-commit.
 aliases:
   - /tracing/software_catalog/guides/dev_onboarding
   - /software_catalog/guides/dev_onboarding

--- a/content/en/internal_developer_portal/use_cases/dev_onboarding.md
+++ b/content/en/internal_developer_portal/use_cases/dev_onboarding.md
@@ -1,5 +1,6 @@
 ---
 title: Accelerate Developer Onboarding
+description: Use Catalog and Software Templates to give new developers quick access to documentation, runbooks, and automated onboarding workflows that reduce time-to-first-commit.
 aliases:
   - /tracing/software_catalog/guides/dev_onboarding
   - /software_catalog/guides/dev_onboarding

--- a/content/en/internal_developer_portal/use_cases/incident_response.md
+++ b/content/en/internal_developer_portal/use_cases/incident_response.md
@@ -1,5 +1,6 @@
 ---
 title: Improve Incident Response
+description: Use Catalog to consolidate ownership details, communication channels, runbooks, and dependency maps to speed up incident detection, escalation, and recovery.
 aliases:
   - /tracing/software_catalog/use_cases/incident_response
   - /tracing/software_catalog/guides/upstream-downstream-dependencies

--- a/content/en/internal_developer_portal/use_cases/pipeline_visibility.md
+++ b/content/en/internal_developer_portal/use_cases/pipeline_visibility.md
@@ -1,5 +1,6 @@
 ---
 title: Streamline the Development Lifecycle with CI Visibility
+description: Use the Catalog Delivery tab to monitor CI pipeline performance, track static analysis violations, and improve pre-production reliability for your services.
 aliases:
   - /tracing/software_catalog/use_cases/pipeline_visibility
   - /service_catalog/use_cases/pipeline_visibility

--- a/content/en/internal_developer_portal/use_cases/production_readiness.md
+++ b/content/en/internal_developer_portal/use_cases/production_readiness.md
@@ -1,5 +1,6 @@
 ---
 title: Evaluate Production Readiness
+description: Use Catalog to assess monitoring coverage, enforce governance best practices, and identify security and cost optimization opportunities before services go to production.
 aliases:
   - /tracing/software_catalog/use_cases/production_readiness
   - /software_catalog/use_cases/production_readiness


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a `description` field to the front matter of all Internal Developer Portal docs that were missing one.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes