### PR TITLE
[DOCS-14899] Add in-context billing callout to Bits Agent Builder

### DIFF
--- a/content/en/actions/agents/_index.md
+++ b/content/en/actions/agents/_index.md
@@ -22,6 +22,8 @@ Bits Agent Builder lets you create custom AI agents that use Datadog's tools and
 
 Use agents to handle work that's too complex for static automation but too repetitive for humans. For example, triaging errors, responding to incidents, analyzing trends, and escalating issues.
 
+<div class="alert alert-info">Bits Agent Builder consumes <a href="/account_management/billing/ai_credits/">AI Credits</a>.</div>
+
 {{< img src="/actions/agents/agent-builder-interface.png" alt="The Bits Agent Builder editor showing instructions, model, tools, and automation configuration" style="width:100%;" >}}
 
 ## Create an agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [DOCS-14899](https://datadoghq.atlassian.net/browse/DOCS-14899)

- Adds an in-context callout to the Bits Agent Builder Overview noting that it consumes AI Credits, linking to the AI Credits billing page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14899]: https://datadoghq.atlassian.net/browse/DOCS-14899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ