### PR TITLE
[FFL-2653] Document .NET flag evaluation metrics setup

### DIFF
--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -31,6 +31,7 @@ Before setting up the .NET Feature Flags SDK, ensure you have:
 - **Datadog .NET SDK** (`dd-trace-dotnet`):
   - Version 3.36.0 or later for .NET 6+
   - Version 3.38.0 or later for .NET Framework 4.6.2+
+  - Version 3.44.0 or later for flag evaluation metrics
 
 Set the following environment variables:
 
@@ -39,7 +40,7 @@ Set the following environment variables:
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 # Optional: Enable flag evaluation metrics
-# See "Set Up Server-Side Flag Evaluation Metrics" documentation
+DD_METRICS_OTEL_ENABLED=true
 
 # Required: Service identification
 DD_SERVICE=<YOUR_SERVICE_NAME>
@@ -65,6 +66,22 @@ Or add them to your `.csproj` file:
 <ItemGroup>
   <PackageReference Include="Datadog.FeatureFlags.OpenFeature" />
   <PackageReference Include="OpenFeature" />
+</ItemGroup>
+{{< /code-block >}}
+
+If you enable flag evaluation metrics, also install the OpenTelemetry SDK and OTLP exporter:
+
+{{< code-block lang="bash" >}}
+dotnet add package OpenTelemetry
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+{{< /code-block >}}
+
+Or add them to your `.csproj` file:
+
+{{< code-block lang="xml" filename="MyProject.csproj" >}}
+<ItemGroup>
+  <PackageReference Include="OpenTelemetry" />
+  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 </ItemGroup>
 {{< /code-block >}}
 

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -38,7 +38,7 @@ Set the following environment variables:
 # Required: Enable the feature flags provider
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
-# Optional: Enable flag evaluation metrics
+# Optional: Emit feature_flag.evaluations
 DD_METRICS_OTEL_ENABLED=true
 
 # Required: Service identification

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -31,7 +31,6 @@ Before setting up the .NET Feature Flags SDK, ensure you have:
 - **Datadog .NET SDK** (`dd-trace-dotnet`):
   - Version 3.36.0 or later for .NET 6+
   - Version 3.38.0 or later for .NET Framework 4.6.2+
-  - Version 3.44.0 or later (only required for flag evaluation metrics)
 
 Set the following environment variables:
 
@@ -49,7 +48,7 @@ DD_ENV=<YOUR_ENVIRONMENT>
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
 
-See <a href="/feature_flags/guide/server_flag_evaluation_metrics/">Set Up Server-Side Flag Evaluation Metrics</a> to enable the experimental <code>feature_flag.evaluations</code> metric. See <a href="/feature_flags/concepts/flag_graphs/">Feature Flag Graphs</a> for more information on available graphing.
+To configure `feature_flag.evaluations`, including the required tracer version and Agent OTLP setup, see [Set Up Server-Side Flag Evaluation Metrics](/feature_flags/guide/server_flag_evaluation_metrics/). See [Feature Flag Graphs](/feature_flags/concepts/flag_graphs/) for more information on available graphing.
 
 ## Installation
 

--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -31,7 +31,7 @@ Before setting up the .NET Feature Flags SDK, ensure you have:
 - **Datadog .NET SDK** (`dd-trace-dotnet`):
   - Version 3.36.0 or later for .NET 6+
   - Version 3.38.0 or later for .NET Framework 4.6.2+
-  - Version 3.44.0 or later for flag evaluation metrics
+  - Version 3.44.0 or later (only required for flag evaluation metrics)
 
 Set the following environment variables:
 


### PR DESCRIPTION
## Motivation
.NET users can configure server-side feature flags without seeing the additional metrics env var and OpenTelemetry package references needed for `feature_flag.evaluations` export.

## Changes
- Add `DD_METRICS_OTEL_ENABLED=true` to the .NET server SDK environment example.
- Add the OpenTelemetry SDK and OTLP exporter packages required for .NET flag evaluation metric export.
- Link the .NET server SDK page to the canonical server-side flag evaluation metrics guide for required tracer versions and Agent OTLP setup.

## Decisions
- Keep the shared guide as the source of truth for metrics-specific tracer minimum versions, Agent OTLP receiver setup, and endpoint troubleshooting.
- Keep this PR scoped to .NET; Java is covered separately in DataDog/documentation#37927.

## Validation
- `git diff --check`
- `vale content/en/feature_flags/server/dotnet.md` (0 errors; existing warnings only)
- Dogfooding proof: evaluated `ffe-dogfooding-json-flag` through `service:ffe-dogfooding-dotnet` on the real staging Agent 7.78.1 path, then queried `feature_flag.evaluations` for the language-specific service/host and observed a nonzero `static`/`openai-1` series count (`30.0`).