### PR TITLE
Add warning to CSI Driver docs on upgrading to Datadog Operator 1.28.0

### DIFF
--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -172,7 +172,7 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 
 <div class="alert alert-warning">
 <strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 or v1.27.0</strong>
-<p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
+<p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver pods are unaffected.</p>
 </div>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -171,6 +171,13 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 {{% /collapse-content %}}
 
 <div class="alert alert-warning">
+<strong>Upgrading the Datadog Operator to v1.28.0 or later</strong>
+<p>In some cases, upgrading to Datadog Operator v1.28.0 or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. If the CSI Driver does not become ready after upgrading, recreate the object once:</p>
+<pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
+<p>The Operator recreates it automatically. Already-mounted volumes and running driver Pods are unaffected.</p>
+</div>
+
+<div class="alert alert-warning">
 <strong>Migrating from Helm-based CSI Driver installation</strong>
 <p>If you previously installed the CSI Driver with the standalone Helm chart, Datadog recommends migrating to Operator-managed installation. Choose one of the following approaches:</p>
 <ul>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -171,7 +171,7 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 {{% /collapse-content %}}
 
 <div class="alert alert-warning">
-<strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 and v1.27.0</strong>
+<strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 or v1.27.0</strong>
 <p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver pods are unaffected.</p>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -170,6 +170,8 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 
 {{% /collapse-content %}}
 
+#### Upgrade and migration notes
+
 <div class="alert alert-warning">
 <strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 or v1.27.0</strong>
 <p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the built-in Kubernetes <code>CSIDriver</code> object (not the <code>DatadogCSIDriver</code> custom resource) in a state that the Operator cannot reconcile. Remediate this issue by deleting the object:</p>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -184,14 +184,6 @@ If you previously installed the CSI Driver with the standalone Helm chart, Datad
 
 - **Let the Operator manage the CSI Driver**: Uninstall the Helm chart (`helm uninstall datadog-csi-driver`) and keep the default values for `csi.enabled` and `csi.autoManage`. The Operator automatically creates a new `DatadogCSIDriver` resource and deploys the driver.
 - **Keep managing the CSI Driver with Helm**: No action is required. The Operator detects the existing `k8s.csi.datadoghq.com` CSIDriver and defers to it, regardless of the `csi.autoManage` value. The Operator does not interfere with your existing Helm-managed driver. To make this intent explicit, set `csi.autoManage: false`.
-<div class="alert alert-warning">
-<strong>Migrating from Helm-based CSI Driver installation</strong>
-<p>If you previously installed the CSI Driver with the standalone Helm chart, Datadog recommends migrating to Operator-managed installation. Choose one of the following approaches:</p>
-<ul>
-<li><strong>Let the Operator manage the CSI Driver</strong>: Uninstall the Helm chart (<code>helm uninstall datadog-csi-driver</code>) and keep the default values for <code>csi.enabled</code> and <code>csi.autoManage</code>. The Operator automatically creates a new <code>DatadogCSIDriver</code> resource and deploys the driver.</li>
-<li><strong>Keep managing the CSI Driver with Helm</strong>: No action is required. The Operator detects the existing <code>k8s.csi.datadoghq.com</code> CSIDriver and defers to it, regardless of the <code>csi.autoManage</code> value. The Operator does not interfere with your existing Helm-managed driver. To make this intent explicit, set <code>csi.autoManage: false</code>.</li>
-</ul>
-</div>
 
 {{% collapse-content title="Legacy Helm-based installation (Operator < v1.26.0)" level="h4" id="legacy-helm-based-installation" %}}
 

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -170,15 +170,20 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 
 {{% /collapse-content %}}
 
-#### Upgrade and migration notes
+#### Upgrading to Datadog Operator v1.28.0+
 
 <div class="alert alert-warning">
-<strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 or v1.27.0</strong>
-<p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the built-in Kubernetes <code>CSIDriver</code> object (not the <code>DatadogCSIDriver</code> custom resource) in a state that the Operator cannot reconcile. Remediate this issue by deleting the object:</p>
+<p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the built-in Kubernetes <code>CSIDriver</code> object (not the <code>DatadogCSIDriver</code> custom resource) in a state that the Operator cannot reconcile. To resolve this issue, delete the object:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver pods are unaffected.</p>
 </div>
 
+#### Migrating from a Helm-based installation
+
+If you previously installed the CSI Driver with the standalone Helm chart, Datadog recommends migrating to Operator-managed installation. Choose one of the following approaches:
+
+- **Let the Operator manage the CSI Driver**: Uninstall the Helm chart (`helm uninstall datadog-csi-driver`) and keep the default values for `csi.enabled` and `csi.autoManage`. The Operator automatically creates a new `DatadogCSIDriver` resource and deploys the driver.
+- **Keep managing the CSI Driver with Helm**: No action is required. The Operator detects the existing `k8s.csi.datadoghq.com` CSIDriver and defers to it, regardless of the `csi.autoManage` value. The Operator does not interfere with your existing Helm-managed driver. To make this intent explicit, set `csi.autoManage: false`.
 <div class="alert alert-warning">
 <strong>Migrating from Helm-based CSI Driver installation</strong>
 <p>If you previously installed the CSI Driver with the standalone Helm chart, Datadog recommends migrating to Operator-managed installation. Choose one of the following approaches:</p>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -174,7 +174,7 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 <strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 and v1.27.0</strong>
 <p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
-<p>The Operator recreates it automatically. Already-mounted volumes and running driver Pods are unaffected.</p>
+<p>The Operator recreates it automatically. Already-mounted volumes and running driver pods are unaffected.</p>
 </div>
 
 <div class="alert alert-warning">

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -171,8 +171,8 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 {{% /collapse-content %}}
 
 <div class="alert alert-warning">
-<strong>Upgrading the Datadog Operator to v1.28.0 or later</strong>
-<p>In some cases, upgrading to Datadog Operator v1.28.0 or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. If the CSI Driver does not become ready after upgrading, recreate the object once:</p>
+<strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 and v1.27.0</strong>
+<p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by recreating the object once:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver Pods are unaffected.</p>
 </div>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -172,7 +172,7 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 
 <div class="alert alert-warning">
 <strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 or v1.27.0</strong>
-<p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
+<p>If you previously ran <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the built-in Kubernetes <code>CSIDriver</code> object (not the <code>DatadogCSIDriver</code> custom resource) in a state that the Operator cannot reconcile. Remediate this issue by deleting the object:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver pods are unaffected.</p>
 </div>

--- a/content/en/containers/kubernetes/csi_driver.md
+++ b/content/en/containers/kubernetes/csi_driver.md
@@ -172,7 +172,7 @@ If you need configuration options not exposed through the `DatadogAgent` spec (f
 
 <div class="alert alert-warning">
 <strong>Upgrading the Datadog Operator to v1.28.0+ from v1.26.0 and v1.27.0</strong>
-<p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by recreating the object once:</p>
+<p>If previously running <code>v1.26.0</code> or <code>v1.27.0</code>, upgrading to Datadog Operator <code>v1.28.0</code> or later can leave the existing <code>k8s.csi.datadoghq.com</code> CSIDriver object in a state that the Operator cannot reconcile. Remediate by deleting the object once:</p>
 <pre><code>kubectl delete csidriver k8s.csi.datadoghq.com</code></pre>
 <p>The Operator recreates it automatically. Already-mounted volumes and running driver Pods are unaffected.</p>
 </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR is in motivation to document a workaround for users upgrading the Datadog Operator to 1.28.0+ if they run into reconciliation issues with the DatadogCSIDriver.

### Merge readiness

- [x] Ready for merge

### AI assistance

Checked grammar and placement with Claude.