### PR TITLE
Reference AWS Secrets Manager rotation for API keys and SATs

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -108,6 +108,8 @@ To add a Datadog application key, navigate to [**Organization Settings** > **App
 <div class="alert alert-info">If your organization has One-Time Read (OTR) mode enabled, make sure to securely store your application key immediately after creation, as the key secret cannot be retrieved later.</div>
 {{< /site-region >}}
 
+Because API keys and application keys are long-lived and have no built-in expiration, store them in a secrets manager, such as AWS Secrets Manager, HashiCorp Vault, or Azure Key Vault, instead of in source code or environment files. AWS Secrets Manager supports [managed rotation for Datadog API keys and application keys][24].
+
 **Notes:**
 
 - Application key names cannot be blank.
@@ -200,3 +202,4 @@ Need help? Contact [Datadog support][19].
 [21]: /api/latest/action-connection/#register-a-new-app-key
 [22]: /account_management/audit_trail/#setup
 [23]: /account_management/rbac/permissions/#compliance
+[24]: https://aws.amazon.com/about-aws/whats-new/2026/05/secrets-manager-managed-external-secrets-datadog-snowflake/

--- a/content/en/account_management/service-access-tokens.md
+++ b/content/en/account_management/service-access-tokens.md
@@ -60,6 +60,11 @@ Copy and store it securely. You cannot retrieve it later.</div>
 After you save, a details panel displays the token secret, name, Token ID, owner, owner roles,
 expiration date, and scopes.
 
+If you configure a SAT with a long expiration or select **Never**, store the secret in a secrets
+manager, such as AWS Secrets Manager, HashiCorp Vault, or Azure Key Vault, instead of in source
+code or environment files. AWS Secrets Manager supports [managed rotation for Datadog service
+account credentials][8].
+
 ## Use a Service Access Token
 
 SATs support two authentication methods.
@@ -161,3 +166,4 @@ GET /api/v2/personal_access_tokens
 [5]: /account_management/rbac/permissions/
 [6]: /account_management/audit_trail/
 [7]: https://app.datadoghq.com/audit-trail
+[8]: https://aws.amazon.com/about-aws/whats-new/2026/05/secrets-manager-managed-external-secrets-datadog-snowflake/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a reference to AWS Secrets Manager's new managed rotation support for Datadog credentials (announced May 2026). Recommends storing long-lived API keys, application keys, and Service Access Tokens (SATs) in a secrets manager such as AWS Secrets Manager, HashiCorp Vault, or Azure Key Vault, rather than in source code or environment files.

Personal Access Tokens (PATs) are not covered, since they require an expiration and aren't supported by the AWS managed rotation feature.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes