### PR TITLE
Fix(WEB-9483): Index HTTP Method + Path (GET /<path>) for API Search

### DIFF
--- a/content/en/bits_ai/bits_chat.md
+++ b/content/en/bits_ai/bits_chat.md
@@ -22,7 +22,7 @@ aliases:
 ---
 
 ## Overview
-Bits Chat helps you search and act across Datadog using natural language. Bits Chat is available in the web application, mobile app, and Slack.
+Bits Chat helps you search and act across Datadog using natural language. Bits Chat is available across the web application, mobile app, and Slack.
 
 Ask Bits Chat questions across these categories:
 

--- a/content/en/bits_ai/bits_chat.md
+++ b/content/en/bits_ai/bits_chat.md
@@ -22,7 +22,7 @@ aliases:
 ---
 
 ## Overview
-Bits Chat helps you search and act across Datadog using natural language. Bits Chat is available across the web application, mobile app, and Slack.
+Bits Chat helps you search and act across Datadog using natural language. Bits Chat is available in the web application, mobile app, and Slack.
 
 Ask Bits Chat questions across these categories:
 

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -5,8 +5,8 @@
 {{ $lang := .lang }}
 {{ $api_version := .api_version }} {{/* "v1" or "v2" */}}
 {{ $endpoint_data := .endpoint_data }}
-{{ $endpoint_path := .endpoint_path }} {{/* REST path, e.g. "/api/v2/..." (used only by the commented-out path-indexing toggle below) */}}
-{{ $method := .method }}            {{/* HTTP verb, e.g. "get" (used only by the commented-out path-indexing toggle below) */}}
+{{ $endpoint_path := .endpoint_path }}
+{{ $method := .method }}
 {{ $api_v1_translate_actions := .api_v1_translate_actions }}
 {{ $api_v2_translate_actions := .api_v2_translate_actions }}
 
@@ -23,8 +23,7 @@
 {{ $section_header := $action_data.summary }}
 {{ $section_content := $action_data.description }}
 
-{{/* Append "METHOD /path" to the content field so endpoint REST paths are searchable.
-     Appended at the END so it doesn't pollute the start of the auto-embedded content. */}}
+{{/* Append "METHOD /path" so the endpoint's REST path is searchable. Kept at the end to stay out of the embedding's truncated input. */}}
 {{ $section_content = printf "%s\n\n%s %s" ($section_content | default "") (upper $method) $endpoint_path | strings.TrimSpace }}
 
 {{ $endpoint_slug := $section_header | anchorize }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -5,8 +5,6 @@
 {{ $lang := .lang }}
 {{ $api_version := .api_version }} {{/* "v1" or "v2" */}}
 {{ $endpoint_data := .endpoint_data }}
-{{ $endpoint_path := .endpoint_path }}
-{{ $method := .method }}
 {{ $api_v1_translate_actions := .api_v1_translate_actions }}
 {{ $api_v2_translate_actions := .api_v2_translate_actions }}
 
@@ -21,10 +19,7 @@
 {{ $translate_actions_datafile := cond (eq $api_version "v1") $api_v1_translate_actions $api_v2_translate_actions }}
 {{ $action_data := index $translate_actions_datafile $operationId }}
 {{ $section_header := $action_data.summary }}
-{{ $section_content := $action_data.description | default "" }}
-
-{{/* Append the HTTP method + REST path so endpoint paths are searchable via the content field (kept at the end to avoid polluting the start of the auto-embedded content). */}}
-{{ $section_content = printf "%s\n\n%s %s" $section_content (upper $method) $endpoint_path | strings.TrimSpace }}
+{{ $section_content := $action_data.description }}
 {{ $endpoint_slug := $section_header | anchorize }}
 {{ $full_url := print $permalink $endpoint_slug "/" }}
 {{ $relpermalink = print $relpermalink $endpoint_slug "/" }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -26,7 +26,7 @@
 
 {{/* When the same operationId+summary exists in both v1 and v2, both versions share one endpoint page with version tabs. Disambiguate the records by linking to the tab anchor. */}}
 {{ $other_action := cond (eq $api_version "v1") (index $api_v2_translate_actions $operationId) (index $api_v1_translate_actions $operationId) }}
-{{ if and (ne $other_action nil) (eq $other_action.summary $section_header) }}
+{{ if and (ne $other_action nil) (eq ($other_action.summary | anchorize) ($section_header | anchorize)) }}
     {{ $tab_anchor := (print $section_header "-" $api_version) | anchorize }}
     {{ $full_url = print $full_url "#" $tab_anchor }}
     {{ $relpermalink = print $relpermalink "#" $tab_anchor }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -5,6 +5,8 @@
 {{ $lang := .lang }}
 {{ $api_version := .api_version }} {{/* "v1" or "v2" */}}
 {{ $endpoint_data := .endpoint_data }}
+{{ $endpoint_path := .endpoint_path }} {{/* REST path, e.g. "/api/v2/..." (used only by the commented-out path-indexing toggle below) */}}
+{{ $method := .method }}            {{/* HTTP verb, e.g. "get" (used only by the commented-out path-indexing toggle below) */}}
 {{ $api_v1_translate_actions := .api_v1_translate_actions }}
 {{ $api_v2_translate_actions := .api_v2_translate_actions }}
 
@@ -20,6 +22,12 @@
 {{ $action_data := index $translate_actions_datafile $operationId }}
 {{ $section_header := $action_data.summary }}
 {{ $section_content := $action_data.description }}
+
+{{/* PATH-INDEXING TOGGLE: uncomment the line below to append "METHOD /path" to the
+     content field so endpoint REST paths become searchable. Appended at the END so it
+     doesn't pollute the start of the auto-embedded content. Left commented out for now. */}}
+{{/* {{ $section_content = printf "%s\n\n%s %s" ($section_content | default "") (upper $method) $endpoint_path | strings.TrimSpace }} */}}
+
 {{ $endpoint_slug := $section_header | anchorize }}
 {{ $full_url := print $permalink $endpoint_slug "/" }}
 {{ $relpermalink = print $relpermalink $endpoint_slug "/" }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -5,6 +5,8 @@
 {{ $lang := .lang }}
 {{ $api_version := .api_version }} {{/* "v1" or "v2" */}}
 {{ $endpoint_data := .endpoint_data }}
+{{ $endpoint_path := .endpoint_path }}
+{{ $method := .method }}
 {{ $api_v1_translate_actions := .api_v1_translate_actions }}
 {{ $api_v2_translate_actions := .api_v2_translate_actions }}
 
@@ -19,7 +21,10 @@
 {{ $translate_actions_datafile := cond (eq $api_version "v1") $api_v1_translate_actions $api_v2_translate_actions }}
 {{ $action_data := index $translate_actions_datafile $operationId }}
 {{ $section_header := $action_data.summary }}
-{{ $section_content := $action_data.description }}
+{{ $section_content := $action_data.description | default "" }}
+
+{{/* Append the HTTP method + REST path so endpoint paths are searchable via the content field (kept at the end to avoid polluting the start of the auto-embedded content). */}}
+{{ $section_content = printf "%s\n\n%s %s" $section_content (upper $method) $endpoint_path | strings.TrimSpace }}
 {{ $endpoint_slug := $section_header | anchorize }}
 {{ $full_url := print $permalink $endpoint_slug "/" }}
 {{ $relpermalink = print $relpermalink $endpoint_slug "/" }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -23,10 +23,9 @@
 {{ $section_header := $action_data.summary }}
 {{ $section_content := $action_data.description }}
 
-{{/* PATH-INDEXING TOGGLE: uncomment the line below to append "METHOD /path" to the
-     content field so endpoint REST paths become searchable. Appended at the END so it
-     doesn't pollute the start of the auto-embedded content. Left commented out for now. */}}
-{{/* {{ $section_content = printf "%s\n\n%s %s" ($section_content | default "") (upper $method) $endpoint_path | strings.TrimSpace }} */}}
+{{/* Append "METHOD /path" to the content field so endpoint REST paths are searchable.
+     Appended at the END so it doesn't pollute the start of the auto-embedded content. */}}
+{{ $section_content = printf "%s\n\n%s %s" ($section_content | default "") (upper $method) $endpoint_path | strings.TrimSpace }}
 
 {{ $endpoint_slug := $section_header | anchorize }}
 {{ $full_url := print $permalink $endpoint_slug "/" }}

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -31,11 +31,13 @@
         {{ end }}
 
         {{/* Get all v1 api actions for this page by matching title with spec data's tag property */}}
+        {{/* $endpoint_path (REST path, map key) and $method (HTTP verb, map key) are forwarded so
+             api-page-index.json's commented-out path-indexing toggle can use them; inert otherwise. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
-            {{ range $endpoint_data }}
+            {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset . "tags" }}
-                  {{ $tags = .tags }}
+                {{ if isset $action "tags" }}
+                  {{ $tags = $action.tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -47,7 +49,9 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v1"
-                            "endpoint_data" .
+                            "endpoint_data" $action
+                            "endpoint_path" $endpoint_path
+                            "method" $method
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )
@@ -59,11 +63,12 @@
         {{ end }}
 
         {{/* Get all v2 api actions for this page by matching title with spec data's tag property */}}
+        {{/* Same capture as the v1 loop: $endpoint_path and $method forwarded for the commented-out toggle. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
-            {{ range $endpoint_data }}
+            {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset . "tags" }}
-                  {{ $tags = .tags }}
+                {{ if isset $action "tags" }}
+                  {{ $tags = $action.tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -75,7 +80,9 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v2"
-                            "endpoint_data" .
+                            "endpoint_data" $action
+                            "endpoint_path" $endpoint_path
+                            "method" $method
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -31,6 +31,7 @@
         {{ end }}
 
         {{/* Get all v1 api actions for this page by matching title with spec data's tag property */}}
+        {{/* $endpoint_path is the REST path (map key, e.g. "/api/v1/..."); $method is the HTTP verb (map key, e.g. "get"). Both are forwarded so api-page-index.json can make the path searchable via the content field. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
             {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
@@ -61,6 +62,7 @@
         {{ end }}
 
         {{/* Get all v2 api actions for this page by matching title with spec data's tag property */}}
+        {{/* $endpoint_path is the REST path (map key, e.g. "/api/v2/..."); $method is the HTTP verb (map key, e.g. "get"). Both are forwarded so api-page-index.json can make the path searchable via the content field. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
             {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -32,10 +32,10 @@
 
         {{/* Get all v1 api actions for this page by matching title with spec data's tag property */}}
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
-            {{ range $endpoint_data }}
+            {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset . "tags" }}
-                  {{ $tags = .tags }}
+                {{ if isset $action "tags" }}
+                  {{ $tags = $action.tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -47,7 +47,9 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v1"
-                            "endpoint_data" .
+                            "endpoint_data" $action
+                            "endpoint_path" $endpoint_path
+                            "method" $method
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )
@@ -60,10 +62,10 @@
 
         {{/* Get all v2 api actions for this page by matching title with spec data's tag property */}}
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
-            {{ range $endpoint_data }}
+            {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset . "tags" }}
-                  {{ $tags = .tags }}
+                {{ if isset $action "tags" }}
+                  {{ $tags = $action.tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -75,7 +77,9 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v2"
-                            "endpoint_data" .
+                            "endpoint_data" $action
+                            "endpoint_path" $endpoint_path
+                            "method" $method
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -31,12 +31,11 @@
         {{ end }}
 
         {{/* Get all v1 api actions for this page by matching title with spec data's tag property */}}
-        {{/* $endpoint_path is the REST path (map key, e.g. "/api/v1/..."); $method is the HTTP verb (map key, e.g. "get"). Both are forwarded so api-page-index.json can make the path searchable via the content field. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
-            {{ range $method, $action := $endpoint_data }}
+            {{ range $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset $action "tags" }}
-                  {{ $tags = $action.tags }}
+                {{ if isset . "tags" }}
+                  {{ $tags = .tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -48,9 +47,7 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v1"
-                            "endpoint_data" $action
-                            "endpoint_path" $endpoint_path
-                            "method" $method
+                            "endpoint_data" .
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )
@@ -62,12 +59,11 @@
         {{ end }}
 
         {{/* Get all v2 api actions for this page by matching title with spec data's tag property */}}
-        {{/* $endpoint_path is the REST path (map key, e.g. "/api/v2/..."); $method is the HTTP verb (map key, e.g. "get"). Both are forwarded so api-page-index.json can make the path searchable via the content field. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
-            {{ range $method, $action := $endpoint_data }}
+            {{ range $endpoint_data }}
                 {{ $tags := slice }}
-                {{ if isset $action "tags" }}
-                  {{ $tags = $action.tags }}
+                {{ if isset . "tags" }}
+                  {{ $tags = .tags }}
                 {{ end }}
 
                 {{ if in $tags $title }}
@@ -79,9 +75,7 @@
                             "title" $title
                             "lang" $lang
                             "api_version" "v2"
-                            "endpoint_data" $action
-                            "endpoint_path" $endpoint_path
-                            "method" $method
+                            "endpoint_data" .
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
                         )

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -31,8 +31,6 @@
         {{ end }}
 
         {{/* Get all v1 api actions for this page by matching title with spec data's tag property */}}
-        {{/* $endpoint_path (REST path, map key) and $method (HTTP verb, map key) are forwarded so
-             api-page-index.json's commented-out path-indexing toggle can use them; inert otherwise. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
             {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}
@@ -63,7 +61,6 @@
         {{ end }}
 
         {{/* Get all v2 api actions for this page by matching title with spec data's tag property */}}
-        {{/* Same capture as the v1 loop: $endpoint_path and $method forwarded for the commented-out toggle. */}}
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
             {{ range $method, $action := $endpoint_data }}
                 {{ $tags := slice }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Previously, only the endpoint description was indexed, consequence: searching the endpoints yields in no result: https://docs.datadoghq.com/search/?s=%2Fapi%2Fv2%2Fip_allowlist

This change adds the HTTP method and path to the search index, allowing searches such as `GET /<path> ` to return the corresponding endpoint.

example: https://docs-staging.datadoghq.com/reda.elissati/fix-index-endpoint-api/search/?s=POST%20api%2Fv2%2Fbits-ai%2Finvestigations

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
