### PR TITLE
[CONTP-1795] Add agent performance metrics to agent telemetry page

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -235,6 +235,11 @@ agent diagnose show-metadata agent-telemetry
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 | appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
+| **Agent Performance**                       |                                                                                                                        |
+| kubernetes_agent.containers_restarts        | Sum of container restart counts for Datadog Cluster Agent and Cluster Checks Runner pods                              |
+| kubernetes_agent.containers_terminated      | Sum of kubelet container terminated-state metrics for Datadog Cluster Agent and Cluster Checks Runner pods, preserving the `reason` tag |
+| kubernetes_agent.memory_usage               | Sum of container runtime memory usage for Datadog Cluster Agent and Cluster Checks Runner pods                        |
+| kubernetes_agent.memory_limit               | Sum of container runtime memory limits for Datadog Cluster Agent and Cluster Checks Runner pods                       |
 | **eBPF**                                    |                                                                                                                        |
 | ebpf.core_load_success                      | Number of successful loads of an eBPF CO-RE program                                                                    |
 | ebpf.core_load_error                        | Number of errors loading an eBPF CO-RE program                                                                         |

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -236,9 +236,9 @@ agent diagnose show-metadata agent-telemetry
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 | appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
 | agent_performance.containers_restarts       | Number of container restarts for the Cluster Agent and Cluster Checks Runner pods                                      |
-| agent_performance.containers_terminated     | Number of container terminations for Cluster Agent and Cluster Checks Runner pods, tagged by reason                    |
-| agent_performance.memory_usage              | Total container runtime memory usage, in bytes, for Cluster Agent and Cluster Checks Runner pods                       |
-| agent_performance.memory_limit              | Total container runtime memory limits, in bytes, for Cluster Agent and Cluster Checks Runner pods                      |
+| agent_performance.containers_terminated     | Number of container terminations for the Cluster Agent and Cluster Checks Runner pods, tagged by reason                |
+| agent_performance.memory_usage              | Total container runtime memory usage, in bytes, for the Cluster Agent and Cluster Checks Runner pods                   |
+| agent_performance.memory_limit              | Total container runtime memory limits, in bytes, for the Cluster Agent and Cluster Checks Runner pods                  |
 | **eBPF**                                    |                                                                                                                        |
 | ebpf.core_load_success                      | Number of successful loads of an eBPF CO-RE program                                                                    |
 | ebpf.core_load_error                        | Number of errors loading an eBPF CO-RE program                                                                         |

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -235,10 +235,10 @@ agent diagnose show-metadata agent-telemetry
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 | appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
-| agent_performance.containers_restarts       | Sum of container restart counts for Datadog Cluster Agent and Cluster Checks Runner pods                              |
-| agent_performance.containers_terminated     | Sum of container terminations for Datadog Cluster Agent and Cluster Checks Runner pods, tagged by reason               |
-| agent_performance.memory_usage              | Sum of container runtime memory usage for Datadog Cluster Agent and Cluster Checks Runner pods                        |
-| agent_performance.memory_limit              | Sum of container runtime memory limits for Datadog Cluster Agent and Cluster Checks Runner pods                       |
+| agent_performance.containers_restarts       | Number of container restarts for the Cluster Agent and Cluster Checks Runner pods                                      |
+| agent_performance.containers_terminated     | Number of container terminations for Cluster Agent and Cluster Checks Runner pods, tagged by reason                    |
+| agent_performance.memory_usage              | Total container runtime memory usage, in bytes, for Cluster Agent and Cluster Checks Runner pods                       |
+| agent_performance.memory_limit              | Total container runtime memory limits, in bytes, for Cluster Agent and Cluster Checks Runner pods                      |
 | **eBPF**                                    |                                                                                                                        |
 | ebpf.core_load_success                      | Number of successful loads of an eBPF CO-RE program                                                                    |
 | ebpf.core_load_error                        | Number of errors loading an eBPF CO-RE program                                                                         |

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -235,11 +235,10 @@ agent diagnose show-metadata agent-telemetry
 | workloadmeta.pull_errors                    | Number of WorkloadMeta pull errors                                                                                     |
 | appsec_injector.watched_changes             | Number of changes detected by the AppSec injector for watched resources                                                |
 | appsec_injector.sidecar_mutations           | Number of AppSec injector sidecar admission outcomes (pod mutation and deletion)                                       |
-| **Agent Performance**                       |                                                                                                                        |
-| kubernetes_agent.containers_restarts        | Sum of container restart counts for Datadog Cluster Agent and Cluster Checks Runner pods                              |
-| kubernetes_agent.containers_terminated      | Sum of kubelet container terminated-state metrics for Datadog Cluster Agent and Cluster Checks Runner pods, preserving the `reason` tag |
-| kubernetes_agent.memory_usage               | Sum of container runtime memory usage for Datadog Cluster Agent and Cluster Checks Runner pods                        |
-| kubernetes_agent.memory_limit               | Sum of container runtime memory limits for Datadog Cluster Agent and Cluster Checks Runner pods                       |
+| agent_performance.containers_restarts       | Sum of container restart counts for Datadog Cluster Agent and Cluster Checks Runner pods                              |
+| agent_performance.containers_terminated     | Sum of container terminations for Datadog Cluster Agent and Cluster Checks Runner pods, tagged by reason               |
+| agent_performance.memory_usage              | Sum of container runtime memory usage for Datadog Cluster Agent and Cluster Checks Runner pods                        |
+| agent_performance.memory_limit              | Sum of container runtime memory limits for Datadog Cluster Agent and Cluster Checks Runner pods                       |
 | **eBPF**                                    |                                                                                                                        |
 | ebpf.core_load_success                      | Number of successful loads of an eBPF CO-RE program                                                                    |
 | ebpf.core_load_error                        | Number of errors loading an eBPF CO-RE program                                                                         |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

- Add the Agent Performance metric group to the Data Security Agent metrics table.
- Document restart, termination, memory usage, and memory limit metrics for the Datadog Cluster Agent and Cluster Checks Runner pods.

Relates to https://github.com/DataDog/datadog-agent/pull/53321

### Merge readiness

- [ ] Agent version `7.82` is released
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. --> 