### PR TITLE
Update experiments MCP setup docs

### DIFF
--- a/content/en/experiments/mcp_tools.md
+++ b/content/en/experiments/mcp_tools.md
@@ -37,11 +37,11 @@ The toolset becomes most powerful when your AI client can also read your codebas
 - Whether the code emits metric events correctly in all variants, or whether there is a path where a metric fires in one variant but not another, or fires twice
 - Whether nearby events or behaviors in the code aren't captured by any metric, and whether segments are worth adding because the code path diverges by platform or context
 
-**While an experiment is running**, the toolset covers several diagnostic dimensions - sample ratio mismatch (SRM), unreliable metrics, zero-data metrics, per-variant exposure imbalances, and more. When `get-experiment-diagnostics` identifies an issue, an agent with source access can trace the root cause: an SDK call inside a conditional that excludes some assigned subjects, or an exposure event that only fires after a late-loading component.
+**While an experiment is running**, the toolset covers several diagnostic dimensions - sample ratio mismatch (SRM), unreliable metrics, zero-data metrics, per-variant exposure imbalances, and more. When `get_experiment_diagnostics` identifies an issue, an agent with source access can trace the root cause: an SDK call inside a conditional that excludes some assigned subjects, or an exposure event that only fires after a late-loading component.
 
-For metric movements, `get-metric-definition` returns the underlying event query and the recommended Datadog MCP tool to call next. An agent can then query the raw event data and reason through what change in your code is most likely driving the movement.
+For metric movements, `get_metric_definition` returns the underlying event query and the recommended Datadog MCP tool to call next. An agent can then query the raw event data and reason through what change in your code is most likely driving the movement.
 
-**Before concluding**, use `explore-experiment-results` to build confidence in the interpretation. An agent can segment the primary metric by device type, country, plan tier, or any other assignment property to check whether the result holds across subgroups or is driven by a single cohort. It can also examine time-bucketed results to check whether the lift held steady over time or faded after the first few days. This segmentation work, which would otherwise require multiple dashboard views, happens within a single conversation.
+**Before concluding**, use `explore_experiment_results` to build confidence in the interpretation. An agent can segment the primary metric by device type, country, plan tier, or any other assignment property to check whether the result holds across subgroups or is driven by a single cohort. It can also examine time-bucketed results to check whether the lift held steady over time or faded after the first few days. This segmentation work, which would otherwise require multiple dashboard views, happens within a single conversation.
 
 **At conclusion**, an agent can record the winning variant decision, find the flag in the source, and draft the code change: inline the winning branch, remove the losing branch, delete the SDK call default that no longer needs a fallback.
 
@@ -49,21 +49,11 @@ For metric movements, `get-metric-definition` returns the underlying event query
 
 ## Setup
 
-The `experiments` toolset is not enabled by default. To enable it, add `experiments` to the `toolsets` parameter when connecting to the Datadog MCP Server. For example:
+The `experiments` toolset is not enabled by default. To enable it, add `experiments` to the `toolsets` parameter when connecting to the Datadog MCP Server. See [Set Up the Datadog MCP Server][3] for connection instructions and toolset configuration.
 
-```text
-https://mcp.{{< region-param key="dd_site" >}}/api/unstable/mcp-server/mcp?toolsets=all,experiments
-```
+For feature flag management tools used alongside experiments — creating flags, syncing allocations, checking canary results — see [Feature Flags MCP Tools][4].
 
-See [Set Up the Datadog MCP Server][3] for full connection instructions and toolset configuration.
-
-For feature flag management tools used alongside experiments — creating flags, syncing allocations, checking canary results. For more information, see [Feature Flags MCP Tools][4].
-
-## Available tools
-
-The `experiments` toolset exposes tools to your AI client. When you ask a question in natural language, your AI client calls these tools on your behalf.
-
-For a full reference of the `experiments` tools including permissions and example prompts, see [Datadog MCP Server Tools][7].
+For the full reference of tools in the `experiments` toolset, including required permissions and example prompts, see [Datadog MCP Server Tools][7].
 
 ## Further reading
 

--- a/content/en/experiments/mcp_tools.md
+++ b/content/en/experiments/mcp_tools.md
@@ -25,7 +25,7 @@ algolia:
 
 The [Datadog MCP Server][1] lets AI agents interact with your experiment data through the [Model Context Protocol (MCP)][2]. The `experiments` toolset gives AI clients like Cursor, Claude Code, OpenAI Codex, and [Bits AI][6] structured access to your experiments, metrics, and diagnostic data.
 
-The toolset becomes most powerful when your AI client can also read your codebase — combining live experiment state with how the associated feature flag is installed in your code.
+The toolset becomes most powerful when your AI client can also read your codebase—combining live experiment state with how the associated feature flag is installed in your code.
 
 <div class="alert alert-info">The <code>experiments</code> toolset is not enabled by default. See <a href="#setup">Setup</a> for instructions on enabling it.</div>
 
@@ -37,7 +37,7 @@ The toolset becomes most powerful when your AI client can also read your codebas
 - Whether the code emits metric events correctly in all variants, or whether there is a path where a metric fires in one variant but not another, or fires twice
 - Whether nearby events or behaviors in the code aren't captured by any metric, and whether segments are worth adding because the code path diverges by platform or context
 
-**While an experiment is running**, the toolset covers several diagnostic dimensions - sample ratio mismatch (SRM), unreliable metrics, zero-data metrics, per-variant exposure imbalances, and more. When `get_experiment_diagnostics` identifies an issue, an agent with source access can trace the root cause: an SDK call inside a conditional that excludes some assigned subjects, or an exposure event that only fires after a late-loading component.
+**While an experiment is running**, the toolset covers several diagnostic dimensions—sample ratio mismatch (SRM), unreliable metrics, zero-data metrics, per-variant exposure imbalances, and more. When `get_experiment_diagnostics` identifies an issue, an agent with source access can trace the root cause: an SDK call inside a conditional that excludes some assigned subjects, or an exposure event that only fires after a late-loading component.
 
 For metric movements, `get_metric_definition` returns the underlying event query and the recommended Datadog MCP tool to call next. An agent can then query the raw event data and reason through what change in your code is most likely driving the movement.
 
@@ -51,7 +51,7 @@ For metric movements, `get_metric_definition` returns the underlying event query
 
 The `experiments` toolset is not enabled by default. To enable it, add `experiments` to the `toolsets` parameter when connecting to the Datadog MCP Server. See [Set Up the Datadog MCP Server][3] for connection instructions and toolset configuration.
 
-For feature flag management tools used alongside experiments — creating flags, syncing allocations, checking canary results — see [Feature Flags MCP Tools][4].
+For feature flag management tools used alongside experiments—creating flags, syncing allocations, checking canary results—see [Feature Flags MCP Tools][4].
 
 For the full reference of tools in the `experiments` toolset, including required permissions and example prompts, see [Datadog MCP Server Tools][7].
 

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -743,7 +743,7 @@ Tools for managing and analyzing [Experiments][62], including creating and concl
 
 <div class="alert alert-info">The <code>experiments</code> toolset is not enabled by default. See <a href="/mcp_server/setup">Set Up the Datadog MCP Server</a> for instructions on enabling toolsets.</div>
 
-### `list-experiments`
+### `list_experiments`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
 Lists experiments for the organization, with optional name search, limit, and offset for pagination.
@@ -751,7 +751,7 @@ Lists experiments for the organization, with optional name search, limit, and of
 - Show me all running experiments.
 - Find experiments with "checkout" in the name.
 
-### `get-experiment`
+### `get_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
 Gets a single experiment by ID, including status, linked feature flag, subject type, primary metric, assignment dates, and decision.
@@ -759,50 +759,50 @@ Gets a single experiment by ID, including status, linked feature flag, subject t
 - Get the details for experiment `abc123`.
 - What is the current status and linked flag for experiment `abc123`?
 
-### `create-experiment`
+### `create_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Write`*\
 Creates a new experiment with a name, hypothesis, subject type, and primary metric.
 
 - Create an experiment called "New Checkout Flow" to test whether the redesign improves conversion rate.
 
-### `link-feature-flag-to-experiment`
+### `link_feature_flag_to_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Write`*\
 Links a feature flag to an experiment.
 
 - Link feature flag `new-checkout-flow` to experiment `abc123`.
 
-### `start-experiment`
+### `start_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Write`*\
 Starts an experiment. Requires a linked flag with an active allocation, a subject type, and a primary metric.
 
 - Start experiment `abc123`.
 
-### `conclude-experiment`
+### `conclude_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Write`*\
 Concludes a running experiment with a permanent winning variant decision.
 
 - Conclude experiment `abc123` with the treatment variant as the winner.
 
-### `cancel-experiment`
+### `cancel_experiment`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Write`*\
 Cancels a running experiment with a required reason.
 
 - Cancel experiment `abc123` because an SRM issue was detected.
 
-### `get-experiment-diagnostics`
+### `get_experiment-diagnostics`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
-Returns a health summary for an experiment before interpreting results: sample ratio mismatch (SRM) status, total subjects, per-variant exposure counts and fractions, and per-metric health including unreliable and zero-data metrics. Call this before `get-experiment-results` — if `srm.has_warning` is true, variant-level comparisons are not safe to interpret.
+Returns a health summary for an experiment before interpreting results: sample ratio mismatch (SRM) status, total subjects, per-variant exposure counts and fractions, and per-metric health including unreliable and zero-data metrics. Call this before `get_experiment-results` — if `srm.has_warning` is true, variant-level comparisons are not safe to interpret.
 
 - Run diagnostics on experiment `abc123` before I look at the results.
 - Is there a sample ratio mismatch in experiment `abc123`?
 
-### `get-experiment-results`
+### `get_experiment-results`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
 Returns computed per-variant, per-metric results. The `verdict` field (`better`, `worse`, `inconclusive`, or `unreliable`) is authoritative — do not recalculate significance from raw p-values or confidence intervals.
@@ -810,29 +810,29 @@ Returns computed per-variant, per-metric results. The `verdict` field (`better`,
 - Show me the results for experiment `abc123`.
 - What is the verdict on the primary metric for experiment `abc123`?
 
-### `explore-experiment-results`
+### `explore_experiment_results`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`, `Product Analytics Metrics Read`*\
-Segments results by an assignment property (device type, country, plan tier, and so on) or over time. Use after `get-experiment-results` for deeper analysis.
+Segments results by an assignment property (device type, country, plan tier, and so on) or over time. Use after `get_experiment-results` for deeper analysis.
 
 - Break down the results for experiment `abc123` by device type.
 - How did the lift for experiment `abc123` trend over the last two weeks?
 
-### `list-experiment-segmentation-properties`
+### `list_experiment_segmentation_properties`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`, `Product Analytics Metrics Read`*\
-Lists the assignment properties an experiment can be split by. Call this before `explore-experiment-results` to get valid property IDs — do not guess them.
+Lists the assignment properties an experiment can be split by. Call this before `explore_experiment_results` to get valid property IDs — do not guess them.
 
 - What segmentation properties can I use to break down experiment `abc123`?
 
-### `get-experiment-segmentation-property-values`
+### `get_experiment-segmentation-property-values`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`, `Product Analytics Metrics Read`*\
-Returns the concrete values for a segmentation property (for example, `["mobile", "desktop", "tablet"]` for device type). Use this before filtering in `explore-experiment-results` to avoid invalid filter strings.
+Returns the concrete values for a segmentation property (for example, `["mobile", "desktop", "tablet"]` for device type). Use this before filtering in `explore_experiment_results` to avoid invalid filter strings.
 
 - What values are available for the device type property in experiment `abc123`?
 
-### `get-metric-definition`
+### `get_metric_definition`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Metrics Read`*\
 Returns the definition of an experiment metric — the underlying event query, data source, and the recommended Datadog MCP tool for investigating why the metric moved. For `datadog`-sourced metrics, the response includes a `recommended_tool_call` field with the structured parameters needed to query the raw event data. Not for Datadog infrastructure or APM metrics; use `get_datadog_metric` for those.
@@ -840,10 +840,10 @@ Returns the definition of an experiment metric — the underlying event query, d
 - What is the event query behind the primary metric for experiment `abc123`?
 - Which MCP tool should I use to investigate why this metric moved?
 
-### `diagnose-experiment-run-failure`
+### `diagnose_experiment_run_failure`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
-Diagnoses why the latest (or a specific) analysis pipeline run for an experiment failed. Returns the root-cause task, a categorized failure explanation, and actionable next steps. Use `get-experiment-diagnostics` for result quality and SRM issues instead.
+Diagnoses why the latest (or a specific) analysis pipeline run for an experiment failed. Returns the root-cause task, a categorized failure explanation, and actionable next steps. Use `get_experiment-diagnostics` for result quality and SRM issues instead.
 
 - Why did the latest analysis run for experiment `abc123` fail?
 - Diagnose the pipeline failure for experiment `abc123`.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -794,15 +794,15 @@ Cancels a running experiment with a required reason.
 
 - Cancel experiment `abc123` because an SRM issue was detected.
 
-### `get_experiment-diagnostics`
+### `get_experiment_diagnostics`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
-Returns a health summary for an experiment before interpreting results: sample ratio mismatch (SRM) status, total subjects, per-variant exposure counts and fractions, and per-metric health including unreliable and zero-data metrics. Call this before `get_experiment-results` — if `srm.has_warning` is true, variant-level comparisons are not safe to interpret.
+Returns a health summary for an experiment before interpreting results: sample ratio mismatch (SRM) status, total subjects, per-variant exposure counts and fractions, and per-metric health including unreliable and zero-data metrics. Call this before `get_experiment_results` — if `srm.has_warning` is true, variant-level comparisons are not safe to interpret.
 
 - Run diagnostics on experiment `abc123` before I look at the results.
 - Is there a sample ratio mismatch in experiment `abc123`?
 
-### `get_experiment-results`
+### `get_experiment_results`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
 Returns computed per-variant, per-metric results. The `verdict` field (`better`, `worse`, `inconclusive`, or `unreliable`) is authoritative — do not recalculate significance from raw p-values or confidence intervals.
@@ -813,7 +813,7 @@ Returns computed per-variant, per-metric results. The `verdict` field (`better`,
 ### `explore_experiment_results`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`, `Product Analytics Metrics Read`*\
-Segments results by an assignment property (device type, country, plan tier, and so on) or over time. Use after `get_experiment-results` for deeper analysis.
+Segments results by an assignment property (device type, country, plan tier, and so on) or over time. Use after `get_experiment_results` for deeper analysis.
 
 - Break down the results for experiment `abc123` by device type.
 - How did the lift for experiment `abc123` trend over the last two weeks?
@@ -825,7 +825,7 @@ Lists the assignment properties an experiment can be split by. Call this before 
 
 - What segmentation properties can I use to break down experiment `abc123`?
 
-### `get_experiment-segmentation-property-values`
+### `get_experiment_segmentation_property_values`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`, `Product Analytics Metrics Read`*\
 Returns the concrete values for a segmentation property (for example, `["mobile", "desktop", "tablet"]` for device type). Use this before filtering in `explore_experiment_results` to avoid invalid filter strings.
@@ -843,7 +843,7 @@ Returns the definition of an experiment metric — the underlying event query, d
 ### `diagnose_experiment_run_failure`
 *Toolset: **experiments***\
 *Permissions Required: `Product Analytics Experiments Read`*\
-Diagnoses why the latest (or a specific) analysis pipeline run for an experiment failed. Returns the root-cause task, a categorized failure explanation, and actionable next steps. Use `get_experiment-diagnostics` for result quality and SRM issues instead.
+Diagnoses why the latest (or a specific) analysis pipeline run for an experiment failed. Returns the root-cause task, a categorized failure explanation, and actionable next steps. Use `get_experiment_diagnostics` for result quality and SRM issues instead.
 
 - Why did the latest analysis run for experiment `abc123` fail?
 - Diagnose the pipeline failure for experiment `abc123`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

- Direct readers to the standard Datadog MCP Server setup docs instead of showing an endpoint example.
- Remove the unstable MCP endpoint URL from the page.
- Fix dash spacing to follow the docs style guide.
- Update mcp tools list to use underscores.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Codex to make and publish a small docs update.

### Additional notes

No Jira ticket.
