### PR TITLE
Add RUM accessibility attributes to iOS and Android data collected pages

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/web_view_tracking/_index.md
@@ -156,7 +156,7 @@ Add `DatadogWebViewTracking` library to your application by following the guide 
    WebViewTracking.enable(webView, allowedHosts)
    ```
 
-`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` accepts plain hostnames (for example, `"example.com"`) and wildcard patterns with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Plain hostnames also match their subdomains. Invalid entries are dropped with a warning.
 
 **Note**:
 In order for instrumentation to work on the WebView component, it is very important that the JavaScript is enabled on the WebView. To enable it, you can use the following code snippet:
@@ -188,7 +188,7 @@ To disable Web View Tracking:
 WebViewTracking.disable(webView: webView)
 ```
 
-`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
+The `hosts` parameter accepts plain hostnames (for example, `"example.com"`) and wildcard patterns with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Plain hostnames also match their subdomains. Invalid entries are dropped with a warning.
 
 {{% /tab %}}
 {{% tab "Flutter" %}}

--- a/content/en/tracing/trace_collection/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/dd_libraries/android.md
@@ -764,11 +764,11 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
      implementation "com.datadoghq:dd-sdk-android-okhttp:x.x.x"
    }
    ```
-2. Add `DatadogInterceptor` to your `OkHttpClient`:
+2. Add `DatadogInterceptor` to your `OkHttpClient`. Each host entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`):
    {{< tabs >}}
    {{% tab "Kotlin" %}}
    ```kotlin
-   val tracedHosts = listOf("example.com", "example.eu")
+   val tracedHosts = listOf("example.com", "*.example.eu")
    val okHttpClient = OkHttpClient.Builder()
      .addInterceptor(
        DatadogInterceptor.Builder(tracedHosts)
@@ -780,7 +780,7 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
    {{% /tab %}}
    {{% tab "Java" %}}
    ```java
-   List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+   List<String> tracedHosts = Arrays.asList("example.com", "*.example.eu");
    OkHttpClient okHttpClient = new OkHttpClient.Builder()
      .addInterceptor(
        new DatadogInterceptor.Builder(tracedHosts)
@@ -801,7 +801,7 @@ The interceptor tracks requests at the application level. You can also add a `Tr
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-val tracedHosts = listOf("example.com", "example.eu")
+val tracedHosts = listOf("example.com", "*.example.eu")
 val okHttpClient =  OkHttpClient.Builder()
   .addInterceptor(
     DatadogInterceptor.Builder(tracedHosts)
@@ -818,7 +818,7 @@ val okHttpClient =  OkHttpClient.Builder()
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+List<String> tracedHosts = Arrays.asList("example.com", "*.example.eu");
 OkHttpClient okHttpClient = new OkHttpClient.Builder()
   .addInterceptor(
     new DatadogInterceptor.Builder(tracedHosts)

--- a/content/en/tracing/trace_collection/dd_libraries/ios.md
+++ b/content/en/tracing/trace_collection/dd_libraries/ios.md
@@ -506,7 +506,7 @@ for (NSString *key in headersWriter.traceHeaderFields) {
 {{< /tabs >}}
 This sets additional tracing headers on your request so your backend can extract the request and continue distributed tracing. Once the request is done, call `span.finish()` within a completion handler. If your backend is also instrumented with [Datadog APM & Distributed Tracing][10], the entire front-to-back trace appears in the Datadog dashboard.
 
-    * To automatically trace all network requests made to the given hosts, specify the `firstPartyHosts` array in the Trace configuration with `urlSessionTracking`:
+    * To automatically trace all network requests made to the given hosts, specify the `firstPartyHosts` array in the Trace configuration with `urlSessionTracking`. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`):
 {{< tabs >}}
 {{% tab "Swift" %}}
 ```swift
@@ -515,7 +515,7 @@ import DatadogTrace
 Trace.enable(
     with: Trace.Configuration(
         urlSessionTracking: Trace.Configuration.URLSessionTracking(
-            firstPartyHostsTracing: .trace(hosts: ["example.com", "api.yourdomain.com"])
+            firstPartyHostsTracing: .trace(hosts: ["example.com", "*.api.yourdomain.com"])
         )
     )
 )

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
@@ -305,13 +305,13 @@ Widgets are not automatically tracked with the SDK. To send UI interactions from
 You can use the following methods in `Configuration.Builder` when creating the Datadog configuration to initialize the library:
 
 `setFirstPartyHosts()`
-: Defines hosts that have tracing enabled and have RUM resources categorized as `first-party`. **Note**: If you define custom tracing header types in the Datadog configuration and are using a tracer registered with `GlobalTracer`, make sure the same tracing header types are set for the SDK in use.
+: Defines hosts that have tracing enabled and have RUM resources categorized as `first-party`. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`). **Note**: If you define custom tracing header types in the Datadog configuration and are using a tracer registered with `GlobalTracer`, make sure the same tracing header types are set for the SDK in use.
 
 `useSite(DatadogSite)`
 : Switches target data to EU1, US1, US3, US5, US1_FED, US2_FED, AP1, and AP2 sites.
 
 `setFirstPartyHostsWithHeaderType`
-: Sets the list of first party hosts and specifies the type of HTTP headers used for distributed tracing.
+: Sets the list of first party hosts and specifies the type of HTTP headers used for distributed tracing. Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"`).
 
 `setBatchSize([SMALL|MEDIUM|LARGE])`
 : Defines the individual batch size for requests sent to Datadog.

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
@@ -700,6 +700,8 @@ If you have more than one delegate type in your app that you want to instrument,
 
 Also, you can configure first party hosts using `urlSessionTracking`. This classifies resources that match the given domain as "first party" in RUM and propagates tracing information to your backend (if you have enabled Tracing). Network traces are sampled with an adjustable sampling rate. A sampling of 20% is applied by default.
 
+Each entry accepts a plain hostname (for example, `"example.com"`) or a wildcard pattern with a single `*` (for example, `"*.example.com"` or `"preview-*.example.com"`). Invalid entries are dropped with a warning.
+
 For instance, you can configure `example.com` as the first party host and enable both RUM and Tracing features:
 
 {% tabs %}

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
@@ -156,6 +156,23 @@ RUM action, error, resource, and long task events contain information about the 
 | `view.time_spent`                             | number (ns) | Time spent on this view.                                    |
 | `view.url`                     | string | Canonical name of the class corresponding to the event.                                                           |
 
+### View accessibility attributes
+
+The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `view.accessibility.text_size` | number | The user's preferred text size as a scale factor relative to the default size (`1.0` is default, greater than `1.0` is larger). |
+| `view.accessibility.screen_reader_enabled` | Boolean | Whether TalkBack is active. |
+| `view.accessibility.invert_colors_enabled` | Boolean | Whether color inversion is enabled. |
+| `view.accessibility.assistive_switch_enabled` | Boolean | Whether Switch Access is active. |
+| `view.accessibility.closed_captioning_enabled` | Boolean | Whether closed captioning is enabled for media playback. |
+| `view.accessibility.mono_audio_enabled` | Boolean | Whether mono audio is enabled. |
+| `view.accessibility.reduced_animations_enabled` | Boolean | Whether the user prefers reduced animations (system animator duration scale is `0`). |
+| `view.accessibility.single_app_mode_enabled` | Boolean | Whether the device is locked to a single app through Screen Pinning. |
+| `view.accessibility.speak_selection_enabled` | Boolean | Whether Select to Speak is enabled. |
+| `view.accessibility.rtl_enabled` | Boolean | Whether right-to-left layout direction is active. |
+
 ### Resource attributes
 
 | Attribute                              | Type           | Description                                                                                                                               |

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
@@ -159,6 +159,35 @@ RUM action, error, resource, and long task events contain information about the 
 | `view.time_spent`     | number (ns) | Time spent on this view.                                                     |
 | `view.url`     | string | URL of the `UIViewController` class corresponding to the event. |
 
+### View accessibility attributes
+
+The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `view.accessibility.text_size` | string | The user's preferred text size category (for example, `UICTContentSizeCategoryM`). |
+| `view.accessibility.screen_reader_enabled` | Boolean | Whether VoiceOver is active. |
+| `view.accessibility.bold_text_enabled` | Boolean | Whether the system-wide bold text setting is enabled. |
+| `view.accessibility.reduce_transparency_enabled` | Boolean | Whether the system-wide reduce transparency setting is enabled. |
+| `view.accessibility.reduce_motion_enabled` | Boolean | Whether the system-wide reduce motion setting is enabled. |
+| `view.accessibility.button_shapes_enabled` | Boolean | Whether button shapes are enabled. |
+| `view.accessibility.invert_colors_enabled` | Boolean | Whether color inversion is enabled. |
+| `view.accessibility.increase_contrast_enabled` | Boolean | Whether the system-wide increase contrast setting is enabled. |
+| `view.accessibility.assistive_switch_enabled` | Boolean | Whether Switch Control is active. |
+| `view.accessibility.assistive_touch_enabled` | Boolean | Whether AssistiveTouch is active. |
+| `view.accessibility.is_video_autoplay_enabled` | Boolean | Whether video autoplay is enabled. |
+| `view.accessibility.closed_captioning_enabled` | Boolean | Whether closed captioning is enabled for media playback. |
+| `view.accessibility.mono_audio_enabled` | Boolean | Whether mono audio is enabled. |
+| `view.accessibility.shake_to_undo_enabled` | Boolean | Whether the Shake to Undo gesture is enabled. |
+| `view.accessibility.reduced_animations_enabled` | Boolean | Whether the user prefers reduced animations or cross-fade transitions. |
+| `view.accessibility.should_differentiate_without_color` | Boolean | Whether the system differentiates interface elements without relying solely on color. |
+| `view.accessibility.grayscale_enabled` | Boolean | Whether grayscale display mode is enabled. |
+| `view.accessibility.single_app_mode_enabled` | Boolean | Whether the device is locked to a single app through Guided Access. |
+| `view.accessibility.on_off_switch_labels_enabled` | Boolean | Whether on/off switch labels are enabled. |
+| `view.accessibility.speak_screen_enabled` | Boolean | Whether the Speak Screen feature is enabled. |
+| `view.accessibility.speak_selection_enabled` | Boolean | Whether the Speak Selection feature is enabled. |
+| `view.accessibility.rtl_enabled` | Boolean | Whether right-to-left layout direction is active. |
+
 ### Resource attributes
 
 | Attribute                         | Type           | Description                                                                                     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the `view.accessibility` attribute group to the iOS and Android RUM data collected reference pages. These attributes were added to the official `rum-events-format` schema in July 2025 but were not yet documented.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes