### PR TITLE
[DOCS-13570] Remove `=` from log search special characters list

### DIFF
--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -77,7 +77,7 @@ Use the syntax `*:search_term` to perform a full-text search across all log attr
 
 ## Escape special characters and spaces
 
-The following characters are considered special and require escaping with the `\` character: `=` `-` `!` `&&` `||` `>` `>=` `<` `<=` `(` `)` `{` `}` `[` `]` `"` `*` `?` `:` `\` `#`, and spaces.
+The following characters are considered special and require escaping with the `\` character: `-` `!` `&&` `||` `>` `>=` `<` `<=` `(` `)` `{` `}` `[` `]` `"` `*` `?` `:` `\` `#`, and spaces.
 - `/` is not considered a special character and doesn't need to be escaped.
 - `@` cannot be used in search queries within Logs Explorer because it is reserved for [Attribute Search](#attributes-search).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-13570

Removes `=` from the list of special characters requiring escaping in log search queries. Testing against Logs Explorer confirmed `=` does not need escaping — an unquoted, unescaped query for a value containing `=` returned the same results as the quoted and escaped versions.

`=` was added back to this list in #34990 to align with an internal wiki page, but that page turned out to be a stale copy of this doc's pre-#31006 text. #31006 had already removed `=` (along with a few other characters) after an engineer manually tested against the live app, so this PR reverts to that previously tested and verified version.

The internal wiki page is also being updated to match, so both sources stay in sync.

### Merge readiness

- [X] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to investigate the discrepancy (git history, prior PRs) and draft the fix; verification testing in Logs Explorer was done manually.

### Additional notes

