### PR TITLE
Document LLMObs trace sampling controls for Python SDK

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -88,11 +88,17 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
+`DD_LLMOBS_SAMPLE_RATE`
+: optional - _float_ - **default**: `1.0`
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). This sampling is independent of in-app controls such as [automation rules][2] and [APM trace sampling][3].
+
 `DD_API_KEY`
 : optional - _string_
 <br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 [1]: /getting_started/tagging/unified_service_tagging?tab=kubernetes#non-containerized-environment
+[2]: /llm_observability/monitoring/automation_rules/
+[3]: /tracing/trace_pipeline/ingestion_mechanisms/
 {{% /tab %}}
 
 {{% tab "Node.js" %}}
@@ -207,6 +213,10 @@ LLMObs.enable(
 `agentless_enabled`
 : optional - _boolean_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
+
+`sample_rate`
+: optional - _float_
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). If unset, this defaults to `DD_LLMOBS_SAMPLE_RATE`, but otherwise takes precedence over the environment variable.
 
 `site`
 : optional - _string_


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents Python LLM Observability (Agent Observability) trace sampling controls in the SDK reference (`instrumentation/sdk.md`). Neither control was documented anywhere in `content/en/llm_observability/` — the existing docs only cover server-side/UI sampling (automation rules, annotation queues, datasets, custom judges), so there was no reference for client-side, pre-ingestion trace sampling in the SDK.

- **`DD_LLMOBS_SAMPLE_RATE`** environment variable — added to the Python *command-line setup* env-var list (float `0.0`–`1.0`, default `1.0`).
- **`sample_rate`** parameter on `LLMObs.enable()` — added to the Python *in-code setup* parameters, following [dd-trace-py#18607](https://github.com/DataDog/dd-trace-py/pull/18607). Documents precedence (`sample_rate` arg > `DD_LLMOBS_SAMPLE_RATE` > default `1.0`) and that out-of-range values are ignored.

Split out from #37602 so the Python and Node.js SDKs can ship on their independent release timelines. The Node.js counterpart is #38076; Java does not expose these controls, so its tabs are intentionally untouched.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Used Claude Code to draft the sampling docs and split the original combined PR into per-SDK PRs.

### Additional notes

<!-- Anything else we should know when reviewing?-->

Cross-links to automation rules and APM ingestion mechanisms; both targets verified to exist. Scoped to sampling mechanisms only — no retention/limits content added.

Claude session: \`8fee0594-7c4c-4d73-89a3-ebe66a4ae63d\`
Resume: \`claude --resume 8fee0594-7c4c-4d73-89a3-ebe66a4ae63d\`