### PR TITLE
Update FIPS proxy version references to 1.1.28

### DIFF
--- a/content/en/agent/faq/fips_proxy.md
+++ b/content/en/agent/faq/fips_proxy.md
@@ -200,7 +200,7 @@ Ensure you add the `fips-proxy` sidecar container to your ECS task definition an
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.27",
+            "image": "datadog/fips-proxy:1.1.28",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Update FIPS proxy version to 1.1.28 to match last release

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->