### PR TITLE
Add a note on deprecated endpoint

### DIFF
--- a/content/en/monitors/guide/_index.md
+++ b/content/en/monitors/guide/_index.md
@@ -62,6 +62,5 @@ cascade:
     {{< nextlink href="monitors/guide/integrate-monitors-with-statuspage" >}}Integrate monitors with Statuspage{{< /nextlink >}}
     {{< nextlink href="monitors/guide/github_gating" >}}Gating your GitHub Actions Deployments with Datadog Monitors{{< /nextlink >}}
     {{< nextlink href="monitors/guide/add-a-minimum-request-threshold-for-error-rate-alerts" >}}Add a minimum request threshold for error rate alerts{{< /nextlink >}}
-    {{< nextlink href="monitors/guide/export-monitor-alerts-to-csv" >}}Export monitor alerts to CSV{{< /nextlink >}}
     {{< nextlink href="monitors/guide/composite_use_cases" >}}Composite monitor use cases{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/monitors/guide/export-monitor-alerts-to-csv.md
+++ b/content/en/monitors/guide/export-monitor-alerts-to-csv.md
@@ -3,7 +3,10 @@ title: Export Monitor Alerts to CSV
 description: "Download monitor alert history as CSV files through hourly monitor data for the past 6 months (Datadog US site only)."
 aliases:
 - /monitors/faq/how-can-i-export-alert-history
+private: true
 ---
+
+<div class="alert alert-warning">The hourly monitor data endpoint is deprecated as of April 2026. The <a href="https://app.datadoghq.com/report/hourly_data/monitor">hourly monitor data</a> link and API only return data up to April 2026.</div>
 
 Download a history of Monitor Alerts through the [hourly monitor data][1], which generates a CSV for the past 6 months (182 days). This CSV is **not** live; it is updated once a week on Monday at 11:59AM UTC.
 

--- a/content/es/monitors/guide/_index.md
+++ b/content/es/monitors/guide/_index.md
@@ -64,6 +64,5 @@ title: Guías de monitores
     {{< nextlink href="monitors/guide/integrate-monitors-with-statuspage" >}}Integrar monitores con page (página) de estado{{< /nextlink >}}
     {{< nextlink href="monitors/guide/github_gating" >}}Canalizar tus despliegues de acciones de GitHub con monitores de Datadog{{< /nextlink >}}
     {{< nextlink href="monitors/guide/add-a-minimum-request-threshold-for-error-rate-alerts" >}}Añadir un umbral mínimo de solicitudes para alertas de tasas de errores{{< /nextlink >}}
-    {{< nextlink href="monitors/guide/export-monitor-alerts-to-csv" >}}Exportar alertas de monitores a CSV{{< /nextlink >}}
     {{< nextlink href="monitors/guide/composite_use_cases" >}}Casos de uso de monitor composite{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/fr/monitors/guide/_index.md
+++ b/content/fr/monitors/guide/_index.md
@@ -18,7 +18,6 @@ title: Guides sur les monitors
     {{< nextlink href="monitors/guide/alert-on-no-change-in-value" >}}Alerte en cas d'absence de changement d'une valeur{{< /nextlink >}}
     {{< nextlink href="monitors/guide/create-cluster-alert" >}}Créer des alertes de cluster pour les monitors basés sur des métriques{{< /nextlink >}}
     {{< nextlink href="monitors/guide/create-monitor-dependencies" >}}Créer des dépendances pour des monitors{{< /nextlink >}}
-    {{< nextlink href="monitors/guide/export-monitor-alerts-to-csv" >}}Exporter des alertes de monitor au format CSV{{< /nextlink >}}
     {{< nextlink href="monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting" >}}Recevoir une alerte lorsqu'un tag spécifique ne transmet plus de données{{< /nextlink >}}
     {{< nextlink href="monitors/guide/recovery-thresholds" >}}Seuils de rétablissement{{< /nextlink >}}
     {{< nextlink href="monitors/guide/adjusting-no-data-alerts-for-metric-monitors" >}}Modifier la configuration des alertes avec un statut No Data pour les monitors basés sur des métriques{{< /nextlink >}}

--- a/content/ja/monitors/guide/_index.md
+++ b/content/ja/monitors/guide/_index.md
@@ -17,7 +17,6 @@ title: モニターガイド
     {{< nextlink href="monitors/guide/alert-on-no-change-in-value" >}}数値に変化がない場合のアラート{{< /nextlink >}}
     {{< nextlink href="monitors/guide/create-cluster-alert" >}}メトリクスモニターのクラスターアラートの作成{{< /nextlink >}}
     {{< nextlink href="monitors/guide/create-monitor-dependencies" >}}モニターの依存関係の作成{{< /nextlink >}}
-    {{< nextlink href="monitors/guide/export-monitor-alerts-to-csv" >}}モニターアラートを CSV にエクスポートする{{< /nextlink >}}
     {{< nextlink href="monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting" >}}特定のタグがレポーティングを停止した場合のアラート設定{{< /nextlink >}}
     {{< nextlink href="monitors/guide/recovery-thresholds" >}}回復のしきい値{{< /nextlink >}}
     {{< nextlink href="monitors/guide/adjusting-no-data-alerts-for-metric-monitors" >}}メトリクスモニターにおける "No Data" アラートの調整{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
- The endpoint is not supported, however customers can still use the endpoint to pull data up until April 2026. 
- This PR makes the guide private, and removes it from the guide index
### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->
