### PR TITLE
[DOCS-15035] Remove rage tap references from mobile RUM frustration signals docs

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/android/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/android/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your Android app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your Android app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/flutter/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/flutter/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your Flutter app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your Flutter app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/ios/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your Apple platform app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your Apple platform app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your Kotlin Multiplatform app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your Kotlin Multiplatform app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/maui/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/maui/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your .NET MAUI app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your .NET MAUI app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/content/en/real_user_monitoring/application_monitoring/react_native/frustration_signals.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/react_native/frustration_signals.mdoc.md
@@ -1,6 +1,6 @@
 ---
 title: Frustration Signals
-description: "Identify user friction in your React Native app with RUM frustration signals, including rage taps and error taps, to improve user experience."
+description: "Identify user friction in your React Native app with RUM frustration signals, including error taps, to improve user experience."
 further_reading:
 - link: /real_user_monitoring/explorer/
   tag: Documentation

--- a/layouts/shortcodes/mdoc/en/real_user_monitoring/frustration_signals/mobile.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/real_user_monitoring/frustration_signals/mobile.mdoc.md
@@ -1,11 +1,8 @@
 ## Overview
 
-Frustration signals identify points of user friction in your mobile application by capturing patterns like rage taps and error taps.
+Frustration signals identify points of user friction in your mobile application by capturing patterns like error taps.
 
-Mobile RUM collects two types of frustration signals:
-
-Rage Taps
-: A user taps on an element more than three times in a one-second sliding window within a radius of approximately 9 mm (48 dp).
+Mobile RUM collects the following type of frustration signal:
 
 Error Taps
 : A user taps on an element, and at least one error occurs during the action's duration or within 100 ms after the action ends.
@@ -19,7 +16,7 @@ Frustration signals appear in the [RUM Explorer][1] as action attributes. Search
 Enter a facet in the search query to begin. Available search fields include:
 
 Frustration Type
-: Find actions with a specific frustration signal. For example, to see all actions with a rage tap, add `action.frustration.type:rage_tap` to the search query.
+: Find actions with a specific frustration signal. For example, to see all actions with an error tap, add `action.frustration.type:error_tap` to the search query.
 
 Frustration Count
 : Find sessions and views where any frustration signal occurred. For example, to find sessions or views with at least one frustration signal, add `session.frustration.count:>1` or `view.frustration.count:>1` to the search query.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15035

Mobile RUM only supports error taps, not rage taps. This PR removes rage tap references from the mobile frustration signals docs (iOS, Android, Flutter, React Native, .NET MAUI, Kotlin Multiplatform) to fix inaccurate information that was causing customer confusion.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes