### PR TITLE
[SDCT-509] Document @test.fingerprint_fqn facet for Test Optimization

### DIFF
--- a/content/en/tests/explorer/_index.md
+++ b/content/en/tests/explorer/_index.md
@@ -46,7 +46,7 @@ The {{< ui >}}Test{{< /ui >}} panel on the left lists default facets you can use
 | Standard Deviation Change | Indicates if the test has been newly added. |
 | Test Code Owners | The name of the test's codeowners as inferred from the repository configuration. |
 | Test Fingerprint | The unique identifier for an individual test run. |
-| Test Fingerprint (FQN) | A stable, unique identifier for a test (`@test.fingerprint_fqn`), derived from a hash of the repository ID and the test's fully qualified name. Because it stays the same across runs, use it to consistently identify the same test — for example, the test ID used by the [Flaky Tests Management API][19]. |
+| Test Fingerprint (FQN) | A stable, unique identifier for a test (`@test.fingerprint_fqn`) across all of its runs, derived from a hash of the repository ID and the test's fully qualified name (FQN). Use it to consistently identify the same test over time. This is also the identifier used by the [Flaky Tests Management API][19]. |
 | Test Framework | The underlying framework or set of tools used for creating and executing tests. |
 | Test Command | The command that was used to execute tests. |
 | Test Bundle | Equivalent to a test module. This is used by earlier Datadog testing library versions. |

--- a/content/en/tests/explorer/_index.md
+++ b/content/en/tests/explorer/_index.md
@@ -46,6 +46,7 @@ The {{< ui >}}Test{{< /ui >}} panel on the left lists default facets you can use
 | Standard Deviation Change | Indicates if the test has been newly added. |
 | Test Code Owners | The name of the test's codeowners as inferred from the repository configuration. |
 | Test Fingerprint | The unique identifier for an individual test run. |
+| Test Fingerprint (FQN) | A stable, unique identifier for a test (`@test.fingerprint_fqn`), derived from a hash of the repository ID and the test's fully qualified name. Because it stays the same across runs, use it to consistently identify the same test — for example, the test ID used by the [Flaky Tests Management API][19]. |
 | Test Framework | The underlying framework or set of tools used for creating and executing tests. |
 | Test Command | The command that was used to execute tests. |
 | Test Bundle | Equivalent to a test module. This is used by earlier Datadog testing library versions. |
@@ -138,3 +139,4 @@ Select a visualization type to visualize the outcomes of your filters and aggreg
 [16]: /intelligent_test_runner/
 [17]: /tests/code_coverage/
 [18]: https://app.datadoghq.com/ci/test-runs?viz=timeseries
+[19]: /api/latest/test-optimization/

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -22,7 +22,7 @@ The [Flaky Tests Management][1] page provides a centralized view to track, triag
 
 From this UI, you can act on flaky tests to mitigate their impact. Quarantine or disable problematic tests to keep known flakes from breaking builds, and create cases and Jira issues to track work toward fixes.
 
-Each flaky test has a stable, unique identifier derived from a hash of the repository ID and the test's fully qualified name. In the Test Optimization Explorer, this is the `@test.fingerprint_fqn` facet. In the [Flaky Tests Management API][18] it is the test's `id`, and you can filter the Search flaky tests endpoint by it with the `fingerprint_fqn` key. Use this identifier to look up or update a specific test through the API.
+Each flaky test has a stable, unique identifier derived from a hash of the repository ID and the test's fully qualified name. In the Test Optimization Explorer, this is the `@test.fingerprint_fqn` facet. In the [Flaky Tests Management API][18], it is the test's `id`, and you can filter the Search flaky tests endpoint using the `fingerprint_fqn` key. Use this identifier to look up or update a specific test through the API.
 
 {{< img src="tests/flaky_management-2.png" alt="Overview of the Flaky Tests Management UI" style="width:100%;" >}}
 

--- a/content/en/tests/flaky_management/_index.md
+++ b/content/en/tests/flaky_management/_index.md
@@ -22,6 +22,8 @@ The [Flaky Tests Management][1] page provides a centralized view to track, triag
 
 From this UI, you can act on flaky tests to mitigate their impact. Quarantine or disable problematic tests to keep known flakes from breaking builds, and create cases and Jira issues to track work toward fixes.
 
+Each flaky test has a stable, unique identifier derived from a hash of the repository ID and the test's fully qualified name. In the Test Optimization Explorer, this is the `@test.fingerprint_fqn` facet. In the [Flaky Tests Management API][18] it is the test's `id`, and you can filter the Search flaky tests endpoint by it with the `fingerprint_fqn` key. Use this identifier to look up or update a specific test through the API.
+
 {{< img src="tests/flaky_management-2.png" alt="Overview of the Flaky Tests Management UI" style="width:100%;" >}}
 
 ## Change a flaky test's state
@@ -268,3 +270,4 @@ The weekly digest summary notification does not have a self-service opt-out. To 
 [14]: /help/
 [16]: /bits_ai/bits_code/
 [17]: /integrations/guide/source-code-integration/
+[18]: /api/latest/test-optimization/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes SDCT-509

Documents the new customer-facing `@test.fingerprint_fqn` facet for Test Optimization:

- Adds a "Test Fingerprint (FQN)" row to the Test Run facets reference table in the Test Optimization Explorer docs.
- Explains on the Flaky Tests Management page that this facet is the stable per-test identifier used as the test `id` in the Flaky Tests Management API, and that the Search flaky tests endpoint can filter on it with the `fingerprint_fqn` key.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes