### PR TITLE
docs(llm-obs): document scheduling for Patterns configs

### DIFF
--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -55,7 +55,13 @@ Each topic shows its interaction volume and share of total traffic. Interactions
    - **Which spans do you want to cluster?:** Filter by application, environment, span type, or other tags to scope the Pattern to a specific slice of traffic.
    - **Sampling Rate:** The percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap.
 5. Under **What should we detect Patterns on?**, enter a template that defines what gets sent to the model for analysis. Use {{variable}} syntax to reference any span field — for example, {{meta.input.value}} to analyze patterns by user input, or {{meta.span.kind}} to analyze by span kind. Click {{< ui >}}Template Examples{{< /ui >}} to see common configurations. As you type, the right panel previews matching spans and shows what percentage of interactions have values for the variables you've referenced.
-6. Click **Save**
+6. Under **How often should we run Patterns?**, choose how the Pattern runs:
+   - **On demand** (default): Run the Pattern manually.
+   - **Daily**, **Weekdays**, or **Weekly**: Run automatically at a time (and, for weekly, a day) you choose.
+   - **Custom**: Run automatically every 1 to 7 days.
+
+   Scheduled times use your Datadog timezone preference. Scheduled runs use the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
+7. Click **Save**
 
 ## Explore your Patterns
 
@@ -108,20 +114,6 @@ From the interactions table inside a topic's detail view, you can act on the int
 To analyze your production traffic, click {{< ui >}}Run analysis{{< /ui >}} in the Patterns header. The pipeline runs in the background and takes 5 to 10 minutes. You can close the page and return later — the header shows the last run date and lookback period when the run completes.
 
 If a run fails, a modal explains the cause and what action to take. The page continues to display results from the most recent successful run while the failed run is shown in the header.
-
-## Schedule runs
-
-Instead of triggering every run manually, configure a Pattern to run automatically on a recurring schedule.
-
-When you create or edit a Pattern, under **How often should we run Patterns?**, choose a cadence:
-
-- **On demand**: No schedule. Run the Pattern manually (default).
-- **Daily**: Every day at a time you choose.
-- **Weekdays**: Monday through Friday at a time you choose.
-- **Weekly**: A chosen day of the week at a time you choose.
-- **Custom**: Every 1 to 7 days.
-
-Scheduled times use your Datadog timezone preference. Each scheduled run uses the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
 
 ## Use topics to improve your application
 

--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -109,6 +109,20 @@ To analyze your production traffic, click {{< ui >}}Run analysis{{< /ui >}} in t
 
 If a run fails, a modal explains the cause and what action to take. The page continues to display results from the most recent successful run while the failed run is shown in the header.
 
+## Schedule runs
+
+Instead of triggering every run manually, configure a Pattern to run automatically on a recurring schedule.
+
+When you create or edit a Pattern, under **How often should we run Patterns?**, choose a cadence:
+
+- **On demand**: No schedule. Run the Pattern manually (default).
+- **Daily**: Every day at a time you choose.
+- **Weekdays**: Monday through Friday at a time you choose.
+- **Weekly**: A chosen day of the week at a time you choose.
+- **Custom**: Every 1 to 7 days.
+
+Scheduled times use your Datadog timezone preference. Each scheduled run uses the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
+
 ## Use topics to improve your application
 
 ### Understand your production traffic


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents that a Pattern can be configured with a recurring **schedule** on the LLM Observability Patterns page (`/llm_observability/monitoring/patterns/`).

Since choosing a schedule is part of creating a Pattern, this adds it as a step in **Set up a Pattern** (before Save): choose how the Pattern runs — **On demand** (default), **Daily**, **Weekdays**, **Weekly**, or **Custom** (every 1–7 days). Notes that scheduled times use the user's Datadog timezone and that scheduled runs use the same pipeline as manual runs (results in the same place; the page shows the most recent run).

### Merge readiness

- [ ] Ready for merge

This feature is currently rolling out behind a feature flag (not yet GA for all orgs). Please hold merge until the rollout is confirmed — I'll check the box once it's ready.

## For Datadog employees:

- Branch name follows the `<name>/<description>` convention (`anis.amar/llm-obs-patterns-schedule-docs`).

### AI assistance

Drafted with Claude Code; content reviewed and adjusted manually to match the existing Patterns page style.

### Additional notes

Scoped to the Patterns page. The cadence wording matches the in-product control ("How often should we run Patterns?").
