### PR TITLE
[DOCS] Document logs_archive_search permission — two-permission model for Archive Search

### DIFF
--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -67,7 +67,7 @@ Two permissions control access to Archive Search. Both are global, and users als
 | **`logs_write_historical_view`** | ✅ | ✅ |
 
 - **`logs_archive_search`**: Grants the ability to run Archive Search in **Search mode** only. Results stream in real time and are retained for 24 hours. The **Rehydrate** option is not available with this permission.
-- **`logs_write_historical_view`**: Grants the ability to run Archive Search in both **Search** and **Search & Rehydration** modes, and to trigger [Rehydration from Archives][10].
+- **`logs_write_historical_view`**: Grants the ability to run Archive Search in both **Search** and **Search & Rehydration** modes.
 
 Archive Search results are visible to all users in your organization who have access to the Archive Search feature. However, **restriction queries**, such as log security filters and data restrictions configured in Datadog, are still enforced on the result page and apply to all users. This means each user may only see logs they are authorized to view based on organization-wide permissions and filters.
 
@@ -245,4 +245,3 @@ In order to search log events from your archives, Datadog uses a service account
 [7]: /logs/log_configuration/archives/?tab=awss3#archive-search-lookup-attribute
 [8]: /logs/log_configuration/archives/?tab=awss3#archive-search-partition-attribute
 [9]: /logs/log_configuration/archives/?tab=awss3#compression
-[10]: /logs/log_configuration/rehydrating/

--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -59,7 +59,15 @@ Before using Archive Search:
 
 ### Permissions
 
-Running an **Archive Search** requires the **`logs_write_historical_view`** permission. It is a **global** permission, but users can only search logs from archives for which they also have the **Logs Read Archive** permission.
+Two permissions control access to Archive Search. Both are global, and users also need the **`logs_read_archives`** permission for each archive they search.
+
+| Permission | Search mode | Search & Rehydration mode |
+|---|---|---|
+| **`logs_archive_search`** | ✅ | ❌ |
+| **`logs_write_historical_view`** | ✅ | ✅ |
+
+- **`logs_archive_search`**: Grants the ability to run Archive Search in **Search mode** only. Results stream in real time and are retained for 24 hours. The **Rehydrate** option is not available with this permission.
+- **`logs_write_historical_view`**: Grants the ability to run Archive Search in both **Search** and **Search & Rehydration** modes, and to trigger [Rehydration from Archives][10].
 
 Archive Search results are visible to all users in your organization who have access to the Archive Search feature. However, **restriction queries**, such as log security filters and data restrictions configured in Datadog, are still enforced on the result page and apply to all users. This means each user may only see logs they are authorized to view based on organization-wide permissions and filters.
 
@@ -237,3 +245,4 @@ In order to search log events from your archives, Datadog uses a service account
 [7]: /logs/log_configuration/archives/?tab=awss3#archive-search-lookup-attribute
 [8]: /logs/log_configuration/archives/?tab=awss3#archive-search-partition-attribute
 [9]: /logs/log_configuration/archives/?tab=awss3#compression
+[10]: /logs/log_configuration/rehydrating/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -102,7 +102,7 @@ This permission is global and enables creating new archives, and editing and del
 
 ### `logs_read_archives`
 
-Grants the ability to access the details of the archive configuration. In conjunction with [Logs Write Historical Views](#logs_write_historical_view), this permission also grants the ability to trigger a [Rehydration][13] from Archives.
+Grants the ability to access the details of the archive configuration. In conjunction with [`logs_archive_search`](#logs_archive_search) or [`logs_write_historical_view`](#logs_write_historical_view), this permission also grants the ability to run [Archive Search][17] or trigger a [Rehydration][13] from Archives.
 
 This permission can be scoped to a subset of archives. An archive with no restrictions is accessible to anyone who belongs to a role with the `logs_read_archives` permission. An archive with restrictions is only accessible to the users who belong to one of the registered roles, provided theses roles have the `logs_read_archives` permission.
 
@@ -132,9 +132,17 @@ Use the Logs Archive API either to [assign][1] or [revoke][2] a role from a give
 {{% /tab %}}
 {{< /tabs >}}
 
+### `logs_archive_search`
+
+Grants the ability to run [Archive Search][17] in **Search mode** only. Results stream in real time and are retained for 24 hours. The Rehydrate option is not available with this permission.
+
+This permission is global. Users also need the [Logs Read Archives](#logs_read_archives) permission for each archive they want to search.
+
+To allow Search & Rehydration mode, grant [`logs_write_historical_view`](#logs_write_historical_view) instead.
+
 ### `logs_write_historical_view`
 
-Grants the ability to write historical views, meaning to trigger a [Log Rehydration*][13].
+Grants the ability to run [Archive Search][17] in both **Search** and **Search & Rehydration** modes, and to trigger a [Log Rehydration*][13] (Historical View).
 
 This permission is global. It enables users to trigger a rehydration for archives on which they have [Logs Read Archive](#logs_read_archives) permission.
 
@@ -163,7 +171,7 @@ Five separate permissions control the ability to view, create, or modify log con
 * [`logs_modify_indexes`](#logs_modify_indexes)
 * [`logs_write_archives`](#logs_write_archives)
 * [`logs_write_pipelines`](#logs_write_pipelines)
-* [`user_access_manage`][14]
+* [`user_access_manage`][17]
 
 ## Log data access
 
@@ -364,6 +372,7 @@ curl -X POST \
 [11]: /logs/explorer/facets/#alias-facets
 [12]: /logs/archives
 [13]: /logs/archives/rehydrating
-[14]: /account_management/rbac/permissions/#access-management
+[17]: /account_management/rbac/permissions/#access-management
 [15]: /api/v2/logs-restriction-queries/
 [16]: /logs/explorer/live_tail/
+[17]: /logs/explorer/archive_search/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -138,7 +138,7 @@ Grants the ability to run [Archive Search][17] in **Search mode** only. Results 
 
 This permission is global. Users also need the [Logs Read Archives](#logs_read_archives) permission for each archive they want to search.
 
-To allow Search & Rehydration mode, grant [`logs_write_historical_view`](#logs_write_historical_view) instead.
+To also allow **Search & Rehydration** mode, grant [`logs_write_historical_view`](#logs_write_historical_view).
 
 ### `logs_write_historical_view`
 

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -102,7 +102,7 @@ This permission is global and enables creating new archives, and editing and del
 
 ### `logs_read_archives`
 
-Grants the ability to access the details of the archive configuration. In conjunction with [`logs_archive_search`](#logs_archive_search) or [`logs_write_historical_view`](#logs_write_historical_view), this permission also grants the ability to run [Archive Search][17] or trigger a [Rehydration][13] from Archives.
+Grants the ability to access the details of the archive configuration. In conjunction with [`logs_archive_search`](#logs_archive_search) or [`logs_write_historical_view`](#logs_write_historical_view), this permission also grants the ability to run [Archive Search][18] or trigger a [Rehydration][13] from Archives.
 
 This permission can be scoped to a subset of archives. An archive with no restrictions is accessible to anyone who belongs to a role with the `logs_read_archives` permission. An archive with restrictions is only accessible to the users who belong to one of the registered roles, provided theses roles have the `logs_read_archives` permission.
 
@@ -134,7 +134,7 @@ Use the Logs Archive API either to [assign][1] or [revoke][2] a role from a give
 
 ### `logs_archive_search`
 
-Grants the ability to run [Archive Search][17] in **Search mode** only. Results stream in real time and are retained for 24 hours. The Rehydrate option is not available with this permission.
+Grants the ability to run [Archive Search][18] in **Search mode** only. Results stream in real time and are retained for 24 hours. The Rehydrate option is not available with this permission.
 
 This permission is global. Users also need the [Logs Read Archives](#logs_read_archives) permission for each archive they want to search.
 
@@ -142,7 +142,7 @@ To also allow **Search & Rehydration** mode, grant [`logs_write_historical_view`
 
 ### `logs_write_historical_view`
 
-Grants the ability to run [Archive Search][17] in both **Search** and **Search & Rehydration** modes.
+Grants the ability to run [Archive Search][18] in both **Search** and **Search & Rehydration** modes.
 
 This permission is global. It enables users to trigger a rehydration for archives on which they have [Logs Read Archive](#logs_read_archives) permission.
 
@@ -171,7 +171,7 @@ Five separate permissions control the ability to view, create, or modify log con
 * [`logs_modify_indexes`](#logs_modify_indexes)
 * [`logs_write_archives`](#logs_write_archives)
 * [`logs_write_pipelines`](#logs_write_pipelines)
-* [`user_access_manage`][17]
+* [`user_access_manage`][14]
 
 ## Log data access
 
@@ -372,7 +372,7 @@ curl -X POST \
 [11]: /logs/explorer/facets/#alias-facets
 [12]: /logs/archives
 [13]: /logs/archives/rehydrating
-[17]: /account_management/rbac/permissions/#access-management
+[14]: /account_management/rbac/permissions/#access-management
 [15]: /api/v2/logs-restriction-queries/
 [16]: /logs/explorer/live_tail/
-[17]: /logs/explorer/archive_search/
+[18]: /logs/explorer/archive_search/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -142,7 +142,7 @@ To allow Search & Rehydration mode, grant [`logs_write_historical_view`](#logs_w
 
 ### `logs_write_historical_view`
 
-Grants the ability to run [Archive Search][17] in both **Search** and **Search & Rehydration** modes, and to trigger a [Log Rehydration*][13] (Historical View).
+Grants the ability to run [Archive Search][17] in both **Search** and **Search & Rehydration** modes.
 
 This permission is global. It enables users to trigger a rehydration for archives on which they have [Logs Read Archive](#logs_read_archives) permission.
 

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -142,7 +142,7 @@ To also allow **Search & Rehydration** mode, grant [`logs_write_historical_view`
 
 ### `logs_write_historical_view`
 
-Grants the ability to run [Archive Search][18] in both **Search** and **Search & Rehydration** modes.
+Grants the ability to run [Archive Search][18] in both **Search** and **Search & Rehydration** modes, and to trigger [Log Rehydration*][13] (Historical Views).
 
 This permission is global. It enables users to trigger a rehydration for archives on which they have [Logs Read Archive](#logs_read_archives) permission.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Introduces documentation for the new `logs_archive_search` permission alongside the existing `logs_write_historical_view`, clarifying which Archive Search modes each permission grants.

**Changes:**

- **`logs/explorer/archive_search.md`**: Replace single-permission mention with a two-permission comparison table in the Permissions section:
  - `logs_archive_search` → Search mode only (no Rehydrate button)
  - `logs_write_historical_view` → Search + Search & Rehydration modes
- **`logs/guide/logs-rbac-permissions.md`**: Add new `logs_archive_search` section before `logs_write_historical_view`, update `logs_write_historical_view` description to mention Archive Search, and update `logs_read_archives` to reference both permissions

### Merge instructions

**⚠️ Do not merge until `logs_archive_search` permission is GA.** The permission is currently in Preview (enabled per account).

Merge readiness:
- [ ] Ready for merge

### Additional notes

The `logs_write_historical_view` permission continues to work exactly as before — users with this permission can still run Archive Search in both modes. The new `logs_archive_search` permission is additive, giving teams the option to grant search-only access without rehydration rights.