### PR TITLE
[DOCS-14953] Clarify Note widget markdown link behavior

### DIFF
--- a/content/en/dashboards/widgets/note.md
+++ b/content/en/dashboards/widgets/note.md
@@ -12,7 +12,7 @@ further_reading:
 
 The Notes & Links widget is similar to the [free text widget][1] but contains more formatting and display options.
 
-**Note**: The Notes & Links widget does not support inline HTML.
+**Note**: The Notes & Links widget does not support inline HTML. Markdown links open in the same tab.
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [DOCS-14953](https://datadoghq.atlassian.net/browse/DOCS-14953)

- Clarifies that markdown links in the Notes & Links widget open in the same tab.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14953]: https://datadoghq.atlassian.net/browse/DOCS-14953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ