### PR TITLE
Update supported Mobile App Testing devices list

### DIFF
--- a/content/en/synthetics/mobile_app_testing/devices.md
+++ b/content/en/synthetics/mobile_app_testing/devices.md
@@ -23,8 +23,18 @@ multifiltersearch:
       id: us
   data:
     # Android devices
-    - device: Google Pixel 4a
-      os: Android 11
+    - device: Google Pixel 10
+      os: Android 16
+      platform: Android
+      eu: 'Yes'
+      us: 'Yes'
+    - device: Google Pixel 10 Pro
+      os: Android 16
+      platform: Android
+      eu: 'Yes'
+      us: 'Yes'
+    - device: Google Pixel 10 Pro XL
+      os: Android 16
       platform: Android
       eu: 'Yes'
       us: 'Yes'
@@ -123,8 +133,8 @@ multifiltersearch:
       platform: Android
       eu: 'Yes'
       us: 'Yes'
-    - device: Google Pixel 3a XL
-      os: Android 11
+    - device: Google Pixel 10 Pro
+      os: Android 17
       platform: Android
       eu: 'No'
       us: 'Yes'


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Regenerates the [Supported Mobile App Testing Devices](https://docs.datadoghq.com/synthetics/mobile_app_testing/devices/) table from the live mobile devices API so it matches what customers see in-product.

Net change: 69 -> 71 devices.

Removed:
- Google Pixel 3a XL (Android 11)
- Google Pixel 4a (Android 11)

Added:
- Google Pixel 10 (Android 16)
- Google Pixel 10 Pro (Android 16, Android 17)
- Google Pixel 10 Pro XL (Android 16)

Only the English source is updated; localized copies are handled by the localization pipeline.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Generated with Claude Code: fetched the live devices API, ran the generator, and validated the output (YAML parse, quoted eu/us flags, 0-mismatch bidirectional diff against a fresh API fetch).

### Additional notes
