### PR TITLE
Remove phone number from Preview callout in SDS scanning rules docs

### DIFF
--- a/content/en/security/sensitive_data_scanner/scanning_rules/_index.md
+++ b/content/en/security/sensitive_data_scanner/scanning_rules/_index.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Telemetry Data
 {{< callout url="https://www.datadoghq.com/product-preview/phone-number-physical-address-pii-detection-in-logs-using-machine-learning/" btn_hidden="false" >}}
-Phone number and physical address PII detection in logs using machine learning are in Preview. To enroll, click <b>Request Access</b>.
+Physical address PII detection in logs using machine learning is in Preview. To enroll, click <b>Request Access</b>.
 {{< /callout >}}
 
 {{< site-region region="gov,gov2" >}}

--- a/content/en/security/sensitive_data_scanner/scanning_rules/library_rules.md
+++ b/content/en/security/sensitive_data_scanner/scanning_rules/library_rules.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 {{< callout url="https://www.datadoghq.com/product-preview/phone-number-physical-address-pii-detection-in-logs-using-machine-learning/" btn_hidden="false" >}}
-Phone number and physical address PII detection in logs using machine learning are in Preview. To enroll, click <b>Request Access</b>.
+Physical address PII detection in logs using machine learning is in Preview. To enroll, click <b>Request Access</b>.
 {{< /callout >}}
 
 {{< site-region region="gov,gov2" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Phone number PII detection in logs using machine learning has shipped to GA. This removes phone number from the Preview callout on two SDS scanning rules pages, leaving physical address PII detection (still in Preview) as the sole item in the notice.

**Pages updated:**
- `/security/sensitive_data_scanner/scanning_rules/`
- `/security/sensitive_data_scanner/scanning_rules/library_rules/`

The callout URL (CTA link) is left unchanged.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

If physical address PII detection has also shipped to GA, the remaining callout on these pages can be removed entirely in a follow-up.