### PR TITLE
chore: correct GCP references in Azure Container Apps docs

### DIFF
--- a/content/en/serverless/azure_container_apps/sidecar/nodejs.md
+++ b/content/en/serverless/azure_container_apps/sidecar/nodejs.md
@@ -98,7 +98,7 @@ logger.info('Hello world!');
 
 ## Troubleshooting
 
-{{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 

--- a/content/en/serverless/azure_container_apps/sidecar/nodejs.md
+++ b/content/en/serverless/azure_container_apps/sidecar/nodejs.md
@@ -92,7 +92,7 @@ logger.info('Hello world!');
 
    <div class="alert alert-info">Datadog's Continuous Profiler is available in preview for Azure Container Apps.</div>
 
-{{% serverless-init-env-vars-sidecar language="nodejs" defaultSource="cloudrun" %}}
+{{% serverless-init-env-vars-sidecar language="nodejs" defaultSource="containerapp" %}}
 
 {{% svl-tracing-env %}}
 

--- a/layouts/shortcodes/serverless-init-configure.html
+++ b/layouts/shortcodes/serverless-init-configure.html
@@ -1,6 +1,6 @@
    After the container is built and pushed to your registry, set the required environment variables for the Datadog Agent:
 
-   - `DD_API_KEY`: Your [Datadog API key][1001], used to send data to your Datadog account. For privacy and safety, configure this API key as a Google Cloud Secret.
+   - `DD_API_KEY`: Your [Datadog API key][1001], used to send data to your Datadog account. For privacy and safety, configure this API key as a {{ if or (eq (.Get "cloudrun") "true") (eq (.Get "cloudrun_jobs") "true") }}Google Cloud Secret{{ else }}Container Apps secret{{ end }}.
    - `DD_SITE`: Your [Datadog site][1002]. For example, `datadoghq.com`.
 
    For more environment variables, see the [Environment variables](#environment-variables) section on this page.{{ if eq (.Get "cloudrun") "true" }}

--- a/layouts/shortcodes/serverless-init-env-vars-sidecar.html
+++ b/layouts/shortcodes/serverless-init-env-vars-sidecar.html
@@ -5,6 +5,9 @@
 | `DD_API_KEY`             | [Datadog API key][1001] - **Required**| Sidecar container |
 | `DD_SITE`                | [Datadog site][1002] - **Required** | Sidecar container |
 | `DD_SERVICE`             | Datadog Service name. **Required** | Both containers |
+{{ if eq (.Get "defaultSource") "containerapp" }}| `DD_AZURE_SUBSCRIPTION_ID` | Azure Subscription ID. **Required** | Sidecar container |
+| `DD_AZURE_RESOURCE_GROUP` | Azure Resource Group name. **Required** | Sidecar container |
+{{ end -}}
 | `DD_SERVERLESS_LOG_PATH` | The path where the sidecar should tail logs from. Recommended to set to `/shared-volume/logs/app.log`. | Sidecar container |
 | `DD_LOGS_INJECTION`      | When true, enrich all logs with trace data for supported loggers. See [Correlate Logs and Traces][1003] for more information. | Application container |
 | `DD_VERSION`             | See [Unified Service Tagging][1004]. | Both containers |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes Google Cloud references that were leaking into the Azure Container Apps docs through shortcodes shared with Cloud Run:

- `serverless-init-configure`: the `DD_API_KEY` guidance now says "Container Apps secret" for Container Apps and keeps "Google Cloud Secret" for Cloud Run.
- Container Apps Node.js sidecar page passed `productNames="Cloud Run services"`; corrected to "Azure Container Apps".
- `serverless-init-env-vars-sidecar`: added the required `DD_AZURE_SUBSCRIPTION_ID` and `DD_AZURE_RESOURCE_GROUP` rows for Container Apps, matching the in-container table and the sidecar install steps.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`).
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to audit the shared serverless-init shortcodes and apply the fixes.

### Additional notes
