### PR TITLE
Add RUM accessibility attributes to iOS and Android data collected pages

### DIFF
--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
@@ -402,6 +402,9 @@ You can use the following methods in `RumConfiguration.Builder` when creating th
 `trackAnonymousUser`
 : When enabled, the SDK generates a unique, non-personal anonymous user ID that is persisted across app launches. This ID is attached to each RUM Session, allowing you to link sessions originating from the same user/device without collecting personal data. By default, this is set to `true`.
 
+`collectAccessibility`
+: Determines whether accessibility settings are collected and included in RUM view events. By default, this is disabled.
+
 ### Automatically track views
 
 To automatically track your views (such as activities and fragments), provide a tracking strategy at initialization. Depending on your application's architecture, you can choose one of the following strategies:

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
@@ -403,7 +403,7 @@ You can use the following methods in `RumConfiguration.Builder` when creating th
 : When enabled, the SDK generates a unique, non-personal anonymous user ID that is persisted across app launches. This ID is attached to each RUM Session, allowing you to link sessions originating from the same user/device without collecting personal data. By default, this is set to `true`.
 
 `collectAccessibility`
-: Determines whether accessibility settings are collected and included in RUM view events. By default, this is disabled.
+: Determines whether accessibility settings are collected and included in RUM view events. By default, this is set to `false`.
 
 ### Automatically track views
 

--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
@@ -324,6 +324,9 @@ You can use the following properties in `RUM.Configuration` when enabling RUM:
 `applicationID`
 : The RUM application identifier.
 
+`collectAccessibility`
+: Determines whether accessibility settings are collected and included in RUM view events. By default, this is set to `false`.
+
 `customEndpoint`
 : A custom server URL for sending RUM data.
 

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
@@ -170,7 +170,7 @@ The following attributes are collected for each view after collection is enabled
 
 | Attribute | Type | Description |
 |---|---|---|
-| `view.accessibility.text_size` | number | The user's preferred text size as a scale factor relative to the default size (`1.0` is default, greater than `1.0` is larger). |
+| `view.accessibility.text_size` | number | The user's preferred text size as a scale factor relative to the default (`1.0`). Values above `1.0` increase text size; values below `1.0` decrease it. |
 | `view.accessibility.screen_reader_enabled` | Boolean | Whether TalkBack is active. |
 | `view.accessibility.invert_colors_enabled` | Boolean | Whether color inversion is enabled. |
 | `view.accessibility.assistive_switch_enabled` | Boolean | Whether Switch Access is active. |

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
@@ -158,7 +158,15 @@ RUM action, error, resource, and long task events contain information about the 
 
 ### View accessibility attributes
 
-The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+Accessibility attribute collection is disabled by default. To enable it, call `collectAccessibility(true)` on your `RumConfiguration.Builder`:
+
+```kotlin
+val rumConfig = RumConfiguration.Builder("<APPLICATION_ID>")
+    .collectAccessibility(true)
+    .build()
+```
+
+The following attributes are collected for each view after collection is enabled. Attributes not supported on the platform are omitted from the event.
 
 | Attribute | Type | Description |
 |---|---|---|

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
@@ -156,6 +156,23 @@ RUM action, error, resource, and long task events contain information about the 
 | `view.time_spent`                             | number (ns) | Time spent on this view.                                    |
 | `view.url`                     | string | Canonical name of the class corresponding to the event.                                                           |
 
+### View accessibility attributes
+
+The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `view.accessibility.text_size` | number | The user's preferred text size as a scale factor relative to the default size (`1.0` is default, greater than `1.0` is larger). |
+| `view.accessibility.screen_reader_enabled` | Boolean | Whether TalkBack is active. |
+| `view.accessibility.invert_colors_enabled` | Boolean | Whether color inversion is enabled. |
+| `view.accessibility.assistive_switch_enabled` | Boolean | Whether Switch Access is active. |
+| `view.accessibility.closed_captioning_enabled` | Boolean | Whether closed captioning is enabled for media playback. |
+| `view.accessibility.mono_audio_enabled` | Boolean | Whether mono audio is enabled. |
+| `view.accessibility.reduced_animations_enabled` | Boolean | Whether the user prefers reduced animations (system animator duration scale is `0`). |
+| `view.accessibility.single_app_mode_enabled` | Boolean | Whether the device is locked to a single app through Screen Pinning. |
+| `view.accessibility.speak_selection_enabled` | Boolean | Whether Select to Speak is enabled. |
+| `view.accessibility.rtl_enabled` | Boolean | Whether right-to-left layout direction is active. |
+
 ### Resource attributes
 
 | Attribute                              | Type           | Description                                                                                                                               |

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
@@ -161,7 +161,15 @@ RUM action, error, resource, and long task events contain information about the 
 
 ### View accessibility attributes
 
-The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+Accessibility attribute collection is disabled by default. To enable it, set `collectAccessibility` to `true` in your `RUMConfiguration`:
+
+```swift
+var config = RUM.Configuration(applicationID: "<APPLICATION_ID>")
+config.collectAccessibility = true
+RUM.enable(with: config)
+```
+
+The following attributes are collected for each view after collection is enabled. Attributes not supported on the platform are omitted from the event.
 
 | Attribute | Type | Description |
 |---|---|---|

--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/ios.mdoc.md
@@ -159,6 +159,35 @@ RUM action, error, resource, and long task events contain information about the 
 | `view.time_spent`     | number (ns) | Time spent on this view.                                                     |
 | `view.url`     | string | URL of the `UIViewController` class corresponding to the event. |
 
+### View accessibility attributes
+
+The following accessibility-related attributes are automatically collected for each view. Attributes not supported on the platform are omitted from the event.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `view.accessibility.text_size` | string | The user's preferred text size category (for example, `UICTContentSizeCategoryM`). |
+| `view.accessibility.screen_reader_enabled` | Boolean | Whether VoiceOver is active. |
+| `view.accessibility.bold_text_enabled` | Boolean | Whether the system-wide bold text setting is enabled. |
+| `view.accessibility.reduce_transparency_enabled` | Boolean | Whether the system-wide reduce transparency setting is enabled. |
+| `view.accessibility.reduce_motion_enabled` | Boolean | Whether the system-wide reduce motion setting is enabled. |
+| `view.accessibility.button_shapes_enabled` | Boolean | Whether button shapes are enabled. |
+| `view.accessibility.invert_colors_enabled` | Boolean | Whether color inversion is enabled. |
+| `view.accessibility.increase_contrast_enabled` | Boolean | Whether the system-wide increase contrast setting is enabled. |
+| `view.accessibility.assistive_switch_enabled` | Boolean | Whether Switch Control is active. |
+| `view.accessibility.assistive_touch_enabled` | Boolean | Whether AssistiveTouch is active. |
+| `view.accessibility.is_video_autoplay_enabled` | Boolean | Whether video autoplay is enabled. |
+| `view.accessibility.closed_captioning_enabled` | Boolean | Whether closed captioning is enabled for media playback. |
+| `view.accessibility.mono_audio_enabled` | Boolean | Whether mono audio is enabled. |
+| `view.accessibility.shake_to_undo_enabled` | Boolean | Whether the Shake to Undo gesture is enabled. |
+| `view.accessibility.reduced_animations_enabled` | Boolean | Whether the user prefers reduced animations or cross-fade transitions. |
+| `view.accessibility.should_differentiate_without_color` | Boolean | Whether the system differentiates interface elements without relying solely on color. |
+| `view.accessibility.grayscale_enabled` | Boolean | Whether grayscale display mode is enabled. |
+| `view.accessibility.single_app_mode_enabled` | Boolean | Whether the device is locked to a single app through Guided Access. |
+| `view.accessibility.on_off_switch_labels_enabled` | Boolean | Whether on/off switch labels are enabled. |
+| `view.accessibility.speak_screen_enabled` | Boolean | Whether the Speak Screen feature is enabled. |
+| `view.accessibility.speak_selection_enabled` | Boolean | Whether the Speak Selection feature is enabled. |
+| `view.accessibility.rtl_enabled` | Boolean | Whether right-to-left layout direction is active. |
+
 ### Resource attributes
 
 | Attribute                         | Type           | Description                                                                                     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the `view.accessibility` attribute group to the iOS and Android RUM data collected reference pages. These attributes were added to the official `rum-events-format` schema in July 2025 but were not yet documented.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes