### PR TITLE
[K9VULN-16596] Update SAST local configuration filename

### DIFF
--- a/content/en/ide_plugins/idea/code_security.md
+++ b/content/en/ide_plugins/idea/code_security.md
@@ -53,7 +53,7 @@ To see the configuration data in your IDE, run the action **Show Datadog Static 
 
 {{< img src="/ide_plugins/idea/code_security/show-sa-config.png" alt="Action to show the Static Analyzer configuration" style="width:80%;" >}}
 
-You can save a local configuration file (`static-analysis.datadog.yml`) at the root of the repository, and its settings will be merged with the remote configuration. When there is no remote configuration available, the local configuration file is used on its own.
+You can save a local configuration file (`code-security.datadog.yaml`) at the root of the repository, and its settings will be merged with the remote configuration. When there is no remote configuration available, the local configuration file is used on its own.
 
 <div class="alert alert-tip">Using a local configuration file is a great way to try out the feature, and it works even without a Datadog login.</div>
 

--- a/content/en/ide_plugins/vscode/code_security.md
+++ b/content/en/ide_plugins/vscode/code_security.md
@@ -29,7 +29,7 @@ Static Code Analysis supports many programming languages. For a complete list, s
 
 ### Get started with Static Code Analysis
 
-When you open a source file, the extension looks for [`static-analysis.datadog.yml`][3] at your repository root and prompts you to create one if it does not exist.
+When you open a source file, the extension looks for [`code-security.datadog.yaml`][3] at your repository root and prompts you to create one if it does not exist.
 
 {{< img src="/ide_plugins/vscode/static-analysis-onboard.png" alt="Onboarding banner for setting up Static Code Analysis with Python files" style="width:75%;" >}}
 
@@ -94,6 +94,6 @@ To toggle Secret Scanning, run the `Datadog: Turn on Secret Scanning` or `Datado
 
 [1]: /security/code_security/static_analysis/
 [2]: /security/code_security/static_analysis/static_analysis_rules/
-[3]: https://github.com/DataDog/datadog-static-analyzer/blob/main/doc/legacy_config.md
+[3]: /security/code_security/static_analysis/configuration/
 [4]: /security/code_security/static_analysis/custom_rules/
 [5]: /security/code_security/secret_scanning/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Code Security products recently implemented a new configuration method via a `code-security.datadog.yaml` file. This replaces an older SAST-only file (the `static-analysis.datadog.yml` file). Documentation for this was added in https://github.com/DataDog/documentation/pull/35307. 

As of last week, the Datadog IDE extensions now have full support for this new configuration file, which is now the default. Thus, this PR converts replaces references to the legacy file.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
