### PR TITLE
Bump geo-locate

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,3 @@ Merging to `master` triggers an automatic deployment. This process typically beg
 [19]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 [20]: https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/3960766866/Build+setup+guide
 [21]: https://www.highviewapps.com/kb/how-do-i-find-my-slack-username/
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ Merging to `master` triggers an automatic deployment. This process typically beg
 [19]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 [20]: https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/3960766866/Build+setup+guide
 [21]: https://www.highviewapps.com/kb/how-do-i-find-my-slack-username/
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v4.4.2.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
-        "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz",
+        "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.3.tgz",
         "highlight.js": "^11.11.1",
         "hugo-bin": "0.148.0",
         "instantsearch.js": "^4.74.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7756,7 +7756,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^2.5.1"
     eslint-plugin-standard: "npm:^4.1.0"
     fancy-log: "npm:^1.3.3"
-    geo-locate: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz"
+    geo-locate: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.3.tgz"
     highlight.js: "npm:^11.11.1"
     hugo-bin: "npm:0.148.0"
     husky: "npm:^9.1.7"
@@ -9557,10 +9557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"geo-locate@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz":
-  version: 1.0.2
-  resolution: "geo-locate@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz"
-  checksum: 10/95a0d22e57f0dbbab3de2bca2f0ac3971faf90e2b67b5d7d3cd796026e90e30aa7b88776ec9715760bc88e53af2865e921eb96b030d5be0996eed99c8105a62c
+"geo-locate@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.3.tgz":
+  version: 1.0.3
+  resolution: "geo-locate@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.3.tgz"
+  checksum: 10/8c7ba0e00ce2863dc9c4ac83712cb6df8668dd04fb29cf7b046f8f26df7f9b16b821e92aa940b6f6ed900fc862778a974b31ecb553c7852e38b7417113ebec3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
Bump geo-locate version for new UK1 DC

### Motivation
https://datadoghq.atlassian.net/browse/WEB-9087

### Testing
https://docs-staging.datadoghq.com/ccole/bump-geo-locate-vers/

1. In dev tools, set value to `uk1`

<img width="1328" height="135" alt="Screenshot 2026-07-08 at 10 48 34 AM" src="https://github.com/user-attachments/assets/f434f735-30fb-40ce-be54-1c59825be0db" />

3. Refresh page
4. Click `Get Started Free` CTA

Expect: The default region selected should be UK1