### PR TITLE
[WIP] Add preview disclaimer to CI/CD checks docs

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5387,6 +5387,11 @@ menu:
       identifier: data_jobs
       parent: data_observability_heading
       weight: 80000
+    - name: CI/CD
+      url: data_observability/cicd/
+      identifier: data_observability_cicd
+      parent: data_observability_heading
+      weight: 90000
     - name: Databricks
       url: data_observability/jobs_monitoring/databricks
       identifier: jobs_monitoring_databricks

--- a/content/en/data_observability/cicd.md
+++ b/content/en/data_observability/cicd.md
@@ -19,6 +19,8 @@ further_reading:
       text: 'Jobs Monitoring'
 ---
 
+<div class="alert alert-info">Data Observability CI/CD checks are in preview. Contact your Datadog representative or <a href="/help/">support</a> to request access.</div>
+
 ## Overview
 
 {{< img src="data_observability/cicd/cicd-overview.png" alt="The CI/CD feature report page" style="width:100%;" >}}


### PR DESCRIPTION
## Summary
- Data Observability CI/CD checks (Impact Lineage, Drift Detection) are gated per-org and per-repo via a feature-store table in `dbt-cicd-worker`, confirming their Preview phase.
- The public docs page (`/data_observability/cicd/`) had no preview banner. Adding the standard disclaimer used elsewhere in this doc tree.

## Evidence
- Code: `dbt-cicd-worker` gates participation via `dbt_cicd_feature_metadata` (per-org + per-repo).
- Tracker: DO Product Features sheet lists both "CI/CD: Impact Preview" and "CI/CD: Drift Detection" as Preview.

## Status
**Work in progress — not ready for review yet.** Opening as draft, no reviewers requested. Will request review once sanity-checked.

## AI assistance
Content and phase verification drafted by Claude Code, grounded in dd-source code (see Evidence above). No new claims beyond the single banner addition — flagging per the AI-assistance disclosure in CONTRIBUTING.md.

## Test plan
- [ ] Confirm current phase with DO PM (Preview vs. GA) before merging
- [ ] Preview build renders the banner correctly