### PR TITLE
Add TIA code coverage backfilling docs

### DIFF
--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -107,7 +107,7 @@ All file paths are considered to be relative to the root of the repository. You 
 
 If you use [Code Coverage][10] and Test Impact Analysis together, reported overall coverage can be skewed because Test Impact Analysis skips tests that do not need to run for the code change.
 
-Code coverage backfilling keeps coverage totals accurate by adjusting total reported coverage to include skipped tests or suites, so Test Impact Analysis savings do not distort coverage totals.
+Code coverage backfilling adjusts the total reported coverage to include tests or suites that were skipped, so Test Impact Analysis savings do not distort coverage totals.
 
 ### Java, .NET, and Go
 
@@ -115,7 +115,7 @@ With `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, no extra configurati
 
 ### JavaScript
 
-With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
+With `dd-trace-js`, backfilling requires uploading the code coverage report. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts the total reported coverage to include skipped tests or suites.
 
 ### Unsupported languages
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -115,17 +115,19 @@ With `dd-trace-java`, no extra configuration is required for backfilling. The li
 
 ### .NET
 
-With the .NET tracer, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+With `dd-trace-dotnet`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
 
 ### Go
 
-With the Go library, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+With `dd-trace-go`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
 
 ### JavaScript
 
-JavaScript requires code coverage report upload for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
+With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 
-This is different from Java, .NET, and Go, where the Datadog library automatically detects an existing code coverage engine.
+This is different from `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, where the Datadog library automatically detects an existing code coverage engine.
+
+### Unsupported languages
 
 Code coverage backfilling is not supported for Ruby, Python, or Swift.
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -103,6 +103,14 @@ All file paths are considered to be relative to the root of the repository. You 
 
 {{< img src="/getting_started/intelligent_test_runner/test-impact-analysis-gs-config-1.png" alt="Select branches to exclude and tracked files." style="width:80%" >}}
 
+## Code coverage backfilling
+
+If you use [Code Coverage][10] and Test Impact Analysis together, reported overall coverage can be skewed because Test Impact Analysis skips tests that do not need to run for the code change.
+
+To keep coverage totals accurate, enable code coverage upload in the [organization-level CI/CD Optimization settings][11]. When this setting is enabled, the Datadog library adjusts total reported coverage to include skipped tests or suites, so Test Impact Analysis savings do not distort coverage totals.
+
+Code coverage backfilling is supported for Java, .NET, and JavaScript.
+
 ## Explore test sessions
 
 You can explore the time savings you get from Test Impact Analysis by looking at the test commit page and test sessions panel.
@@ -136,3 +144,5 @@ The dashboard also tracks adoption of Test Impact Analysis throughout your organ
 [7]: https://app.datadoghq.com/ci/test-runs
 [8]: https://app.datadoghq.com/dash/integration/30941/ci-visibility-intelligent-test-runner
 [9]: /integrations/github/
+[10]: /code_coverage/
+[11]: https://app.datadoghq.com/ci/settings/ci-cd/repositories?tab=organization

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -109,6 +109,8 @@ If you use [Code Coverage][10] and Test Impact Analysis together, reported overa
 
 Code coverage backfilling adjusts the total reported coverage to include tests or suites that were skipped, so Test Impact Analysis savings do not distort coverage totals.
 
+Code coverage backfilling is supported for Java, .NET, Go, and JavaScript. It is not supported for Ruby, Python, or Swift.
+
 ### Java, .NET, and Go
 
 With `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, no extra configuration is required for backfilling. These libraries automatically detect when tests run with a code coverage engine and backfill code coverage data from tests skipped by Test Impact Analysis.
@@ -116,10 +118,6 @@ With `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, no extra configurati
 ### JavaScript
 
 With `dd-trace-js`, backfilling requires uploading the code coverage report. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts the total reported coverage to include skipped tests or suites.
-
-### Unsupported languages
-
-Code coverage backfilling is not supported for Ruby, Python, or Swift.
 
 ## Explore test sessions
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -109,21 +109,11 @@ If you use [Code Coverage][10] and Test Impact Analysis together, reported overa
 
 Code coverage backfilling keeps coverage totals accurate by adjusting total reported coverage to include skipped tests or suites, so Test Impact Analysis savings do not distort coverage totals.
 
-### Java
+### Java, .NET, and Go
 
-With `dd-trace-java`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
-
-### .NET
-
-With `dd-trace-dotnet`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
-
-### Go
-
-With `dd-trace-go`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+With `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, no extra configuration is required for backfilling. These libraries automatically detect when tests run with a code coverage engine and backfill code coverage data from tests skipped by Test Impact Analysis.
 
 ### JavaScript
-
-With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 
 With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -107,9 +107,21 @@ All file paths are considered to be relative to the root of the repository. You 
 
 If you use [Code Coverage][10] and Test Impact Analysis together, reported overall coverage can be skewed because Test Impact Analysis skips tests that do not need to run for the code change.
 
-To keep coverage totals accurate, enable code coverage upload in the [organization-level CI/CD Optimization settings][11]. When this setting is enabled, the Datadog library adjusts total reported coverage to include skipped tests or suites, so Test Impact Analysis savings do not distort coverage totals.
+Code coverage backfilling keeps coverage totals accurate by adjusting total reported coverage to include skipped tests or suites, so Test Impact Analysis savings do not distort coverage totals.
 
-Code coverage backfilling is supported for Java, .NET, and JavaScript.
+### Java
+
+With `dd-trace-java`, no extra configuration is required. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+
+### .NET
+
+With the .NET tracer, no extra configuration is required. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+
+### JavaScript
+
+JavaScript requires code coverage report upload for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
+
+This is different from Java and .NET, where the Datadog library automatically detects an existing code coverage engine.
 
 ## Explore test sessions
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -111,17 +111,23 @@ Code coverage backfilling keeps coverage totals accurate by adjusting total repo
 
 ### Java
 
-With `dd-trace-java`, no extra configuration is required. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+With `dd-trace-java`, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
 
 ### .NET
 
-With the .NET tracer, no extra configuration is required. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+With the .NET tracer, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
+
+### Go
+
+With the Go library, no extra configuration is required for backfilling. The library automatically detects when tests run with a code coverage engine and backfills code coverage data from tests skipped by Test Impact Analysis.
 
 ### JavaScript
 
 JavaScript requires code coverage report upload for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 
-This is different from Java and .NET, where the Datadog library automatically detects an existing code coverage engine.
+This is different from Java, .NET, and Go, where the Datadog library automatically detects an existing code coverage engine.
+
+Code coverage backfilling is not supported for Ruby, Python, or Swift.
 
 ## Explore test sessions
 

--- a/content/en/tests/test_impact_analysis/_index.md
+++ b/content/en/tests/test_impact_analysis/_index.md
@@ -125,7 +125,7 @@ With `dd-trace-go`, no extra configuration is required for backfilling. The libr
 
 With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 
-This is different from `dd-trace-java`, `dd-trace-dotnet`, and `dd-trace-go`, where the Datadog library automatically detects an existing code coverage engine.
+With `dd-trace-js`, code coverage report upload is required for backfilling. Enable code coverage upload in the [organization-level CI/CD Optimization settings][11] so the Datadog library adjusts total reported coverage to include skipped tests or suites.
 
 ### Unsupported languages
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a section to the Test Impact Analysis docs that explains code coverage backfilling when Code Coverage and Test Impact Analysis are used together.

The section describes how skipped tests can skew reported coverage totals, links to organization-level CI/CD Optimization settings, covers Java, .NET, Go, and JavaScript behavior, and notes that backfilling is not supported for Ruby, Python, or Swift.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Codex drafted the documentation update and prepared this PR.

### Additional notes

No Jira ticket.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
