### PR TITLE
Document wildcard host pattern support for iOS and Android first-party hosts and WebView tracking

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/web_view_tracking/_index.md
@@ -156,7 +156,7 @@ Add `DatadogWebViewTracking` library to your application by following the guide 
    WebViewTracking.enable(webView, allowedHosts)
    ```
 
-`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` accepts plain hostnames (for example, `"example.com"`, which also matches its subdomains) and wildcard patterns with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Invalid entries are dropped with a warning.
 
 **Note**:
 In order for instrumentation to work on the WebView component, it is very important that the JavaScript is enabled on the WebView. To enable it, you can use the following code snippet:
@@ -180,7 +180,7 @@ import WebKit
 import DatadogWebViewTracking
 
 let webView = WKWebView(...)
-WebViewTracking.enable(webView: webView, hosts: ["example.com"])
+WebViewTracking.enable(webView: webView, hosts: ["example.com", "*.example.com"])
 ```
 
 To disable Web View Tracking:
@@ -188,7 +188,7 @@ To disable Web View Tracking:
 WebViewTracking.disable(webView: webView)
 ```
 
-`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
+`hosts` accepts plain hostnames (for example, `"example.com"`, which also matches its subdomains) and wildcard patterns with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Invalid entries are dropped with a warning.
 
 {{% /tab %}}
 {{% tab "Flutter" %}}

--- a/content/en/tracing/trace_collection/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/dd_libraries/android.md
@@ -806,11 +806,11 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
      implementation "com.datadoghq:dd-sdk-android-okhttp:x.x.x"
    }
    ```
-2. Add `DatadogInterceptor` to your `OkHttpClient`:
+2. Add `DatadogInterceptor` to your `OkHttpClient`. Each host entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`). A wildcard may only match subdomains of a registrable domain, so patterns such as `"*.com"` are rejected:
    {{< tabs >}}
    {{% tab "Kotlin" %}}
    ```kotlin
-   val tracedHosts = listOf("example.com", "example.eu")
+   val tracedHosts = listOf("example.com", "example.eu", "*.example.eu")
    val okHttpClient = OkHttpClient.Builder()
      .addInterceptor(
        DatadogInterceptor.Builder(tracedHosts)
@@ -822,7 +822,7 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
    {{% /tab %}}
    {{% tab "Java" %}}
    ```java
-   List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+   List<String> tracedHosts = Arrays.asList("example.com", "example.eu", "*.example.eu");
    OkHttpClient okHttpClient = new OkHttpClient.Builder()
      .addInterceptor(
        new DatadogInterceptor.Builder(tracedHosts)
@@ -843,7 +843,7 @@ The interceptor tracks requests at the application level. You can also add a `Tr
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-val tracedHosts = listOf("example.com", "example.eu")
+val tracedHosts = listOf("example.com", "example.eu", "*.example.eu")
 val okHttpClient =  OkHttpClient.Builder()
   .addInterceptor(
     DatadogInterceptor.Builder(tracedHosts)
@@ -860,7 +860,7 @@ val okHttpClient =  OkHttpClient.Builder()
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+List<String> tracedHosts = Arrays.asList("example.com", "example.eu", "*.example.eu");
 OkHttpClient okHttpClient = new OkHttpClient.Builder()
   .addInterceptor(
     new DatadogInterceptor.Builder(tracedHosts)

--- a/content/en/tracing/trace_collection/dd_libraries/ios.md
+++ b/content/en/tracing/trace_collection/dd_libraries/ios.md
@@ -536,7 +536,7 @@ for (NSString *key in headersWriter.traceHeaderFields) {
 {{< /tabs >}}
 This sets additional tracing headers on your request so your backend can extract the request and continue distributed tracing. Once the request is done, call `span.finish()` within a completion handler. If your backend is also instrumented with [Datadog APM & Distributed Tracing][10], the entire front-to-back trace appears in the Datadog dashboard.
 
-    * To automatically trace all network requests made to the given hosts, specify the `firstPartyHosts` array in the Trace configuration with `urlSessionTracking`:
+    * To automatically trace all network requests made to the given hosts, specify the `firstPartyHosts` array in the Trace configuration with `urlSessionTracking`. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`):
 {{< tabs >}}
 {{% tab "Swift" %}}
 ```swift
@@ -545,7 +545,7 @@ import DatadogTrace
 Trace.enable(
     with: Trace.Configuration(
         urlSessionTracking: Trace.Configuration.URLSessionTracking(
-            firstPartyHostsTracing: .trace(hosts: ["example.com", "api.yourdomain.com"])
+            firstPartyHostsTracing: .trace(hosts: ["example.com", "api.yourdomain.com", "*.api.yourdomain.com"])
         )
     )
 )

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
@@ -305,13 +305,13 @@ Widgets are not automatically tracked with the SDK. To send UI interactions from
 You can use the following methods in `Configuration.Builder` when creating the Datadog configuration to initialize the library:
 
 `setFirstPartyHosts()`
-: Defines hosts that have tracing enabled and have RUM resources categorized as `first-party`. **Note**: If you define custom tracing header types in the Datadog configuration and are using a tracer registered with `GlobalTracer`, make sure the same tracing header types are set for the SDK in use.
+: Defines hosts that have tracing enabled and have RUM resources categorized as `first-party`. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`); the wildcard must target a subdomain of a registrable domain, so patterns like `"*.com"` are dropped. **Note**: If you define custom tracing header types in the Datadog configuration and are using a tracer registered with `GlobalTracer`, make sure the same tracing header types are set for the SDK in use.
 
 `useSite(DatadogSite)`
 : Switches target data to EU1, US1, US3, US5, US1_FED, US2_FED, AP1, and AP2 sites.
 
 `setFirstPartyHostsWithHeaderType`
-: Sets the list of first party hosts and specifies the type of HTTP headers used for distributed tracing.
+: Sets the list of first party hosts and specifies the type of HTTP headers used for distributed tracing. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`); the wildcard must target a subdomain of a registrable domain, so patterns like `"*.com"` are dropped.
 
 `setBatchSize([SMALL|MEDIUM|LARGE])`
 : Defines the individual batch size for requests sent to Datadog.

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
@@ -703,6 +703,8 @@ If you have more than one delegate type in your app that you want to instrument,
 
 Also, you can configure first party hosts using `urlSessionTracking`. This classifies resources that match the given domain as "first party" in RUM and propagates tracing information to your backend (if you have enabled Tracing). Network traces are sampled with an adjustable sampling rate. A sampling of 20% is applied by default.
 
+Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Invalid entries are dropped with a warning.
+
 For instance, you can configure `example.com` as the first party host and enable both RUM and Tracing features:
 
 {% tabs %}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents wildcard host pattern support added to WebView tracking and first-party hosts on iOS and Android. Both SDKs now accept patterns like `*.example.com` or `preview-*.example.com` in addition to plain hostnames.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

Waiting on:
-  DataDog/dd-sdk-android#3540
- `RUM-16668`

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
