### PR TITLE
[ AGNTLOG-581 ] Add new telemetry metrics to Agent data security page

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -163,8 +163,16 @@ agent diagnose show-metadata agent-telemetry
 | logs.decoded                                | Total number of decoded logs                                                                                           |
 | logs.dropped                                | Total number of logs dropped                                                                                           |
 | logs.encoded_bytes_sent                     | Total number of bytes sent after encoding, if applicable                                                               |
+| logs.http_connectivity_check                | Count of HTTP connectivity checks, tagged by status (success/failure)                                                  |
+| logs.http_connectivity_failure              | Count of HTTP connectivity check failures, tagged by root cause (dns, tls, timeout, connection, http_status, other)    |
+| logs.http_connectivity_retry_attempt        | Count of HTTP connectivity retry attempts, tagged by status (success/failure)                                          |
+| logs.restart_attempt                        | Count of logs agent restart attempts, tagged by status and target transport                                             |
 | logs.sender_latency                         | HTTP sender latency in milliseconds                                                                                    |
+| logs.auto_multi_line_default_total_lines    | Total log lines processed by the detecting aggregator for sources relying on the auto multiline detection default           |
+| logs.auto_multi_line_default_would_combine  | Number of lines that would be combined if auto multiline detection were enabled by default                              |
+| logs.auto_multi_line_default_would_truncate | Number of lines in groups that would be truncated if auto multiline detection were enabled by default                   |
 | logs.truncated                              | Total number of logs truncated by the Agent                                                                            |
+| logs_destination.destination_workers        | Maximum number of active HTTP connections per log destination                                                          |
 | point.dropped                               | Total number of dropped metrics                                                                                        |
 | point.sent                                  | Total number of sent metrics                                                                                           |
 | transactions.input_count                    | Incoming transaction count                                                                                             |

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -158,19 +158,19 @@ agent diagnose show-metadata agent-telemetry
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |
 | dogstatsd.uds_packets_bytes                 | DogStatsD UDS packets bytes                                                                                            |
 | logs.auto_multi_line_aggregator_flush       | Number of multi-line logs aggregated by the Agent                                                                       |
+| logs.auto_multi_line_default_total_lines    | Total log lines processed by the detecting aggregator for sources relying on the auto multi-line detection default           |
+| logs.auto_multi_line_default_would_combine  | Number of lines that would be combined if auto multi-line detection were enabled by default                              |
+| logs.auto_multi_line_default_would_truncate | Number of lines in groups that would be truncated if auto multi-line detection were enabled by default                   |
 | logs.bytes_missed                           | Total number of bytes lost before they could be consumed by the Agent, for example, after log rotation                 |
 | logs.bytes_sent                             | Total number of bytes sent before encoding, if applicable                                                              |
 | logs.decoded                                | Total number of decoded logs                                                                                           |
 | logs.dropped                                | Total number of logs dropped                                                                                           |
 | logs.encoded_bytes_sent                     | Total number of bytes sent after encoding, if applicable                                                               |
-| logs.http_connectivity_check                | Count of HTTP connectivity checks, tagged by status (success/failure)                                                  |
+| logs.http_connectivity_check                | Count of HTTP connectivity checks, tagged by status (success or failure)                                               |
 | logs.http_connectivity_failure              | Count of HTTP connectivity check failures, tagged by root cause (dns, tls, timeout, connection, http_status, other)    |
-| logs.http_connectivity_retry_attempt        | Count of HTTP connectivity retry attempts, tagged by status (success/failure)                                          |
+| logs.http_connectivity_retry_attempt        | Count of HTTP connectivity retry attempts, tagged by status (success or failure)                                       |
 | logs.restart_attempt                        | Count of logs agent restart attempts, tagged by status and target transport                                             |
 | logs.sender_latency                         | HTTP sender latency in milliseconds                                                                                    |
-| logs.auto_multi_line_default_total_lines    | Total log lines processed by the detecting aggregator for sources relying on the auto multiline detection default           |
-| logs.auto_multi_line_default_would_combine  | Number of lines that would be combined if auto multiline detection were enabled by default                              |
-| logs.auto_multi_line_default_would_truncate | Number of lines in groups that would be truncated if auto multiline detection were enabled by default                   |
 | logs.truncated                              | Total number of logs truncated by the Agent                                                                            |
 | logs_destination.destination_workers        | Maximum number of active HTTP connections per log destination                                                          |
 | point.dropped                               | Total number of dropped metrics                                                                                        |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds eight new telemetry metrics to the telemetry collection table on the Agent Data Security page. The new entries cover HTTP connectivity checks and retries, logs agent restarts, auto multi-line detection line counting, destination worker connections, and log truncation. 
### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

N/A