### PR TITLE
Document AWS metric name filtering

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -139,6 +139,21 @@ See the [Integrations page][13] for a full listing of the available sub-integrat
 
 Use the {{< ui >}}Metric Collection{{< /ui >}} tab on the [AWS integration page][8] to configure which services the Datadog integration collects metrics from.
 
+### Filter metrics by metric name
+
+Use the {{< ui >}}Metric Collection{{< /ui >}} tab on the [AWS integration page][8] to filter CloudWatch metrics by namespace. Expand a namespace in the CloudWatch metric collection table and choose an **Include** or **Exclude** filter:
+
+- **Include**: Collect only Datadog metric names that match the configured patterns for that namespace.
+- **Exclude**: Collect all Datadog metric names for that namespace except those that match the configured patterns.
+
+Each namespace can use one filter mode at a time. Filter patterns support lowercase letters, numbers, `.`, `_`, and `*`. For example, `aws.ec2.network_*` matches EC2 network metrics. The table previews how many metrics match each pattern before you save changes.
+
+Metric name filters apply per namespace and are evaluated after the namespace is enabled for metric collection.
+
+<div class="alert alert-info">
+Metric name filters cannot remove <code>aws.ec2.cpuutilization</code> or <code>aws.lambda.invocations</code>. Datadog always collects these required metrics.
+</div>
+
 ### Add regions
 
 Under the {{< ui >}}General{{< /ui >}} tab on the [AWS integration page][8], you can control the AWS regions where Datadog collects metrics, CloudWatch events, and resources.

--- a/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
+++ b/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
@@ -11,6 +11,12 @@ aliases:
 
 Yes. Enable **Collect Custom Metrics** under the **Metric Collection** tab on the [AWS integration page][1].
 
+### Can I filter AWS metrics by metric name?
+
+Yes. On the [AWS integration page][1], open the **Metric Collection** tab, expand a CloudWatch namespace, and add metric name filters. Use **Include** to collect only matching Datadog metric names for that namespace, or **Exclude** to collect everything except matching metric names.
+
+For more information on syntax and required metrics, see [Getting Started with AWS][14].
+
 ### How do I collect metrics from a service for which Datadog doesn't have an official integration?
 
 AWS metrics coming from an `AWS/<namespace>` for which there is no official integration are also brought in under the custom namespace when the `Collect custom metrics` option is enabled. You can filter these metrics out and only keep the metrics you want by using the filter string under custom namespace with the [Set an AWS tag filter][2] API.
@@ -119,3 +125,4 @@ Some AWS services do not emit metrics to CloudWatch by default and require extra
 [11]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html#turning_on_billing_metrics
 [12]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
 [13]: /integrations/guide/monitor-your-aws-billing-details/
+[14]: /getting_started/integrations/aws/#filter-metrics-by-metric-name


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds docs for AWS metric name filters in the setup page and FAQ.


- [Getting started](https://docs-staging.datadoghq.com/sergio.najm/07-07-added_docs_for_aws_integration_metric_name_filtering/getting_started/integrations/aws/#filter-metrics-by-metric-name)
- [FAQ](https://docs-staging.datadoghq.com/sergio.najm/07-07-added_docs_for_aws_integration_metric_name_filtering/integrations/guide/aws-integration-and-cloudwatch-faq/#can-i-filter-aws-metrics-by-metric-name)

