### PR TITLE
[DBM Doc] Add automatic diagnostics feature for Postgres

### DIFF
--- a/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -362,6 +362,15 @@ After you enable logging collection:
 
 [Run the Agent's status subcommand][13] and look for `postgres` under the Checks section. Or visit the [Databases][14] page to get started!
 
+**Note:** The Postgres check includes an automatic diagnostics feature that can periodically run setup diagnostics and report results as Agent Health events. This feature is disabled by default. If enabled by support or for troubleshooting, configure it in your `postgres.d/conf.yaml`:
+
+```yaml
+instances:
+  - automatic_diagnostics:
+      enabled: true
+      interval: 600  # seconds between diagnostic runs
+```
+
 ## Example Agent Configurations
 {{% dbm-postgres-agent-config-examples %}}
 


### PR DESCRIPTION
## Confidence: DISCUSSION

**Source PR:** https://github.com/DataDog/integrations-core/pull/23645

### What changed

The Postgres integration now includes an automatic diagnostics feature that:
- Runs setup diagnostics on check initialization
- Periodically re-runs diagnostics (configurable interval, default 600 seconds)
- Emits diagnostic results as Agent Health events

This is a new user-facing feature controlled by the `automatic_diagnostics` configuration option (disabled by default).

### Why this might need documentation

This is a new diagnostic capability that users could enable. However, the feature is:
1. Hidden in the config spec (`hidden: true`, `fleet_configurable: false`)
2. Disabled by default (`enabled: false`)
3. Not clear if this is intended for general user consumption or internal/support use

The draft edit below adds a minimal mention in the "Verify Agent setup" section. **Please review whether this feature should be documented at all** — if it's intended only for internal use or support-assisted troubleshooting, no documentation may be preferable.