### PR TITLE
[OTAGENT-1152] Document custom DDOT Collector config on ECS Fargate

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install/ecs_fargate.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/ecs_fargate.md
@@ -164,6 +164,37 @@ Refer to your language's OpenTelemetry SDK documentation to add the ECS resource
 - **Go**: [go.opentelemetry.io/contrib/detectors/aws/ecs][5]
 - **All languages**: See the [ECS resource detector documentation][6] in the OpenTelemetry Collector contrib repository.
 
+### Use a custom Collector configuration
+
+The default DDOT Collector configuration supports standard OTLP ingestion. To customize the pipeline, for example to add a processor that drops specific metrics, provide your own `otel-config.yaml`.
+
+The DDOT Collector always loads its configuration from a fixed path inside the container: `/etc/datadog-agent/otel-config.yaml`. Because ECS Fargate doesn't support host volumes, build a custom image that includes your configuration at this path:
+
+1. Create your `otel-config.yaml` file with the pipeline you need.
+1. Create a `Dockerfile` that copies your configuration into the Datadog Agent image:
+
+   {{< code-block lang="dockerfile" filename="Dockerfile" collapsible="true" >}}
+FROM public.ecr.aws/datadog/agent:latest-full
+COPY otel-config.yaml /etc/datadog-agent/otel-config.yaml
+{{< /code-block >}}
+
+1. Build the image and push it to a container registry that your ECS task can access, such as Amazon ECR:
+
+   {{< code-block lang="bash" >}}
+docker build -t <YOUR_REGISTRY>/datadog-agent-ddot:<TAG> .
+docker push <YOUR_REGISTRY>/datadog-agent-ddot:<TAG>
+{{< /code-block >}}
+
+1. In your task definition, set the `datadog-agent` container's `image` field to your custom image instead of `public.ecr.aws/datadog/agent:latest-full`.
+
+Repeat this process for each Agent version upgrade to keep the DDOT Collector version compatible with the rest of the image.
+
+<div class="alert alert-info">
+  The Datadog Agent's entrypoint always starts the DDOT Collector with <code>--config /etc/datadog-agent/otel-config.yaml</code>. Passing a configuration through an environment variable, such as an OpenTelemetry Collector <code>env:</code> configuration provider, is not supported on ECS Fargate.
+</div>
+
+To add OpenTelemetry components not included by default, see [Use Custom OpenTelemetry Components][11].
+
 ## Send your telemetry to Datadog
 
 To send your telemetry data to Datadog:
@@ -300,3 +331,4 @@ View metrics from the DDOT Collector to monitor the Collector health.
 [8]: https://github.com/DataDog/opentelemetry-examples/tree/main/apps/rest-services/java/calendar
 [9]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/src/main/java/com/otel/service/CalendarService.java#L27-L48
 [10]: /getting_started/tagging/unified_service_tagging
+[11]: /opentelemetry/setup/ddot_collector/custom_components


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes OTAGENT-1152

Adds a "Use a custom Collector configuration" section to the DDOT Collector ECS Fargate install guide, explaining how to supply a custom `otel-config.yaml` by building a custom Agent image, since ECS Fargate doesn't support host volumes and the Collector always reads its config from a fixed in-container path.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes