### PR TITLE
[DOCS-14930] Restructure monitor API options guide and fix evaluation_delay scope

### DIFF
--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -3,7 +3,10 @@ title: Monitor API Options
 description: "Comprehensive reference for monitor API configuration options including common settings, permissions, anomaly alerts, and metric alerts."
 ---
 
-This guide describes the options available when configuring monitors through the [Monitors API][7]. It covers options common to all monitor types, options for controlling edit permissions, and options that only apply to specific monitor types, such as metric, anomaly, log, service check, and Synthetic test monitors.
+This guide describes the options available when configuring monitors through the [Monitors API][7]. It covers options that: 
+- Are common to all monitor types.
+- Control edit permissions.
+- Only apply to specific monitor types, such as metric, anomaly, log, service check, and Synthetic test monitors.
 
 ## Common options
 
@@ -25,12 +28,12 @@ Time (in seconds) before alerting on new groups, so new applications or containe
 
 `notify_no_data`
 : **Default**: `false`<br>
-A boolean indicating whether the monitor notifies when data stops reporting.
+A Boolean indicating whether the monitor notifies when data stops reporting.
 
 `no_data_timeframe`
 : **Default**: `null`<br>
 Minutes before the monitor notifies after data stops reporting.<br>
-Recommended: 2x the monitor timeframe for query alerts, or 2 minutes for service checks.
+Recommended: 2x the monitor time frame for query alerts, or 2 minutes for service checks.
 
 `timeout_h`
 : **Default**: `null`<br>
@@ -57,7 +60,7 @@ Requires `renotify_interval`.
 
 `notify_audit`
 : **Default**: `false`<br>
-A boolean indicating whether tagged users are notified of changes to the monitor.
+A Boolean indicating whether tagged users are notified of changes to the monitor.
 
 `notify_by`
 : **Default**: `null`<br>
@@ -69,7 +72,7 @@ Controls how much extra content, such as the query or notified handles, appears 
 
 `include_tags`
 : **Default**: `true`<br>
-A boolean indicating whether notifications include the triggering tags in the title.<br>
+A Boolean indicating whether notifications include the triggering tags in the title.<br>
 **Example**: `true` results in `[Triggered on {host:h1}] Monitor Title`; `false` results in `[Triggered] Monitor Title`.
 
 `evaluation_delay`
@@ -104,13 +107,13 @@ _These options only apply to anomaly monitors and are ignored for other monitor 
 _These options only apply to metric alerts._
 
 `thresholds`
-: A dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`. To use a dynamic threshold based on a formula, use `critical_query` and `critical_recovery_query` with a formula query and the `variables` option. This is in preview.
+: A dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
 
   **Example**: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
 
 `require_full_window`
 : **Default**: `false`<br>
-A boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `false` for sparse metrics, otherwise some evaluations are skipped.
+A Boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `false` for sparse metrics; otherwise some evaluations are skipped.
 
 {{% /collapse-content %}}
 
@@ -145,7 +148,7 @@ _These options only apply to logs alerts._
 
 `enable_logs_sample`
 : **Default**: `false`<br>
-A boolean to add samples or values to the notification message.
+A Boolean to add samples or values to the notification message.
 
 {{% /collapse-content %}}
 
@@ -168,15 +171,15 @@ The minimum number of test locations that must be in failure at the same time du
 _These options only apply to the monitor types listed in this section's title._
 
 `group_retention_duration`
-: The time span after which groups with missing data are dropped from the monitor state. Minimum: one hour. Maximum: 72 hours.
+: The time span after which groups with missing data is dropped from the monitor state. Minimum: one hour. Maximum: 72 hours.
 
   **Example values**: `60m`, `1h`, `2d`.
 
 `on_missing_data`
-: Controls how groups or monitors behave when an evaluation returns no data points. The default behavior depends on the query type: monitors using a count query treat an empty evaluation as `0` and compare it to the threshold conditions, and monitors using another query type, such as gauge, measure, or rate, show the last known status. One of `default`, `show_no_data`, `show_and_notify_no_data`, or `resolve`.
+: Controls how groups or monitors behave when an evaluation returns no datapoints. The default behavior depends on the query type: monitors using a count query treat an empty evaluation as `0` and compare it to the threshold conditions, and monitors using another query type, such as gauge, measure, or rate, show the last known status. One of `default`, `show_no_data`, `show_and_notify_no_data`, or `resolve`.
 
 `enable_samples`
-: A boolean to send a list of samples when the monitor triggers. Only available for CI Test and CI Pipeline monitors.
+: A Boolean to send a list of samples when the monitor triggers. Only available for CI Test and CI Pipeline monitors.
 
 {{% /collapse-content %}}
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -5,35 +5,29 @@ description: "Comprehensive reference for monitor API configuration options incl
 
 ## Common options
 
-- **`silenced`** dictionary of scopes to timestamps or `null`. Each scope is muted until the given POSIX timestamp or forever if the value is `null`. Default: **null**. Examples:
+| Option | Description | Default |
+|--------|--------------|---------|
+| `silenced` | Dictionary of scopes to timestamps, or `null`. Each scope is muted until the given POSIX timestamp, or forever if the value is `null`. For example, `{'*': null}` mutes the alert completely, and `{'role:db': 1412798116}` mutes `role:db` until the given timestamp. **Deprecated**: reflects v1 downtimes only. Use the [Downtimes API][6] to schedule downtimes. | `null` |
+| `new_group_delay` | Time (in seconds) before starting alerting on new groups, so newly created applications or containers have time to fully start. Must be a non-negative integer. For example, in a containerized architecture, setting a delay prevents a monitor's group-by containers from triggering when a new container starts, which can cause latency or a CPU spike in the first few minutes. | `60` |
+| `new_host_delay` | Time (in seconds) to allow a host to boot and applications to fully start before evaluating monitor results. **Deprecated**: use `new_group_delay` instead. | `300` |
+| `notify_no_data` | Boolean indicating whether the monitor notifies when data stops reporting. | `false` |
+| `no_data_timeframe` | Number of minutes before the monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for query alerts, or 2 minutes for service checks. If omitted, defaults to 2x the evaluation timeframe for query alerts, or 24 hours for service checks. | `null` |
+| `timeout_h` | Number of hours the monitor can go without reporting data before it automatically resolves from a triggered state. Range: 0-24. | `null` |
+| `renotify_interval` | Number of minutes after the last notification before the monitor re-notifies on the current status. Only re-notifies if the monitor is unresolved. | `null` |
+| `renotify_statuses` | Statuses that trigger re-notification. If `renotify_interval` is set and this option is omitted, defaults to `alert` and `no data`. | `null` |
+| `renotify_occurrences` | Number of times to send re-notifications at the `renotify_interval`. Requires `renotify_interval` to be set. | `null` |
+| `escalation_message` | Message to include with a re-notification. Supports `@username` notifications. Not applicable if `renotify_interval` is `null`. | `null` |
+| `notify_audit` | Boolean indicating whether tagged users are notified of changes to the monitor. | `false` |
+| `notify_by` | Tags that control the granularity a monitor alerts on. Only available for monitors with groupings. For example, a monitor grouped by `cluster` and `namespace` can be set to notify on each new `cluster` alone by setting `notify_by` to `["cluster"]`. Tags in `notify_by` must be a subset of the query's group-by tags. Set to `["*"]` to notify as a simple alert. | `null` |
+| `notification_preset_name` | Controls how much additional content, such as the triggering query or notified handles, appears in the notification. One of `show_all`, `hide_query`, `hide_handles`, `hide_all`, `hide_query_and_handles`, `show_only_snapshot`, or `hide_handles_and_footer`. | `show_all` |
+| `include_tags` | Boolean indicating whether notifications automatically include the triggering tags in the title. For example, `true` results in `[Triggered on {host:h1}] Monitor Title`, and `false` results in `[Triggered] Monitor Title`. | `true` |
+| `evaluation_delay` | Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is `300` (5 minutes), the timeframe is `last_5m`, and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is commonly used with metric alerts for backfilled data sources, such as AWS CloudWatch, but is available on most monitor types. Not supported on SLO monitors outside of burn rate alerts. | `null` |
 
-  - To mute the alert completely: `{'*': null}`
-  - To mute `role:db` for a short time: `{'role:db': 1412798116}`
+## Permissions options
 
-- **`new_group_delay`** time (in seconds) before starting alerting on new groups, to allow newly created applications or containers to fully start. Should be a non negative integer. Default: **60**. Example: If you are using a containerized architecture, setting an evaluation delay prevents your monitor's group-by containers from triggering when a new container is created, which may cause some latency or a spike in CPU usage in the first minutes.
+- **`restricted_roles`** an array listing the UUIDs of the roles allowed to edit the monitor. Monitor editing includes updates to the monitor configuration, deleting the monitor, and muting the monitor for any amount of time. Pull role UUIDs from the [Roles API][1].
 
-- **`new_host_delay`** time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead.**
-
-- **`notify_no_data`** a boolean indicating whether this monitor notifies when data stops reporting. Default: **False**.
-- **`no_data_timeframe`** the number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.**
-- **`timeout_h`** the number of hours of the monitor not reporting data before it automatically resolves from a triggered state. The minimum allowed value is 0 hours. The maximum allowed value is 24 hours. Default: **null**.
-
--  **`require_full_window`** a boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `False` for sparse metrics, otherwise some evaluations are skipped. Default: **False**.
-- **`renotify_interval`** the number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it's not resolved. Default: **null**.
-- **`renotify_statuses`** the states from which a monitor re-notifies. Default: *null* if `renotify_interval` is **null**. If `renotify_interval` is set, defaults to re-notify on `Alert` and `No Data`.
-- **`renotify_occurrences`** the number of times a monitor re-notifies. It can only be set if `renotify_interval` is set. Default: **null**, it renotifies without a limit.
-- **`escalation_message`** a message to include with a re-notification. Supports the '@username' notification that is allowed elsewhere. Not applicable if `renotify_interval` is `null`. Default: **null**.
-- **`notify_audit`** a boolean indicating whether tagged users are notified on changes to this monitor. Default: **False**
-- **`include_tags`** a boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title. Default: **True**. Examples:
-
-  - `True`: `[Triggered on {host:h1}] Monitor Title`
-  - `False`: `[Triggered] Monitor Title`
-
-### Permissions options
-
-- **`restricted_roles`** an array listing the UUIDs of the roles allowed to edit the monitor. Monitor editing includes updates to the monitor configuration, deleting the monitor, and muting of the monitor for any amount of time. Role UUIDs can be pulled from the [Roles API][1].
-
-**Note:** You can now set up permissions on monitors based on [Teams][4] and users, in addition to roles, with [Restriction Policies][5]. For more information on restricting permissions for monitors, see the [dedicated guide][2].
+**Note**: You can also set up permissions on monitors based on [Teams][4] and users, in addition to roles, with [Restriction Policies][5]. For more information on restricting permissions for monitors, see the [dedicated guide][2].
 
 ## Anomaly options
 
@@ -50,11 +44,11 @@ Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window'
 
 _These options only apply to metric alerts._
 
-- **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
+- **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`. To use a dynamic threshold based on a formula, use `critical_query` and `critical_recovery_query` with a formula query and the `variables` option. This is in preview.
 
 Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
 
-- **`evaluation_delay`** time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+- **`require_full_window`** a boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `False` for sparse metrics, otherwise some evaluations are skipped. Default: **False**.
 
 ## Service check options
 
@@ -81,8 +75,24 @@ Example: `{"metric": "count","type": "count","groupBy": "core_service"}`
 
 - **`enable_logs_sample`** a boolean to add samples or values to the notification message. Default: `False`
 
+## Synthetic test monitor options
+
+_These options only apply to Synthetic test monitors._
+
+- **`min_failure_duration`** how long, in seconds, a test must be in failure before alerting. Maximum: `7200`. Default: **0**.
+- **`min_location_failed`** the minimum number of test locations that must be in failure at the same time during the `min_failure_duration` window before alerting. Used with `min_failure_duration` as part of the advanced alerting rules. Default: **1**.
+
+## Options for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+
+_These options only apply to the monitor types listed in this section's title._
+
+- **`group_retention_duration`** the time span after which groups with missing data are dropped from the monitor state. Minimum: one hour. Maximum: 72 hours. Example values: `60m`, `1h`, `2d`.
+- **`on_missing_data`** controls how groups or monitors behave when an evaluation returns no data points. The default behavior depends on the query type: monitors using a count query treat an empty evaluation as `0` and compare it to the threshold conditions, and monitors using another query type, such as gauge, measure, or rate, show the last known status. One of `default`, `show_no_data`, `show_and_notify_no_data`, or `resolve`.
+- **`enable_samples`** a boolean to send a list of samples when the monitor triggers. Only available for CI Test and CI Pipeline monitors.
+
 [1]: /api/latest/roles/
 [2]: /monitors/guide/how-to-set-up-rbac-for-monitors/
 [3]: /monitors/guide/recovery-thresholds/
 [4]: /account_management/teams/
-[5]:/api/latest/restriction-policies/
+[5]: /api/latest/restriction-policies/
+[6]: /api/latest/downtimes/

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -3,92 +3,182 @@ title: Monitor API Options
 description: "Comprehensive reference for monitor API configuration options including common settings, permissions, anomaly alerts, and metric alerts."
 ---
 
+This guide describes the options available when configuring monitors through the [Monitors API][7]. It covers options common to all monitor types, options for controlling edit permissions, and options that only apply to specific monitor types, such as metric, anomaly, log, service check, and Synthetic test monitors.
+
 ## Common options
 
-| Option | Description | Default |
-|--------|--------------|---------|
-| `silenced` | Dictionary of scopes to timestamps, or `null`. Each scope is muted until the given POSIX timestamp, or forever if the value is `null`. For example, `{'*': null}` mutes the alert completely, and `{'role:db': 1412798116}` mutes `role:db` until the given timestamp. **Deprecated**: reflects v1 downtimes only. Use the [Downtimes API][6] to schedule downtimes. | `null` |
-| `new_group_delay` | Time (in seconds) before starting alerting on new groups, so newly created applications or containers have time to fully start. Must be a non-negative integer. For example, in a containerized architecture, setting a delay prevents a monitor's group-by containers from triggering when a new container starts, which can cause latency or a CPU spike in the first few minutes. | `60` |
-| `new_host_delay` | Time (in seconds) to allow a host to boot and applications to fully start before evaluating monitor results. **Deprecated**: use `new_group_delay` instead. | `300` |
-| `notify_no_data` | Boolean indicating whether the monitor notifies when data stops reporting. | `false` |
-| `no_data_timeframe` | Number of minutes before the monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for query alerts, or 2 minutes for service checks. If omitted, defaults to 2x the evaluation timeframe for query alerts, or 24 hours for service checks. | `null` |
-| `timeout_h` | Number of hours the monitor can go without reporting data before it automatically resolves from a triggered state. Range: 0-24. | `null` |
-| `renotify_interval` | Number of minutes after the last notification before the monitor re-notifies on the current status. Only re-notifies if the monitor is unresolved. | `null` |
-| `renotify_statuses` | Statuses that trigger re-notification. If `renotify_interval` is set and this option is omitted, defaults to `alert` and `no data`. | `null` |
-| `renotify_occurrences` | Number of times to send re-notifications at the `renotify_interval`. Requires `renotify_interval` to be set. | `null` |
-| `escalation_message` | Message to include with a re-notification. Supports `@username` notifications. Not applicable if `renotify_interval` is `null`. | `null` |
-| `notify_audit` | Boolean indicating whether tagged users are notified of changes to the monitor. | `false` |
-| `notify_by` | Tags that control the granularity a monitor alerts on. Only available for monitors with groupings. For example, a monitor grouped by `cluster` and `namespace` can be set to notify on each new `cluster` alone by setting `notify_by` to `["cluster"]`. Tags in `notify_by` must be a subset of the query's group-by tags. Set to `["*"]` to notify as a simple alert. | `null` |
-| `notification_preset_name` | Controls how much additional content, such as the triggering query or notified handles, appears in the notification. One of `show_all`, `hide_query`, `hide_handles`, `hide_all`, `hide_query_and_handles`, `show_only_snapshot`, or `hide_handles_and_footer`. | `show_all` |
-| `include_tags` | Boolean indicating whether notifications automatically include the triggering tags in the title. For example, `true` results in `[Triggered on {host:h1}] Monitor Title`, and `false` results in `[Triggered] Monitor Title`. | `true` |
-| `evaluation_delay` | Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is `300` (5 minutes), the timeframe is `last_5m`, and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is commonly used with metric alerts for backfilled data sources, such as AWS CloudWatch, but is available on most monitor types. Not supported on SLO monitors outside of burn rate alerts. | `null` |
+`silenced`
+: **Deprecated**: Reflects v1 downtimes only. Use the [Downtimes API][6] instead.<br>
+**Default**: `null`<br>
+Dictionary of scopes to timestamps, or `null` to mute forever.
+
+  **Example**: `{'*': null}` mutes everything; `{'role:db': 1412798116}` mutes `role:db` until that timestamp.
+
+`new_host_delay`
+: **Deprecated**: Use `new_group_delay` instead.<br>
+**Default**: `300`<br>
+Time (in seconds) to allow a host to boot before evaluating monitor results.
+
+`new_group_delay`
+: **Default**: `60`<br>
+Time (in seconds) before alerting on new groups, so new applications or containers have time to start. Non-negative integer. Prevents alerts on newly created group-by values, such as containers that spike CPU on startup.
+
+`notify_no_data`
+: **Default**: `false`<br>
+A boolean indicating whether the monitor notifies when data stops reporting.
+
+`no_data_timeframe`
+: **Default**: `null`<br>
+Minutes before the monitor notifies after data stops reporting.<br>
+Recommended: 2x the monitor timeframe for query alerts, or 2 minutes for service checks.
+
+`timeout_h`
+: **Default**: `null`<br>
+Hours without data before the monitor auto-resolves from a triggered state.<br>
+Range: 0-24.
+
+`renotify_interval`
+: **Default**: `null`<br>
+Minutes after the last notification before the monitor re-notifies, if unresolved.
+
+`renotify_statuses`
+: **Default**: `null`<br>
+Statuses that trigger re-notification. Defaults to `alert` and `no data` when `renotify_interval` is set.
+
+`renotify_occurrences`
+: **Default**: `null`<br>
+Number of re-notifications to send at the `renotify_interval`.<br>
+Requires `renotify_interval`.
+
+`escalation_message`
+: **Default**: `null`<br>
+Message to include with a re-notification. Supports `@username`.<br>
+Requires `renotify_interval`.
+
+`notify_audit`
+: **Default**: `false`<br>
+A boolean indicating whether tagged users are notified of changes to the monitor.
+
+`notify_by`
+: **Default**: `null`<br>
+Tags that control alert granularity for grouped monitors. Must be a subset of the query's group-by tags. Set to `["*"]` to notify as a simple alert.
+
+`notification_preset_name`
+: **Default**: `show_all`<br>
+Controls how much extra content, such as the query or notified handles, appears in the notification. One of `show_all`, `hide_query`, `hide_handles`, `hide_all`, `hide_query_and_handles`, `show_only_snapshot`, `hide_handles_and_footer`.
+
+`include_tags`
+: **Default**: `true`<br>
+A boolean indicating whether notifications include the triggering tags in the title.<br>
+**Example**: `true` results in `[Triggered on {host:h1}] Monitor Title`; `false` results in `[Triggered] Monitor Title`.
+
+`evaluation_delay`
+: **Default**: `null`<br>
+Time (in seconds) to delay evaluation. Useful for backfilled data sources, such as AWS CloudWatch. Available on most monitor types; not supported on SLO monitors outside of burn rate alerts.
 
 ## Permissions options
 
-- **`restricted_roles`** an array listing the UUIDs of the roles allowed to edit the monitor. Monitor editing includes updates to the monitor configuration, deleting the monitor, and muting the monitor for any amount of time. Pull role UUIDs from the [Roles API][1].
+`restricted_roles`
+: An array listing the UUIDs of the roles allowed to edit the monitor. Monitor editing includes updates to the monitor configuration, deleting the monitor, and muting the monitor for any amount of time. Pull role UUIDs from the [Roles API][1].
 
 **Note**: You can also set up permissions on monitors based on [Teams][4] and users, in addition to roles, with [Restriction Policies][5]. For more information on restricting permissions for monitors, see the [dedicated guide][2].
 
-## Anomaly options
+## Options by monitor type
+
+{{% collapse-content title="Anomaly options" level="h3" %}}
 
 _These options only apply to anomaly monitors and are ignored for other monitor types._
 
-- **`threshold_windows`** a dictionary containing `recovery_window` and `trigger_window`.
+`threshold_windows`
+: A dictionary containing `recovery_window` and `trigger_window`.
 
-  - `recovery_window` describes how long an anomalous metric must be normal before the alert recovers
-  - `trigger_window` describes how long a metric must be anomalous before an alert triggers
+  - `recovery_window`: How long an anomalous metric must be normal before the alert recovers.
+  - `trigger_window`: How long a metric must be anomalous before an alert triggers.
 
-Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
+  **Example**: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
 
-## Metric alert options
+{{% /collapse-content %}}
+
+{{% collapse-content title="Metric alert options" level="h3" %}}
 
 _These options only apply to metric alerts._
 
-- **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`. To use a dynamic threshold based on a formula, use `critical_query` and `critical_recovery_query` with a formula query and the `variables` option. This is in preview.
+`thresholds`
+: A dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][3] for your monitor, use the attributes `critical_recovery` and `warning_recovery`. To use a dynamic threshold based on a formula, use `critical_query` and `critical_recovery_query` with a formula query and the `variables` option. This is in preview.
 
-Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
+  **Example**: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
 
-- **`require_full_window`** a boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `False` for sparse metrics, otherwise some evaluations are skipped. Default: **False**.
+`require_full_window`
+: **Default**: `false`<br>
+A boolean indicating whether this monitor needs a full window of data before it's evaluated. Datadog recommends you set this to `false` for sparse metrics, otherwise some evaluations are skipped.
 
-## Service check options
+{{% /collapse-content %}}
+
+{{% collapse-content title="Service check options" level="h3" %}}
 
 _These options only apply to service checks and are ignored for other monitor types._
 
-- **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, they aren't defined directly in the query.
+`thresholds`
+: A dictionary of thresholds by status. Because service checks can have multiple thresholds, they aren't defined directly in the query.
 
-Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
+  **Example**: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
-## Logs alert options
+{{% /collapse-content %}}
+
+{{% collapse-content title="Logs alert options" level="h3" %}}
 
 _These options only apply to logs alerts._
 
-- **`thresholds`** a dictionary of thresholds by status.
+`thresholds`
+: A dictionary of thresholds by status.
 
-Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
+  **Example**: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
-- **`aggregation`** a dictionary of `type`, `metric`, and `groupBy`.
+`aggregation`
+: A dictionary of `type`, `metric`, and `groupBy`.
+
+  **Example**: `{"metric": "count","type": "count","groupBy": "core_service"}`
+
   - `type`: Three types are supported: `count`, `cardinality`, and `avg`.
   - `metric`: For `cardinality`, use the name of the facet. For `avg`, use the name of the metric. For `count`, put `count` as metric.
   - `groupBy`: Name of the facet on which you want to group by.
 
-Example: `{"metric": "count","type": "count","groupBy": "core_service"}`
+`enable_logs_sample`
+: **Default**: `false`<br>
+A boolean to add samples or values to the notification message.
 
-- **`enable_logs_sample`** a boolean to add samples or values to the notification message. Default: `False`
+{{% /collapse-content %}}
 
-## Synthetic test monitor options
+{{% collapse-content title="Synthetic test monitor options" level="h3" %}}
 
 _These options only apply to Synthetic test monitors._
 
-- **`min_failure_duration`** how long, in seconds, a test must be in failure before alerting. Maximum: `7200`. Default: **0**.
-- **`min_location_failed`** the minimum number of test locations that must be in failure at the same time during the `min_failure_duration` window before alerting. Used with `min_failure_duration` as part of the advanced alerting rules. Default: **1**.
+`min_failure_duration`
+: **Default**: `0`<br>
+How long, in seconds, a test must be in failure before alerting. Maximum: `7200`.
 
-## Options for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+`min_location_failed`
+: **Default**: `1`<br>
+The minimum number of test locations that must be in failure at the same time during the `min_failure_duration` window before alerting. Used with `min_failure_duration` as part of the advanced alerting rules.
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="Options for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors" level="h3" %}}
 
 _These options only apply to the monitor types listed in this section's title._
 
-- **`group_retention_duration`** the time span after which groups with missing data are dropped from the monitor state. Minimum: one hour. Maximum: 72 hours. Example values: `60m`, `1h`, `2d`.
-- **`on_missing_data`** controls how groups or monitors behave when an evaluation returns no data points. The default behavior depends on the query type: monitors using a count query treat an empty evaluation as `0` and compare it to the threshold conditions, and monitors using another query type, such as gauge, measure, or rate, show the last known status. One of `default`, `show_no_data`, `show_and_notify_no_data`, or `resolve`.
-- **`enable_samples`** a boolean to send a list of samples when the monitor triggers. Only available for CI Test and CI Pipeline monitors.
+`group_retention_duration`
+: The time span after which groups with missing data are dropped from the monitor state. Minimum: one hour. Maximum: 72 hours.
+
+  **Example values**: `60m`, `1h`, `2d`.
+
+`on_missing_data`
+: Controls how groups or monitors behave when an evaluation returns no data points. The default behavior depends on the query type: monitors using a count query treat an empty evaluation as `0` and compare it to the threshold conditions, and monitors using another query type, such as gauge, measure, or rate, show the last known status. One of `default`, `show_no_data`, `show_and_notify_no_data`, or `resolve`.
+
+`enable_samples`
+: A boolean to send a list of samples when the monitor triggers. Only available for CI Test and CI Pipeline monitors.
+
+{{% /collapse-content %}}
 
 [1]: /api/latest/roles/
 [2]: /monitors/guide/how-to-set-up-rbac-for-monitors/
@@ -96,3 +186,4 @@ _These options only apply to the monitor types listed in this section's title._
 [4]: /account_management/teams/
 [5]: /api/latest/restriction-policies/
 [6]: /api/latest/downtimes/
+[7]: /api/latest/monitors/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [DOCS-14930](https://datadoghq.atlassian.net/browse/DOCS-14930)

- Reformat Common options section to a table for easier scanning.
- Update the options to match monitor api.
- Adds two new sections for option groups that existed in the API but weren't documented here: Synthetic test monitor options, and options for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14930]: https://datadoghq.atlassian.net/browse/DOCS-14930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ