### PR TITLE
[DOCS-14909] Fix RBAC permission typo

### DIFF
--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -59,7 +59,7 @@ Before using Archive Search:
 
 ### Permissions
 
-Running an **Archive Search** requires the **`logs_write_historical_views`** permission. It is a **global** permission, but users can only search logs from archives for which they also have the **Logs Read Archive** permission.
+Running an **Archive Search** requires the **`logs_write_historical_view`** permission. It is a **global** permission, but users can only search logs from archives for which they also have the **Logs Read Archive** permission.
 
 Archive Search results are visible to all users in your organization who have access to the Archive Search feature. However, **restriction queries**, such as log security filters and data restrictions configured in Datadog, are still enforced on the result page and apply to all users. This means each user may only see logs they are authorized to view based on organization-wide permissions and filters.
 

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -102,7 +102,7 @@ This permission is global and enables creating new archives, and editing and del
 
 ### `logs_read_archives`
 
-Grants the ability to access the details of the archive configuration. In conjunction with [Logs Write Historical Views](#logs_write_historical_views), this permission also grants the ability to trigger a [Rehydration][13] from Archives.
+Grants the ability to access the details of the archive configuration. In conjunction with [Logs Write Historical Views](#logs_write_historical_view), this permission also grants the ability to trigger a [Rehydration][13] from Archives.
 
 This permission can be scoped to a subset of archives. An archive with no restrictions is accessible to anyone who belongs to a role with the `logs_read_archives` permission. An archive with restrictions is only accessible to the users who belong to one of the registered roles, provided theses roles have the `logs_read_archives` permission.
 
@@ -132,7 +132,7 @@ Use the Logs Archive API either to [assign][1] or [revoke][2] a role from a give
 {{% /tab %}}
 {{< /tabs >}}
 
-### `logs_write_historical_views`
+### `logs_write_historical_view`
 
 Grants the ability to write historical views, meaning to trigger a [Log Rehydration*][13].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Update instances of `logs_write_historical_views` to the correct name, `logs_write_historical_view`.

### Merge readiness

- [X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
