### PR TITLE
[WEB-9543] Add `prodname` shortcode to protect product names from translation.

### DIFF
--- a/layouts/shortcodes/notranslate.html
+++ b/layouts/shortcodes/notranslate.html
@@ -1,0 +1,1 @@
+<span class="notranslate">{{- .Inner -}}</span>

--- a/layouts/shortcodes/notranslate.html
+++ b/layouts/shortcodes/notranslate.html
@@ -1,1 +1,0 @@
-<span class="notranslate">{{- .Inner -}}</span>

--- a/layouts/shortcodes/prodname.html
+++ b/layouts/shortcodes/prodname.html
@@ -1,0 +1,1 @@
+<span class="prodname">{{- .Inner -}}</span>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
docs editors can use `{{< prodname >}}...{{< /prodname >}}` tags to ensure product names are not localized by the AI translation engine.  

### Merge readiness

- [] Ready for merge

<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

This is essentially a no-op.   It's usage would be the same as https://github.com/DataDog/documentation/blob/master/layouts/shortcodes/ui.html
