### PR TITLE
Add CloudPrem v0.1.30 release note

### DIFF
--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -37,6 +37,19 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 ## Releases
 
+### v0.1.30 — 2026-06-30
+
+*Bundled in chart: `0.4.3`.*
+
+#### Changed
+- Reduces search CPU time for date histogram queries by up to 20%, with the largest gains on seven-day windows.
+- Adds a dedicated health check listener on port `7284` for CloudPrem component liveness and readiness checks.
+
+#### Helm chart changes
+- Adds global `volumes` and `volumeMounts` values that apply to all CloudPrem components and merge with existing per-component `extraVolumes` and `extraVolumeMounts`.
+- Adds global `topologySpreadConstraints` support, merged with per-component constraints, to spread CloudPrem workload pods across topology domains.
+- Updates CloudPrem services and AWS ALB internal ingress health checks to use the dedicated health endpoint.
+
 ### v0.1.29 — 2026-06-05
 
 *Bundled in chart: `0.4.2`.*

--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -42,7 +42,7 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 *Bundled in chart: `0.4.3`.*
 
 #### Changed
-- Reduces search CPU time for date histogram queries by up to 20%, with the largest gains on seven-day windows.
+- Reduces search CPU time for nested date histogram queries by up to 20%, with the largest gains on seven-day windows.
 - Adds a dedicated health check listener on port `7284` for CloudPrem component liveness and readiness checks.
 
 #### Helm chart changes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the CloudPrem v0.1.30 release note, bundled in the `datadog/cloudprem` Helm chart `0.4.3`.

Related Helm chart update: DataDog/helm-charts#2757

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Validation:
- `git diff --check -- content/en/byoc-logs/release_notes.md`

Vale was not run because this checkout points to a missing local styles path: `/Users/francois.massot/Documents/products/pm/datadog-vale/styles`.