### PR TITLE
Fix broken image-card links on Azure Database and Messaging Services page

### DIFF
--- a/content/en/serverless/azure_database_messaging_services/_index.md
+++ b/content/en/serverless/azure_database_messaging_services/_index.md
@@ -7,9 +7,9 @@ title: Azure Database and Messaging Services
 Datadog APM uses **inferred spans** to collect traces and trace metrics from Azure Cosmos DB, Event Hubs, and Service Bus. Inferred spans appear automatically in flame graph and waterfall views for Datadog-instrumented services running on Azure. No additional configuration is required. To set up instrumentation for Azure Serverless workloads, see [Serverless Monitoring][1].
 
 {{< card-grid card_width="170px" >}}
-  {{< image-card href="azure_cosmosdb/" src="integrations_logos/azure_cosmosdb.png" alt="azure_cosmosdb" >}}
-  {{< image-card href="azure_event_hubs/" src="integrations_logos/azure_event_hub.png" alt="azure_event_hubs" >}}
-  {{< image-card href="azure_service_bus/" src="integrations_logos/azure_service_bus.png" alt="azure_service_bus" >}}
+  {{< image-card href="/serverless/azure_database_messaging_services/azure_cosmosdb/" src="integrations_logos/azure_cosmosdb.png" alt="azure_cosmosdb" >}}
+  {{< image-card href="/serverless/azure_database_messaging_services/azure_event_hubs/" src="integrations_logos/azure_event_hub.png" alt="azure_event_hubs" >}}
+  {{< image-card href="/serverless/azure_database_messaging_services/azure_service_bus/" src="integrations_logos/azure_service_bus.png" alt="azure_service_bus" >}}
 {{< /card-grid >}}
 
 [1]: /serverless


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
The three image-card links on the Azure Database and Messaging Services page used relative hrefs (e.g. `azure_service_bus/`). When the [page URL was missing its trailing slash](https://docs.datadoghq.com/serverless/azure_database_messaging_services), which happened when the "Azure Database & Messaging Services" tab was clicked in the left column, the browser resolved these links incorrectly, causing a 404. This PR switches the hrefs to absolute paths, matching the convention used elsewhere in the docs, so the links resolve correctly regardless of the URL's trailing slash.

To reproduce the existing error, go to any page in Serverless, e.g. [Azure Container Apps](https://docs.datadoghq.com/serverless/azure_container_apps), click on Azure Database and Messaging Services in the left navigation column, and click into one of the three Azure-managed services images.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->
Used Claude Code for initial draft

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
