### PR TITLE
Add CSI Driver metrics to Agent telemetry collection

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -232,6 +232,16 @@ agent diagnose show-metadata agent-telemetry
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 | appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
+| **CSI Driver**                              |                                                                                                                        |
+| datadog_csi_driver.node_publish_volume_attempts   | Number of volume publish (mount) requests received by the CSI node server, tagged by status and volume type      |
+| datadog_csi_driver.node_unpublish_volume_attempts | Number of volume unpublish (unmount) requests received by the CSI node server, tagged by status                  |
+| datadog_csi_driver.library_resolutions            | Number of attempts to resolve an APM library for a volume, tagged by library and result                          |
+| datadog_csi_driver.library_download_duration_seconds_count | Number of library downloads from a registry (count of the download duration histogram), tagged by library and registry |
+| datadog_csi_driver.library_download_duration_seconds_sum   | Total time spent downloading libraries from a registry, in seconds (sum of the download duration histogram), tagged by library and registry |
+| datadog_csi_driver.library_cleanup                | Number of cleanup attempts for unused cached libraries, tagged by library, status, and strategy                  |
+| datadog_csi_driver.libraries_cached               | Number of library versions currently stored on disk, per library                                                |
+| datadog_csi_driver.libraries_cached_bytes         | Cumulative on-disk size of cached libraries, in bytes, per library                                              |
+| datadog_csi_driver.library_volume_links           | Number of volumes currently linked to a library, per library                                                    |
 
 Only applicable metrics are emitted. For example, if DBM is not enabled, none of the database related metrics are emitted.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a **CSI Driver** category to the Agent telemetry collection table on the
[Agent Data Security](https://docs.datadoghq.com/data_security/agent/#telemetry-collection)
page.

The Datadog CSI driver check now emits nine agent-telemetry (COAT) series so that
usage of the driver's APM library injection can be understood. This documents them
for transparency, alongside the existing Agent, Cluster Agent, and other components.

The `library_download_duration_seconds` histogram is exposed to COAT as two
counters (`_count` and `_sum`) because the internal telemetry registry does not
support histograms directly; both are documented as such.

Onboarding tracked in ASUP-68. Metric definitions:
- Registry profiles: `comp/core/agenttelemetry/impl/defaultProfiles.yaml` (datadog-agent)
- Source metrics: `pkg/metrics/metrics.go` (datadog-csi-driver)

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Drafted with Cursor; metric names and descriptions cross-checked against the
CSI driver source and the COAT profile definitions, then manually reviewed.