### PR TITLE
[DOCS-14284] Clarify CCM AWS setup requires the root management account

### DIFF
--- a/content/en/cloud_cost_management/setup/aws.md
+++ b/content/en/cloud_cost_management/setup/aws.md
@@ -34,7 +34,7 @@ You can setup using the [API][21], [Terraform][22], or directly in Datadog by fo
 
 Navigate to [Setup & Configuration][7], add an AWS account and follow the steps to configure the AWS integration.
 
-**Note**: Datadog recommends configuring a Cost and Usage Report from an [AWS **management account**][2] for cost visibility into related **member accounts**.
+**Note**: Datadog recommends configuring a Cost and Usage Report from an [AWS **management account**][2], not a delegated administrator account, for cost visibility into related **member accounts**. A delegated administrator account cannot discover other member accounts.
 
 If you send a Cost and Usage Report from an AWS **member account**, ensure that you have selected the following options in your **management account's** [preferences][3]:
 - {{< ui >}}Linked Account Access{{< /ui >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Clarifies that the Cost and Usage Report for Cloud Cost Management setup must be configured from the AWS organization's actual management account, not a delegated administrator account. A customer using a delegated administrator account found it couldn't discover other member accounts, so their CUR didn't provide organization-wide cost visibility.

### Merge readiness

- [x] Ready for merge

### AI assistance

Used Claude Code to draft the clarifying note and verify it against the AWS management account documentation.

### Additional notes

References:
- DOCS-14284