### PR TITLE
Add appsec_injector.watched_changes and appsec_injector.sidecar_mutations to Agent telemetry metrics

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -230,6 +230,7 @@ agent diagnose show-metadata agent-telemetry
 | tagger.stored_entities                      | Number of entities stored in the Tagger                                                                                |
 | workloadmeta.stored_entities                | Number of entities stored in WorkloadMeta                                                                              |
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
+| appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 
 Only applicable metrics are emitted. For example, if DBM is not enabled, none of the database related metrics are emitted.
 

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -231,6 +231,7 @@ agent diagnose show-metadata agent-telemetry
 | workloadmeta.stored_entities                | Number of entities stored in WorkloadMeta                                                                              |
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
+| appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
 
 Only applicable metrics are emitted. For example, if DBM is not enabled, none of the database related metrics are emitted.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Documents the following Agent telemetry metrics in the Agent Data Security telemetry table (`content/en/data_security/agent.md`):

- `appsec_injector.watched_changes` — number of changes detected by the AppSec injector for watched resources (DataDog/datadog-agent#53076).
- `appsec_injector.sidecar_mutations` — number of AppSec injector sidecar admission outcomes, for pod mutation and deletion (DataDog/datadog-agent#53190).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Documentation counterpart to DataDog/datadog-agent#53076 and DataDog/datadog-agent#53190. Merge after the corresponding Agent releases are generally available.
