### PR TITLE
Fix incorrectly positioned API doc breadcrumbs

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -56,6 +56,10 @@ $ddpurple: #632ca6;
     }
     .api-toolbar {
         margin-top: 0;
+
+        @include media-breakpoint-up(lg) {
+            top: 95px;
+        }
     }
 
     .main-api,
@@ -187,7 +191,7 @@ $ddpurple: #632ca6;
             background: white;
             position: sticky;
             z-index: 5;
-            top: 94px;
+            top: 65px;
             height: 65px;
         }
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Since the DASH banner was removed from the docs site, the API docs breadcrumbs have been positioned incorrectly on scroll. You can see the issue if you scroll down on an API page in prod ([example](https://docs.datadoghq.com/api/latest/action-connection/)).

This fix updates the CSS to support both cases (banner and no banner). You can see [the fixed page in staging](https://docs-staging.datadoghq.com/jen.gilbert/WEB-9491-breadcrumbs-fix/api/latest/action-connection/).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
