### PR TITLE
Update Operations Monitoring preview link

### DIFF
--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -7,7 +7,7 @@ further_reading:
   text: 'Learn about RUM'
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/journey-monitoring/" btn_hidden="false" header="Join the Preview!">}}
+{{< callout url="https://www.datadoghq.com/product-preview/operations-monitoring/" btn_hidden="false" header="Join the Preview!">}}
 Operations Monitoring is in Preview.
 {{< /callout >}}
 


### PR DESCRIPTION
Corrects the preview link on the Operations Monitoring page, which currently goes to the Journey Monitoring preview page instead.

### Merge readiness
- [x] Ready for merge

### AI assistance
n/a
