### PR TITLE
fix: remove incorrect escaping from $basearch in the Datadog Security CLI repository URL 

### DIFF
--- a/content/en/security/cloud_security_management/setup/ci_cd/_index.md
+++ b/content/en/security/cloud_security_management/setup/ci_cd/_index.md
@@ -92,7 +92,7 @@ sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
 sudo tee /etc/yum.repos.d/datadog-security-cli.repo > /dev/null <<'EOF'
 [datadog-security-cli]
 name=Datadog Security CLI
-baseurl=https://yum.datadoghq.com/stable/datadog-security-cli/\$basearch/
+baseurl=https://yum.datadoghq.com/stable/datadog-security-cli/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public


### PR DESCRIPTION
Remove the unnecessary escape character before the $basearch variable in the Datadog Security CLI YUM repository URL for Red Hat/CentOS.

The escaped value (\$basearch) caused YUM/DNF to generate an invalid repository path, resulting in a 404 error while fetching repository metadata. Using $basearch directly allows YUM/DNF to correctly resolve the system architecture (for example, x86_64) and access the appropriate package repository.

This change ensures that the Datadog Security CLI can be installed successfully using the package repository instructions for Red Hat/CentOS and other supported RPM-based systems.

**The attached file consist of code snippet of the tested code :** [security-cli-code-snippet.txt](https://github.com/user-attachments/files/29977240/security-cli-code-snippet.txt)