### PR TITLE
djm k8s ssi doc fix: remove enabledNamespaces, just keep targets

### DIFF
--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -167,10 +167,11 @@ features:
   apm:
     instrumentation:
       enabled: true
-      enabledNamespaces:
-        - <NAMESPACE>  # namespace where your Spark jobs run
       targets:
         - name: spark-driver
+          namespaceSelector:
+            matchNames:
+              - <NAMESPACE>   # namespace where your Spark jobs run
           podSelector:
             matchLabels:
               spark-role: driver   # replace with your submitter pod labels if running in client mode
@@ -180,6 +181,9 @@ features:
             - name: DD_DATA_JOBS_ENABLED
               value: "true"
         - name: spark-executor
+          namespaceSelector:
+            matchNames:
+              - <NAMESPACE>
           podSelector:
             matchLabels:
               spark-role: executor
@@ -206,10 +210,11 @@ datadog:
   apm:
     instrumentation:
       enabled: true
-      enabledNamespaces:
-        - <NAMESPACE>  # namespace where your Spark jobs run
       targets:
         - name: spark-driver
+          namespaceSelector:
+            matchNames:
+              - <NAMESPACE>   # namespace where your Spark jobs run
           podSelector:
             matchLabels:
               spark-role: driver   # replace with your submitter pod labels if running in client mode
@@ -219,6 +224,9 @@ datadog:
             - name: DD_DATA_JOBS_ENABLED
               value: "true"
         - name: spark-executor
+          namespaceSelector:
+            matchNames:
+              - <NAMESPACE>
           podSelector:
             matchLabels:
               spark-role: executor
@@ -237,7 +245,6 @@ helm upgrade <RELEASE_NAME> datadog/datadog -f datadog-values.yaml
 {{< /tabs >}}
 
 After applying the configuration, restart the targeted pods. SSI injects the init container into each pod on startup.
-
 
 ## Validation
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

With the version requirements we make, targets namespaces and enabledNamespaces are not supported when both set at the same time so injection is not working. 

targets match names namespaceSelector is the correct way of specifying which namespace should be injected

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
