### PR TITLE
[DOCS] Partition and Lookup Attributes — GA, limits, glossary

### DIFF
--- a/content/en/glossary/terms/lookup_attribute.md
+++ b/content/en/glossary/terms/lookup_attribute.md
@@ -1,0 +1,10 @@
+---
+id: lookup_attribute
+title: lookup attribute
+core_product:
+  - log management
+related_terms:
+  - partition_attribute
+  - archive_search
+---
+A lookup attribute creates an index for high-cardinality fields (such as `trace_id` or `user_id`) in log archives. When running an [Archive Search](/logs/explorer/archive_search/), Datadog uses this index to pinpoint specific logs without scanning the full archive, speeding up targeted investigations. You can configure up to 2 lookup attributes per archive.

--- a/content/en/glossary/terms/partition_attribute.md
+++ b/content/en/glossary/terms/partition_attribute.md
@@ -1,0 +1,10 @@
+---
+id: partition_attribute
+title: partition attribute
+core_product:
+  - log management
+related_terms:
+  - lookup_attribute
+  - archive_search
+---
+A partition attribute groups archived logs in storage by common field values (such as `service` or `env`). When running an [Archive Search](/logs/explorer/archive_search/), Datadog skips entire partitions that don't match the query, reducing the volume of data scanned. Use low-cardinality attributes as partition attributes. You can configure up to 2 partition attributes per archive.

--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -125,8 +125,8 @@ Archive Search scans archived log files within your selected time range. **Scan 
 To optimize performance and reduce costs:
 * **Narrow the time range:** Limit your search to the smallest window possible.
 * **Set Scan Limits:** Admins with `Logs Write Archives` permissions can set a maximum scan size per Archive in the {{< ui >}}Settings{{< /ui >}}.
-* **Use Partition Attributes (Preview):** The most effective way to accelerate searches on low-cardinality data like `service`, `env`, or `status`. Datadog skips entire partitions that don't match your query.
-* **Use Lookup Attributes (Preview):** The most effective way to accelerate searches on high-cardinality data like `trace_id` or `user_id`.
+* **Use Partition Attributes:** The most effective way to accelerate searches on low-cardinality data like `service`, `env`, or `status`. Datadog skips entire partitions that don't match your query. Up to 2 per archive.
+* **Use Lookup Attributes:** The most effective way to accelerate searches on high-cardinality data like `trace_id` or `user_id`. Up to 2 per archive.
 * **Use zstd compression:** Archives use zstd compression by default, which reduces scan volume and cloud egress costs compared to gzip. If your archive uses gzip, see [Log Archives][9] to switch to zstd.
 
 **Note**: Only logs archived after you configure Partition or Lookup attributes benefit from accelerated searches. Logs archived before this configuration are not affected.
@@ -234,6 +234,6 @@ In order to search log events from your archives, Datadog uses a service account
 [4]: https://app.datadoghq.com/logs/archive-search/new
 [5]: https://app.datadoghq.com/logs/archive-search/
 [6]: /logs/guide/logs-rbac/?tab=ui#restrict-access-to-logs
-[7]: /logs/log_configuration/archives/?tab=awss3#archive-search-lookup-attribute
-[8]: /logs/log_configuration/archives/?tab=awss3#archive-search-partition-attribute
+[7]: /logs/log_configuration/archives/?tab=awss3#archive-lookup-attribute
+[8]: /logs/log_configuration/archives/?tab=awss3#archive-partition-attribute
 [9]: /logs/log_configuration/archives/?tab=awss3#compression

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -240,21 +240,25 @@ Use this optional configuration step to define the maximum volume of log data (i
 
 For Archives with a maximum scan size defined, all users need to estimate the scan size before they are allowed to start an Archive Search or Rehydration. If the estimated scan size is greater than what is permitted for that Archive, users must reduce the time range of their request. Reducing the time range will reduce the scan size and allow the user to start the Archive Search or Rehydration.
 
-**Note**: To reduce the volume of data scanned during [Archive Search][16], consider configuring [Partition Attributes](#archive-search-partition-attribute) and [Lookup Attributes](#archive-lookup-attribute-preview) on your archive. Partition attributes narrow the search scope by skipping irrelevant data segments, while lookup attributes accelerate pinpointing specific log entries.
+**Note**: To reduce the volume of data scanned during [Archive Search][16], configure [Partition Attributes](#archive-partition-attribute) and [Lookup Attributes](#archive-lookup-attribute) on your archive. Partition attributes narrow the search scope by skipping irrelevant data segments, while lookup attributes accelerate pinpointing specific log entries.
 
-#### Archive Partition Attribute (Preview) {#archive-search-partition-attribute}
+#### Archive Partition Attribute {#archive-partition-attribute}
 
-To optimize how your archived logs are physically organized in storage (and accelerate [Archive Search][16]), configure partition attributes in your Datadog Archive.
+Partition attributes organize archived logs into groups based on common field values. Use them for broad filters to skip irrelevant archive segments and reduce scan volume during [Archive Search][16].
 
-* **Partition Attributes**: Add low-cardinality attributes such as `service`, `source`, `env`, or `status` that you frequently use as search filters.
-* **Benefit**: Logs sharing the same partition attribute values are co-located in storage. When searching, Datadog can skip entire partitions that don't match your query, drastically reducing the volume of data scanned.
+You can configure up to **2 partition attributes** per archive.
 
-#### Archive Lookup Attribute (Preview)
+* **Use for**: Low-cardinality attributes such as `service`, `source`, `env`, or `status` that you frequently use as search filters.
+* **How it works**: Logs sharing the same partition attribute values are co-located in storage. Datadog skips entire partitions that don't match your query, drastically reducing the volume of data scanned.
 
-To accelerate searches and investigations in your archives (with [Archive Search][16]), configure lookup attributes in your Datadog Archive.
+#### Archive Lookup Attribute {#archive-lookup-attribute}
 
-* **Lookup Attributes**: Add high-cardinality attributes such as `trace_id`, `container_id`, or `customer_id`.
-* **Benefit**: This allows you to pinpoint specific logs within your long-term storage much faster, reducing the time and data scanned during ad-hoc investigations.
+Lookup attributes create a fast path to logs with specific values. Use them for high-cardinality identifiers to speed up targeted investigations with [Archive Search][16].
+
+You can configure up to **2 lookup attributes** per archive.
+
+* **Use for**: High-cardinality attributes such as `trace_id`, `container_id`, `user_id`, or `request_id`.
+* **How it works**: Datadog builds an index for these attributes at write time, allowing Archive Search to pinpoint specific logs without scanning the full archive.
 
 **Partition vs. Lookup attributes**
 
@@ -262,8 +266,9 @@ To accelerate searches and investigations in your archives (with [Archive Search
 |---|---|---|
 | **Cardinality** | Low (tens to hundreds of values) | High (millions of values) |
 | **Typical attributes** | `service`, `source`, `env`, `status` | `trace_id`, `container_id`, `user_id`, `transaction_id` |
-| **How it helps** | Prunes entire partitions from scan | Pinpoints individual log entries within your archive |
+| **How it helps** | Skips entire partitions that don't match your query | Pinpoints specific log entries without scanning the full archive |
 | **Best used for** | Broad filtering by environment or service | Ad-hoc investigations on specific identifiers |
+| **Limit** | Up to 2 per archive | Up to 2 per archive |
 
 For maximum search performance, combine both: partition attributes narrow the search scope to the relevant data segments, while lookup attributes let you find specific logs within those segments instantly.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Partition and Lookup Attributes for Archive Search are now generally available. This PR updates the documentation to reflect the GA status, adds the attribute limit (2 of each per archive), and adds glossary entries for both terms.

**Changes:**

- **`logs/log_configuration/archives.md`**: Remove `(Preview)` labels from section headings, update anchor IDs (`#archive-partition-attribute` and `#archive-lookup-attribute`), add 2-attribute limit per archive, improve descriptions based on bug bash feedback (clearer distinction between partition vs. lookup use cases), add limit row to comparison table
- **`logs/explorer/archive_search.md`**: Remove `(Preview)` from optimization bullet points, add limit note, update anchor links to match new IDs
- **Glossary**: Add `partition_attribute` and `lookup_attribute` entries with `core_product: log management` and cross-references

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Anchor IDs were updated from `#archive-search-partition-attribute` / `#archive-lookup-attribute-preview` to `#archive-partition-attribute` / `#archive-lookup-attribute`. Old anchors from earlier PRs are updated in `archive_search.md`.