### PR TITLE
docs(agent): document stack trace aggregation for auto multi-line detection

### DIFF
--- a/content/en/agent/logs/auto_multiline_detection.md
+++ b/content/en/agent/logs/auto_multiline_detection.md
@@ -285,7 +285,7 @@ DD_LOGS_CONFIG_AUTO_MULTI_LINE_ENABLE_JSON_AGGREGATION=false
 
 ## Stack trace aggregation
 
-In Datadog Agent version 7.81+, multi-line go stack traces are automatically detected and aggregated into a single log.
+In Datadog Agent version 7.81+, multi-line Go stack traces are automatically detected and aggregated into a single log.
 
 For example, the following log:
 

--- a/content/en/agent/logs/auto_multiline_detection.md
+++ b/content/en/agent/logs/auto_multiline_detection.md
@@ -283,6 +283,50 @@ DD_LOGS_CONFIG_AUTO_MULTI_LINE_ENABLE_JSON_AGGREGATION=false
 {{% /tab %}}
 {{< /tabs >}}
 
+## Stack trace aggregation
+
+In Datadog Agent version 7.81+, multi-line go stack traces are automatically detected and aggregated into a single log.
+
+For example, the following log:
+
+```
+panic: INVALID ADDRESS runtime error: invalid memory address or nil pointer dereference [iter=249]
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x45e1f2]
+
+goroutine 1 [running]:
+main.doWork(0x0)
+	/app/main.go:24 +0x1d
+main.run(...)
+	/app/main.go:18
+main.main()
+	/app/main.go:14 +0x2c
+```
+
+is automatically aggregated into a single log instead of being split into separate lines.
+
+Like JSON aggregation, stack trace aggregation is enabled automatically when auto multi-line detection is enabled.
+
+You can disable stack trace aggregation by setting `stack_trace_parsers` to an empty list. By default, it is set to `["go"]`:
+
+{{< tabs >}}
+{{% tab "Configuration file" %}}
+
+```yaml
+logs_config:
+  auto_multi_line:
+    stack_trace_parsers: []
+```
+
+{{% /tab %}}
+{{% tab "Environment Variable" %}}
+
+```shell
+DD_LOGS_CONFIG_AUTO_MULTI_LINE_STACK_TRACE_PARSERS='[]'
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Advanced customization
 
@@ -366,6 +410,7 @@ You can search for this tag by querying `aggregated_json:true` in the Logs Explo
 | `logs_config.auto_multi_line.enable_datetime_detection` | Bool | True | Enable datetime detection |
 | `logs_config.auto_multi_line.timestamp_detector_match_threshold` | Float | 0.5 | Timestamp matching threshold |
 | `logs_config.auto_multi_line.tokenizer_max_input_bytes` | Int | 60 | Bytes to tokenize |
+| `logs_config.auto_multi_line.stack_trace_parsers` | List | `["go"]` | Stack trace parsers to use for aggregation. Set to `[]` to disable. |
 
 
 ## Further reading

--- a/content/en/agent/logs/auto_multiline_detection.md
+++ b/content/en/agent/logs/auto_multiline_detection.md
@@ -287,7 +287,7 @@ DD_LOGS_CONFIG_AUTO_MULTI_LINE_ENABLE_JSON_AGGREGATION=false
 
 In Datadog Agent version 7.81+, multi-line Go stack traces are automatically detected and aggregated into a single log.
 
-For example, the following log:
+For example, auto multi-line detection aggregates the following stack trace into a single log instead of splitting it into separate lines:
 
 ```
 panic: INVALID ADDRESS runtime error: invalid memory address or nil pointer dereference [iter=249]

--- a/content/en/agent/logs/auto_multiline_detection.md
+++ b/content/en/agent/logs/auto_multiline_detection.md
@@ -302,7 +302,6 @@ main.main()
 	/app/main.go:14 +0x2c
 ```
 
-is automatically aggregated into a single log instead of being split into separate lines.
 
 Like JSON aggregation, stack trace aggregation is enabled automatically when auto multi-line detection is enabled.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the new **Stack trace aggregation** feature (Datadog Agent **7.81+**) on the Auto Multi-line Detection and Aggregation page.

- Adds a **Stack trace aggregation** section below the JSON aggregation section, following the same format.
- Explains that stack trace aggregation is enabled automatically alongside auto multi-line detection (like JSON aggregation), and can be disabled by setting `logs_config.auto_multi_line.stack_trace_parsers` to `[]` (default `["go"]`).
- Adds the `stack_trace_parsers` setting to the Configuration reference table.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Cursor: located the existing docs, wrote the new section to mirror the JSON aggregation format, and updated the configuration reference table.

### Additional notes