### PR TITLE
[CCT-1606] Remove 'to help improve the algorithm' from anomaly resolution step

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -105,7 +105,7 @@ As you investigate anomalies, you may find some that are not significant, were a
 To resolve an anomaly:
 
 1. Click {{< ui >}}Resolve Anomaly{{< /ui >}} to open the resolution popup.
-1. Select one of the following resolutions to help improve the algorithm:
+1. Select one of the following resolutions:
    - {{< ui >}}The anomaly amount was too small{{< /ui >}}
    - {{< ui >}}This is an unexpected increase{{< /ui >}}
    - {{< ui >}}This is an expected increase{{< /ui >}}


### PR DESCRIPTION
## What does this PR do?
[CCT-1606](https://datadoghq.atlassian.net/browse/CCT-1606)

Removes the phrase "to help improve the algorithm" from the anomaly resolution step on the CCM Anomalies Page (`content/en/cloud_cost_management/cost_changes/anomalies.md`).

## Motivation

The resolution selections are user-provided context, not an algorithm-training signal, so the phrasing was misleading.

## Preview

[Anomalies Page (preview)](https://docs-staging.datadoghq.com/bianca.catarau/ccm-anomalies-remove-algorithm-copy/cloud_cost_management/cost_changes/anomalies/)

## Additional Notes

Docs-only, single-line change.


[CCT-1606]: https://datadoghq.atlassian.net/browse/CCT-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ