### PR TITLE
Document forms sections and dashboard sharing

### DIFF
--- a/content/en/actions/forms/_index.md
+++ b/content/en/actions/forms/_index.md
@@ -70,7 +70,11 @@ To configure sharing for a form:
 The following sharing options are available:
 
 {{% collapse-content title="Share within Datadog" level="h4" expanded=false %}}
-Share the form with users in your Datadog organization. Enable the **Self-Service Action** toggle to surface the form in the [Self-Service Actions][5] catalog, a central place where platform and infrastructure teams publish tools that the rest of the organization can discover and use without leaving Datadog.
+Share the form with users in your Datadog organization.
+
+Under {{< ui >}}Add to Dashboard{{< /ui >}}, use the dropdown to add the form to an existing dashboard or create a new dashboard.
+
+Enable the {{< ui >}}Add to IDP Self-Service Actions{{< /ui >}} toggle to surface the form in the [Self-Service Actions][5] catalog, a central place where platform and infrastructure teams publish tools that the rest of the organization can discover and use without leaving Datadog.
 {{% /collapse-content %}}
 
 {{% collapse-content title="Share with external users" level="h4" expanded=false %}}

--- a/content/en/actions/forms/components.md
+++ b/content/en/actions/forms/components.md
@@ -28,6 +28,7 @@ When building a form, click **Add Component** to get started. The following comp
 | Ranking | A ranked ordering of a list of options. |
 | Date picker | A calendar date selector. |
 | Image | An image embedded in the form for context or instructions. |
+| Section | A container that groups other components together, with optional conditions applied to the whole group. |
 
 ## Component elements
 
@@ -61,6 +62,18 @@ To configure a conditional field:
 1. Click {{< ui >}}Save{{< /ui >}}.
 
 You can also view conditions in the {{< ui >}}Fields{{< /ui >}} panel by clicking the <i class="icon-source-control-branch-wui" style="display:inline-block;transform:rotate(180deg)"></i> branch icon.
+
+## Sections
+
+Sections let you group components together within a form. For example, you might create one section for personal information and another for preferences. You can drag and drop components between sections to reorganize a form.
+
+You can also configure conditional logic at the section level, showing or hiding an entire section based on a respondent's answer to a previous question, in addition to setting conditions on individual components. See [Conditional fields](#conditional-fields).
+
+To add a section:
+1. In the form, click {{< ui >}}+ Add{{< /ui >}}.
+1. Click {{< ui >}}Section{{< /ui >}}.
+1. Drag existing components into the section, or add new components directly within it.
+1. To set conditions on the section, click the section, then click {{< ui >}}Conditions{{< /ui >}} and define the rule.
 
 ## Dynamic dropdown options
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

- Documents the new Sections component, which groups form components together and supports section-level conditional logic.
- Updates the "Share within Datadog" section to document the Add to Dashboard option (add to an existing dashboard or create a new one) and the renamed Add to IDP Self-Service Actions toggle.

### Merge instructions

**Do not merge** Pending feature release

### Additional notes