### PR TITLE
Harden pre-commit/pre-push hooks against master bypass

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,6 +10,17 @@ if [ "$branch" = "master" ]; then
   exit 1
 fi
 
+# If HEAD is detached, `git branch --show-current` returns empty and the
+# check above silently passes even when HEAD points at master's tip.
+if [ -z "$branch" ]; then
+  head_sha=$(git rev-parse HEAD)
+  master_sha=$(git rev-parse refs/heads/master 2>/dev/null)
+  if [ -n "$master_sha" ] && [ "$head_sha" = "$master_sha" ]; then
+    echo "${YELLOW}You're in a detached HEAD at master's tip. Check out a feature branch instead.${ENDCOLOR}"
+    exit 1
+  fi
+fi
+
 # Check for circular aliases in markdown files
 echo "Checking for circular aliases..."
 python3 .husky/check-circular-aliases.py

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,13 @@
-branch=$(git branch --show-current)
-
 YELLOW="\033[1;33m"
 ENDCOLOR="\033[0m"
 WHITE="\033[1m"
 
-# If the current branch is master, abort the push
-if [ "$branch" = "master" ]; then
-  echo "${YELLOW}You're trying to push to master. Use a feature branch instead.${ENDCOLOR}"
-  exit 1
-fi
+# Block any push whose destination ref is master, regardless of the local
+# branch name (covers detached HEAD, differently-named local branches, and
+# explicit refspecs like `push origin HEAD:master`).
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$remote_ref" = "refs/heads/master" ]; then
+    echo "${YELLOW}You're trying to push to master. Use a feature branch instead.${ENDCOLOR}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `pre-commit` and `pre-push` hooks in `.husky/` only checked the current local branch name against `master`. This check silently passes when:

- HEAD is detached (`git branch --show-current` returns an empty string)
- A differently-named local branch is pushed straight to `master` via an explicit refspec (e.g. `git push origin HEAD:master` or `some-branch:master`)

This PR hardens both hooks:

- `pre-push` now reads the actual destination ref from stdin (the standard git pre-push hook input) and blocks any push whose destination is `refs/heads/master`, regardless of the local branch name.
- `pre-commit` additionally blocks committing while in a detached HEAD state that sits at `master`'s current tip.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Verified in an isolated sandbox repository against several scenarios: same-named branch push, differently-named branch pushed via explicit refspec, detached HEAD push, detached HEAD commit, and normal feature-branch commit/push (unaffected).