### PR TITLE
Improve OpenTelemetry onboarding navigation

### DIFF
--- a/content/en/opentelemetry/_index.md
+++ b/content/en/opentelemetry/_index.md
@@ -62,6 +62,29 @@ cascade:
 
 [OpenTelemetry][1] (OTel) provides standardized protocols for collecting and routing telemetry data. Datadog supports multiple ways to collect and analyze telemetry data from OpenTelemetry-instrumented applications, whether you're using existing Datadog infrastructure or prefer a vendor-neutral setup.
 
+### Where to start
+
+Choose the entry point that matches your situation:
+
+{{< whatsnext desc=" " >}}
+    {{< nextlink href="/opentelemetry/getting_started/" >}}
+    <h3>I'm new to OpenTelemetry</h3>
+    Follow a hands-on tutorial to send your first traces, metrics, and logs to Datadog.
+    {{< /nextlink >}}
+    {{< nextlink href="/opentelemetry/setup/" >}}
+    <h3>My application already uses OpenTelemetry</h3>
+    Choose how to send your existing OpenTelemetry data to Datadog.
+    {{< /nextlink >}}
+    {{< nextlink href="/opentelemetry/instrument/" >}}
+    <h3>I use Datadog SDKs today</h3>
+    Use the OpenTelemetry API with Datadog's SDKs to keep vendor-neutral instrumentation while accessing Datadog's full feature set.
+    {{< /nextlink >}}
+    {{< nextlink href="/opentelemetry/setup/collector_exporter/" >}}
+    <h3>I already run an OpenTelemetry Collector</h3>
+    Send data through the OpenTelemetry Collector with the Datadog Exporter, or move to the DDOT Collector.
+    {{< /nextlink >}}
+{{< /whatsnext >}}
+
 ### Why OpenTelemetry with Datadog?
 
 Datadog provides advanced observability for all your application telemetry, regardless of its source. By supporting OpenTelemetry, Datadog offers:

--- a/content/en/opentelemetry/getting_started/_index.md
+++ b/content/en/opentelemetry/getting_started/_index.md
@@ -21,9 +21,20 @@ further_reading:
 
 OpenTelemetry is an open source framework that provides standardized tools for collecting observability data from your applications. Datadog fully supports OpenTelemetry, allowing you to send your metrics, traces, and logs for powerful analysis and monitoring.
 
-These guides provide two hands-on ways to learn how to send OpenTelemetry data to Datadog. Choose the tutorial that best fits your learning goal.
+Choose the path that fits your goal: connect an application you've already instrumented, or learn OpenTelemetry hands-on with a sample application.
 
-## Getting started tutorials
+## Already instrumented with OpenTelemetry?
+
+{{< whatsnext desc=" " >}}
+    {{< nextlink href="/opentelemetry/getting_started/quickstart" >}}
+    <h3>Quickstart: Send Your Data to Datadog</h3>
+    Get data from an application that already uses OpenTelemetry into Datadog, using either the recommended DDOT Collector or a lightweight OTLP-in-the-Agent setup.
+    {{< /nextlink >}}
+{{< /whatsnext >}}
+
+## Learn with a sample application
+
+These guides provide two hands-on ways to learn how to send OpenTelemetry data to Datadog. Choose the tutorial that best fits your learning goal.
 
 {{< whatsnext desc=" " >}}
     {{< nextlink href="/opentelemetry/getting_started/datadog_example" >}}

--- a/content/en/opentelemetry/getting_started/quickstart.md
+++ b/content/en/opentelemetry/getting_started/quickstart.md
@@ -1,0 +1,119 @@
+---
+title: Quickstart - Send OpenTelemetry Data to Datadog
+description: Get data from an application that is already instrumented with OpenTelemetry into Datadog, using either the recommended DDOT Collector or a lightweight OTLP-in-the-Agent setup.
+further_reading:
+- link: "/opentelemetry/setup/"
+  tag: "Documentation"
+  text: "Compare all setup paths"
+- link: "/opentelemetry/setup/ddot_collector/"
+  tag: "Documentation"
+  text: "Datadog Distribution of the OpenTelemetry Collector"
+- link: "/opentelemetry/setup/otlp_ingest_in_the_agent/"
+  tag: "Documentation"
+  text: "OTLP Ingestion by the Datadog Agent"
+---
+
+## Overview
+
+This quickstart gets data from an application that is **already instrumented with OpenTelemetry** into Datadog. It offers two tracks depending on your goal:
+
+- **Production (recommended)**: Deploy the [Datadog Distribution of the OpenTelemetry (DDOT) Collector][2]. This is Datadog's recommended setup and unlocks Datadog Agent-based features such as Fleet Automation, Live Container Monitoring, and {{< translate key="integration_count" >}}+ integrations. Best for Kubernetes or Linux hosts.
+- **Quick evaluation**: Enable [OTLP ingestion in the Datadog Agent][3]. This is the fastest way to see your data flowing, with minimal configuration and no Collector to deploy.
+
+Prefer a different starting point?
+
+- **New to OpenTelemetry?** Learn the concepts with a sample application in the [getting started tutorials][1].
+- **Comparing every option?** See the full breakdown in [Choose your setup path][4].
+
+## Prerequisites
+
+- A [Datadog account][5] and [API key][6].
+- An application instrumented with OpenTelemetry SDKs. If you haven't instrumented your application yet, see [Instrument Your Applications][7].
+
+## Set up and send data
+
+{{< tabs >}}
+{{% tab "Production: DDOT Collector (Recommended)" %}}
+
+The DDOT Collector runs as part of the Datadog Agent on Kubernetes or Linux. These steps summarize the Kubernetes (Helm) install; for the Datadog Operator, Linux, and full configuration details, follow [Install the DDOT Collector][101].
+
+**Requirements**: A Kubernetes cluster (v1.29+), [Helm][102] (v3+), and [kubectl][103].
+
+1. Add the Datadog Helm repository:
+   ```shell
+   helm repo add datadog https://helm.datadoghq.com
+   helm repo update
+   ```
+
+2. Store your Datadog API key as a Kubernetes secret:
+   ```shell
+   kubectl create secret generic datadog-secret --from-literal api-key=<DD_API_KEY>
+   ```
+
+3. Enable the OpenTelemetry Collector in your Datadog Agent Helm values and deploy. See [Install the DDOT Collector][101] for the complete `datadog-values.yaml` and deployment command.
+
+4. Point your application at the Collector's OTLP endpoint. The exact endpoint depends on your environment; see the [install guide][101] for the correct value.
+
+[101]: /opentelemetry/setup/ddot_collector/install/
+[102]: https://helm.sh/docs/intro/install/
+[103]: https://kubernetes.io/docs/tasks/tools/
+{{% /tab %}}
+
+{{% tab "Quick evaluation: OTLP in the Agent" %}}
+
+This track uses OTLP ingestion in the Datadog Agent. It's generally available and requires only a running Agent on the same host as your application.
+
+**Requirements**: A running [Datadog Agent][201] (v7.32.0+) on the same host as your application. The Agent is already configured with your API key.
+
+1. Enable the OTLP/HTTP receiver on its default port (`4318`) by adding the following to your `datadog.yaml`, then restart the Agent. Metrics and traces ingestion are on by default.
+   ```yaml
+   otlp_config:
+     receiver:
+       protocols:
+         http:
+           endpoint: 0.0.0.0:4318
+   ```
+   For gRPC, environment-variable configuration, or containerized setups (Docker, Kubernetes, Helm), see [OTLP Ingestion by the Datadog Agent][202].
+
+2. In your **application's** environment, set the OTLP endpoint so the OpenTelemetry SDK exports to the Agent:
+   ```shell
+   export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+   ```
+   Without this variable, your application does not send telemetry to the Agent, even when the receiver is enabled.
+
+[201]: /agent/
+[202]: /opentelemetry/setup/otlp_ingest_in_the_agent/
+{{% /tab %}}
+{{< /tabs >}}
+
+## View your data in Datadog
+
+Start your application and generate some traffic. Within a few minutes, your telemetry appears in Datadog:
+
+- View traces in [APM Traces][8].
+- View metrics in the [Metrics Explorer][9].
+
+If you don't see data, see [Troubleshooting][10].
+
+## Next steps
+
+- **Moving from quick evaluation to production?** Compare the trade-offs of each path in [Choose your setup path][4].
+- **Send logs**: OTLP logs ingestion is disabled by default. To enable it, see [Enabling OTLP logs ingestion][11].
+- **Correlate your data**: Connect traces with logs, metrics, and RUM. See [Correlate OpenTelemetry Data][12].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /opentelemetry/getting_started/
+[2]: /opentelemetry/setup/ddot_collector/
+[3]: /opentelemetry/setup/otlp_ingest_in_the_agent/
+[4]: /opentelemetry/setup/
+[5]: https://app.datadoghq.com/signup
+[6]: /account_management/api-app-keys/
+[7]: /opentelemetry/instrument/
+[8]: https://app.datadoghq.com/apm/traces
+[9]: https://app.datadoghq.com/metric/explorer
+[10]: /opentelemetry/troubleshooting/
+[11]: /opentelemetry/setup/otlp_ingest_in_the_agent/#enabling-otlp-logs-ingestion
+[12]: /opentelemetry/correlate/

--- a/content/en/opentelemetry/setup/_index.md
+++ b/content/en/opentelemetry/setup/_index.md
@@ -18,6 +18,19 @@ further_reading:
 
 This page describes all of the ways you can send OpenTelemetry (OTel) data to Datadog.
 
+## Choose your setup path
+
+Datadog supports several ways to send OpenTelemetry data. The right choice depends on your platform, how much of the telemetry pipeline you want to manage, and which Datadog features you need. Use the table below to compare your options at a glance, then follow the links for setup instructions.
+
+| Setup path | Best when | Trade-offs |
+|---|---|---|
+| [**DDOT Collector**][7] (Recommended) | You want OpenTelemetry pipelines *and* Datadog Agent-based features such as Fleet Automation, Live Container Monitoring, and {{< translate key="integration_count" >}}+ integrations. | Deployed on the same host as your applications (Agent deployment pattern); the Gateway-only pattern is not supported. |
+| [**Standalone OpenTelemetry Collector**][2] | You want a completely vendor-neutral pipeline or advanced processing such as tail-based sampling and data transformations. | You install, configure, and maintain the Collector yourself; some Agent-based features are unavailable. |
+| [**OTLP Ingest in the Agent**][6] | You run on a platform other than Kubernetes or Linux, or you want minimal configuration without managing Collector pipelines. | The ingesting Agent must be local to each app or Collector; fewer pipeline processing options. |
+| [**Direct OTLP Intake Endpoint**][3] (Preview) | Deploying a Collector or Agent isn't feasible, such as serverless functions, managed platforms, or resource-constrained environments. | No metadata enrichment, signal normalization, or centralized sampling; host metadata does not populate the Infrastructure Host List. |
+
+<div class="alert alert-info">For a feature-by-feature breakdown of what each path unlocks, see the <a href="/opentelemetry/compatibility/">Feature Compatibility</a> table.</div>
+
 ## DDOT Collector (Recommended)
 
 The Datadog Distribution of OpenTelemetry (DDOT) Collector is an open source solution that combines the flexibility of OpenTelemetry with the comprehensive observability capabilities of Datadog.
@@ -70,3 +83,4 @@ Alternative methods are available for specific use cases, such as maintaining a 
 [4]: /opentelemetry/ingestion_sampling#tail-based-sampling
 [5]: /opentelemetry/agent
 [6]: /opentelemetry/setup/otlp_ingest_in_the_agent
+[7]: /opentelemetry/setup/ddot_collector/


### PR DESCRIPTION
## What

Two additive navigation improvements to the OpenTelemetry docs:

- **Setup hub decision matrix** — a new "Choose your setup path" table on `/opentelemetry/setup/` comparing the four ways to send OTel data (DDOT Collector, standalone OpenTelemetry Collector, OTLP Ingest in the Agent, and Direct OTLP Intake), with **Best when** and **Trade-offs** columns.
- **Situation-based entry points** — a "Where to start" card block on the OpenTelemetry landing page (`/opentelemetry/`) that routes users by their starting situation.

## Gaps this addresses

- **No at-a-glance way to choose a setup path.** The four setup options were only described in separate prose sections with scattered "Best for" bullets. To compare them, a user had to open and read each page. The new table puts the decision — platform, how much of the pipeline you manage, and which Datadog features you get — in one place, then links out for detail.
- **The landing page assumed prior context.** It opened directly into the "two key decisions" framing, which presumes the reader already knows they need to make those decisions. New users, users who already run OpenTelemetry, and current Datadog SDK users had no clear self-service entry point. The "Where to start" cards let each of these audiences route themselves to the right page immediately.

## Notes

- **Additive only** — no existing content was removed or reworded; all links point to existing pages.
- The decision matrix reuses the same paths and links already present on the setup hub, and complements (does not replace) the Feature Compatibility table.
- Opening as a **draft** for early feedback on framing and wording.
