### PR TITLE
Add descriptive comments for applicationId and clientToken in browser SDK snippets

### DIFF
--- a/content/en/feature_flags/client/angular.md
+++ b/content/en/feature_flags/client/angular.md
@@ -58,8 +58,11 @@ Create a `DatadogProvider` instance with your Datadog credentials. For live Brow
 import { DatadogProvider } from '@datadog/openfeature-browser';
 
 const provider = new DatadogProvider({
-  // Required client-side Datadog credentials
+  // Required
+  // applicationId is a unique identifier to distinguish multiple frontend applications.
+  // This should match the app ID you provide to your RUM SDK.
   applicationId: '<APPLICATION_ID>',
+  // Required
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
   env: '<ENV_NAME>',

--- a/content/en/feature_flags/client/javascript.md
+++ b/content/en/feature_flags/client/javascript.md
@@ -54,8 +54,11 @@ import { DatadogProvider } from '@datadog/openfeature-browser';
 import { OpenFeature } from '@openfeature/web-sdk';
 
 const provider = new DatadogProvider({
-  // Required client-side Datadog credentials
+  // Required
+  // applicationId is a unique identifier to distinguish multiple frontend applications.
+  // This should match the app ID you provide to your RUM SDK.
   applicationId: '<APPLICATION_ID>',
+  // Required
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
   env: '<ENV_NAME>',

--- a/content/en/feature_flags/client/react.md
+++ b/content/en/feature_flags/client/react.md
@@ -53,8 +53,11 @@ Create a `DatadogProvider` instance and register it with OpenFeature. Do this as
 import { DatadogProvider } from '@datadog/openfeature-browser';
 
 const provider = new DatadogProvider({
-  // Required client-side Datadog credentials
+  // Required
+  // applicationId is a unique identifier to distinguish multiple frontend applications.
+  // This should match the app ID you provide to your RUM SDK.
   applicationId: '<APPLICATION_ID>',
+  // Required
   clientToken: '<CLIENT_TOKEN>',
   site: '{{< region-param key="dd_site" code="true" >}}',
   env: '<ENV_NAME>',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies what applicationId & clientToken represent in feature flags client sdk initialization options.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
