### PR TITLE
docs(llm-obs): document GA project and dataset MCP tools

### DIFF
--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -260,6 +260,7 @@ The Agent Observability MCP tools enable AI-assisted workflows for:
 - **Discovering experiment patterns**: Filter and sort experiment events by metric performance to find the best and worst-performing cases.
 - **Managing evaluators**: List, inspect, create, update, and delete evaluator configurations across an ML application or the entire organization.
 - **Exploring Patterns**: List pattern configurations, check run status, and browse the discovered topic hierarchy to understand what users are asking and how traffic is distributed.
+- **Managing datasets**: Look up projects and datasets, browse and inspect dataset records, and add new records to a dataset for use in experiments.
 
 ## Available tools
 
@@ -322,6 +323,23 @@ The `llmobs` toolset includes the following tools:
 `delete_llmobs_evaluator`
 : Delete an LLM-judge evaluator configuration by name.
 
+### Project and dataset tools
+
+`get_llmobs_project`
+: Look up an LLM Observability experiments project by ID or name. Use this to resolve a `project_id` UUID before calling dataset tools.
+
+`list_llmobs_datasets`
+: List datasets within a project, with optional ID or name filter. Returns dataset metadata and pagination fields. Use this before `get_llmobs_dataset_records` or `add_llmobs_dataset_records` — those tools require a dataset UUID.
+
+`get_llmobs_dataset_records`
+: Read dataset records with structured previews and a schema summary. Shapes arbitrary JSON fields (`input`, `expected_output`, `metadata`) into readable previews. Use `compute_schema=true` to get a type-aware sketch of record structure before constructing new records.
+
+`get_llmobs_full_dataset_records`
+: Fetch up to 3 specific records with full, untrimmed content. Use this to inspect individual records in detail after finding record IDs with `get_llmobs_dataset_records`.
+
+`add_llmobs_dataset_records`
+: Create records in a dataset using a two-step preview-then-confirm flow. Call with `confirmed=false` to preview the planned write, then `confirmed=true` to commit after user approval.
+
 ### Patterns tools
 
 `list_llmobs_pattern_configs`
@@ -365,6 +383,14 @@ The `llmobs` toolset includes the following tools:
 4. **Analyze metrics**: Use `get_llmobs_experiment_metric_values` to get percentile distributions, true/false rates, or compare across dimension segments.
 5. **Discover dimensions**: Use `get_llmobs_experiment_dimension_values` to find valid filter and segment values.
 
+### Dataset management
+
+1. **Resolve project**: Use `get_llmobs_project` with a project name or ID to get the `project_id` UUID.
+2. **Find dataset**: Use `list_llmobs_datasets` to find the target dataset and get its UUID.
+3. **Inspect records**: Use `get_llmobs_dataset_records` with `compute_schema=true` to browse existing records and understand the dataset schema.
+4. **Read full records**: Use `get_llmobs_full_dataset_records` to retrieve the complete content of up to 3 specific records by ID.
+5. **Add records**: Use `add_llmobs_dataset_records` with `confirmed=false` to preview a write, then `confirmed=true` after user approval.
+
 ### Patterns analysis
 
 1. **List configs**: Use `list_llmobs_pattern_configs` to find available Patterns configurations and their `config_id` values.
@@ -385,6 +411,8 @@ After connecting, try prompts like:
 - Analyze experiment `exp-456` and generate a markdown table of the worst-performing dimensions broken down by evaluation scores. Include any other relevant columns that help me understand where and why performance is degrading.
 - Compare experiment `exp-123` (baseline) against experiment `exp-456`. Summarize what improved, what regressed, and by how much. Give me a recommendation on whether the changes are worth shipping.
 - Summarize experiment `exp-456` and identify the top 5 lowest-scoring events. For each, show the input, output, and which evaluations failed.
+- List the datasets in my `my-project` project and show me a sample of records from the dataset named `qa-golden-set`, including its schema.
+- I have a CSV of new test cases. Add them to the `qa-golden-set` dataset in `my-project` as a new version. Show me a preview first.
 
 ## Combine with other Datadog tools
 

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -388,12 +388,11 @@ The `llmobs` toolset includes the following tools:
 
 ### Dataset management
 
-1. **Discover projects**: Use `list_llmobs_projects` to browse available projects and find the one you want.
-2. **Resolve project**: Use `get_llmobs_project` with a project name or ID to get the `project_id` UUID.
-3. **Find dataset**: Use `list_llmobs_datasets` to find the target dataset and get its UUID.
-4. **Inspect records**: Use `get_llmobs_dataset_records` with `compute_schema=true` to browse existing records and understand the dataset schema.
-5. **Read full records**: Use `get_llmobs_full_dataset_records` to retrieve the complete content of up to 3 specific records by ID.
-6. **Add records**: Use `add_llmobs_dataset_records` with `confirmed=false` to preview a write, then `confirmed=true` after user approval.
+1. **Find your project**: Use `list_llmobs_projects` to browse projects — each result includes the `id` UUID you need for subsequent calls. If you already know the project name but not its UUID, use `get_llmobs_project` to resolve it directly.
+2. **Find your dataset**: Use `list_llmobs_datasets` with the `project_id` to list datasets and get their UUIDs.
+3. **Understand the data**: Use `get_llmobs_dataset_records` with `compute_schema=true` to browse records and get a type sketch of the fields before reading or writing.
+4. **Read specific records**: Use `get_llmobs_full_dataset_records` to retrieve the complete content of up to 3 records by ID.
+5. **Add records**: Use `add_llmobs_dataset_records` with `confirmed=false` to preview a write, then `confirmed=true` after user approval.
 
 ### Patterns analysis
 

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -325,6 +325,9 @@ The `llmobs` toolset includes the following tools:
 
 ### Project and dataset tools
 
+`list_llmobs_projects`
+: List all LLM Observability experiments projects for the org, sorted by creation date (newest first). Returns each project's `id`, `name`, and timestamps, plus pagination fields (`next_cursor`, `truncated`). Use this to discover project names and IDs when you don't already know them.
+
 `get_llmobs_project`
 : Look up an LLM Observability experiments project by ID or name. Use this to resolve a `project_id` UUID before calling dataset tools.
 
@@ -385,11 +388,12 @@ The `llmobs` toolset includes the following tools:
 
 ### Dataset management
 
-1. **Resolve project**: Use `get_llmobs_project` with a project name or ID to get the `project_id` UUID.
-2. **Find dataset**: Use `list_llmobs_datasets` to find the target dataset and get its UUID.
-3. **Inspect records**: Use `get_llmobs_dataset_records` with `compute_schema=true` to browse existing records and understand the dataset schema.
-4. **Read full records**: Use `get_llmobs_full_dataset_records` to retrieve the complete content of up to 3 specific records by ID.
-5. **Add records**: Use `add_llmobs_dataset_records` with `confirmed=false` to preview a write, then `confirmed=true` after user approval.
+1. **Discover projects**: Use `list_llmobs_projects` to browse available projects and find the one you want.
+2. **Resolve project**: Use `get_llmobs_project` with a project name or ID to get the `project_id` UUID.
+3. **Find dataset**: Use `list_llmobs_datasets` to find the target dataset and get its UUID.
+4. **Inspect records**: Use `get_llmobs_dataset_records` with `compute_schema=true` to browse existing records and understand the dataset schema.
+5. **Read full records**: Use `get_llmobs_full_dataset_records` to retrieve the complete content of up to 3 specific records by ID.
+6. **Add records**: Use `add_llmobs_dataset_records` with `confirmed=false` to preview a write, then `confirmed=true` after user approval.
 
 ### Patterns analysis
 


### PR DESCRIPTION
## Summary

- Adds a **Project and dataset tools** section to the `llmobs` toolset reference documenting `get_llmobs_project`, `list_llmobs_datasets`, `get_llmobs_dataset_records`, `get_llmobs_full_dataset_records`, and `add_llmobs_dataset_records`
- Adds a **Dataset management** recommended workflow with step-by-step usage
- Adds a **Managing datasets** entry to the Use cases section
- Adds two dataset-related example prompts

## Context

These tools were previously restricted to org 2 (Datadog internal) while the v2 LLM-Obs dataset surface was being validated. They are now generally available to all customers with `LlmObservabilityRead`/`Write` permissions.

Related code change: https://github.com/ddoghq/dd-source/pull/8955

## Test plan

- [ ] Verify tool descriptions render correctly in the Available tools section
- [ ] Verify the Dataset management workflow renders with correct numbering
- [ ] Check links and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)