### PR TITLE
[K9CODESEC-2491] Add Ruby/Bundler domains to Bits Code default allowlist

### DIFF
--- a/content/en/bits_ai/bits_code/setup.md
+++ b/content/en/bits_ai/bits_code/setup.md
@@ -116,6 +116,7 @@ The default allowlist includes the following domains. This list will evolve over
 | .NET/C# | `api.nuget.org` |
 | PHP | `packagist.org`, `repo.packagist.org` |
 | Python | `files.pythonhosted.org`, `pypi.org`, `pypi.python.org`, `pythonhosted.org` |
+| Ruby | `api.rubygems.org`, `index.rubygems.org`, `rubygems.org` |
 | Rust | `index.crates.io`, `static.crates.io` |
 | Ubuntu | `archive.ubuntu.com`, `ports.ubuntu.com`, `security.ubuntu.com` |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds Ruby/Bundler registry domains to the default allowlist table in the Bits Code setup guide. The sandbox now supports Bundler for Ruby dependency installation, which requires access to `rubygems.org`, `api.rubygems.org`, and `index.rubygems.org`.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.
