### PR TITLE
Update Python minimum version to v3.14.2

### DIFF
--- a/content/en/tracing/trace_pipeline/adaptive_sampling.md
+++ b/content/en/tracing/trace_pipeline/adaptive_sampling.md
@@ -41,7 +41,7 @@ The following table lists minimum SDK versions required for adaptive sampling:
 |-------------|--------------------------|
 | Java        | [v1.34.0][5]             |
 | Go          | [v1.68.0][6]             |
-| Python      | [v2.9.6][10]             |
+| Python      | [v3.14.2][10]             |
 | Ruby        | [v2.0.0][11]             |
 | Node.js     | [v5.16.0][12]            |
 | .NET        | [v2.54.0][13]            |


### PR DESCRIPTION
Python tracers between v2.9.6 and v3.14.2 advertise adaptive sampling support but don't correctly apply sampling rules due to a tracer bug.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
