### PR TITLE
Update Bazel Test Optimization setup docs

### DIFF
--- a/content/en/tests/setup/bazel/_index.md
+++ b/content/en/tests/setup/bazel/_index.md
@@ -58,7 +58,7 @@ test:test-optimization --remote_download_regex=.*test[.]outputs.*
 test:test-optimization --zip_undeclared_test_outputs
 ```
 
-Bazel does not support a fixed `--build_event_json_file` path in a shared `.bazelrc` block. In CI, create a unique Bazel Build Event Protocol (BEP) JSON file for each `bazel test` invocation, pass it to the test command with `--build_event_json_file=<path>`, and pass the same path to the doctor and uploader with `--bep-json=<path>`.
+Do not add a fixed `--build_event_json_file` path to a shared `.bazelrc` block. In CI, create a unique Bazel Build Event Protocol (BEP) JSON file for each `bazel test` invocation. Pass the file to the test command with `--build_event_json_file=<path>`, and pass the same file to the doctor and uploader with `--bep-json=<path>`.
 
 ## Upload payloads
 

--- a/content/en/tests/setup/bazel/_index.md
+++ b/content/en/tests/setup/bazel/_index.md
@@ -39,7 +39,7 @@ This section includes setup pages for the following language test targets:
 | Python | `dd_topt_py_test` | Supports the managed `pytest` runner and repository-owned pytest wrappers. See [Python compatibility][3]. |
 | Go | `dd_topt_go_test` | Use `test_optimization` mode for the faster standard-library `testing` path, or `general` mode for broader Orchestrion support. See [Go compatibility][4]. |
 
-Use `datadog-rules-test-optimization` version `1.2.0` and the commit pin shown on each language setup page.
+Use `datadog-rules-test-optimization` version `1.3.0` or later. When a setup snippet uses `git_override`, use the full commit SHA for the release you select.
 
 ## How the Bazel setup flow works
 
@@ -50,17 +50,21 @@ For detailed setup guides, see the [language-specific setup pages](#language-set
 1. Replace the language test rule with the Datadog Bazel macro for each instrumented test target.
 1. Run tests, validate local payloads with the doctor target, validate enrichment with the uploader dry run, and then upload payloads.
 
-For remote execution, configure Bazel to download test outputs locally:
+For CI with remote cache or remote execution, configure Bazel to materialize Test Optimization outputs and zip undeclared test outputs:
 
 ```text
-test:test-optimization --remote_download_outputs=all
+test:test-optimization --remote_download_minimal
+test:test-optimization --remote_download_regex=.*test[.]outputs.*
+test:test-optimization --zip_undeclared_test_outputs
 ```
 
-Without local `test.outputs` directories, the doctor and uploader cannot inspect payload files after `bazel test`.
+Bazel does not support a fixed `--build_event_json_file` path in a shared `.bazelrc` block. In CI, create a unique Bazel Build Event Protocol (BEP) JSON file for each `bazel test` invocation, pass it to the test command with `--build_event_json_file=<path>`, and pass the same path to the doctor and uploader with `--bep-json=<path>`.
 
 ## Upload payloads
 
-Run the upload flow after your Bazel tests complete. Replace `//tools/test_optimization` with the package where you declared the doctor and uploader targets:
+Run the upload flow after your Bazel tests complete. Replace `//tools/test_optimization` with the package where you declared the doctor and uploader targets.
+
+For local development where `bazel-testlogs` contains fresh `test.outputs` directories, run:
 
 ```bash
 bazel test --config=test-optimization //...
@@ -69,7 +73,49 @@ bazel run --config=test-optimization //tools/test_optimization:dd_upload_payload
 DD_API_KEY=<DATADOG_API_KEY> DD_SITE=<DATADOG_SITE> bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads
 ```
 
+For CI with remote cache or remote execution, pass the matching BEP file to the doctor and uploader:
+
+```bash
+BEP_JSON="$(mktemp -t bazel-bep.XXXXXX.json)"
+ARTIFACT_STAGING_DIR="$(mktemp -d -t dd-test-optimization-artifacts.XXXXXX)"
+
+bazel test --config=test-optimization --build_event_json_file="$BEP_JSON" //...
+bazel run --config=test-optimization //tools/test_optimization:dd_test_optimization_doctor -- \
+  --bep-json="$BEP_JSON" \
+  --freshness-source=bep \
+  --freshness-mode=required \
+  --artifact-source=bep \
+  --artifact-staging-dir="$ARTIFACT_STAGING_DIR"
+bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads -- \
+  --dry-run \
+  --validate-enrichment \
+  --bep-json="$BEP_JSON" \
+  --freshness-source=bep \
+  --freshness-mode=required \
+  --artifact-source=bep \
+  --artifact-staging-dir="$ARTIFACT_STAGING_DIR"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE=<DATADOG_SITE> bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads -- \
+  --bep-json="$BEP_JSON" \
+  --freshness-source=bep \
+  --freshness-mode=required \
+  --artifact-source=bep \
+  --artifact-staging-dir="$ARTIFACT_STAGING_DIR"
+```
+
+Keep remote artifact downloads disabled unless the BEP file points to remote-only artifacts that Bazel did not materialize locally. For HTTP or HTTPS `outputs.zip` artifacts, add `--remote-artifacts=download` or `--remote-artifacts=required`. For custom remote artifact providers, configure `--bep-artifact-downloader=<path>`.
+
 Do not pass `DD_API_KEY`, `DD_SITE`, `DD_GIT_*`, or upload endpoint variables through `--test_env`. Forward sync metadata with `--repo_env`, and pass upload credentials only to the uploader runtime.
+
+## Collect diagnostic reports
+
+When you need to share diagnostics with Datadog Support, run the doctor with `--support-bundle` after tests complete:
+
+```bash
+bazel run --config=test-optimization //tools/test_optimization:dd_test_optimization_doctor -- \
+  --support-bundle .topt/reports/dd-test-optimization-support.zip
+```
+
+For CI runs that use BEP-based freshness or artifact staging, pass the same `--bep-json`, `--freshness-*`, and `--artifact-*` flags to the support-bundle command.
 
 ## Further reading
 

--- a/content/en/tests/setup/bazel/go.md
+++ b/content/en/tests/setup/bazel/go.md
@@ -90,7 +90,7 @@ orchestrion.from_source(
 use_repo(orchestrion, "rules_go_orchestrion_tool")
 ```
 
-If your repository uses `rules_go` `0.61.1`, use `strip_prefix = "third_party/rgo/v0_61_1/base"` for the managed `rules_go` override.
+If your repository uses `rules_go` `0.61.1`, set `bazel_dep(name = "rules_go", version = "0.61.1")` and use `strip_prefix = "third_party/rgo/v0_61_1/base"` for the managed `rules_go` override.
 
 ## Use `WORKSPACE` mode
 
@@ -102,7 +102,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
 load(

--- a/content/en/tests/setup/bazel/go.md
+++ b/content/en/tests/setup/bazel/go.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 
-Datadog provides official Bazel rules for Go Test Optimization. Guided bootstrap writes a local `dd_go_test` wrapper that calls Datadog's `dd_topt_go_test` macro with the recommended Test Optimization defaults. Use `dd_go_test` in package `BUILD.bazel` files after running bootstrap. Use `dd_topt_go_test` directly when you maintain your own wrapper or need to set Datadog attributes such as `orchestrion_mode`.
+Datadog provides official Bazel rules for Go Test Optimization. Guided bootstrap writes a local `dd_go_test` wrapper, managed `rules_go` and Orchestrion wiring, and a Bazel config for Test Optimization. Use `dd_go_test` in package `BUILD.bazel` files after running bootstrap. Use `dd_topt_go_test` directly when you maintain your own wrapper or need to set Datadog attributes such as `orchestrion_mode`.
 
 ## Compatibility
 
@@ -32,10 +32,10 @@ Use the following minimum versions:
 
 | Component | Version |
 |---|---|
-| `datadog-rules-test-optimization` | `>=1.2.0` |
-| `datadog-rules-test-optimization-go` | `>=1.2.0` |
-| `rules_go` | `0.60.0` |
-| `dd-trace-go` | `>=v2.9.0-rc.2` |
+| `datadog-rules-test-optimization` | `>=1.3.0` |
+| `datadog-rules-test-optimization-go` | `>=1.3.0` |
+| `rules_go` | `0.60.0` by default, or `0.61.1` with the `v0_61_1` support line |
+| `dd-trace-go` | `>=v2.9.0` |
 | Orchestrion | `>=v1.9.0` |
 
 ## Prerequisites
@@ -52,25 +52,45 @@ Before setting up Test Optimization for Go tests in Bazel:
 Add the core module, the Go companion module, and `rules_go` to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "datadog-rules-test-optimization", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
-bazel_dep(name = "datadog-rules-test-optimization-go", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization-go", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization-go",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     strip_prefix = "modules/go",
 )
 
 bazel_dep(name = "rules_go", version = "0.60.0")
 ```
 
-Use the same commit SHA for the core module and the Go companion module.
+Use the same release commit SHA for the core module and the Go companion module.
+
+Guided bootstrap writes a managed `rules_go` override and Orchestrion extension block to `MODULE.bazel`. If you do not run guided bootstrap, add the managed block manually:
+
+```starlark
+git_override(
+    module_name = "rules_go",
+    remote = "https://github.com/DataDog/rules_test_optimization.git",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
+    strip_prefix = "third_party/rgo/v0_60_0/base",
+)
+
+orchestrion = use_extension("@rules_go//go:extensions.bzl", "orchestrion")
+orchestrion.from_source(
+    version = "v1.9.0",
+    dd_trace_go_version = "v2.9.0",
+)
+use_repo(orchestrion, "rules_go_orchestrion_tool")
+```
+
+If your repository uses `rules_go` `0.61.1`, use `strip_prefix = "third_party/rgo/v0_61_1/base"` for the managed `rules_go` override.
 
 ## Use `WORKSPACE` mode
 
@@ -91,13 +111,12 @@ load(
 )
 
 datadog_go_test_optimization_workspace_repositories(
-    rto_commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    rto_commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     rules_go_repo_name = "io_bazel_rules_go",
-    rules_go_variant = "base",
 )
 ```
 
-In the `datadog_go_test_optimization_workspace_repositories(...)` call, keep `rules_go_variant = "base"`. Set `rules_go_variant = "complete"` only when the repository needs the extended monorepo compatibility variant.
+The helper uses the default `rules_go` `0.60.0` support line. If your repository uses `rules_go` `0.61.1`, set `rules_go_upstream = "v0_61_1"` in the `datadog_go_test_optimization_workspace_repositories(...)` call.
 
 ## Run guided bootstrap
 
@@ -108,11 +127,10 @@ bazel run @datadog-rules-test-optimization-go//:dd_topt_go_bootstrap -- \
   --guided \
   --service <SERVICE_NAME> \
   --runtime-version 1.25.0 \
-  --dd-trace-go-version v2.9.0-rc.2 \
   --write-bazelrc
 ```
 
-The bootstrap creates local wrapper targets and a managed `.bazelrc` config named `test-optimization`. By default, bootstrap uses targeted Go module sync. This updates the Orchestrion and `dd-trace-go` tool requirements without running `go mod tidy` for the whole module.
+The bootstrap creates local wrapper targets, managed Bzlmod wiring, and a managed `.bazelrc` config named `test-optimization`. By default, bootstrap uses targeted Go module sync. This updates the Orchestrion and `dd-trace-go` tool requirements without running `go mod tidy` for the whole module. Pass `--dd-trace-go-version` only when your repository must use a different supported `dd-trace-go` version.
 
 If your Go module lives below the workspace root, pass its path:
 
@@ -121,7 +139,6 @@ bazel run @datadog-rules-test-optimization-go//:dd_topt_go_bootstrap -- \
   --guided \
   --service <SERVICE_NAME> \
   --runtime-version 1.25.0 \
-  --dd-trace-go-version v2.9.0-rc.2 \
   --go-module-dir path/to/go-module \
   --write-bazelrc
 ```
@@ -185,6 +202,21 @@ dd_topt_go_test(
 
 ## Run and validate tests
 
+Guided bootstrap writes the managed Bazel config. If you maintain `.bazelrc` manually, add the following test config:
+
+```text
+common:test-optimization --repo_env=DD_API_KEY
+common:test-optimization --repo_env=DD_SITE
+common:test-optimization --repo_env=DD_GIT_REPOSITORY_URL
+common:test-optimization --repo_env=DD_GIT_BRANCH
+common:test-optimization --repo_env=DD_GIT_TAG
+common:test-optimization --repo_env=DD_GIT_COMMIT_SHA
+common:test-optimization --repo_env=DD_PR_NUMBER
+test:test-optimization --remote_download_minimal
+test:test-optimization --remote_download_regex=.*test[.]outputs.*
+test:test-optimization --zip_undeclared_test_outputs
+```
+
 Run tests with the generated Bazel config:
 
 ```bash
@@ -193,6 +225,8 @@ bazel run --config=test-optimization //:dd_test_optimization_doctor
 bazel run --config=test-optimization //:dd_upload_payloads -- --dry-run --validate-enrichment
 DD_API_KEY=<DATADOG_API_KEY> DD_SITE=<DATADOG_SITE> bazel run --config=test-optimization //:dd_upload_payloads
 ```
+
+For CI with remote cache or remote execution, pass a unique BEP file from each `bazel test` invocation to the doctor and uploader. See the [Bazel upload flow][3].
 
 You do not need to set the Test Optimization runtime variables manually. The `dd_topt_go_test` macro adds them to the generated test target, including:
 
@@ -218,12 +252,11 @@ bazel run @datadog-rules-test-optimization-go//:dd_topt_go_bootstrap -- \
   --service <SERVICE_NAME> \
   --runtime-version 1.25.0 \
   --sync-repo-name test_optimization_data \
-  --rto-commit 69953536d4ef1252c8181c267d16c61263f0aa4c \
-  --rules-go-variant base \
+  --rto-commit <RULES_TEST_OPTIMIZATION_RELEASE_COMMIT> \
   --rules-go-repo-name io_bazel_rules_go
 ```
 
-Use `--rules-go-variant complete` only when the repository needs the extended monorepo compatibility variant.
+If your repository uses `rules_go` `0.61.1`, pass `--rules-go-upstream v0_61_1`.
 
 Keep repository-specific scheduling, tags, flaky policy, Docker defaults, and platform constraints in your local wrapper. The optimized wrapper should own only Test Optimization wiring, Orchestrion mode, and pin files.
 
@@ -243,7 +276,7 @@ This can happen when the instrumented test target did not run. It can also happe
 To fix this issue:
 
 1. Run the exact `dd_go_test` or `dd_topt_go_test` target before running the doctor.
-1. For remote execution, add `test:test-optimization --remote_download_outputs=all` to `.bazelrc`.
+1. For remote execution, use the BEP-based upload flow on the [Bazel setup page][3].
 1. Confirm the target uses `orchestrion_mode = "test_optimization"` or `orchestrion_mode = "general"` when using `dd_topt_go_test` directly.
 
 ### The doctor reports `full_bundle_no_match`
@@ -260,7 +293,7 @@ To fix this issue, rerun bootstrap with the `dd-trace-go` version used by your w
 
 ```bash
 bazel run @datadog-rules-test-optimization-go//:dd_topt_go_bootstrap -- \
-  --dd-trace-go-version v2.9.0-rc.2
+  --dd-trace-go-version v2.9.0
 ```
 
 ## Further reading
@@ -269,3 +302,4 @@ bazel run @datadog-rules-test-optimization-go//:dd_topt_go_bootstrap -- \
 
 [1]: /tests/test_impact_analysis/
 [2]: /code_coverage/configuration/
+[3]: /tests/setup/bazel/#upload-payloads

--- a/content/en/tests/setup/bazel/java.md
+++ b/content/en/tests/setup/bazel/java.md
@@ -25,8 +25,8 @@ Use the following minimum versions:
 
 | Component | Version |
 |---|---|
-| `datadog-rules-test-optimization` | `>=1.2.0` |
-| `datadog-rules-test-optimization-java` | `>=1.2.0` |
+| `datadog-rules-test-optimization` | `>=1.3.0` |
+| `datadog-rules-test-optimization-java` | `>=1.3.0` |
 | Java runtime example | `>=17` |
 | `dd-java-agent` example | `>=1.60.0` |
 
@@ -46,23 +46,23 @@ Before setting up Test Optimization for Java tests in Bazel:
 Add the core module and the Java companion module to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "datadog-rules-test-optimization", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
-bazel_dep(name = "datadog-rules-test-optimization-java", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization-java", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization-java",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     strip_prefix = "modules/java",
 )
 ```
 
-Use the same commit SHA for the core module and the Java companion module.
+Use the same release commit SHA for the core module and the Java companion module.
 
 ## Use `WORKSPACE` mode
 
@@ -74,7 +74,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
 load(
@@ -83,7 +83,7 @@ load(
 )
 
 datadog_java_test_optimization_workspace_repositories(
-    rto_commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    rto_commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     rules_java_repo_name = "rules_java",
 )
 ```
@@ -213,7 +213,9 @@ common:test-optimization --repo_env=DD_GIT_BRANCH
 common:test-optimization --repo_env=DD_GIT_TAG
 common:test-optimization --repo_env=DD_GIT_COMMIT_SHA
 common:test-optimization --repo_env=DD_PR_NUMBER
-test:test-optimization --remote_download_outputs=all
+test:test-optimization --remote_download_minimal
+test:test-optimization --remote_download_regex=.*test[.]outputs.*
+test:test-optimization --zip_undeclared_test_outputs
 ```
 
 Run tests, validate local payloads, validate enrichment, and upload:
@@ -224,6 +226,8 @@ bazel run --config=test-optimization //tools/test_optimization:dd_test_optimizat
 bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads -- --dry-run --validate-enrichment
 DD_API_KEY=<DATADOG_API_KEY> DD_SITE=<DATADOG_SITE> bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads
 ```
+
+For CI with remote cache or remote execution, pass a unique BEP file from each `bazel test` invocation to the doctor and uploader. See the [Bazel upload flow][3].
 
 Do not pass upload credentials, upload endpoints, or `DD_GIT_*` values through `--test_env`.
 
@@ -289,7 +293,7 @@ This can happen when the test target uses the raw `java_test` rule. It can also 
 To fix this issue:
 
 1. Confirm the target uses `dd_topt_java_test`.
-1. For remote execution, add `test:test-optimization --remote_download_outputs=all` to `.bazelrc`.
+1. For remote execution, use the BEP-based upload flow on the [Bazel setup page][3].
 1. Run the doctor target before upload.
 1. Run uploader dry-run enrichment validation before the real upload.
 
@@ -305,3 +309,4 @@ To fix this issue, pass Git metadata through `--repo_env`, not `--test_env`.
 
 [1]: /tests/test_impact_analysis/
 [2]: /code_coverage/configuration/
+[3]: /tests/setup/bazel/#upload-payloads

--- a/content/en/tests/setup/bazel/python.md
+++ b/content/en/tests/setup/bazel/python.md
@@ -29,8 +29,8 @@ Use the following minimum versions:
 
 | Component | Version |
 |---|---|
-| `datadog-rules-test-optimization` | `>=1.2.0` |
-| `datadog-rules-test-optimization-python` | `>=1.2.0` |
+| `datadog-rules-test-optimization` | `>=1.3.0` |
+| `datadog-rules-test-optimization-python` | `>=1.3.0` |
 | Python runtime example | `>=3.12` |
 
 The repository that consumes the Bazel rule owns Python toolchains, `pytest`, `ddtrace`, and lockfiles.
@@ -49,23 +49,23 @@ Before setting up Test Optimization for Python tests in Bazel:
 Add the core module and the Python companion module to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "datadog-rules-test-optimization", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
-bazel_dep(name = "datadog-rules-test-optimization-python", version = "1.2.0")
+bazel_dep(name = "datadog-rules-test-optimization-python", version = "1.3.0")
 git_override(
     module_name = "datadog-rules-test-optimization-python",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     strip_prefix = "modules/python",
 )
 ```
 
-Use the same commit SHA for the core module and the Python companion module.
+Use the same release commit SHA for the core module and the Python companion module.
 
 ## Use `WORKSPACE` mode
 
@@ -77,7 +77,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "datadog-rules-test-optimization",
     remote = "https://github.com/DataDog/rules_test_optimization.git",
-    commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
 )
 
 load(
@@ -86,7 +86,7 @@ load(
 )
 
 datadog_python_test_optimization_workspace_repositories(
-    rto_commit = "69953536d4ef1252c8181c267d16c61263f0aa4c",
+    rto_commit = "<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>",
     rules_python_repo_name = "rules_python",
 )
 ```
@@ -201,7 +201,9 @@ common:test-optimization --repo_env=DD_GIT_BRANCH
 common:test-optimization --repo_env=DD_GIT_TAG
 common:test-optimization --repo_env=DD_GIT_COMMIT_SHA
 common:test-optimization --repo_env=DD_PR_NUMBER
-test:test-optimization --remote_download_outputs=all
+test:test-optimization --remote_download_minimal
+test:test-optimization --remote_download_regex=.*test[.]outputs.*
+test:test-optimization --zip_undeclared_test_outputs
 ```
 
 Run tests, validate local payloads, validate enrichment, and upload:
@@ -212,6 +214,8 @@ bazel run --config=test-optimization //tools/test_optimization:dd_test_optimizat
 bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads -- --dry-run --validate-enrichment
 DD_API_KEY=<DATADOG_API_KEY> DD_SITE=<DATADOG_SITE> bazel run --config=test-optimization //tools/test_optimization:dd_upload_payloads
 ```
+
+For CI with remote cache or remote execution, pass a unique BEP file from each `bazel test` invocation to the doctor and uploader. See the [Bazel upload flow][3].
 
 Do not pass upload credentials, upload endpoints, or `DD_GIT_*` values through `--test_env`.
 
@@ -285,7 +289,7 @@ This can happen when the instrumented target did not run, test outputs were not 
 To fix this issue:
 
 1. Run the exact `dd_topt_py_test` target before running the doctor.
-1. For remote execution, add `test:test-optimization --remote_download_outputs=all` to `.bazelrc`.
+1. For remote execution, use the BEP-based upload flow on the [Bazel setup page][3].
 1. Confirm the target depends on both `pytest` and `ddtrace`.
 
 ### `consumer_runner` fails during analysis
@@ -300,3 +304,4 @@ To fix this issue, pass your repository's Python test wrapper with `py_test_rule
 
 [1]: /tests/test_impact_analysis/
 [2]: /code_coverage/configuration/
+[3]: /tests/setup/bazel/#upload-payloads


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Bazel Test Optimization setup docs for the next `rules_test_optimization` release.

This PR documents:
- Version `1.3.0` or later for the Datadog Bazel rules.
- BEP-based doctor and uploader flows for CI with remote cache or remote execution.
- Selective `test.outputs` materialization with `--remote_download_minimal`, `--remote_download_regex`, and `--zip_undeclared_test_outputs`.
- Go setup changes for the managed `rules_go` override, the `v0_61_1` support line, and `dd-trace-go` `v2.9.0`.
- Support bundle collection for Bazel Test Optimization diagnostics.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Draft until the `rules_test_optimization` release commit for `v1.3.0` is available. The setup snippets use `<RULES_TEST_OPTIMIZATION_RELEASE_COMMIT>` as the release commit placeholder.

Validation:
- `git diff --cached --check`
- `yarn run build:hugo` rendered the affected Bazel pages, but exited with existing site-wide data errors unrelated to these files.
- Confirmed generated pages exist under `public/tests/setup/bazel/`, `public/tests/setup/bazel/go/`, `public/tests/setup/bazel/java/`, and `public/tests/setup/bazel/python/`.
- Vale was not run because the `vale` binary is not installed in this environment.
