### PR TITLE
[FFL-2653] Document Node.js flag evaluation metrics setup

### DIFF
--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -29,7 +29,7 @@ Before setting up the Node.js Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration](/agent/remote_config/) enabled. See [Agent Configuration](/feature_flags/server#agent-configuration) for details.
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later. Version 5.99.0 or later is required for flag evaluation metrics.
+- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later
 - **@openfeature/server-sdk** version ~1.20.0
 
 ## Installing and initializing
@@ -59,7 +59,7 @@ DD_ENV=<YOUR_ENVIRONMENT>
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
-See <a href="/feature_flags/guide/server_flag_evaluation_metrics/">Set Up Server-Side Flag Evaluation Metrics</a> to enable the experimental <code>feature_flag.evaluations</code> metric. See <a href="/feature_flags/concepts/flag_graphs/">Feature Flag Graphs</a> for more information on available graphing.
+To configure `feature_flag.evaluations`, including the required tracer version and Agent OTLP setup, see [Set Up Server-Side Flag Evaluation Metrics](/feature_flags/guide/server_flag_evaluation_metrics/). See [Feature Flag Graphs](/feature_flags/concepts/flag_graphs/) for more information on available graphing.
 
 Or enable the provider in code:
 

--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -29,7 +29,7 @@ Before setting up the Node.js Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration](/agent/remote_config/) enabled. See [Agent Configuration](/feature_flags/server#agent-configuration) for details.
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later (version 5.99.0 or later required for flag evaluation metrics)
+- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later. Version 5.99.0 or later is required for flag evaluation metrics.
 - **@openfeature/server-sdk** version ~1.20.0
 
 ## Installing and initializing
@@ -52,7 +52,7 @@ DD_REMOTE_CONFIGURATION_ENABLED=true
 # Optional: Enable flag evaluation metrics
 DD_METRICS_OTEL_ENABLED=true
 
-# Required: Service identification
+# Required for feature flags and metrics: Service identification
 DD_SERVICE=<YOUR_SERVICE_NAME>
 DD_ENV=<YOUR_ENVIRONMENT>
 ```

--- a/content/en/feature_flags/server/nodejs.md
+++ b/content/en/feature_flags/server/nodejs.md
@@ -29,7 +29,7 @@ Before setting up the Node.js Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** version 7.55 or later with [Remote Configuration](/agent/remote_config/) enabled. See [Agent Configuration](/feature_flags/server#agent-configuration) for details.
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later
+- **Datadog Node.js SDK** `dd-trace` version 5.80.0 or later (version 5.99.0 or later required for flag evaluation metrics)
 - **@openfeature/server-sdk** version ~1.20.0
 
 ## Installing and initializing
@@ -46,8 +46,15 @@ Enable the provider with environment variables:
 # Required: Enable the feature flags provider
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
+# Required: Enable Remote Configuration in the tracer
+DD_REMOTE_CONFIGURATION_ENABLED=true
+
 # Optional: Enable flag evaluation metrics
-# See "Set Up Server-Side Flag Evaluation Metrics" documentation
+DD_METRICS_OTEL_ENABLED=true
+
+# Required: Service identification
+DD_SERVICE=<YOUR_SERVICE_NAME>
+DD_ENV=<YOUR_ENVIRONMENT>
 ```
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>


### PR DESCRIPTION
## Motivation
Node.js users can meet the shared Agent prerequisites and still miss the app-side tracer settings required for the Datadog OpenFeature provider and evaluation metric export.

## Changes
- Add `DD_REMOTE_CONFIGURATION_ENABLED=true` to the Node.js server SDK environment example.
- Add `DD_METRICS_OTEL_ENABLED=true` and service/env identification to the Node.js setup example.
- Link the Node.js server SDK page to the canonical server-side flag evaluation metrics guide for required tracer versions and Agent OTLP setup.

## Decisions
- Keep the shared guide as the source of truth for metrics-specific tracer minimum versions, Agent OTLP receiver setup, and endpoint troubleshooting.
- Keep this PR scoped to Node.js; Java is covered separately in DataDog/documentation#37927.

## Validation
- `git diff --check`
- `vale content/en/feature_flags/server/nodejs.md` (0 errors; existing warnings only)
- Dogfooding proof: evaluated `ffe-dogfooding-integer-flag` from the Node.js dogfood app container through `service:ffe-dogfooding-node` on the real staging Agent 7.78.1 path, then queried `feature_flag.evaluations` for the language-specific service/host and observed a nonzero `targeting_match`/`-5` series count (`31`).