### PR TITLE
Promote RUM MCP toolset to GA

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -682,6 +682,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `product-analytics`: Tools for interacting with [Product Analytics][41] queries
 - `profiling`: Tools for discovering, exploring, and analyzing [Continuous Profiler][58] data
 - `reference-tables`: Tools for managing [Reference Tables][48], including listing tables, reading rows, appending rows, and creating tables from cloud storage
+- `rum`: Tools for [Real User Monitoring][57], including resolving applications, summarizing performance, surfacing aggregated insights, reading retention filters and metrics, and managing custom RUM metrics
 - `security`: Tools for code security scanning and searching [security signals][39] and [security findings][40]
 - `software-delivery`: Tools for interacting with Software Delivery ([CI Visibility][30] and [Test Optimization][31])
 - `synthetics`: Tools for interacting with Datadog [Synthetic tests][29]
@@ -694,7 +695,6 @@ These toolsets are in Preview. Sign up for a toolset by completing the Product P
 - `apm`: ([Sign up][45]) Tools for in-depth [APM][34] trace analysis, span search, Watchdog insights, and performance investigation
 - `code-exec`: ([Sign up][60]) A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 - `remote-actions`: ([Sign up][62]) Tools for on-host diagnostics, including reading files, listing directories, and running safe read-only shell commands directly on instrumented hosts through the Agent
-- `rum`: Tools for [Real User Monitoring][57], including summarizing application performance, inspecting application configuration, and running performance investigations
 
 ## Supported clients
 

--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -682,7 +682,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `product-analytics`: Tools for interacting with [Product Analytics][41] queries
 - `profiling`: Tools for discovering, exploring, and analyzing [Continuous Profiler][58] data
 - `reference-tables`: Tools for managing [Reference Tables][48], including listing tables, reading rows, appending rows, and creating tables from cloud storage
-- `rum`: Tools for [Real User Monitoring][57], including resolving applications, summarizing performance, surfacing aggregated insights, reading retention filters and metrics, and managing custom RUM metrics
+- `rum`: Tools for [Real User Monitoring][57], including resolving applications, summarizing performance, surfacing aggregated insights, exploring metrics, managing retention filters, and managing custom RUM metrics
 - `security`: Tools for code security scanning and searching [security signals][39] and [security findings][40]
 - `software-delivery`: Tools for interacting with Software Delivery ([CI Visibility][30] and [Test Optimization][31])
 - `synthetics`: Tools for interacting with Datadog [Synthetic tests][29]

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -196,7 +196,7 @@ Searches logs with filters (time, query, service, host, storage tier, and so on)
 - Get all 500 status code logs from production.
 
 ### `search_datadog_rum_events`
-*Toolset: **core***\
+*Toolset: **core**, **rum***\
 *Permissions Required: `RUM Apps Read`*\
 Search Datadog RUM events using advanced query syntax.
 
@@ -205,7 +205,7 @@ Search Datadog RUM events using advanced query syntax.
 - Show recent user interactions on product detail pages.
 
 ### `aggregate_rum_events`
-*Toolset: **core***\
+*Toolset: **core**, **rum***\
 *Permissions Required: `RUM Apps Read`*\
 Aggregates RUM events to compute counts, sums, averages, min, max, cardinality, and percentiles, with grouping support. Use this for statistical analysis and trend data, not for inspecting individual events.
 
@@ -1272,7 +1272,7 @@ Creates a RUM retention filter, appended to the end of the evaluation order. Ret
 ### `update_rum_retention_filter`
 *Toolset: **rum***\
 *Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
-Updates an existing RUM retention filter's attributes in place, such as its name, event type, query, sample rate, or enabled state. Affects data retention and billing. Confirm the change before applying.
+Updates an existing RUM retention filter's attributes in place, such as its name, event type, query, sample rate, or enabled state. Confirm the change before applying.
 
 - Increase the sample rate on the "checkout errors" retention filter to 100%.
 - Disable the "long tasks" retention filter on my main RUM app.
@@ -1280,7 +1280,7 @@ Updates an existing RUM retention filter's attributes in place, such as its name
 ### `reorder_rum_retention_filters`
 *Toolset: **rum***\
 *Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
-Sets the full evaluation order of a RUM application's retention filters. Filters are evaluated top-down and each event stops at the first match, so order determines which sample rate applies. Affects data retention and billing. Confirm the new order before applying.
+Sets the full evaluation order of a RUM application's retention filters. Filters are evaluated top-down and each event stops at the first match, so order determines which sample rate applies. Confirm the new order before applying.
 
 - Move the "checkout errors" retention filter above the catch-all filter on "checkout-web".
 - Reorder my retention filters so the specific filters are evaluated before the broad ones.
@@ -1288,7 +1288,7 @@ Sets the full evaluation order of a RUM application's retention filters. Filters
 ### `delete_rum_retention_filter`
 *Toolset: **rum***\
 *Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
-Permanently deletes a RUM retention filter by ID. This action cannot be undone and affects data retention and billing. Confirm the deletion before applying. This operation is idempotent.
+Permanently deletes a RUM retention filter by ID. Confirm the deletion before applying. This operation is idempotent.
 
 - Delete the "legacy sessions" retention filter from "checkout-web".
 - Remove the retention filter with ID `abc-123-def` from my main RUM app.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1219,7 +1219,7 @@ Runs a read-only shell command on a specified host. Supported commands include: 
 
 ## RUM
 
-Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, exploring metrics, inspecting application configuration, and managing custom RUM metrics.
+Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, exploring metrics, inspecting application configuration, managing retention filters, and managing custom RUM metrics.
 
 ### `search_rum_applications`
 *Toolset: **rum***\
@@ -1260,6 +1260,38 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 
 - List the retention filters configured on the "checkout-web" application.
 - What retention filters do I have on my main RUM app?
+
+### `append_new_rum_retention_filter`
+*Toolset: **rum***\
+*Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
+Creates a RUM retention filter, appended to the end of the evaluation order. Retention filters control which RUM events are indexed and retained, which affects billing. Confirm the change before applying.
+
+- Create a retention filter on "checkout-web" that retains 100% of error events.
+- Add a filter to my main RUM app that keeps all sessions matching `@view.url_path:/checkout`.
+
+### `update_rum_retention_filter`
+*Toolset: **rum***\
+*Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
+Updates an existing RUM retention filter's attributes in place, such as its name, event type, query, sample rate, or enabled state. Affects data retention and billing. Confirm the change before applying.
+
+- Increase the sample rate on the "checkout errors" retention filter to 100%.
+- Disable the "long tasks" retention filter on my main RUM app.
+
+### `reorder_rum_retention_filters`
+*Toolset: **rum***\
+*Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
+Sets the full evaluation order of a RUM application's retention filters. Filters are evaluated top-down and each event stops at the first match, so order determines which sample rate applies. Affects data retention and billing. Confirm the new order before applying.
+
+- Move the "checkout errors" retention filter above the catch-all filter on "checkout-web".
+- Reorder my retention filters so the specific filters are evaluated before the broad ones.
+
+### `delete_rum_retention_filter`
+*Toolset: **rum***\
+*Permissions Required: `RUM Retention Filters Write` or `Product Analytics Apps Write`*\
+Permanently deletes a RUM retention filter by ID. This action cannot be undone and affects data retention and billing. Confirm the deletion before applying. This operation is idempotent.
+
+- Delete the "legacy sessions" retention filter from "checkout-web".
+- Remove the retention filter with ID `abc-123-def` from my main RUM app.
 
 ### `upsert_rum_metric`
 *Toolset: **rum***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -204,6 +204,15 @@ Search Datadog RUM events using advanced query syntax.
 - Find pages that are loading slowly (more than 3 seconds).
 - Show recent user interactions on product detail pages.
 
+### `aggregate_rum_events`
+*Toolset: **core***\
+*Permissions Required: `RUM Apps Read`*\
+Aggregates RUM events to compute counts, sums, averages, min, max, cardinality, and percentiles, with grouping support. Use this for statistical analysis and trend data, not for inspecting individual events.
+
+- Count JavaScript errors by page in the last 24 hours.
+- Show me the p95 loading time grouped by country for my main RUM application.
+- How many sessions had a Core Web Vitals failure this week?
+
 ### `create_datadog_notebook`
 *Toolset: **core***\
 *Permissions Required: `Notebooks Read` and `Notebooks Write`*\
@@ -1210,9 +1219,7 @@ Runs a read-only shell command on a specified host. Supported commands include: 
 
 ## RUM
 
-Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, exploring metrics, and inspecting application configuration.
-
-<div class="alert alert-info">The <code>rum</code> toolset is in Preview. Contact <a href="/help">Datadog support</a> to request access.</div>
+Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, exploring metrics, inspecting application configuration, and managing custom RUM metrics.
 
 ### `search_rum_applications`
 *Toolset: **rum***\
@@ -1253,6 +1260,22 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 
 - List the retention filters configured on the "checkout-web" application.
 - What retention filters do I have on my main RUM app?
+
+### `upsert_rum_metric`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
+Creates or updates a custom RUM metric. Checks immutable fields before updating an existing metric. This operation is idempotent.
+
+- Create a custom RUM metric that counts page views on the checkout page, grouped by country.
+- Update the filter on my "error-rate-by-service" custom metric to exclude bot traffic.
+
+### `delete_rum_metric`
+*Toolset: **rum***\
+*Permissions Required: `RUM Generate Metrics`*\
+Permanently deletes a custom RUM metric by ID. This operation is destructive and idempotent.
+
+- Delete the custom RUM metric with ID "my-custom-metric".
+- Remove the "legacy-page-views" RUM metric from my organization.
 
 ## Security
 

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1253,6 +1253,22 @@ Explores RUM metrics for an application, including out-of-the-box metrics and cu
 - List the custom RUM metrics defined on the "checkout-web" application.
 - Show me available RUM metrics related to page load time on my main app.
 
+### `upsert_rum_metric`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
+Creates or updates a custom RUM metric. Checks immutable fields before updating an existing metric. This operation is idempotent.
+
+- Create a distribution metric `rum.view.lcp_by_country` that tracks p95 LCP for view events, grouped by country.
+- Update the filter on `rum.error.checkout_errors` to exclude synthetic test traffic.
+
+### `delete_rum_metric`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
+Permanently deletes a custom RUM metric by ID. This operation is idempotent.
+
+- Delete the custom RUM metric `rum.view.my_custom_metric`.
+- Remove the `rum.view.legacy_page_views` RUM metric from my organization.
+
 ### `search_rum_retention_filters`
 *Toolset: **rum***\
 *Permissions Required: `RUM Retention Filters Read`*\
@@ -1292,22 +1308,6 @@ Permanently deletes a RUM retention filter by ID. Confirm the deletion before ap
 
 - Delete the "legacy sessions" retention filter from "checkout-web".
 - Remove the retention filter with ID `abc-123-def` from my main RUM app.
-
-### `upsert_rum_metric`
-*Toolset: **rum***\
-*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
-Creates or updates a custom RUM metric. Checks immutable fields before updating an existing metric. This operation is idempotent.
-
-- Create a distribution metric `rum.view.lcp_by_country` that tracks p95 LCP for view events, grouped by country.
-- Update the filter on `rum.error.checkout_errors` to exclude synthetic test traffic.
-
-### `delete_rum_metric`
-*Toolset: **rum***\
-*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
-Permanently deletes a custom RUM metric by ID. This operation is idempotent.
-
-- Delete the custom RUM metric `rum.view.my_custom_metric`.
-- Remove the `rum.view.legacy_page_views` RUM metric from my organization.
 
 ## Security
 

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1266,16 +1266,16 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 *Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
 Creates or updates a custom RUM metric. Checks immutable fields before updating an existing metric. This operation is idempotent.
 
-- Create a custom RUM metric that counts page views on the checkout page, grouped by country.
-- Update the filter on my "error-rate-by-service" custom metric to exclude bot traffic.
+- Create a custom RUM metric `rum.view.checkout_page_views` that counts page views on the checkout page, grouped by country.
+- Update the filter on the `rum.error.error_rate_by_service` custom metric to exclude bot traffic.
 
 ### `delete_rum_metric`
 *Toolset: **rum***\
 *Permissions Required: `RUM Generate Metrics`*\
 Permanently deletes a custom RUM metric by ID. This operation is destructive and idempotent.
 
-- Delete the custom RUM metric with ID "my-custom-metric".
-- Remove the "legacy-page-views" RUM metric from my organization.
+- Delete the custom RUM metric `rum.view.my_custom_metric`.
+- Remove the `rum.view.legacy_page_views` RUM metric from my organization.
 
 ## Security
 

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1272,7 +1272,7 @@ Creates or updates a custom RUM metric. Checks immutable fields before updating 
 ### `delete_rum_metric`
 *Toolset: **rum***\
 *Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
-Permanently deletes a custom RUM metric by ID. This operation is destructive and idempotent.
+Permanently deletes a custom RUM metric by ID. This operation is idempotent.
 
 - Delete the custom RUM metric `rum.view.my_custom_metric`.
 - Remove the `rum.view.legacy_page_views` RUM metric from my organization.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1266,8 +1266,8 @@ Lists retention filters configured on a RUM application. Read-only; available fo
 *Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
 Creates or updates a custom RUM metric. Checks immutable fields before updating an existing metric. This operation is idempotent.
 
-- Create a custom RUM metric `rum.view.checkout_page_views` that counts page views on the checkout page, grouped by country.
-- Update the filter on the `rum.error.error_rate_by_service` custom metric to exclude bot traffic.
+- Create a distribution metric `rum.view.lcp_by_country` that tracks p95 LCP for view events, grouped by country.
+- Update the filter on `rum.error.checkout_errors` to exclude synthetic test traffic.
 
 ### `delete_rum_metric`
 *Toolset: **rum***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1271,7 +1271,7 @@ Creates or updates a custom RUM metric. Checks immutable fields before updating 
 
 ### `delete_rum_metric`
 *Toolset: **rum***\
-*Permissions Required: `RUM Generate Metrics`*\
+*Permissions Required: `RUM Apps Read` and `RUM Generate Metrics`*\
 Permanently deletes a custom RUM metric by ID. This operation is destructive and idempotent.
 
 - Delete the custom RUM metric `rum.view.my_custom_metric`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Promotes the `rum` toolset from Preview to GA in the MCP Server documentation:

- Moves `rum` from the Preview toolsets section to GA in `setup.md`
- Adds a `## RUM` section to `tools.md` documenting `upsert_rum_metric` and `delete_rum_metric`
- Adds `aggregate_rum_events` to `tools.md` and labels both `search_datadog_rum_events` and `aggregate_rum_events` with the `core` and `rum` toolsets
- Documents the four RUM retention filter write tools: `append_new_rum_retention_filter`, `update_rum_retention_filter`, `reorder_rum_retention_filters`, and `delete_rum_retention_filter`
- Updates the `rum` toolset summary in `setup.md` to reflect that retention filters are now manageable, not just readable
- Uses correct RUM metric ID format (`rum.<event_type>.<description>`) in all examples
- Uses monitoring-oriented examples (LCP distribution, checkout error filtering) rather than page view counts, which are already covered by built-in metrics

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
