### PR TITLE
Remove migration banner from findings schema page

### DIFF
--- a/content/en/security/guide/findings-schema.md
+++ b/content/en/security/guide/findings-schema.md
@@ -20,10 +20,6 @@ Security findings in Datadog represent vulnerabilities, misconfigurations, and s
 
 All findings share a common schema that enables unified querying and analysis across different security products.
 
-{{< learning-center-callout header="" btn_title="Learn more" btn_url="/security/guide/security-findings-migration/" hide_image="true" >}}
-  Learn about migrating to this new schema so you can avoid any interruptions to your workflows.
-{{< /learning-center-callout >}}
-
 ## Examples
 
 There are eleven different categories for security findings. Click on a category to view a sample security finding belonging to that category.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the learning center callout banner ("Learn about migrating to this new schema so you can avoid any interruptions to your workflows.") from the [Security Findings Schema Reference](https://docs.datadoghq.com/security/guide/findings-schema/) page.

<img width="532" height="234" alt="image" src="https://github.com/user-attachments/assets/36054996-e112-4f29-b391-3a307a9713ce" />
