### PR TITLE
Clarify allowed characters in RUM operation names

### DIFF
--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -130,7 +130,7 @@ m.global.datadogRumAgent@.startOperation(
 {{% /tab %}}
 {{< /tabs >}}
 
-<div class="alert alert-warning">The Operation's name cannot contain any whitespaces.</div>
+<div class="alert alert-warning">The Operation's name may only contain letters, digits, or the characters <code>- _ . @ $</code>, and cannot contain any whitespaces.</div>
 
 ### Stop an operation with success
 


### PR DESCRIPTION
## Summary
- Documents that RUM operation names may only contain letters, digits, or the characters `- _ . @ $`, in addition to the existing no-whitespace restriction.

## Test plan
- [ ] Docs build/preview renders the updated warning callout correctly on the Operations Monitoring page