### PR TITLE
[DOCS-XXXXX] Update Node.js Lambda support in DSM compatibility matrices

### DIFF
--- a/content/en/data_streams/setup/technologies/kinesis.md
+++ b/content/en/data_streams/setup/technologies/kinesis.md
@@ -35,7 +35,7 @@ title: Data Streams Monitoring for Amazon Kinesis
       <td><a href="https://www.npmjs.com/package/@aws-sdk/client-kinesis">client-kinesis</a></td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-kinesis" type="minimal" >}}</td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-kinesis" type="recommended" >}}</td>
-      <td>Not supported</td>
+      <td><a href="https://github.com/DataDog/datadog-lambda-js/releases/tag/v12.128.0">128</a></td>
     </tr>
     <tr>
       <td><a href="/data_streams/python">Python</a></td>

--- a/content/en/data_streams/setup/technologies/sns.md
+++ b/content/en/data_streams/setup/technologies/sns.md
@@ -35,7 +35,7 @@ title: Data Streams Monitoring for Amazon SNS
       <td><a href="https://www.npmjs.com/package/@aws-sdk/client-sns">client-sns</a></td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-sns" type="minimal" >}}</td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-sns" type="recommended" >}}</td>
-      <td>Not supported</td>
+      <td><a href="https://github.com/DataDog/datadog-lambda-js/releases/tag/v12.128.0">128</a></td>
     </tr>
     <tr>
       <td><a href="/data_streams/python">Python</a></td>

--- a/content/en/data_streams/setup/technologies/sqs.md
+++ b/content/en/data_streams/setup/technologies/sqs.md
@@ -35,7 +35,7 @@ title: Data Streams Monitoring for Amazon SQS
       <td><a href="https://www.npmjs.com/package/@aws-sdk/client-sqs">client-sqs</a></td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-sqs" type="minimal" >}}</td>
       <td>{{< dsm-tracer-version lang="nodejs" lib="client-sqs" type="recommended" >}}</td>
-      <td>Not supported</td>
+      <td><a href="https://github.com/DataDog/datadog-lambda-js/releases/tag/v12.128.0">128</a></td>
     </tr>
     <tr>
       <td><a href="/data_streams/python">Python</a></td>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Updates the "Minimal Lambda Library version" cell for Node.js in the Data Streams Monitoring compatibility matrices for SQS, SNS, and Kinesis. These previously showed "Not supported," but `datadog-lambda-js` v12.128.0 added support, matching the existing prose note on the Node.js setup page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes