### PR TITLE
fix: correct component names in otelcol-config-extras.yml

### DIFF
--- a/content/en/opentelemetry/getting_started/otel_demo_to_datadog.md
+++ b/content/en/opentelemetry/getting_started/otel_demo_to_datadog.md
@@ -138,16 +138,20 @@ Complete the following steps to configure these components.
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resourcedetection, memory_limiter, resource, transform/sanitize_spans]
-          exporters: [otlp_grpc/jaeger, debug, spanmetrics, datadog, datadog/connector]
+          processors: [resourcedetection, memory_limiter, transform/sanitize_spans, resource]
+          exporters: [debug, span_metrics, datadog, datadog/connector]
         metrics:
-          receivers: [datadog/connector, docker_stats, httpcheck/frontend-proxy, hostmetrics, nginx, otlp, postgresql, redis, spanmetrics]
+          receivers: [datadog/connector, docker_stats, http_check/frontend-proxy, host_metrics, nginx, otlp, redis, postgresql, prometheus/ad, span_metrics]
           processors: [resourcedetection, memory_limiter, resource]
-          exporters: [otlp_http/prometheus, debug, datadog]
+          exporters: [debug, datadog]
         logs:
           receivers: [otlp]
-          processors: [resourcedetection, memory_limiter, resource]
-          exporters: [opensearch, debug, datadog]
+          processors: [resourcedetection, memory_limiter, transform/sanitize_logs, resource]
+          exporters: [debug, datadog]
+        profiles:
+          receivers: [otlp]
+          processors: [filter/sanitize_profiles, memory_limiter]
+          exporters: [debug]
     ```
 
     By default, the collector in the demo application merges the configuration from two files:


### PR DESCRIPTION
## Problem

Following the official Datadog tutorial to send OTel Demo data to Datadog,
filling in otelcol-config-extras.yml with the provided example causes the
collector to crash on startup with the following errors:

  Error: references exporter "otlp_grpc/jaeger" which is not configured
  Error: references exporter "opensearch" which is not configured
  Error: references receiver "httpcheck/frontend-proxy" which is not configured
  Error: references exporter "otlp_http/prometheus" which is not configured

The root cause is that the OTel Collector merges config files but replaces
arrays — as documented in the file's own comments. This means any pipeline
defined in otelcol-config-extras.yml fully replaces the corresponding pipeline
from otelcol-config.yml. All component names must therefore be repeated
exactly as defined in the base config.

The component names in the example were out of sync with those actually
defined in otelcol-config.yml, likely because the opentelemetry-demo repo
was updated after the Datadog documentation was written.

## Changes

Aligned all component names with otelcol-config.yml:

- spanmetrics → span_metrics
- httpcheck/frontend-proxy → http_check/frontend-proxy
- hostmetrics → host_metrics
- otlp_grpc/jaeger removed (defined in otelcol-config-observability.yml, not the base config)
- otlp_http/prometheus removed (same reason)
- opensearch removed (same reason)
- transform/sanitize_logs added to logs pipeline (defined in base config)
- resource processor moved after transform/sanitize_spans in traces pipeline
- profiles pipeline added (defined in base config — must be repeated to avoid
  being silently dropped by the array replacement mechanism)

## Testing

Tested locally with Docker Compose. Collector starts successfully and
sends traces, metrics and logs to Datadog with env:otel tag.