### PR TITLE
docs(feature-flags): add Flutter client integration

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6267,7 +6267,7 @@ menu:
       parent: feature_flags_client
       identifier: feature_flags_client_angular
       weight: 102
-    - name: Dart
+    - name: Dart and Flutter
       url: feature_flags/client/flutter
       parent: feature_flags_client
       identifier: feature_flags_client_flutter

--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -25,7 +25,7 @@ Datadog Feature Flags is built on the [OpenFeature standard](https://openfeature
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_large.svg" alt="Android" >}}
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_tv_large.svg" alt="Android TV" >}}
   {{< image-card href="/feature_flags/client/angular/" src="integrations_logos/angular_large.svg" alt="Angular" >}}
-  {{< image-card href="/feature_flags/client/flutter/" src="integrations_logos/flutter_large.svg" alt="Dart" >}}
+  {{< image-card href="/feature_flags/client/flutter/" src="integrations_logos/flutter_large.svg" alt="Dart and Flutter" >}}
   {{< image-card href="/feature_flags/client/ios/" src="integrations_logos/ios_large.svg" alt="iOS" >}}
   {{< image-card href="/feature_flags/client/javascript/" src="integrations_logos/javascript_large.svg" alt="JavaScript" >}}
   {{< image-card href="/feature_flags/client/react/" src="integrations_logos/react_large.svg" alt="React" >}}
@@ -46,7 +46,7 @@ Default: `true`. Set to `false` to disable.
 
 - **Web** (`@datadog/openfeature-browser`): `enableExposureLogging`
 - **Android** (`dd-sdk-android-flags`): `trackExposures`
-- **Dart** (`datadog_flags`): `trackExposures`
+- **Dart and Flutter** (`datadog_flags`): `trackExposures`
 - **iOS** (`DatadogFlags`): `trackExposures`
 - **React Native**: `trackExposures`
 - **Unity**: `trackExposures`
@@ -57,7 +57,7 @@ Default: `true`. Set to `false` to disable.
 
 - **Web** (`@datadog/openfeature-browser`): `enableFlagEvaluationTracking`
 - **Android** (`dd-sdk-android-flags`): `trackEvaluations`
-- **Dart** (`datadog_flags`): `trackEvaluations`
+- **Dart and Flutter** (`datadog_flags`): `trackEvaluations`
 - **iOS** (`DatadogFlags`): `trackEvaluations`
 - **React Native**: Not exposed
 - **Unity**: `trackEvaluations`
@@ -68,6 +68,7 @@ Default: `true`. Set to `false` to disable.
 
 - **Web** (`@datadog/openfeature-browser`): `enableRumFeatureFlagTracking`
 - **Android** (`dd-sdk-android-flags`): `rumIntegrationEnabled`
+- **Flutter** (`datadog_flutter_plugin`): `rumIntegrationEnabled`
 - **iOS** (`DatadogFlags`): `rumIntegrationEnabled`
 - **React Native**: `rumIntegrationEnabled`
 - **Unity**: Not exposed

--- a/content/en/feature_flags/client/flutter.md
+++ b/content/en/feature_flags/client/flutter.md
@@ -1,10 +1,13 @@
 ---
-title: Dart Feature Flags
-description: Set up Datadog Feature Flags for Dart applications.
+title: Dart and Flutter Feature Flags
+description: Set up Datadog Feature Flags for Dart and Flutter applications.
 further_reading:
 - link: "/feature_flags/client/"
   tag: "Documentation"
   text: "Client-Side Feature Flags"
+- link: "/real_user_monitoring/application_monitoring/flutter/"
+  tag: "Documentation"
+  text: "Flutter Monitoring"
 - link: "https://github.com/DataDog/dd-sdk-flutter/tree/develop/packages/datadog_flags"
   tag: "Source Code"
   text: "datadog_flags source code"
@@ -12,15 +15,21 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument a Dart application with the Datadog Feature Flags SDK. Datadog feature flags provide a unified way to remotely control feature availability in your app, experiment safely, and deliver new experiences with confidence.
+This page describes how to instrument Dart and Flutter applications with the Datadog Feature Flags SDK. Datadog feature flags provide a unified way to remotely control feature availability in your app, experiment safely, and deliver new experiences with confidence.
 
-The Datadog Feature Flags SDK for Dart is a native Dart package. It fetches precomputed assignments from Datadog, evaluates typed flag values locally, and reports exposure and flag evaluation telemetry back to Datadog. Flutter applications can also use this package directly from Dart code.
+The Datadog Feature Flags SDK for Dart is a native Dart package. It fetches precomputed assignments from Datadog, evaluates typed flag values locally, and reports exposure and flag evaluation telemetry back to Datadog. Flutter applications can use the standalone Dart package directly or register the Flutter plugin integration to derive configuration from `datadog_flutter_plugin`.
 
-<div class="alert alert-info">This package provides an OpenFeature-compatible API for Dart, but it is not built on the OpenFeature Dart SDK. Datadog is working on an OpenFeature-provider-based integration for Dart and Flutter. Until that is available, use the APIs on this page directly.</div>
+<div class="alert alert-info">This package provides an OpenFeature-compatible API for Dart and Flutter, but it is not built on the OpenFeature Dart SDK. Datadog is working on an OpenFeature-provider-based integration for Dart and Flutter. Until that is available, use the APIs on this page directly.</div>
 
 ## Installation
 
-Install `datadog_flags`:
+For a Flutter app that already uses the Datadog Flutter SDK, install or update `datadog_flutter_plugin`:
+
+{{< code-block lang="bash" >}}
+flutter pub add datadog_flutter_plugin
+{{< /code-block >}}
+
+For standalone Dart usage, install `datadog_flags`:
 
 {{< tabs >}}
 {{% tab "Dart" %}}
@@ -42,7 +51,54 @@ Then import the public API:
 import 'package:datadog_flags/datadog_flags.dart';
 {{< /code-block >}}
 
-## Initialize the SDK
+## Flutter-integrated setup
+
+Use this setup when your Flutter app already initializes `datadog_flutter_plugin`. Add `DatadogFlagsPluginConfiguration` to your existing `DatadogConfiguration` before initializing the Datadog SDK. The plugin derives the client token, environment, site, service, version, and RUM application ID from the Flutter SDK configuration. To create a client token, see [Client tokens][1].
+
+{{< site-region region="gov,gov2" >}}<div class="alert alert-danger">Flutter Feature Flags are not supported for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>{{< /site-region >}}
+
+{{< code-block lang="dart" >}}
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+
+final configuration = DatadogConfiguration(
+  clientToken: '<CLIENT_TOKEN>',
+  env: '<ENV_NAME>',
+  site: DatadogSite.{{< region-param key="dd_site_name" code="true" >}},
+  service: '<SERVICE_NAME>',
+  version: '<APP_VERSION>',
+  rumConfiguration: DatadogRumConfiguration(
+    applicationId: '<RUM_APPLICATION_ID>',
+  ),
+)..addPlugin(const DatadogFlagsPluginConfiguration());
+
+await DatadogSdk.instance.initialize(configuration, TrackingConsent.granted);
+{{< /code-block >}}
+
+After initialization, retrieve a flags client from the plugin and initialize it with the evaluation context for the current subject:
+
+{{< code-block lang="dart" >}}
+final flags = DatadogSdk.instance.flags;
+if (flags == null) {
+  return;
+}
+
+final flagsClient = flags.sharedClient();
+await flagsClient.initialize(
+  const FlagsEvaluationContext(
+    targetingKey: 'user-123',
+    attributes: {
+      'companyId': 'company-456',
+      'plan': 'enterprise',
+    },
+  ),
+);
+{{< /code-block >}}
+
+Successful evaluations are sent through the Datadog Feature Flags telemetry pipeline. With the Flutter-integrated setup, successful evaluations that return a variant are also added to the active RUM view as feature flag evaluations.
+
+## Standalone Dart setup
+
+Use this setup when you are not using `datadog_flutter_plugin`, or when you want to manage Feature Flags independently from Flutter SDK initialization.
 
 Enable Datadog Feature Flags early in your app startup. For live Feature Flags configuration, `clientToken`, `env`, and `site` are required. To create a client token, see [Client tokens][1].
 
@@ -239,6 +295,30 @@ DatadogFlagsConfiguration(
 : Advanced overrides for tests, proxies, or custom routing.
 
 If `enable()` is called without a `datadogConfig`, the SDK creates no live provider. Evaluations return the caller-provided default with `FlagEvaluationError.providerNotReady`.
+
+For Flutter-integrated setup, pass these options through `DatadogFlagsPluginConfiguration`:
+
+{{< code-block lang="dart" >}}
+final configuration = DatadogConfiguration(
+  clientToken: '<CLIENT_TOKEN>',
+  env: '<ENV_NAME>',
+  site: DatadogSite.{{< region-param key="dd_site_name" code="true" >}},
+  rumConfiguration: DatadogRumConfiguration(
+    applicationId: '<RUM_APPLICATION_ID>',
+  ),
+)..addPlugin(
+    const DatadogFlagsPluginConfiguration(
+      flagsConfiguration: DatadogFlagsConfiguration(
+        trackExposures: true,
+        trackEvaluations: true,
+      ),
+      rumIntegrationEnabled: true,
+    ),
+  );
+{{< /code-block >}}
+
+`rumIntegrationEnabled`
+: When `true` (default), successful evaluations that return a variant are added to the active RUM view as feature flag evaluations. If your app does not use RUM, this option has no effect.
 
 ## Last-known assignment storage
 

--- a/content/en/feature_flags/guide/migrate_from_launchdarkly.md
+++ b/content/en/feature_flags/guide/migrate_from_launchdarkly.md
@@ -39,7 +39,7 @@ Follow the installation instructions for your platform:
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_large.svg" alt="Android" >}}
   {{< image-card href="/feature_flags/client/android/" src="integrations_logos/android_tv_large.svg" alt="Android TV" >}}
   {{< image-card href="/feature_flags/client/angular/" src="integrations_logos/angular_large.svg" alt="Angular" >}}
-  {{< image-card href="/feature_flags/client/flutter/" src="integrations_logos/flutter_large.svg" alt="Dart" >}}
+  {{< image-card href="/feature_flags/client/flutter/" src="integrations_logos/flutter_large.svg" alt="Dart and Flutter" >}}
   {{< image-card href="/feature_flags/client/ios/" src="integrations_logos/ios_large.svg" alt="iOS" >}}
   {{< image-card href="/feature_flags/client/javascript/" src="integrations_logos/javascript_large.svg" alt="JavaScript" >}}
   {{< image-card href="/feature_flags/client/react/" src="integrations_logos/react_large.svg" alt="React" >}}


### PR DESCRIPTION
## Motivation

Flutter customers who already initialize `datadog_flutter_plugin` should not have to duplicate Datadog client token, environment, site, service, version, and RUM application configuration just to use Feature Flags. `DataDog/dd-sdk-flutter#1071` adds a Flutter plugin integration layer over the standalone Dart Flags SDK, so the docs need a stacked update that explains the integrated setup path without blocking the standalone Dart guide.

## Changes

This PR stacks on `DataDog/documentation#37809` and adds the Flutter-integrated setup to the same client guide. The page now documents `DatadogFlagsPluginConfiguration`, `DatadogSdk.instance.flags?.sharedClient()`, client initialization with `FlagsEvaluationContext`, and the default behavior that successful variant evaluations are added to the active RUM view as feature flag evaluations.

The PR also restores the customer-facing label from Dart to Dart and Flutter in the client SDK card grid, side navigation, and LaunchDarkly migration picker. The telemetry comparison table now includes the Flutter `rumIntegrationEnabled` option from `datadog_flutter_plugin`.

## Decisions

The Flutter integration docs stay stacked on the standalone Dart docs because `datadog_flutter_plugin` integration depends on the API added in `DataDog/dd-sdk-flutter#1071`. The standalone page remains the base layer for pure Dart apps and Flutter apps that want full lifecycle control; this PR adds the SDK-owned Flutter initialization path for apps that already use the Datadog Flutter SDK.

The integration section uses the same API shape as `DataDog/dd-sdk-flutter#1071`: register `DatadogFlagsPluginConfiguration` with `DatadogConfiguration.addPlugin`, initialize `DatadogSdk`, retrieve the plugin through `DatadogSdk.instance.flags`, and evaluate through the same typed `DatadogFlagsClient` methods as the standalone package.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("config/_default/menus/main.en.yaml"); ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' content/en/feature_flags/client/_index.md content/en/feature_flags/client/flutter.md content/en/feature_flags/guide/migrate_from_launchdarkly.md`
- `python3` shortcode balance check for tabs, code blocks, and site-region blocks in touched Markdown files.
