### PR TITLE
[FFL-2653] Document Python flag evaluation metrics setup

### DIFF
--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -28,7 +28,7 @@ Before setting up the Python Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Python SDK** `ddtrace` version 3.19.0 or later (version 4.7.0 or later required for flag evaluation metrics)
+- **Datadog Python SDK** `ddtrace` version 3.19.0 or later (version 4.7.0 or later is required for flag evaluation metrics)
 - **OpenFeature Python SDK** `openfeature-sdk`: version 0.5.0 or later (version 0.7.0 or later required if you use provider event handlers to wait for initialization)
 
 Set the following environment variables:

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -28,7 +28,7 @@ Before setting up the Python Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Python SDK** `ddtrace` version 3.19.0 or later (version 4.7.0 or later is required for flag evaluation metrics)
+- **Datadog Python SDK** `ddtrace` version 3.19.0 or later
 - **OpenFeature Python SDK** `openfeature-sdk`: version 0.5.0 or later (version 0.7.0 or later required if you use provider event handlers to wait for initialization)
 
 Set the following environment variables:
@@ -47,7 +47,7 @@ export DD_ENV=<YOUR_ENVIRONMENT>
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
-See <a href="/feature_flags/guide/server_flag_evaluation_metrics/">Set Up Server-Side Flag Evaluation Metrics</a> to enable the experimental <code>feature_flag.evaluations</code> metric. See <a href="/feature_flags/concepts/flag_graphs/">Feature Flag Graphs</a> for more information on available graphing.
+To configure `feature_flag.evaluations`, including the required tracer version and Agent OTLP setup, see [Set Up Server-Side Flag Evaluation Metrics](/feature_flags/guide/server_flag_evaluation_metrics/). See [Feature Flag Graphs](/feature_flags/concepts/flag_graphs/) for more information on available graphing.
 
 ## Installation
 

--- a/content/en/feature_flags/server/python.md
+++ b/content/en/feature_flags/server/python.md
@@ -28,7 +28,7 @@ Before setting up the Python Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Python SDK** `ddtrace` version 3.19.0 or later
+- **Datadog Python SDK** `ddtrace` version 3.19.0 or later (version 4.7.0 or later required for flag evaluation metrics)
 - **OpenFeature Python SDK** `openfeature-sdk`: version 0.5.0 or later (version 0.7.0 or later required if you use provider event handlers to wait for initialization)
 
 Set the following environment variables:
@@ -38,7 +38,7 @@ Set the following environment variables:
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 # Optional: Enable flag evaluation metrics
-# See "Set Up Server-Side Flag Evaluation Metrics" documentation
+export DD_METRICS_OTEL_ENABLED=true
 
 # Required: Service identification
 export DD_SERVICE=<YOUR_SERVICE_NAME>
@@ -62,6 +62,19 @@ Or add them to your `requirements.txt`:
 {{< code-block lang="text" filename="requirements.txt" >}}
 ddtrace>=3.19.0
 openfeature-sdk>=0.5.0
+{{< /code-block >}}
+
+If you enable flag evaluation metrics, also install the OpenTelemetry SDK and OTLP exporter:
+
+{{< code-block lang="bash" >}}
+pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc
+{{< /code-block >}}
+
+Or add them to your `requirements.txt`:
+
+{{< code-block lang="text" filename="requirements.txt" >}}
+opentelemetry-sdk>=1.41.0
+opentelemetry-exporter-otlp-proto-grpc>=1.41.0
 {{< /code-block >}}
 
 ## Initialize the SDK


### PR DESCRIPTION
## Motivation
Python users can follow the server-side feature flag setup and still miss the extra pieces needed for evaluation metrics: the metrics env var and OpenTelemetry SDK/exporter dependency.

## Changes
- Add `DD_METRICS_OTEL_ENABLED=true` to the Python server SDK environment example.
- Add the OpenTelemetry SDK and OTLP exporter packages required for Python flag evaluation metric export.
- Link the Python server SDK page to the canonical server-side flag evaluation metrics guide for required tracer versions and Agent OTLP setup.

## Decisions
- Keep the shared guide as the source of truth for metrics-specific tracer minimum versions, Agent OTLP receiver setup, and endpoint troubleshooting.
- Keep this PR scoped to Python; Java is covered separately in DataDog/documentation#37927.

## Validation
- `git diff --check`
- `vale content/en/feature_flags/server/python.md` (0 errors; existing warnings only)
- Dogfooding proof: evaluated `ffe-dogfooding-string-flag` through `service:ffe-dogfooding-python` on the real staging Agent 7.78.1 path, then queried `feature_flag.evaluations` for the language-specific service/host and observed a nonzero `static`/`variant_1` series count (`41.0`).