### PR TITLE
relative alias fix

### DIFF
--- a/content/en/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
+++ b/content/en/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
@@ -7,7 +7,7 @@ further_reading:
   tag: "Documentation"
   text: "Set up Audit Trail"
 aliases:
-- ./track_dashboard_usage/
+- /account_management/audit_trail/guides/track_dashboard_usage/
 ---
 
 ## Overview
@@ -44,7 +44,7 @@ You can use [event queries][7] in Audit Trail to see a list of dashboards that h
 
 1. Navigate to [Audit Trail][2].
 1. In the {{< ui >}}Search for{{< /ui >}} field, paste a query to filter for the kind of changes you want to see. Here are some common examples:
-   
+
    | Audit event                       | Query in audit explorer                                      |
    |-----------------------------------|--------------------------------------------------------------|
    | [Recently created dashboards][4]  | `@evt.name:Dashboard @asset.type:dashboard @action:created`  |
@@ -52,7 +52,7 @@ You can use [event queries][7] in Audit Trail to see a list of dashboards that h
    | [Recently deleted dashboards][6]  | `@evt.name:Dashboard @asset.type:dashboard @action:deleted`  |
 
 1. Optionally, on the facet panel, use filters like {{< ui >}}Asset ID{{< /ui >}} or {{< ui >}}Asset Name{{< /ui >}} to narrow your results down to a specific dashboard.
-1. For each event in the table, you can see the email address of the user who performed the last change, and a summary of what happened. 
+1. For each event in the table, you can see the email address of the user who performed the last change, and a summary of what happened.
 
    To see additional information about a specific change, click the row in the table. Then, click the {{< ui >}}Inspect Changes (Diff){{< /ui >}} tab to see the changes that were made to the dashboard's configuration:
 

--- a/content/fr/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
+++ b/content/fr/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /fr/./track_dashboard_usage/
+- /fr/account_management/audit_trail/guides/track_dashboard_usage/
 description: Utilisez Audit Trail pour suivre l'utilisation des dashboards, les modèles
   d'accès et les modifications de configuration avec la surveillance des requêtes
   API et l'inspection des différences.
@@ -49,7 +49,7 @@ Vous pouvez utiliser des [requêtes d'événements][7] dans Audit Trail pour aff
 
    | Événement d'audit                       | Requête dans l'audit explorer                                      |
    |-----------------------------------|--------------------------------------------------------------|
-   | [Dashboards récemment créés][4] | `@evt.name:Dashboard @asset.type:dashboard @action:created` 
+   | [Dashboards récemment créés][4] | `@evt.name:Dashboard @asset.type:dashboard @action:created`
    | [Dashboards récemment modifiés][5] | `@evt.name:Dashboard @asset.type:dashboard @action:modified` |
    | [Dashboards récemment supprimés][6]  | `@evt.name:Dashboard @asset.type:dashboard @action:deleted`  |
 

--- a/content/ja/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
+++ b/content/ja/account_management/audit_trail/guides/track_dashboard_access_and_configuration_changes.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /ja/./track_dashboard_usage/
+- /ja/account_management/audit_trail/guides/track_dashboard_usage/
 disable_toc: false
 further_reading:
 - link: account_management/audit_trail/

--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,10 +1,8 @@
 {{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$|^security/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
 {{- range $p := .Site.Pages -}}
     {{- range .Aliases -}}
-        {{- /* Strip leading ./ from relative aliases */ -}}
-        {{- $temp := strings.TrimPrefix "./" . -}}
         {{- /* Normalize by replacing multi slashes with one */ -}}
-        {{- $temp = (replaceRE `(?m)(\/\/+)` "/" $temp) -}}
+        {{- $temp := (replaceRE `(?m)(\/\/+)` "/" .) -}}
         {{- $temp = strings.TrimPrefix "/" $temp -}}
         {{- $alias := strings.TrimSuffix "/" $temp -}}
         {{- if not (findRE $pattern $alias) -}}

--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,8 +1,10 @@
 {{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$|^security/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
 {{- range $p := .Site.Pages -}}
     {{- range .Aliases -}}
+        {{- /* Strip leading ./ from relative aliases */ -}}
+        {{- $temp := strings.TrimPrefix "./" . -}}
         {{- /* Normalize by replacing multi slashes with one */ -}}
-        {{- $temp := (replaceRE `(?m)(\/\/+)` "/" .) -}}
+        {{- $temp = (replaceRE `(?m)(\/\/+)` "/" $temp) -}}
         {{- $temp = strings.TrimPrefix "/" $temp -}}
         {{- $alias := strings.TrimSuffix "/" $temp -}}
         {{- if not (findRE $pattern $alias) -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

As we layer redirects at the edge based off aliases, I caught this relative one `./track_dashboard_usage/` in the data store that won't work. Hugo is pretty forgiving so it didn't error, i've updated the frontmatter to have the full expanded alias.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

https://docs-staging.datadoghq.com/david.jones/alias-fix/account_management/audit_trail/guides/track_dashboard_usage/
