### PR TITLE
[SVLS-9158] Document DD_LAMBDA_CUSTOMER_METRICS_EXCLUDE_TAGS for Lambda

### DIFF
--- a/content/en/serverless/aws_lambda/configuration.md
+++ b/content/en/serverless/aws_lambda/configuration.md
@@ -33,6 +33,7 @@ First, [install][1] Datadog Serverless Monitoring to begin collecting metrics, t
 - [Connect logs and traces](#connect-logs-and-traces)
 - [Link errors to your source code](#link-errors-to-your-source-code)
 - [Submit custom metrics][27]
+- [Exclude auto-injected tags from custom metrics](#exclude-auto-injected-tags-from-custom-metrics)
 - [Collect Profiling data](#collect-profiling-data)
 - [Send telemetry over PrivateLink or proxy](#send-telemetry-over-privatelink-or-proxy)
 - [Send telemetry to multiple Datadog organizations](#send-telemetry-to-multiple-datadog-organizations)
@@ -518,6 +519,21 @@ If you are using a runtime or custom logger that isn't supported, follow these s
 For instructions on setting up the source code integration on your serverless applications, see the [Embed Git information in your build artifacts section][101].
 
 [101]: /integrations/guide/source-code-integration/?tab=go#serverless
+
+## Exclude auto-injected tags from custom metrics
+
+The Datadog Lambda extension enriches the [custom metrics][27] you submit through DogStatsD with auto-injected tags such as `function_arn`, `region`, and `account_id`.
+
+To drop specific auto-injected tags from your custom metrics, set the `DD_LAMBDA_CUSTOMER_METRICS_EXCLUDE_TAGS` environment variable to a comma-separated list of tag keys. For example, to exclude both the `function_arn` and `region` tags:
+
+```yaml
+DD_LAMBDA_CUSTOMER_METRICS_EXCLUDE_TAGS: function_arn,region
+```
+
+**Notes**:
+   - This setting applies only to custom (DogStatsD) metrics. It does not change the tags on [enhanced Lambda metrics][7] or traces.
+   - By default, no tags are excluded.
+   - This is available for version 98+ of the Datadog Lambda extension.
 
 ## Collect profiling data
 

--- a/content/en/serverless/aws_lambda/metrics.md
+++ b/content/en/serverless/aws_lambda/metrics.md
@@ -484,6 +484,8 @@ Distributions provide `avg`, `sum`, `max`, `min`, `count` aggregations by defaul
 
 Datadog provides granular information about the custom metrics you're ingesting, the tag cardinality, and management tools for your custom metrics within the [{{< ui >}}Metrics Summary{{< /ui >}} page][15] of the Datadog app. You can view all serverless custom metrics under the {{< ui >}}Serverless{{< /ui >}} tag in the {{< ui >}}Distribution Metric Origin{{< /ui >}} [{{< ui >}}facet panel{{< /ui >}}][16]. You can also control custom metrics volumes and costs with [Metrics without Limits™][17].
 
+You can also exclude specific auto-injected tags (such as `function_arn`) from your custom metrics. See [Exclude auto-injected tags from custom metrics][19].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -497,3 +499,4 @@ Datadog provides granular information about the custom metrics you're ingesting,
 [15]: https://app.datadoghq.com/metric/summary
 [16]: /metrics/summary/#facet-panel
 [17]: /metrics/summary/#metrics-without-limits
+[19]: /serverless/aws_lambda/configuration/#exclude-auto-injected-tags-from-custom-metrics


### PR DESCRIPTION
Add documentation for the DD_LAMBDA_CUSTOMER_METRICS_EXCLUDE_TAGS environment variable, which excludes auto-injected tags (such as function_arn) from custom DogStatsD metrics. Available in Datadog Lambda extension v98+.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
* Follow up to https://datadoghq.atlassian.net/browse/SVLS-9158 (https://github.com/DataDog/datadog-lambda-extension/pull/1234) , adding documentation for allowing customer to exclude tags on custom metrics. 

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
