### PR TITLE
[DBM Doc] Update MySQL replication documentation for MariaDB multi-channel support

### DIFF
--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -90,6 +90,8 @@ GRANT PROCESS ON *.* TO datadog@'%';
 GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```
 
+**Note**: For MariaDB, the Agent automatically detects and monitors all replication channels when no specific `replication_channel` is configured. Each channel is tagged with `channel:<connection_name>`.
+
 {{% /tab %}}
 {{% tab "MySQL 5.6" %}}
 


### PR DESCRIPTION
**Confidence**: AUTO

**Source PR**: https://github.com/DataDog/integrations-core/pull/24178

**What changed**: The MySQL integration now properly supports MariaDB multi-channel replication by using `SHOW ALL REPLICAS STATUS` (or `SHOW ALL SLAVES STATUS` for older versions) when no specific replication channel is configured. Previously, MariaDB would report 0 channels in multi-channel replication setups.

**Why this matters**: Users monitoring MariaDB replication with multiple channels will now see correct replication metrics for all channels, tagged with `channel:<connection_name>`. The Agent now recognizes MariaDB's `Connection_name` field in addition to MySQL's `Channel_Name` field.

**Doc update**: Added a note to the replication configuration section explaining that MariaDB multi-channel replication is automatically detected when no specific channel is configured.