### PR TITLE
[FFL-2653] Document PHP flag evaluation metrics setup

### DIFF
--- a/content/en/feature_flags/server/php.md
+++ b/content/en/feature_flags/server/php.md
@@ -8,6 +8,12 @@ further_reading:
 - link: "/tracing/trace_collection/dd_libraries/php/"
   tag: "Documentation"
   text: "PHP Tracing"
+- link: "/feature_flags/guide/server_flag_evaluation_metrics/"
+  tag: "Guide"
+  text: "Set Up Server-Side Flag Evaluation Metrics"
+- link: "/feature_flags/concepts/flag_graphs/"
+  tag: "Concept"
+  text: "Feature Flag Graphs"
 ---
 
 ## Overview
@@ -27,7 +33,7 @@ Before setting up the PHP Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog PHP SDK** `datadog/dd-trace` version 1.21.0 or later
+- **Datadog PHP SDK** `datadog/dd-trace` version 1.21.0 or later (version 1.21.1 or later required for flag evaluation metrics)
 - **Supported PHP runtime**: PHP 7 or later with the Datadog PHP API, or PHP 8 or later with the OpenFeature adapter
 - **OpenFeature PHP SDK** `open-feature/sdk` version 2.1 or later, if you use the OpenFeature adapter
 
@@ -411,7 +417,7 @@ If targeting rules do not match as expected:
 
 #### Flag evaluation metrics
 
-Flag evaluation counts appear in Datadog when `DD_METRICS_OTEL_ENABLED=true` is set for the PHP tracer. Each evaluation emits a `feature_flag.evaluations` counter metric tagged with the flag key, result variant, and evaluation reason. If this metric does not appear, confirm `DD_METRICS_OTEL_ENABLED=true` is set in your environment and that your PHP tracer version supports flag evaluation metrics.
+Flag evaluation counts appear in Datadog when `DD_METRICS_OTEL_ENABLED=true` is set for the PHP tracer. Each evaluation emits a `feature_flag.evaluations` counter metric tagged with the flag key, result variant, and evaluation reason. If this metric does not appear, confirm `DD_METRICS_OTEL_ENABLED=true` is set in your environment and that your PHP tracer version supports flag evaluation metrics. See [Set Up Server-Side Flag Evaluation Metrics][6] for Agent OTLP receiver setup and troubleshooting.
 
 #### Experiment exposures
 
@@ -430,3 +436,4 @@ Exposures appear in Datadog only for flags associated with an experiment. Standa
 [3]: /account_management/api-app-keys/#api-keys
 [4]: /tracing/trace_collection/dd_libraries/php/
 [5]: /feature_flags/concepts/environments/
+[6]: /feature_flags/guide/server_flag_evaluation_metrics/

--- a/content/en/feature_flags/server/php.md
+++ b/content/en/feature_flags/server/php.md
@@ -33,7 +33,7 @@ Before setting up the PHP Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** with [Remote Configuration][2] enabled
 - **Datadog [API key][3]** configured on the Agent
-- **Datadog PHP SDK** `datadog/dd-trace` version 1.21.0 or later (version 1.21.1 or later required for flag evaluation metrics)
+- **Datadog PHP SDK** `datadog/dd-trace` version 1.21.0 or later
 - **Supported PHP runtime**: PHP 7 or later with the Datadog PHP API, or PHP 8 or later with the OpenFeature adapter
 - **OpenFeature PHP SDK** `open-feature/sdk` version 2.1 or later, if you use the OpenFeature adapter
 
@@ -56,6 +56,8 @@ export DD_METRICS_OTEL_ENABLED=true
 {{< /code-block >}}
 
 <div class="alert alert-info">The <code>EXPERIMENTAL_</code> prefix is retained for backwards compatibility; the provider itself is stable.</div>
+
+To configure `feature_flag.evaluations`, including the required tracer version and Agent OTLP setup, see [Set Up Server-Side Flag Evaluation Metrics][6].
 
 ## Installation
 


### PR DESCRIPTION
## Motivation
The PHP server SDK page already exposed the metrics env var, but it did not link clearly back to the shared setup guide near the setup instructions.

## Changes
- Add the shared server-side flag evaluation metrics guide to PHP further reading, setup, and troubleshooting.
- Add the Feature Flag Graphs concept link for parity with the other server SDK pages.
- Keep metrics-specific tracer minimum versions centralized in the canonical metrics guide.

## Decisions
- Keep the existing PHP API and OpenFeature adapter setup unchanged.
- Keep Agent OTLP receiver setup and endpoint troubleshooting in the shared server-side flag evaluation metrics guide.
- Keep this PR scoped to PHP; Java is covered separately in DataDog/documentation#37927.

## Validation
- `git diff --check`
- `vale content/en/feature_flags/server/php.md` (0 errors; existing warnings only)
- Dogfooding proof: evaluated `ffe-dogfooding-string-flag` through `service:ffe-dogfooding-php7` and `ffe-dogfooding-boolean-flag` through `service:ffe-dogfooding-php8-openfeature` on the real staging Agent 7.78.1 path, then queried `feature_flag.evaluations` for each language-specific service/host and observed nonzero series for both PHP APIs.