### PR TITLE
Update LLM experiments filter docs

### DIFF
--- a/content/en/llm_observability/experiments/advanced_runs.md
+++ b/content/en/llm_observability/experiments/advanced_runs.md
@@ -240,10 +240,9 @@ To retrieve and compare runs through the API, call `GET /api/v2/llm-obs/v1/exper
 - `filter[experiment]=<pipeline-name>` returns all runs sharing the same logical pipeline name.
 - `filter[metadata]={"branch":"main"}` returns runs whose metadata contains those key-value pairs.
 - Combine both filters to narrow comparisons, for example: `?filter[experiment]=my-pipeline&filter[metadata]={"commit":"abc123"}`.
+- `filter[parent_experiment_id]=<uuid>` returns all experiments that were run against a given baseline experiment. Can be repeated for multiple baseline IDs.
 
 Each matching experiment includes `aggregate_data` with pre-computed eval score distributions, token costs, and error rates, so you can compare runs without querying individual spans.
-
-`page[cursor]` is not supported when `filter[experiment]` or `filter[metadata]` is used.
 
 `filter[experiment]` matches the shared logical pipeline name stored in the `experiment` column (for example, `my-pipeline`). This is distinct from the unique per-run `name` field (for example, `my-pipeline-<run-id>`).
 

--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -397,9 +397,10 @@ List all experiments, sorted by creation date. The most recently-created experim
 | `filter[project_id]` (_required_ if dataset not provided) | string | The ID of a project to retrieve experiments for. |
 | `filter[dataset_id]` | string | The ID of a dataset to retrieve experiments for. |
 | `filter[id]` | string | The ID(s) of an experiment to search for. To query for multiple experiments, use `?filter[id]=<>&filter[id]=<>`. |
-| `filter[experiment]` | string | Filter by the logical experiment name (the shared pipeline name set across all runs of the same pipeline). Composes with `filter[project_id]` and `filter[dataset_id]`.<br />**Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
-| `filter[metadata]` | json (string) | Filter experiments whose metadata contains all the provided key-value pairs. Must be a valid JSON object string (for example, `{"commit":"abc123","branch":"main"}`). Composes with `filter[experiment]` and other filters.<br />**Note**: Cannot be combined with `page[cursor]`; returns `400` if both are provided. |
-| `page[cursor]` | string | List results with a cursor provided in the previous query. Not supported when `filter[experiment]` or `filter[metadata]` is provided. |
+| `filter[experiment]` | string | Filter by the logical experiment name (the shared pipeline name set across all runs of the same pipeline). Composes with `filter[project_id]` and `filter[dataset_id]`. |
+| `filter[metadata]` | json (string) | Filter experiments whose metadata contains all the provided key-value pairs. Must be a valid JSON object string (for example, `{"commit":"abc123","branch":"main"}`). Composes with `filter[experiment]` and other filters. |
+| `filter[parent_experiment_id]` | string (UUID) | Filter experiments by the ID of their parent (baseline) experiment. Returns all experiments that were run against the given baseline. Can be specified multiple times: `?filter[parent_experiment_id]=<uuid1>&filter[parent_experiment_id]=<uuid2>`. |
+| `page[cursor]` | string | List results with a cursor provided in the previous query. |
 | `page[limit]` | int | Limits the number of results. |
 
 **Response**
@@ -421,7 +422,7 @@ List all experiments, sorted by creation date. The most recently-created experim
 | `config` | json | Configuration used when creating the experiment. |
 | `created_at` | timestamp | Timestamp representing when the resource was created. |
 | `updated_at` | timestamp | Timestamp representing when the resource was last updated. |
-| `aggregate_data` | json | Pre-computed aggregate metrics for this experiment run (eval score distributions, token costs, error rates). Present when `filter[experiment]` or `filter[metadata]` is used. |
+| `aggregate_data` | json | Pre-computed aggregate metrics for this experiment run (eval score distributions, token costs, error rates). Always populated when available. |
 
 {{% /collapse-content %}}
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b0adcca3-3135-44aa-a513-721ccab1c18f","source":"chat","resourceId":"78b6766b-a618-4a31-b28f-78856388bab2","workflowId":"f34ef482-5f93-4dbe-856a-9ec4557fc4d4","codeChangeId":"f34ef482-5f93-4dbe-856a-9ec4557fc4d4","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

#### Why
- Aligns LLM Observability Experiments API documentation with backend behavior after the experiments listing endpoint moved from Elasticsearch to Postgres.
- Removes stale pagination/filter limitations that no longer apply.

#### What changed
- Added `filter[parent_experiment_id]` to the `GET /api/v2/llm-obs/v1/experiments` query parameter table in `content/en/llm_observability/experiments/api.md`.
- Removed outdated notes stating `filter[experiment]` and `filter[metadata]` cannot be used with `page[cursor]`.
- Updated the `page[cursor]` description to reflect current support with all filters.
- Updated the `aggregate_data` field description to state it is always populated when available.
- Updated `content/en/llm_observability/experiments/advanced_runs.md` to remove the stale cursor restriction sentence and add `filter[parent_experiment_id]` usage guidance.

#### How I verified
- Reviewed the rendered markdown diff for both files to confirm all requested wording and placements.
- Attempted to run `vale` on the changed docs, but `vale` is not installed in this environment.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI-assisted drafting and editing; changes manually reviewed.

### Additional notes

Please open as a draft PR.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/78b6766b-a618-4a31-b28f-78856388bab2)