### PR TITLE
LLM Observability: document page limit response size and latency

### DIFF
--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -299,7 +299,7 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 
 | Field | Type | Description |
 |-------|------|-------------|
-| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit, and large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `cursor`. |
+| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. Large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `cursor`. |
 | cursor | string | List following results with a cursor provided in the previous query. |
 
 ### SearchedSpanResource

--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -123,7 +123,7 @@ Method
 | sort | string | Sort order. Allowed values: timestamp, -timestamp |
 | include_attachments | boolean | Whether to retrieve truncated input and output content. Defaults to True. |
 | page[cursor] | string | List following results with a cursor provided in the previous query. |
-| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. If your spans contain large inputs or outputs, use a lower limit and paginate with `page[cursor]`. |
+| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit, and large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `page[cursor]`. |
 
 #### Code example
 
@@ -299,7 +299,7 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 
 | Field | Type | Description |
 |-------|------|-------------|
-| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. If your spans contain large inputs or outputs, use a lower limit and paginate with `cursor`. |
+| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit, and large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `cursor`. |
 | cursor | string | List following results with a cursor provided in the previous query. |
 
 ### SearchedSpanResource

--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -123,7 +123,7 @@ Method
 | sort | string | Sort order. Allowed values: timestamp, -timestamp |
 | include_attachments | boolean | Whether to retrieve truncated input and output content. Defaults to True. |
 | page[cursor] | string | List following results with a cursor provided in the previous query. |
-| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit, and large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `page[cursor]`. |
+| page[limit] | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. <br>**Note:** Responses are subject to a 50 MB size limit. Large limits (100+) can increase response time. If your spans contain large inputs or outputs, use a lower limit and paginate with `page[cursor]`. |
 
 #### Code example
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Clarifies the `page[limit]` documentation in the LLM Observability spans export API reference (`evaluations/export_api.md`). Updates both the request query-parameter table and the `PageQuery` schema field to state that:

- Responses are subject to a 50 MB size limit.
- Large limits (100+) can increase response time.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes