### PR TITLE
[FFL-2653] Document Ruby flag evaluation metrics setup

### DIFF
--- a/content/en/feature_flags/guide/server_flag_evaluation_metrics.md
+++ b/content/en/feature_flags/guide/server_flag_evaluation_metrics.md
@@ -69,6 +69,8 @@ gem "opentelemetry-exporter-otlp-metrics", ">= 0.4"
 
 Install the gems with `bundle install`. These gems provide the OpenTelemetry meter provider and OTLP metrics exporter. The Ruby tracer uses them when `DD_METRICS_OTEL_ENABLED=true` is set. If the gems are missing, the Ruby tracer does not emit `feature_flag.evaluations` metrics and logs `Failed to load OpenTelemetry metrics gems`.
 
+### Endpoint configuration
+
 By default, most tracers send OTLP metrics to the Agent at `DD_AGENT_HOST` on port `4318` (HTTP). If your application already sets `DD_AGENT_HOST` to reach the Agent, no endpoint configuration is required.
 
 Set an OTLP endpoint explicitly in any of these cases:

--- a/content/en/feature_flags/guide/server_flag_evaluation_metrics.md
+++ b/content/en/feature_flags/guide/server_flag_evaluation_metrics.md
@@ -58,6 +58,17 @@ Set the following environment variable on your application, in addition to the s
 DD_METRICS_OTEL_ENABLED=true
 {{< /code-block >}}
 
+### Ruby: Add the OpenTelemetry metrics gems
+
+For Ruby applications, add the OpenTelemetry metrics SDK and OTLP metrics exporter gems to your application bundle:
+
+{{< code-block lang="ruby" filename="Gemfile" >}}
+gem "opentelemetry-metrics-sdk", ">= 0.8"
+gem "opentelemetry-exporter-otlp-metrics", ">= 0.4"
+{{< /code-block >}}
+
+Install the gems with `bundle install`. These gems provide the OpenTelemetry meter provider and OTLP metrics exporter. The Ruby tracer uses them when `DD_METRICS_OTEL_ENABLED=true` is set. If the gems are missing, the Ruby tracer does not emit `feature_flag.evaluations` metrics and logs `Failed to load OpenTelemetry metrics gems`.
+
 By default, most tracers send OTLP metrics to the Agent at `DD_AGENT_HOST` on port `4318` (HTTP). If your application already sets `DD_AGENT_HOST` to reach the Agent, no endpoint configuration is required.
 
 Set an OTLP endpoint explicitly in any of these cases:

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -32,6 +32,7 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Datadog Ruby SDK** `datadog` version 2.24.0 or later
 - **Ruby runtime** version 3.1 or later to use the full Datadog Feature Flags OpenFeature integration
 - **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later for provider hooks, exposure logging, and flag evaluation metrics support
+- **OpenTelemetry metrics gems** for [flag evaluation metrics][5]: `opentelemetry-metrics-sdk` version 0.8.0 or later. Add `opentelemetry-exporter-otlp-metrics` version 0.4.0 or later.
 - **Service and environment configured** - Feature flags are targeted by service and environment
 - **Supported operating system** - Production support is limited to [Linux operating systems][2]. macOS and Windows are not natively supported production targets, but Dockerized Linux environments running on those operating systems are. For local development on macOS, you can use a compatible prebuilt native artifact when one is available.
 
@@ -45,6 +46,13 @@ Feature Flagging is provided by Application Performance Monitoring (APM). To int
 gem install datadog openfeature-sdk
 ```
 
+To emit flag evaluation metrics, add the OpenTelemetry metrics gems to your application bundle:
+
+```ruby
+gem "opentelemetry-metrics-sdk", ">= 0.8"
+gem "opentelemetry-exporter-otlp-metrics", ">= 0.4"
+```
+
 You can enable Feature Flags with environment variables:
 
 ```shell
@@ -52,7 +60,7 @@ You can enable Feature Flags with environment variables:
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 # Optional: Enable flag evaluation metrics
-# See "Set Up Server-Side Flag Evaluation Metrics" documentation
+DD_METRICS_OTEL_ENABLED=true
 ```
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
@@ -314,3 +322,4 @@ Look for messages about:
 [2]: /tracing/trace_collection/compatibility/ruby/#supported-operating-systems
 [3]: https://openfeature.dev/
 [4]: /account_management/api-app-keys/#api-keys
+[5]: /feature_flags/guide/server_flag_evaluation_metrics/

--- a/content/en/feature_flags/server/ruby.md
+++ b/content/en/feature_flags/server/ruby.md
@@ -32,7 +32,7 @@ Before setting up the Ruby Feature Flags SDK, ensure you have:
 - **Datadog Ruby SDK** `datadog` version 2.24.0 or later
 - **Ruby runtime** version 3.1 or later to use the full Datadog Feature Flags OpenFeature integration
 - **OpenFeature Ruby SDK** `openfeature-sdk` version 0.5.1 or later for provider hooks, exposure logging, and flag evaluation metrics support
-- **OpenTelemetry metrics gems** for [flag evaluation metrics][5]: `opentelemetry-metrics-sdk` version 0.8.0 or later. Add `opentelemetry-exporter-otlp-metrics` version 0.4.0 or later.
+- **OpenTelemetry metrics gems** for [flag evaluation metrics][5]: `opentelemetry-metrics-sdk` version 0.8.0 or later, and `opentelemetry-exporter-otlp-metrics` version 0.4.0 or later
 - **Service and environment configured** - Feature flags are targeted by service and environment
 - **Supported operating system** - Production support is limited to [Linux operating systems][2]. macOS and Windows are not natively supported production targets, but Dockerized Linux environments running on those operating systems are. For local development on macOS, you can use a compatible prebuilt native artifact when one is available.
 


### PR DESCRIPTION
### Motivation

Ruby applications that enable server-side flag evaluation metrics also need the OpenTelemetry metrics SDK and OTLP metrics exporter gems in their application bundle. The shared setup guide documents the Agent OTLP receiver and `DD_METRICS_OTEL_ENABLED=true`, but it does not call out this Ruby-specific Bundler requirement.

### Changes

- Add a Ruby subsection to the server-side flag evaluation metrics guide with the required OpenTelemetry metrics gems.
- Update the Ruby Feature Flags page prerequisites and setup flow to mention the same metrics-only gem requirement.
- Replace the placeholder metrics comment in the Ruby env-var example with `DD_METRICS_OTEL_ENABLED=true`.

### Decisions

- Keep the existing Ruby tracer minimum version unchanged.
- Keep the shared Agent OTLP receiver and endpoint guidance as the primary setup path.
- Document the Ruby gem requirement separately from the Java-specific dependency work in #37927.

### Validation

- `git diff --check`
- `vale content/en/feature_flags/guide/server_flag_evaluation_metrics.md content/en/feature_flags/server/ruby.md` returned 0 errors; remaining warnings and suggestions are on pre-existing unchanged lines.

### Merge instructions

Merge readiness:
- [ ] Ready for merge
