### PR TITLE
[SDTEST-3880] Document Android test support in Java Test Optimization

### DIFF
--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -57,6 +57,14 @@ Other build systems, such as Ant, Bazel, or SBT are supported with the following
 - Automatic coverage configuration and reporting is not supported.
 - When building a multi-module project, every module is reported in a separate trace.
 
+### Android
+
+Android unit tests are fully supported. UI and integration tests are supported only through [Robolectric][11], which lets these tests run on the JVM. If you haven't used Robolectric before, see the [Robolectric documentation][11] to learn how to set it up.
+
+Tests that run on an Android emulator or a physical device **are not supported**.
+
+Configure Android tests the same way as other Gradle-based Java tests, applying `GRADLE_OPTS` to the Gradle task that runs your Robolectric-based tests (for example, `testDebugUnitTest`). See the [Gradle tab](#running-your-tests) for configuration details.
+
 ## Setup
 
 You may follow interactive setup steps on the [Datadog site][2] or the instructions below.
@@ -571,3 +579,4 @@ To disable all integrations, augment the list of `-javaagent` arguments with `dd
 [8]: /tests/#parameterized-test-configurations
 [9]: https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-display-names
 [10]: /tracing/trace_collection/compatibility/java#integrations
+[11]: https://robolectric.org/getting-started/

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -61,7 +61,7 @@ Other build systems, such as Ant, Bazel, or SBT are supported with the following
 
 Android tests that run on the JVM are supported. Tests that depend on the Android API, such as Espresso tests, Compose UI tests, and some unit tests, are supported only with the [Robolectric][11] framework.
 
-Tests that have to be executed on an emulator or a physical device **are not supported**.
+Tests that require an emulator or a physical device **are not supported**.
 
 ## Setup
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -59,7 +59,7 @@ Other build systems, such as Ant, Bazel, or SBT are supported with the following
 
 ### Android
 
-Android tests that run on the JVM are supported. Tests that depend on the Android API are supported only with the [Robolectric][11] framework.
+Android tests that run on the JVM are supported. Tests that depend on the Android API, such as Espresso tests, Compose UI tests, and some unit tests, are supported only with the [Robolectric][11] framework.
 
 Tests that have to be executed on an emulator or a physical device **are not supported**.
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -59,11 +59,9 @@ Other build systems, such as Ant, Bazel, or SBT are supported with the following
 
 ### Android
 
-Android unit tests are fully supported. UI and integration tests are supported only through [Robolectric][11], which lets these tests run on the JVM. If you haven't used Robolectric before, see the [Robolectric documentation][11] to learn how to set it up.
+Android tests that run on the JVM are supported. Tests that depend on the Android API are supported only with the [Robolectric][11] framework.
 
-Tests that run on an Android emulator or a physical device **are not supported**.
-
-Configure Android tests the same way as other Gradle-based Java tests, applying `GRADLE_OPTS` to the Gradle task that runs your Robolectric-based tests (for example, `testDebugUnitTest`). See the [Gradle tab](#running-your-tests) for configuration details.
+Tests that have to be executed on an emulator or a physical device **are not supported**.
 
 ## Setup
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -61,7 +61,7 @@ Other build systems, such as Ant, Bazel, or SBT are supported with the following
 
 Android tests that run on the JVM are supported. Tests that depend on the Android API, such as Espresso tests, Compose UI tests, and some unit tests, are supported only with the [Robolectric][11] framework.
 
-Tests that require an emulator or a physical device **are not supported**.
+Tests that require an emulator or a physical device are not supported.
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes SDTEST-3880

Adds an Android section to the Java Test Optimization setup page:
- Android unit tests are fully supported.
- UI and integration tests are supported only through Robolectric, with a link to the Robolectric documentation.
- Tests running on an Android emulator or a physical device are not supported.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes