### PR TITLE
Fix curl example ignoring scenario-specific request body

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -183,7 +183,7 @@
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}
 {{ " \\" }}
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>
-<span class="s1">{{ .exampleValue | default $body | default (.dollarScratch.Get "jsonRequestBody") }}</span>
+<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
 <span class="n">EOF</span>
 {{- end -}}
 <br/>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The `curl.html`'s plain-JSON branch rendered the spec-level `examples.default` value instead of the scenario-matched `request.<operationId><suffix>.json` body, so every scenario dropdown card (for example, cost/data-jobs/data-quality monitors) showed identical curl output regardless of which one was selected.
<img width="890" height="525" alt="image" src="https://github.com/user-attachments/assets/c95c1f69-faa9-4e6a-802c-a75e0f189119" />

This PR swaps the precedence to prefer the scenario-matched body first, falling back to the spec example only when no scenario body exists.

> [!CAUTION]
> On any operation that has at least one hand-curated spec-level example, it no longer renders anywhere on the page. It's only used as a fallback for operations with no generated scenario coverage at all.

For example, the Webhook Integration API originally is
```
# Curl command
curl -X POST "https://api.datadoghq.com/api/v1/integration/webhooks/configuration/webhooks" \
-H "Accept: application/json" \
-H "Content-Type: application/json" \
-H "DD-API-KEY: ${DD_API_KEY}" \
-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
-d @- << EOF
{
  "encode_as": "json",
  "name": "WEBHOOK_NAME",
  "url": "https://example.com/webhook"
}
EOF
```

And the changed example is 
```
# Curl command
curl -X POST "https://api.datadoghq.com/api/v1/integration/webhooks/configuration/webhooks" \
-H "Accept: application/json" \
-H "Content-Type: application/json" \
-H "DD-API-KEY: ${DD_API_KEY}" \
-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
-d @- << EOF
{
  "name": "Example-Webhooks-Integration",
  "url": "https://example.com/webhook"
}
EOF
```