### PR TITLE
[SEC-33791] Document granular access control support for critical assets

### DIFF
--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -18,6 +18,7 @@ Use the different principals to control access patterns in your organization and
 | [Case Management projects][10]                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Connections][14]                                | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Connection Groups][15]                          | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Critical Assets][26]                            | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Cross Org Connections][20]                      | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Dashboards][2]                                  | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Datastores][16]                                 | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
@@ -71,3 +72,4 @@ A user with the `user_access_manage` permission can elevate their access to any 
 [23]: /observability_pipelines/configuration/access_control/
 [24]: /logs/log_configuration/pipelines/#pipeline-permissions
 [25]: /getting_started/feature_flags/
+[26]: /security/cloud_siem/detect_and_monitor/critical_assets/#restrict-edit-permissions

--- a/content/en/security/access_control.md
+++ b/content/en/security/access_control.md
@@ -23,7 +23,7 @@ further_reading:
 
 Datadog's access management system uses role-based access control, enabling you to define the level of access users have to Datadog resources. Users are assigned to roles that define their account permissions, including what data they can read and which account assets they can modify. When permissions are granted to a role, any user who is associated with that role receives those permissions. See the [Account Management Access Control][1] documentation for more information.
 
-For Datadog Security products, [granular access control][3] is available for [detection rules](#restrict-access-to-detection-rules) and [suppressions](#restrict-access-to-suppression-rules), allowing you to restrict access by teams, roles, or service accounts.
+For Datadog Security products, [granular access control][3] is available for [detection rules](#restrict-access-to-detection-rules), [suppressions](#restrict-access-to-suppression-rules), and [critical assets](#restrict-access-to-critical-assets), allowing you to restrict access by teams, roles, or service accounts.
 
 ## Permissions
 
@@ -36,6 +36,10 @@ See the [list of permissions][2] for Security products.
 ## Restrict access to suppression rules
 
 {{% security-products/suppressions-granular-access %}}
+
+## Restrict access to critical assets
+
+{{% security-products/critical-assets-granular-access %}}
 
 [1]: /account_management/rbac/#role-based-access-control
 [2]: /account_management/rbac/permissions/#cloud-security-platform

--- a/content/en/security/cloud_siem/detect_and_monitor/critical_assets.md
+++ b/content/en/security/cloud_siem/detect_and_monitor/critical_assets.md
@@ -52,6 +52,10 @@ In every security signal that a critical asset has modified, an {{< ui >}}Adjust
 On the {{< ui >}}JSON{{< /ui >}} tab of a security signal, you can also find the `critical_assets_data` object, which includes information about the critical assets associated with it, and how they affected the signal's severity.
 <div class="alert alert-info">If a critical asset's severity level was overridden by a higher severity level, it may not appear in the <code>critical_assets_data</code> object.</div>
 
+## Restrict edit permissions
+
+{{% security-products/critical-assets-granular-access %}}
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/layouts/shortcodes/security-products/critical-assets-granular-access.md
+++ b/layouts/shortcodes/security-products/critical-assets-granular-access.md
@@ -1,0 +1,16 @@
+By default, all users have view and edit access to [critical assets][301]. To use granular access controls to limit the roles that may edit a critical asset:
+
+1. Click the vertical three-dot menu for the critical asset and select **Permissions**.
+1. Click **Restrict Access**. The dialog box updates to show that members of your organization have **Viewer** access by default. Use that dropdown menu to select one or more roles, teams, or users that may edit the critical asset.
+1. Click **Add**.
+1. Click **Save**.
+
+**Note**: To maintain your edit access to the critical asset, Datadog requires you to include at least one role that you are a member of before saving.
+
+To restore access to a critical asset:
+
+1. Click the vertical three-dot menu for the critical asset and select **Permissions**.
+1. Click **Restore Full Access**.
+1. Click **Save**.
+
+[301]: /security/cloud_siem/detect_and_monitor/critical_assets/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

[SEC-33791](https://datadoghq.atlassian.net/browse/SEC-33791)

Documents that critical assets support granular access control, following the same pattern established for detection rules and suppressions in #25586. This adds:

- A reusable `critical-assets-granular-access` shortcode
- A "Restrict access to critical assets" section on the Security Access Control page
- A "Restrict edit permissions" section on the Critical Assets page
- A Critical Assets row in the granular access control resource table

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes



[SEC-33791]: https://datadoghq.atlassian.net/browse/SEC-33791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ