### PR TITLE
Add Service Discovery preview section to APM instrumentation docs

### DIFF
--- a/content/en/tracing/trace_collection/_index.md
+++ b/content/en/tracing/trace_collection/_index.md
@@ -54,7 +54,20 @@ Application {{< tooltip glossary="instrumentation" >}} with Datadog APM involves
 Service Discovery is in Preview. Use this form to submit your request today.
 {{< /callout >}}
 
-Service Discovery automatically detects services already running across your infrastructure that aren't yet instrumented with Datadog APM, highlighting gaps in your observability coverage. View all the unmonitored services in your fleet in one place, understand the importance of each service through contextual information such as infrastructure footprint, process command, resource consumption, and dependencies, and then close the gaps by instrumenting your services with [Single Step Instrumentation](#single-step-instrumentation-recommended).
+Service Discovery automatically detects services already running across your infrastructure that aren't yet instrumented with Datadog APM. It highlights gaps in your observability coverage so you know what to instrument next.
+
+With Service Discovery, you can:
+
+- View all the unmonitored services in your fleet in one place.
+- Understand the importance of each service through contextual information, such as infrastructure footprint, process command, resource consumption, and dependencies.
+- Close the gaps by instrumenting your services with [Single Step Instrumentation](#single-step-instrumentation-recommended).
+
+To qualify for this preview, you must meet the following requirements:
+
+- Run the Datadog Agent version 7.80 or later.
+- Run your services on Linux hosts.
+- Enable [Remote Configuration][11] and Remote Agent Management.
+- Not yet be using Datadog APM.
 
 ### Single step instrumentation (recommended)
 
@@ -191,4 +204,5 @@ The following tutorials guide you through setting up distributed tracing for a s
 [3]: /tracing/trace_collection/custom_instrumentation/
 [4]: /tracing/trace_collection/dynamic_instrumentation/
 [5]: /agent/
+[11]: /agent/remote_config/
 

--- a/content/en/tracing/trace_collection/_index.md
+++ b/content/en/tracing/trace_collection/_index.md
@@ -48,6 +48,14 @@ Application {{< tooltip glossary="instrumentation" >}} with Datadog APM involves
 <strong>Prefer vendor-neutral instrumentation?</strong> See the <a href="/opentelemetry/">OpenTelemetry documentation</a> for using OpenTelemetry with Datadog.
 </div>
 
+### Service Discovery
+
+{{< callout url="https://www.datadoghq.com/product-preview/service-discovery/" btn_hidden="false" header="Join the Preview!" >}}
+Service Discovery is in Preview. Use this form to submit your request today.
+{{< /callout >}}
+
+Service Discovery automatically detects services already running across your infrastructure that aren't yet instrumented with Datadog APM, highlighting gaps in your observability coverage. View all the unmonitored services in your fleet in one place, understand the importance of each service through contextual information such as infrastructure footprint, process command, resource consumption, and dependencies, and then close the gaps by instrumenting your services with [Single Step Instrumentation](#single-step-instrumentation-recommended).
+
 ### Single step instrumentation (recommended)
 
 [Single Step Instrumentation][1] (SSI) automatically installs and configures Datadog SDKs with a single command. Auto-instrumentation then immediately begins capturing traces from your supported frameworks and libraries, with no code changes required.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a **Service Discovery** section to the top of the *Getting started* area on the Application Instrumentation page (`/tracing/trace_collection/`). Service Discovery is a preview feature that detects services already running across a customer's infrastructure that aren't yet instrumented with Datadog APM, surfacing observability gaps. The section includes a preview signup callout and hands off to Single Step Instrumentation for enabling APM.

New anchor: `/tracing/trace_collection/#service-discovery`.

### Merge instructions

Draft PR — not ready for review or merge yet. Confirming the preview signup form URL before requesting review.

Merge readiness:
- [ ] Ready for merge

### AI assistance

Drafted with Claude Code (Claude Opus 4.8) — located the feature context, mirrored the existing Trace Patterns preview callout pattern, and wrote the section copy.

### Additional notes

Preview callout currently points to `https://www.datadoghq.com/product-preview/service-discovery/` (the URL used in the original Dec 2024 addition). To be confirmed against the live form before review.