### PR TITLE
Document IP allowlist support for the MCP Server

### DIFF
--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -23,6 +23,7 @@ If a user's IP is not contained in the IP allowlist, they are effectively blocke
 - Datadog's public [API][1], including both documented and unpublished endpoints
 - Datadog's mobile apps (iOS, Android)
 - Third-party integrations and applications that access Datadog through OAuth
+- The [Datadog MCP Server][9], including remote connections from AI agents and MCP clients
 
 The IP allowlist feature does not block access to the following:
 - Data ingest endpoints to which the Agent sends data, such as metrics, traces, and logs
@@ -106,3 +107,4 @@ See the [`ip_allowlist` resource][8] to manage the IP allowlist in Terraform.
 [6]: https://app.datadoghq.com/organization-settings/ip-allowlist
 [7]: /api/latest/ip-allowlist/
 [8]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/ip_allowlist
+[9]: /mcp_server/

--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -743,6 +743,10 @@ Users with the {{< ui >}}Datadog Standard Role{{< /ui >}} have both MCP Server p
 
 Organization administrators can manage global MCP access and write capabilities from [Organization Settings][27].
 
+### Restrict network access
+
+To control which networks can connect to the Datadog MCP Server, enable the [IP allowlist][68]. This prevents users from connecting to the MCP Server from unapproved origins, even if they have the required permissions.
+
 ## Authentication
 
 For most users, OAuth 2.0 is the recommended authentication method, and your MCP client handles it during setup. Use one of the header-based methods below only when you cannot complete the OAuth flow, for example on a server or in a CI environment.
@@ -934,3 +938,4 @@ Local authentication is recommended for Cline and when remote authentication is 
 [65]: https://awesome-copilot.github.com/plugins/#file=plugins%2Fdatadog
 [66]: /account_management/personal-access-tokens/
 [67]: /account_management/service-access-tokens/
+[68]: /account_management/org_settings/ip_allowlist/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Admins looking to restrict who can connect to the Datadog MCP Server had no way to find that the IP allowlist covers it. This cross-links the two docs: the MCP Server setup page now points to the IP allowlist as a way to block connections from unapproved origins, and the IP allowlist page lists the MCP Server among the resources it protects.

This is motivated by some users asking for this functionality in the MCP server and not realizing we already have it.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

