### PR TITLE
[DOCS-14998] Fix App Builder gov/gov2 site-support banners

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -292,6 +292,7 @@ unsupported_sites:
   ai_agents_console: [gov, gov2]
   byoc-logs: [gov, gov2]
   actions: [gov,gov2]
+  app-builder: [gov2]
   adaptive_sampling: [gov,gov2]
   advanced_analysis: [gov,gov2]
   agent_flare: [gov,gov2]

--- a/content/en/actions/app_builder/_index.md
+++ b/content/en/actions/app_builder/_index.md
@@ -39,7 +39,14 @@ further_reading:
   tag: "Learning Center"
   text: "Build Self-Serve Apps with App Builder for Third-Party Integrations"
 
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 ## Overview 
 

--- a/content/en/actions/app_builder/access_and_auth.md
+++ b/content/en/actions/app_builder/access_and_auth.md
@@ -4,7 +4,14 @@ description: Access and authentication for App builder
 aliases:
     - /service_management/app_builder/auth
     - /actions/app_builder/auth
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 A few tools control access and authentication for apps and their components.
 

--- a/content/en/actions/app_builder/build.md
+++ b/content/en/actions/app_builder/build.md
@@ -12,7 +12,14 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/getting-started-app-builder/"
   tag: "Learning Center"
   text: "Getting Started with App Builder"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 You can create an app or edit existing apps from the [App Builder][1] page. The page lists information about existing apps, including the following:
 - Author

--- a/content/en/actions/app_builder/components/_index.md
+++ b/content/en/actions/app_builder/components/_index.md
@@ -18,7 +18,14 @@ further_reading:
   tag: "Learning Center"
   text: "Build Self-Serve Apps with App Builder for Third-Party Integrations"
 
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 This page provides a list of UI components that you can use when creating apps in App Builder.
 

--- a/content/en/actions/app_builder/components/custom_charts.md
+++ b/content/en/actions/app_builder/components/custom_charts.md
@@ -12,7 +12,14 @@ further_reading:
 - link: "/actions/workflows/build/"
   tag: "Documentation"
   text: "Build Apps"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 This page provides an example of how to use the custom chart component in your App Builder apps.
 

--- a/content/en/actions/app_builder/components/react_renderer.md
+++ b/content/en/actions/app_builder/components/react_renderer.md
@@ -9,7 +9,14 @@ further_reading:
 - link: "/actions/app_builder/build/"
   tag: "Documentation"
   text: "Build Apps"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 The React renderer enables users to create fully custom UI components using the language and libraries they already know. This component gives builders access to [React APIs][1] so they can create flexible, dynamic, and visually impactful apps in App Builder.
 

--- a/content/en/actions/app_builder/components/reusable_modules.md
+++ b/content/en/actions/app_builder/components/reusable_modules.md
@@ -12,7 +12,14 @@ further_reading:
 - link: "/actions/app_builder/queries/"
   tag: "Documentation"
   text: "Queries"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 Use the _Reusable Modules_ feature to save groups of components and queries as templates for reuse across your App Builder applications. Modules automatically include all dependencies to ensure your components function correctly.
 

--- a/content/en/actions/app_builder/components/tables.md
+++ b/content/en/actions/app_builder/components/tables.md
@@ -12,7 +12,14 @@ further_reading:
 - link: "/actions/app_builder/build/"
   tag: "Documentation"
   text: "Build Apps"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 This page describes advanced features you can use to manipulate table components in your App Builder apps.
 

--- a/content/en/actions/app_builder/embedded_apps/_index.md
+++ b/content/en/actions/app_builder/embedded_apps/_index.md
@@ -8,7 +8,14 @@ further_reading:
 - link: "https://app.datadoghq.com/actions/action-catalog/"
   tag: "App"
   text: "Action Catalog"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 When you have Datadog App Builder apps embedded in your dashboards, you can take direct actions on your resources, and all of the relevant data and context is immediately available. Link your app with the dashboard's time frame and template variables to dynamically set the scope of the app's actions, which allows you to carry out actions in your environment at any needed scope.
 

--- a/content/en/actions/app_builder/embedded_apps/input_parameters.md
+++ b/content/en/actions/app_builder/embedded_apps/input_parameters.md
@@ -2,7 +2,14 @@
 title: Input Parameters
 description: Input parameters allow you to embed the same app in multiple dashboards or notebooks using different configurations for each instance.
 disable_toc: false
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 Input parameters allow you to embed the same app in multiple dashboards or notebooks using different configurations for each instance. 
 

--- a/content/en/actions/app_builder/events.md
+++ b/content/en/actions/app_builder/events.md
@@ -15,7 +15,14 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/app-builder-integration"
   tag: "Learning Center"
   text: "Build Self-Serve Apps with App Builder for Third-Party Integrations"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 UI components can trigger reactions on an {{< ui >}}Event{{< /ui >}}. Event triggers differ according to the component. For example, a button component can trigger a reaction on a click event, and a table component can trigger a reaction on a page change or table row click event. To see what event triggers are available for a given component, see [Components][1].
 

--- a/content/en/actions/app_builder/expressions.md
+++ b/content/en/actions/app_builder/expressions.md
@@ -10,7 +10,14 @@ further_reading:
 - link: "/actions/app_builder/components/"
   tag: "Documentation"
   text: "Components"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you begin an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
 

--- a/content/en/actions/app_builder/queries.md
+++ b/content/en/actions/app_builder/queries.md
@@ -10,7 +10,14 @@ further_reading:
 - link: "/actions/app_builder/build/"
   tag: "Documentation"
   text: "Build Apps"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 Queries are actions that populate your app with data from Datadog APIs or supported integrations. They take inputs from other queries or from UI components and return outputs for use in other queries or in UI components.
 

--- a/content/en/actions/app_builder/saved_actions.md
+++ b/content/en/actions/app_builder/saved_actions.md
@@ -14,7 +14,14 @@ further_reading:
   tag: "Documentation"
   text: "Learn about integrations"
 
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 Use the _Saved Actions_ feature to save a copy of an action for reuse. You can insert a saved action into your app as a new step, or use a saved action to populate an existing step's parameters.
 

--- a/content/en/actions/app_builder/variables.md
+++ b/content/en/actions/app_builder/variables.md
@@ -12,7 +12,14 @@ further_reading:
 - link: "/actions/app_builder/expressions/"
   tag: "Documentation"
   text: "JavaScript Expressions"
+site_support_id: app-builder
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App Builder is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 If you want to encapsulate logic within your app, you can use state variables.
 

--- a/content/en/agent/fleet_automation/_index.md
+++ b/content/en/agent/fleet_automation/_index.md
@@ -23,7 +23,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/fleet-automation/"
   tag: "Blog"
   text: "Centrally govern and remotely manage Datadog Agents at scale with Fleet Automation"
-site-support-id: fleet-automation-standard-features
+site_support_id: fleet-automation-standard-features
 ---
 
 ## Overview

--- a/content/en/agent/fleet_automation/configure_agents.md
+++ b/content/en/agent/fleet_automation/configure_agents.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
-site-support-id: fleet-automation-standard-features  
+site_support_id: fleet-automation-standard-features
 ---
 
 Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes through guided workflows in the UI or with custom YAML files.

--- a/content/en/agent/fleet_automation/configure_integrations.md
+++ b/content/en/agent/fleet_automation/configure_integrations.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
-site-support-id: fleet-automation-standard-features  
+site_support_id: fleet-automation-standard-features
 ---
 
 Fleet Automation can deploy, update, and remove [integration][1] configuration files (`conf.d`) on your Agents remotely. Select target Agents by host or tag, choose an integration, and Fleet Automation pushes the configuration change across your fleet.

--- a/content/en/agent/fleet_automation/upgrade_agents.md
+++ b/content/en/agent/fleet_automation/upgrade_agents.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
-site-support-id: fleet-automation-standard-features
+site_support_id: fleet-automation-standard-features
 ---
 
 Fleet Automation allows you to remotely upgrade Datadog Agents across your fleet without direct access to individual hosts. You can trigger upgrades immediately, schedule them during maintenance windows, or automate them through the API.

--- a/content/en/agent/fleet_automation/upgrade_sdks.md
+++ b/content/en/agent/fleet_automation/upgrade_sdks.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "/agent/fleet_automation/"
   tag: "Documentation"
   text: "Fleet Automation"
-site-support-id: fleet-automation-standard-features
+site_support_id: fleet-automation-standard-features
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/remote-upgrade-of-sdk-versions/" btn_hidden="false" header="Join the Preview!" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14998, DOCS-14999, DOCS-15000, DOCS-15001, DOCS-15002, DOCS-15003, DOCS-15004, DOCS-15005, DOCS-15006, DOCS-15007

Updates the 15 App Builder documentation pages to reflect their current site-support status on Datadog Government sites:

- **US1-FED (gov)**: App Builder is in Preview — pages now show a Preview notice.
- **US2-FED (gov2)**: App Builder is unsupported — pages now show the standard unsupported-site banner.

Adds a dedicated `app-builder` key to `unsupported_sites` in `params.yaml` and a `site_support_id` to each page's front matter, so App Builder pages no longer inherit the shared `actions` section's site-support state.

Also fixes the `site_support_id` front-matter key on the Fleet Automation pages (`fleet_automation/_index.md`, `configure_agents.md`, `configure_integrations.md`, `upgrade_agents.md`, `upgrade_sdks.md`), which used a hyphenated `site-support-id` key that the banner template doesn't recognize. This silently prevented the unsupported-site banner from rendering on those pages.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes