### PR TITLE
Update AI Credits hyperlink to direct URL

### DIFF
--- a/content/en/account_management/billing/ai_credits.md
+++ b/content/en/account_management/billing/ai_credits.md
@@ -91,5 +91,5 @@ AI Credits are available to all Datadog customers except:
 [3]: /bits_ai/bits_investigation/
 [4]: /actions/agents/
 [5]: https://www.datadoghq.com/pricing/?site=us&product=ai-credits#products
-[6]: https://app.datadoghq.com/account/login?next=%2Fbilling%2Fbill-overview%3Fdetail_bd%3Dai_credits
+[6]: https://app.datadoghq.com/billing/ai-credits
 [7]: https://app.datadoghq.com/account/login?next=%2Forganization-settings%2Froles


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the **Plan & Usage > AI Credits** hyperlink on the AI Credits billing page to point directly to `https://app.datadoghq.com/billing/ai-credits` instead of the login redirect URL.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes