### PR TITLE
Doc: Add GHES to custom tags and measures compatibility table

### DIFF
--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -26,6 +26,7 @@ Custom tags and measures work with the following CI providers:
 - CircleCI
 - GitLab (SaaS or self-hosted >= 14.1)
 - GitHub.com (SaaS)
+- GitHub Enterprise Server (GHES) 3.5.0 or later
 - Jenkins: For Jenkins, follow [these instructions][5] to set up custom tags in your pipelines.
 - Azure DevOps Pipelines
 
@@ -150,3 +151,4 @@ If you are using `datadog-ci` version `2.29.0` to `4.1.0` and the job name does 
 [10]: /continuous_integration/explorer
 [11]: /continuous_integration/pipelines/
 [12]: /getting_started/site/
+

--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -25,8 +25,7 @@ Custom tags and measures work with the following CI providers:
 - Buildkite
 - CircleCI
 - GitLab (SaaS or self-hosted >= 14.1)
-- GitHub.com (SaaS)
-- GitHub Enterprise Server (GHES) 3.5.0 or later
+- GitHub (SaaS or GitHub Enterprise Server (GHES) >= 3.5.0)
 - Jenkins: For Jenkins, follow [these instructions][5] to set up custom tags in your pipelines.
 - Azure DevOps Pipelines
 


### PR DESCRIPTION
## What does this PR do?

Adds GitHub Enterprise Server (GHES) 3.5.0 or later to the CI Visibility custom tags and measures compatibility table. `datadog-ci tag`/`measure` talk directly to the Datadog API from the runner, so support is identical to GitHub.com (SaaS); this was a documentation gap, not a functional limitation.

## Motivation

Flagged by a customer via support ([internal Slack thread](https://dd.slack.com/archives/C0279FZSTNH/p1782851657603179)): the [GitHub Actions CI Visibility setup page](/continuous_integration/pipelines/github/) already lists GHES 3.5.0+ as supported, but this page's compatibility table only mentioned GitHub.com (SaaS).

## Additional Notes

None.