### PR TITLE
Document mobile feature flag state changes

### DIFF
--- a/content/en/feature_flags/client/android.md
+++ b/content/en/feature_flags/client/android.md
@@ -253,6 +253,8 @@ Flag details help you debug evaluation behavior and understand why a user receiv
 
 ## Observe provider events
 
+<div class="alert alert-info">Provider event observation is available in <code>dd-sdk-android-flags-openfeature</code> 3.6.0 and later. Use the same version for <code>dd-sdk-android-flags</code>.</div>
+
 Use `OpenFeatureAPI.observe()` to react to provider state changes. The Datadog OpenFeature provider emits `ProviderReady`, `ProviderStale`, and `ProviderError` based on the underlying `FlagsClient` state.
 
 {{< code-block lang="kotlin" >}}
@@ -399,6 +401,8 @@ flagsClient.setEvaluationContext(
 This method fetches flag assignments from the server asynchronously in the background. The operation is non-blocking and thread-safe. Flag updates are available for subsequent evaluations after the background operation completes.
 
 ### Observe direct client state changes
+
+<div class="alert alert-info">Direct client state observation with <code>flagsClient.state</code> is available in <code>dd-sdk-android-flags</code> 3.4.0 and later.</div>
 
 Use `flagsClient.state` to check the current direct-client state or register a listener for state changes:
 

--- a/content/en/feature_flags/client/android.md
+++ b/content/en/feature_flags/client/android.md
@@ -251,6 +251,45 @@ Similar detail methods exist for other types: `getBooleanDetails()`, `getInteger
 
 Flag details help you debug evaluation behavior and understand why a user received a given value.
 
+## Observe provider events
+
+Use `OpenFeatureAPI.observe()` to react to provider state changes. The Datadog OpenFeature provider emits `ProviderReady`, `ProviderStale`, and `ProviderError` based on the underlying `FlagsClient` state.
+
+{{< code-block lang="kotlin" >}}
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+val stateJob = lifecycleScope.launch {
+    OpenFeatureAPI.observe<OpenFeatureProviderEvents>()
+        .catch {
+            // Handle Flow collection errors.
+        }
+        .collect { event ->
+            when (event) {
+                is OpenFeatureProviderEvents.ProviderReady -> {
+                    // The provider is ready to evaluate flags.
+                }
+                is OpenFeatureProviderEvents.ProviderStale -> {
+                    // Cached assignments are available, but they may be out of date.
+                }
+                is OpenFeatureProviderEvents.ProviderError -> {
+                    // The provider cannot evaluate flags.
+                }
+                is OpenFeatureProviderEvents.ProviderConfigurationChanged -> {
+                    // The provider configuration changed.
+                }
+                else -> {
+                    // Handle other OpenFeature provider events as needed.
+                }
+            }
+        }
+}
+{{< /code-block >}}
+
+Cancel the collection job when the observing component stops. For example, collect from `lifecycleScope` in an Android `Activity` or `Fragment`, or from `viewModelScope` in a `ViewModel`.
+
 ## Advanced configuration
 
 ### Global configuration
@@ -358,6 +397,43 @@ flagsClient.setEvaluationContext(
 {{< /code-block >}}
 
 This method fetches flag assignments from the server asynchronously in the background. The operation is non-blocking and thread-safe. Flag updates are available for subsequent evaluations after the background operation completes.
+
+### Observe direct client state changes
+
+Use `flagsClient.state` to check the current direct-client state or register a listener for state changes:
+
+{{< code-block lang="kotlin" >}}
+import com.datadog.android.flags.FlagsStateListener
+import com.datadog.android.flags.model.FlagsClientState
+
+val listener = object : FlagsStateListener {
+    override fun onStateChanged(newState: FlagsClientState) {
+        when (newState) {
+            FlagsClientState.NotReady -> {
+                // The client has not loaded assignments yet.
+            }
+            FlagsClientState.Reconciling -> {
+                // The client is fetching assignments for a context change.
+            }
+            FlagsClientState.Ready -> {
+                // Assignments are loaded and available for evaluation.
+            }
+            FlagsClientState.Stale -> {
+                // Cached assignments are available, but the latest fetch failed.
+            }
+            is FlagsClientState.Error -> {
+                // No assignments are available for evaluation.
+            }
+        }
+    }
+}
+
+flagsClient.state.addListener(listener)
+
+val currentState = flagsClient.state.getCurrentState()
+{{< /code-block >}}
+
+The listener receives the current state when it is registered, then receives future state changes. Keep the callback fast and dispatch long-running work to another thread. Call `flagsClient.state.removeListener(listener)` when the observing component stops.
 
 ### Evaluate flags (FlagsClient)
 

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -412,6 +412,7 @@ final class FeatureFlagEventObserver {
             switch event {
             case .ready:
                 // The provider is ready to evaluate flags.
+                break
             case .stale:
                 // Cached assignments are available, but they may be out of date.
             case .error(_, _):

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -257,6 +257,8 @@ Flag details may help you debug evaluation behavior and understand why a user re
 
 ## Observe state changes
 
+<div class="alert alert-info">State observation with <code>FlagsClient.state</code> is available in <code>dd-sdk-ios</code> 3.11.0 and later.</div>
+
 Use `flagsClient.state` to check whether a `FlagsClient` is ready to evaluate flags and to react when its state changes. State changes occur when you call `setEvaluationContext` and the SDK fetches assignments for that context.
 
 {{< code-block lang="swift" >}}
@@ -296,7 +298,7 @@ The examples above use Datadog's `FlagsClient` API directly. If you prefer the [
 Add `dd-openfeature-provider-swift` to your `Package.swift`:
 
 {{< code-block lang="swift" filename="Package.swift" >}}
-.package(url: "https://github.com/DataDog/dd-openfeature-provider-swift.git", .upToNextMajor(from: "0.1.0"))
+.package(url: "https://github.com/DataDog/dd-openfeature-provider-swift.git", .upToNextMajor(from: "0.2.0"))
 {{< /code-block >}}
 
 Link the `DatadogOpenFeatureProvider` product to your app target. The bridge depends on OpenFeature Swift SDK 0.3.0.
@@ -388,6 +390,8 @@ print(details.errorCode) // Error code, if evaluation failed
 {{< /code-block >}}
 
 ### Observe provider events
+
+<div class="alert alert-info">Provider event observation for the Datadog OpenFeature provider is available in <code>dd-openfeature-provider-swift</code> 0.2.0 and later. Version 0.2.0 depends on <code>dd-sdk-ios</code> 3.13.0 or later.</div>
 
 Use `OpenFeatureAPI.shared.observe()` to react to OpenFeature provider events. The Datadog OpenFeature provider emits `.ready`, `.stale`, and `.error` based on the underlying `FlagsClient` state. The OpenFeature SDK can also emit life cycle events such as `.reconciling` and `.contextChanged` when the evaluation context changes.
 

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -270,12 +270,16 @@ final class FeatureFlagStateObserver: FlagsStateListener {
             break
         case .reconciling:
             // The client is fetching assignments for a context change.
+            break
         case .ready:
             // Assignments are loaded and available for evaluation.
+            break
         case .stale:
             // Cached assignments are available, but the latest fetch failed.
+            break
         case .error:
             // No assignments are available for evaluation.
+            break
         }
     }
 }

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -255,6 +255,36 @@ print(details.error)    // The error that occurred during evaluation, if any
 
 Flag details may help you debug evaluation behavior and understand why a user received a given value.
 
+## Observe state changes
+
+Use `flagsClient.state` to check whether a `FlagsClient` is ready to evaluate flags and to react when its state changes. State changes occur when you call `setEvaluationContext` and the SDK fetches assignments for that context.
+
+{{< code-block lang="swift" >}}
+final class FeatureFlagStateObserver: FlagsStateListener {
+    func flagsStateDidChange(_ newState: FlagsClientState) {
+        switch newState {
+        case .notReady:
+            // The client has not loaded assignments yet.
+        case .reconciling:
+            // The client is fetching assignments for a context change.
+        case .ready:
+            // Assignments are loaded and available for evaluation.
+        case .stale:
+            // Cached assignments are available, but the latest fetch failed.
+        case .error:
+            // No assignments are available for evaluation.
+        }
+    }
+}
+
+let observer = FeatureFlagStateObserver()
+flagsClient.state.addListener(observer)
+
+let currentState = flagsClient.state.currentState
+{{< /code-block >}}
+
+Keep a strong reference to the listener for as long as you want to receive updates. The listener receives the current state when it is registered, then receives future state changes.
+
 ## Use with OpenFeature
 
 The examples above use Datadog's `FlagsClient` API directly. If you prefer the [OpenFeature](https://openfeature.dev/) standard API, Datadog ships an OpenFeature provider for iOS that wraps `FlagsClient` and exposes it through `OpenFeatureAPI.shared`. The same flag data is served through either surface; pick whichever API fits your app.
@@ -355,6 +385,42 @@ print(details.value)    // Evaluated value
 print(details.variant)  // Variant name, if applicable
 print(details.reason)   // Reason (for example: "TARGETING_MATCH" or "DEFAULT")
 print(details.errorCode) // Error code, if evaluation failed
+{{< /code-block >}}
+
+### Observe provider events
+
+Use `OpenFeatureAPI.shared.observe()` to react to OpenFeature provider events. The Datadog OpenFeature provider emits `.ready`, `.stale`, and `.error` based on the underlying `FlagsClient` state. The OpenFeature SDK can also emit life cycle events such as `.reconciling` and `.contextChanged` when the evaluation context changes.
+
+{{< code-block lang="swift" >}}
+import Combine
+import OpenFeature
+
+final class FeatureFlagEventObserver {
+    private var cancellable: AnyCancellable?
+
+    func startObserving() {
+        cancellable = OpenFeatureAPI.shared.observe().sink { event in
+            guard let event else {
+                return
+            }
+
+            switch event {
+            case .ready:
+                // The provider is ready to evaluate flags.
+            case .stale:
+                // Cached assignments are available, but they may be out of date.
+            case .error(_, _):
+                // The provider cannot evaluate flags.
+            case .reconciling:
+                // The provider is reconciling after a context change.
+            case .contextChanged:
+                // The context change completed.
+            case .configurationChanged:
+                // The provider configuration changed.
+            }
+        }
+    }
+}
 {{< /code-block >}}
 
 ## Advanced configuration

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -267,6 +267,7 @@ final class FeatureFlagStateObserver: FlagsStateListener {
         switch newState {
         case .notReady:
             // The client has not loaded assignments yet.
+            break
         case .reconciling:
             // The client is fetching assignments for a context change.
         case .ready:

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -394,7 +394,7 @@ print(details.errorCode) // Error code, if evaluation failed
 
 <div class="alert alert-info">Provider event observation for the Datadog OpenFeature provider is available in <code>dd-openfeature-provider-swift</code> 0.2.0 and later. Version 0.2.0 depends on <code>dd-sdk-ios</code> 3.13.0 or later.</div>
 
-Use `OpenFeatureAPI.shared.observe()` to react to OpenFeature provider events. The Datadog OpenFeature provider emits `.ready`, `.stale`, and `.error` based on the underlying `FlagsClient` state. The OpenFeature SDK can also emit life cycle events such as `.reconciling` and `.contextChanged` when the evaluation context changes.
+Use `OpenFeatureAPI.shared.observe()` to react to OpenFeature provider events. The Datadog OpenFeature provider emits `.ready`, `.stale`, and `.error` based on the underlying `FlagsClient` state. The OpenFeature SDK can also emit lifecycle events such as `.reconciling` and `.contextChanged` when the evaluation context changes.
 
 {{< code-block lang="swift" >}}
 import Combine

--- a/content/en/feature_flags/client/ios.md
+++ b/content/en/feature_flags/client/ios.md
@@ -415,14 +415,19 @@ final class FeatureFlagEventObserver {
                 break
             case .stale:
                 // Cached assignments are available, but they may be out of date.
+                break
             case .error(_, _):
                 // The provider cannot evaluate flags.
+                break
             case .reconciling:
                 // The provider is reconciling after a context change.
+                break
             case .contextChanged:
                 // The context change completed.
+                break
             case .configurationChanged:
                 // The provider configuration changed.
+                break
             }
         }
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

#### Motivation

Mobile Feature Flags users can observe provider and client state changes, but the iOS and Android setup pages did not show how to wire those callbacks. This adds customer-facing examples for reacting to ready, stale, and error states.

#### Changes and Decisions

This PR adds an iOS `FlagsClient.state` listener example and an OpenFeature `observe()` example for the iOS bridge. It also adds Android OpenFeature Flow observation and direct `FlagsClient` listener examples.

The Android page keeps OpenFeature as the recommended path and places direct client state observation in the advanced section, matching the existing page structure.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

No Jira issue was provided.

Validation:
- `/tmp/docs-vale-venv/bin/vale content/en/feature_flags/client/ios.md content/en/feature_flags/client/android.md` (0 errors; existing warnings and suggestions remain in pre-existing page text)
- `git diff --check`