### PR TITLE
Remove Preview CTA for Cloud Storage scanning (now GA)

### DIFF
--- a/content/en/security/sensitive_data_scanner/_index.md
+++ b/content/en/security/sensitive_data_scanner/_index.md
@@ -139,10 +139,6 @@ To configure scanning for Agent Observability data, navigate to the [Agent Obser
 
 ### Cloud storage
 
-{{< callout url="https://www.datadoghq.com/product-preview/data-security" >}}
-  Scanning support for Amazon S3 buckets and RDS instances is in Preview. To enroll, click <strong>Request Access</strong>.
-{{< /callout >}}
-
 {{< img src="sensitive_data_scanner/cloud_storage_issues.png" alt="The Findings page's datastore section with three Amazon S3 findings" style="width:100%;" >}}
 
 If you have Sensitive Data Scanner enabled, you can catalog and classify sensitive data in your Amazon S3 buckets. **Note**: Sensitive Data Scanner does not redact sensitive data in your cloud storage resources.

--- a/content/en/security/sensitive_data_scanner/setup/cloud_storage.md
+++ b/content/en/security/sensitive_data_scanner/setup/cloud_storage.md
@@ -24,10 +24,6 @@ further_reading:
 
 ## Overview
 
-{{< callout url="https://www.datadoghq.com/product-preview/data-security/" header="Join the Preview Program!"  >}}
-Scanning support for Amazon S3 buckets and RDS instances is in Preview. To enroll, click Request Access.
-{{< /callout >}}
-
 Deploy Datadog Agentless scanners in your environment to scan for sensitive information in your cloud storage resources. Agentless scanners are EC2 instances that you control and run within your environment. The scanners use [Remote Configuration][1] to retrieve a list of S3 buckets as well as their dependencies. They scan many types of text files, such as CSVs and JSONs in your S3 buckets.
 
 When an Agentless scanner finds a match with any of the [SDS library rules][2], the scanning instance sends the rule type and location of the match to Datadog. **Note**: Cloud storage resources and their files are only read in your environment - no sensitive data that was scanned is sent back to Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Sensitive Data Scanner's cloud storage scanning (Amazon S3 buckets and RDS instances) is generally available. This PR removes the "Join the Preview Program" / "Request Access" callouts that referenced the now-closed preview enrollment:

- `content/en/security/sensitive_data_scanner/_index.md`
- `content/en/security/sensitive_data_scanner/setup/cloud_storage.md`

No Jira ticket was provided for this change.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes