### PR TITLE
[DOCS-10635] Fix broken kubernetes.yaml example link in Agent v5 guide

### DIFF
--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -289,7 +289,7 @@ Checks
 [7]: https://kubernetes.io/docs/concepts/configuration/secret
 [8]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
 [9]: /getting_started/agent/autodiscovery/
-[10]: https://github.com/DataDog/integrations-core/blob/master/kubernetes/datadog_checks/kubernetes/data/conf.yaml.example
+[10]: https://github.com/DataDog/integrations-core/blob/3d9e6ebfad2629c559c2174ec7a533e6d62d1ae6/kubernetes/datadog_checks/kubernetes/data/conf.yaml.example
 [11]: /agent/configuration/agent-commands/#agent-status-and-information
 [12]: https://github.com/kubernetes/kube-state-metrics
 [13]: https://quay.io/coreos/kube-state-metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-10635

The "example kubernetes.yaml" link in the Agent v5 Kubernetes Basic Agent Usage guide returned a 404. It pointed to the `kubernetes` check's `conf.yaml.example` on `master`, but that check's code was removed from `master` (integrations-core #6999, which made the kubernetes check a tile only); only the tile and README remain.

Because this is a legacy Agent v5 guide referencing an Agent v5-only check, this PR pins the link to the last commit where the example file existed, preserving the exact configuration options the surrounding prose describes.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Created with Claude Code and the documentation:process-tickets skill. Reviewed and verified by me.

### Additional notes
