### PR TITLE
Rename Bits AI Memories to Bits Memories

### DIFF
--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -145,9 +145,9 @@ To narrow down your initial list for triage, in [Vulnerabilities][6], turn on th
 Each finding includes a section with an explanation of the assessment. You can provide Bits AI with feedback on its assessment using a thumbs up &#128077; or thumbs down &#128078;.
 {{< img src="/code_security/static_analysis/false_positive_filtering_sast_side_panel_higher_res_png.png" alt="Visual indicator of a false positive assessment in SAST side panel" style="width:100%;">}}
 
-### Bits AI Memories
+### Bits Memories
 
-Bits AI Memories lets teams add rule-specific context that Bits AI uses when assessing SAST findings. Use memories to describe organization-specific frameworks, sanitizers, validation patterns, or codebase details that help Bits AI interpret findings for that rule.
+Bits Memories lets teams add rule-specific context that Bits AI uses when assessing SAST findings. Use memories to describe organization-specific frameworks, sanitizers, validation patterns, or codebase details that help Bits AI interpret findings for that rule.
 
 In the SAST rule side panel, expand the false positive reports accordion to review reports shared by your organization for the selected rule. Use the custom context tab in the same section to add guidance for future Bits AI assessments. Memories apply at the organization and rule level for SAST. They apply only to security category SAST rules in Datadog's default rulesets and do not apply to custom rules.
 


### PR DESCRIPTION
## Motivation
Renames the "Bits AI Memories" section heading and intro sentence to "Bits Memories" to match the updated feature name.

## Changes
 - Updated `### Bits AI Memories` heading to `### Bits Memories`
 - Updated the opening sentence of the section to match
