### PR TITLE
Add BYOC Logs 0.1.31 release notes

### DIFF
--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -43,7 +43,7 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 #### Changed
 - Fixes single-token phrase prefix queries on raw fields so `match_phrase_prefix` searches return all matching prefix terms instead of being capped by `max_expansions`.
-- up to 3x faster intersection for selective terms with time ranges
+- Up to 3x faster intersection for selective terms queries with time range.
 #### Helm chart changes
 - Adds `indexer.volumeAttributesClass` and `searcher.volumeAttributesClass` values to provision Kubernetes `VolumeAttributesClass` resources for indexer and searcher persistent volumes. Use these values to tune volume attributes such as IOPS and throughput. This feature is disabled by default, requires Kubernetes 1.31 or later, and requires `driverName` when enabled.
 - Fixes the Kubernetes advertise address by setting `KUBERNETES_POD_IP` from the pod IP instead of the pod name.

--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -43,7 +43,7 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 #### Changed
 - Fixes single-token phrase prefix queries on raw fields so `match_phrase_prefix` searches return all matching prefix terms instead of being capped by `max_expansions`.
-
+- up to 3x faster intersection for selective terms with time ranges
 #### Helm chart changes
 - Adds `indexer.volumeAttributesClass` and `searcher.volumeAttributesClass` values to provision Kubernetes `VolumeAttributesClass` resources for indexer and searcher persistent volumes. Use these values to tune volume attributes such as IOPS and throughput. This feature is disabled by default, requires Kubernetes 1.31 or later, and requires `driverName` when enabled.
 - Fixes the Kubernetes advertise address by setting `KUBERNETES_POD_IP` from the pod IP instead of the pod name.

--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -37,6 +37,19 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 ## Releases
 
+### v0.1.31 — 2026-07-08
+
+*Bundled in chart: `0.4.5`.*
+
+#### Changed
+- Fixes single-token phrase prefix queries on raw fields so `match_phrase_prefix` searches return all matching prefix terms instead of being capped by `max_expansions`.
+
+#### Helm chart changes
+- Adds `indexer.volumeAttributesClass` and `searcher.volumeAttributesClass` values to provision Kubernetes `VolumeAttributesClass` resources for indexer and searcher persistent volumes. Use these values to tune volume attributes such as IOPS and throughput. This feature is disabled by default, requires Kubernetes 1.31 or later, and requires `driverName` when enabled.
+- Fixes the Kubernetes advertise address by setting `KUBERNETES_POD_IP` from the pod IP instead of the pod name.
+- Disables `serviceAccount.automountServiceAccountToken` by default to reduce token exposure on pods that do not need Kubernetes API access.
+- Enables `securityContext.readOnlyRootFilesystem` by default across workloads for defense-in-depth hardening.
+
 ### v0.1.30 — 2026-06-30
 
 *Bundled in chart: `0.4.3`.*


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds BYOC Logs release notes for CloudPrem v0.1.31, bundled with Helm chart v0.4.5.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Validation:
- `git diff --check -- content/en/byoc-logs/release_notes.md` passed.
- `vale content/en/byoc-logs/release_notes.md` could not run because the local Datadog Vale styles directory is missing.
