### PR TITLE
[DOCS-14861] Azure log forwarding perm pre-req

### DIFF
--- a/content/en/logs/guide/azure-automated-log-forwarding.md
+++ b/content/en/logs/guide/azure-automated-log-forwarding.md
@@ -17,6 +17,10 @@ The ARM template deploys resources from a series of Azure services (storage acco
 
 **Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported.
 
+## Prerequisites
+
+You must have permission on the management group to deploy automated log forwarding with the ARM template.
+
 ## How to choose between automated and manual setup
 
 Choose the manual setup method if you want to:
@@ -49,12 +53,12 @@ Alternatively, you can deploy automated log forwarding with an [Azure Public ARM
 
 #### Basics
 
-1. Under {{< ui >}}Project details{{< /ui >}}, select the management group. This is needed for the ARM template to grant permissions to the subscriptions you select for automated log forwarding.
+1. Under {{< ui >}}Project details{{< /ui >}}, select a management group. This field is required. The ARM template uses the management group to grant permissions to the subscriptions you select for automated log forwarding.
 2. Under {{< ui >}}Instance details{{< /ui >}}, select values for:
    - {{< ui >}}Region{{< /ui >}}. This is where the control plane is deployed.
    - {{< ui >}}Subscriptions to Forward Logs{{< /ui >}}. These are the subscriptions to be configured for log forwarding.
    - {{< ui >}}Control Plane Subscription{{< /ui >}}. This is the subscription that the control plane is deployed to.
-   - {{< ui >}}Resource Group Name{{< /ui >}}. This is the resource group to be used by the control plane. It is recommended to choose a new, unused resource group name to simplify management of control plane services.
+   - {{< ui >}}Resource Group Name{{< /ui >}}. This is the resource group to be used by the control plane. Datadog recommends you choose a new, unused resource group name to simplify management of control plane services.
 
 {{< img src="logs/guide/azure-automated-log-forwarding/deployment_basics.png" alt="The Basics page of the ARM template for Azure automated log forwarding" popup="true" style="width:100%">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Addresses DOCS-14861

Adds a prerequisite section to [Azure automated log forwarding](https://docs.datadoghq.com/logs/guide/azure-automated-log-forwarding/?site=us) to ensure users have the correct permissions for the management group before setting up log forwarding.

### Merge readiness

- [X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Used Claude to locate existing examples of similar prerequisite sections and add the corresponding info to this page.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
