### PR TITLE
Add LLM Observability Data Deletion docs

### DIFF
--- a/content/en/llm_observability/data_deletion.md
+++ b/content/en/llm_observability/data_deletion.md
@@ -1,0 +1,51 @@
+---
+title: Data Deletion
+description: How LLM Observability handles data deletion requests, including automatic deletion of dataset records that match an Event Platform deletion search.
+further_reading:
+  - link: "/llm_observability/data_security_and_rbac"
+    tag: "Documentation"
+    text: "Data Security and RBAC"
+  - link: "/llm_observability/experiments/datasets"
+    tag: "Documentation"
+    text: "Datasets"
+---
+
+When a data deletion request is submitted for LLM Observability events in the Event Platform — for example to satisfy a GDPR or CCPA right-to-erasure request — Datadog automatically extends the deletion to any **dataset records** that were created from those events. This helps ensure that sensitive data is consistently removed from both the trace store and the Experiments dataset store.
+
+## How it works
+
+1. A deletion request arrives carrying an org ID, a time range, and a tag-based search filter (for example `env:prod service:myapp` or `@trace_id:<id>`).
+2. Before the Event Platform deletion runs, LLM Observability translates the search filter into a tag-containment condition and starts a row-scoped deletion workflow targeting the dataset records store.
+3. Dataset records whose tags match the translated condition and whose org ID matches are deleted.
+4. If the search cannot be translated to an exact tag filter — for example it contains free-text terms, wildcard patterns on tag values, or unsupported query constructs — the dataset record deletion is skipped and the Event Platform deletion still proceeds. The system fails closed to avoid deleting the wrong rows.
+5. The deletion workflow is idempotent: if the same deletion request is redelivered, a second workflow is not started.
+
+## Tag filter translation
+
+The following query forms are supported and translated to tag-containment filters:
+
+- **`key:value`** terms (for example `env:prod`) — matched against the tags on the dataset record
+- **`@tags:"key:value"`** quoted form, equivalent to the bare `key:value` form
+- **AND / OR / NOT** combinations of the above
+- **`key:(value1 OR value2)`** value lists
+
+Reserved scalar attributes are matched against their own dedicated columns rather than the tags object:
+
+- `@trace_id:<value>` — equality match on the `trace_id` column
+- `@span_id:<value>` — equality match on the `span_id` column
+- `@trace_id:<glob>` / `@span_id:<glob>` — pattern match on the column
+
+The following are **not supported** and cause the dataset record deletion to be skipped (the Event Platform deletion still proceeds):
+
+- Free-text terms with no `key:` prefix
+- Wildcard or glob patterns on tag values (for example `service:ai-*`)
+- Numeric comparisons or range queries
+- Queries consisting only of event-scoping attributes such as `@event_type`, which have no dataset record counterpart
+
+## Relationship to org-level deletion
+
+When an organization leaves Datadog, all of its LLM Observability data — including every dataset record row — is removed through a separate org-wide deletion flow. The tag-scoped deletion described on this page is a complementary, targeted mechanism for individual data-subject requests; it deletes only the rows that match the specific search filter of the request.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/llm_observability/data_security_and_rbac.md
+++ b/content/en/llm_observability/data_security_and_rbac.md
@@ -5,6 +5,9 @@ further_reading:
   - link: "/account_management/rbac/data_access"
     tag: "Documentation"
     text: "Learn more about data access controls"
+  - link: "/llm_observability/data_deletion"
+    tag: "Documentation"
+    text: "Data Deletion"
 ---
 {{< whatsnext desc=" ">}}
   {{< nextlink href="https://datadoghq.com/legal/hipaa-eligible-services">}}<u>HIPAA-Eligible Services</u>: Datadog Legal's list of HIPAA-eligible services{{< /nextlink >}}
@@ -33,6 +36,10 @@ Agent Observability integrates with [Sensitive Data Scanner][3], which helps pre
 
 By proactively scanning for sensitive data, Agent Observability ensures that conversations remain secure and compliant with data protection regulations. This additional layer of security reinforces Datadog's commitment to maintaining the confidentiality and integration of user interactions with LLMs.
 
+## Data Deletion
+
+When a data deletion request is submitted for LLM Observability events — for example to satisfy a GDPR or CCPA erasure request — Datadog automatically extends the deletion to any dataset records that were created from those events, based on the request's tag filter. For more information, see [Data Deletion][4].
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -40,4 +47,5 @@ By proactively scanning for sensitive data, Agent Observability ensures that con
 [1]: /account_management/rbac/data_access
 [2]: /llm_observability/instrumentation/sdk/#span-processing
 [3]: /security/sensitive_data_scanner/
+[4]: /llm_observability/data_deletion
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"26510e64-fb7d-4670-9348-8e75d0ece8c2","source":"chat","resourceId":"86fda161-5b82-4241-8e54-992843cb1760","workflowId":"6a5b45ef-cdf2-42b9-a8f8-f154957f13c8","codeChangeId":"6a5b45ef-cdf2-42b9-a8f8-f154957f13c8","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the new automatic dataset-record deletion feature for LLM Observability, implemented in https://github.com/ddoghq/dd-source/pull/8891 and https://github.com/ddoghq/dd-source/pull/13000. When a data deletion request arrives for LLM Observability events in the Event Platform (for example, a GDPR/CCPA right-to-erasure request), Datadog now automatically extends the deletion to any dataset records created from those events. This feature had no existing documentation.

Changes:
- **New page** `content/en/llm_observability/data_deletion.md`: covers the end-to-end deletion flow, supported tag filter translations, unsupported query forms, and the relationship to org-level deletion.
- **Updated** `content/en/llm_observability/data_security_and_rbac.md`: added a `## Data Deletion` cross-reference section and a `further_reading` entry pointing to the new page.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code (Datadog AI agent) to draft and write the documentation pages.

### Additional notes

Source PRs: https://github.com/ddoghq/dd-source/pull/8891, https://github.com/ddoghq/dd-source/pull/13000

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/86fda161-5b82-4241-8e54-992843cb1760)