### PR TITLE
Add Aurora PostgreSQL 18 to DBM setup docs

### DIFF
--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -17,6 +17,7 @@ disable_sidebar: true
 | Postgres 15  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}}      | {{< X >}} | {{< X >}} |
 | Postgres 16  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}}      | {{< X >}} | {{< X >}} |
 | Postgres 17  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}}      |           | {{< X >}} |
+| Postgres 18  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}}      | {{< X >}} |           |
 
 ### Setup instructions by hosting type
 

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -22,7 +22,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 ## Before you begin
 
 Supported PostgreSQL versions
-: 9.6, 10, 11, 12, 13, 14, 15, 16, 17
+: 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 Supported Agent versions
 : 7.36.1+


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds PostgreSQL 18 support to the Aurora DBM setup documentation.

- `setup_postgres/aurora.md`: adds 18 to the supported PostgreSQL versions list (was 9.6–17)
- `setup_postgres/_index.md`: adds a Postgres 18 row to the version support matrix (Self-hosted, RDS, Aurora, GCS, AlloyDB, Azure all supported; Supabase not yet)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes