### PR TITLE
Document LLMObs trace sampling controls for Node.js SDK

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -124,11 +124,17 @@ DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> NODE_OPTIONS="--import dd-trace/initialize.m
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
+`DD_LLMOBS_SAMPLE_RATE`
+: optional - _float_ - **default**: `1.0`
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). This sampling is independent of in-app controls such as [automation rules][2] and [APM trace sampling][3].
+
 `DD_API_KEY`
 : optional - _string_
 <br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 [1]: /getting_started/tagging/unified_service_tagging?tab=kubernetes#non-containerized-environment
+[2]: /llm_observability/monitoring/automation_rules/
+[3]: /tracing/trace_pipeline/ingestion_mechanisms/
 {{% /tab %}}
 {{% tab "Java" %}}
 
@@ -257,6 +263,10 @@ const llmobs = tracer.llmobs;
 `agentlessEnabled`
 : optional - _boolean_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `true`. This configures the `dd-trace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
+
+`sampleRate`
+: optional - _number_
+<br />The fraction of traces to submit to Agent Observability, between `0.0` (drop everything) and `1.0` (submit everything). The sampling decision is made on the root span and inherited by all of its child spans (including downstream services). If unset, this defaults to `DD_LLMOBS_SAMPLE_RATE`, but otherwise takes precedence over the environment variable.
 
 **Options for general tracer configuration**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents Node.js LLM Observability (Agent Observability) trace sampling controls in the SDK reference (`instrumentation/sdk.md`).

- **`DD_LLMOBS_SAMPLE_RATE`** environment variable — added to the Node.js *command-line setup* env-var list (float, default `1.0`).
- **`sampleRate`** parameter under `llmobs` in `tracer.init({ llmobs: { sampleRate } })` — added to the Node.js *in-code setup* parameters. Documents precedence (`sampleRate` > `DD_LLMOBS_SAMPLE_RATE` > default `1`).

Split out from #37602 so the Python and Node.js SDKs can ship on their independent release timelines. The Python counterpart is #38075; Java does not expose these controls, so its tabs are intentionally untouched.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

Assumes [dd-trace-js#9030](https://github.com/DataDog/dd-trace-js/pull/9030) merges first — hold until that ships.

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Used Claude Code to draft the sampling docs and split the original combined PR into per-SDK PRs.

### Additional notes

<!-- Anything else we should know when reviewing?-->

Cross-links to automation rules and APM ingestion mechanisms; both targets verified to exist. Scoped to sampling mechanisms only — no retention/limits content added.

Claude session: \`8fee0594-7c4c-4d73-89a3-ebe66a4ae63d\`
Resume: \`claude --resume 8fee0594-7c4c-4d73-89a3-ebe66a4ae63d\`