### PR TITLE
Update quota processor synchronization limits

### DIFF
--- a/content/en/observability_pipelines/processors/quota.md
+++ b/content/en/observability_pipelines/processors/quota.md
@@ -20,7 +20,7 @@ You can also use field-based partitioning, such as `service`, `env`, `status`. E
 ### Limits
 
 - Each pipeline can have up to 1000 buckets. If you need to increase the bucket limit, [contact support][5].
-- The quota processor is synchronized across all Workers in a Datadog organization. For the synchronization, there is a default rate limit of 50 Workers per organization. When there are more than 50 Workers for an organization:
+- The quota processor is synchronized across all Workers in a Datadog organization. For the synchronization, there is a default rate limit of 100 Workers per organization (300 for worker versions 2.16+). When there are more than this limit of Workers for an organization:
     - The processor continues to run, but does not sync correctly with the other Workers, which can result in logs being sent after the quota limit has been reached.
     - The Worker prints `Failed to sync quota state` errors.
     - [Contact support][5] if you want to increase the default number of Workers per organization.


### PR DESCRIPTION
Updated the default rate limit for the quota processor to 100 Workers per organization (300 for worker versions 2.16+). Clarified the behavior when exceeding the Worker limit.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
