### PR TITLE
[DOCS-14965] Fix typo in go_expvar documentation links

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -214,8 +214,8 @@ Used for Agent services communicating with each other locally within the host on
 | [Agent browser GUI][16]      | 5002 | TCP      |                                                                                                                                |
 | APM receiver                 | 8126 | TCP      | Includes Tracing and the Profiler.                                                                                             |
 | [DogStatsD][18]              | 8125 | UDP      | Port for DogStatsD unless `dogstatsd_non_local_traffic` is set to true. This port is available on IPv4 localhost: `127.0.0.1`. |
-| go_expvar server (APM)       | 5012 | TCP      | For more information, see [the go_expar integration documentation][15].                                                        |
-| go_expvar integration server | 5000 | TCP      | For more information, see [the go_expar integration documentation][15].                                                        |
+| go_expvar server (APM)       | 5012 | TCP      | For more information, see [the go_expvar integration documentation][15].                                                        |
+| go_expvar integration server | 5000 | TCP      | For more information, see [the go_expvar integration documentation][15].                                                        |
 | IPC API                      | 5001 | TCP      | Port used for Inter Process Communication (IPC).                                                                               |
 | Process Agent debug          | 6062 | TCP      | Debug endpoints for the Process Agent.                                                                                         |
 | Process Agent runtime        | 6162 | TCP      | Runtime configuration settings for the Process Agent.                                                                          |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

A support engineer flagged that `go_expvar` is spelled wrong in a couple places on this page; updated to the right spelling.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

### AI assistance

none

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
