### PR TITLE
Add AWS metric name filters API guide

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -154,6 +154,8 @@ Metric name filters apply per namespace and are evaluated after the namespace is
 Metric name filters cannot remove <code>aws.ec2.cpuutilization</code> or <code>aws.lambda.invocations</code>. Datadog always collects these required metrics.
 </div>
 
+To manage metric name filters programmatically, see [Configure AWS metric name filters with the API][61].
+
 ### Add regions
 
 Under the {{< ui >}}General{{< /ui >}} tab on the [AWS integration page][8], you can control the AWS regions where Datadog collects metrics, CloudWatch events, and resources.
@@ -309,3 +311,4 @@ If you encounter the error `Datadog is not authorized to perform sts:AssumeRole`
 [58]: /integrations/ecs_fargate/?tab=webui#installation-for-aws-batch
 [59]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-get-template.html
 [60]: /integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/
+[61]: /integrations/guide/aws-metric-name-filters/

--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -41,6 +41,7 @@ cascade:
     {{< nextlink href="integrations/guide/aws-organizations-setup" tag=" AWS" >}}AWS integration multi-account setup for Organizations{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-manual-setup" tag=" AWS" >}}AWS integration manual setup{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-integration-troubleshooting" tag=" AWS" >}}Troubleshooting the AWS integration{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/aws-metric-name-filters" tag=" AWS" >}}Configure AWS metric name filters with the API{{< /nextlink >}}
     {{< nextlink href="integrations/guide/monitor-your-aws-billing-details" tag=" AWS" >}}Monitor your AWS billing details{{< /nextlink >}}
     {{< nextlink href="integrations/guide/error-datadog-not-authorized-sts-assume-role" tag=" AWS" >}}Error: Datadog is not authorized to perform sts:AssumeRole{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose" tag=" AWS" >}}AWS CloudWatch Metric Streams with Amazon Data Firehose{{< /nextlink >}}

--- a/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
+++ b/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
@@ -15,7 +15,7 @@ Yes. Enable **Collect Custom Metrics** under the **Metric Collection** tab on th
 
 Yes. On the [AWS integration page][1], open the **Metric Collection** tab, expand a CloudWatch namespace, and add metric name filters. Use **Include** to collect only matching Datadog metric names for that namespace, or **Exclude** to collect everything except matching metric names.
 
-For more information on syntax and required metrics, see [Getting Started with AWS][14].
+For more information on syntax and required metrics, see [Getting Started with AWS][14]. To manage metric name filters programmatically, see [Configure AWS metric name filters with the API][15].
 
 ### How do I collect metrics from a service for which Datadog doesn't have an official integration?
 
@@ -126,3 +126,4 @@ Some AWS services do not emit metrics to CloudWatch by default and require extra
 [12]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
 [13]: /integrations/guide/monitor-your-aws-billing-details/
 [14]: /getting_started/integrations/aws/#filter-metrics-by-metric-name
+[15]: /integrations/guide/aws-metric-name-filters/

--- a/content/en/integrations/guide/aws-metric-name-filters.md
+++ b/content/en/integrations/guide/aws-metric-name-filters.md
@@ -1,0 +1,167 @@
+---
+title: Configure AWS Metric Name Filters with the API
+description: "Use the Datadog API to preview and configure AWS CloudWatch metric name filters."
+further_reading:
+- link: "/api/latest/aws-integration/#update-an-aws-integration"
+  tag: "API"
+  text: "Update an AWS integration"
+- link: "/api/latest/aws-integration/#get-aws-metric-name-filter-preview"
+  tag: "API"
+  text: "Get AWS metric name filter preview"
+- link: "/getting_started/integrations/aws/#filter-metrics-by-metric-name"
+  tag: "Documentation"
+  text: "Filter AWS metrics by metric name"
+---
+
+AWS metric name filters control which CloudWatch metric names Datadog collects for a namespace in an AWS account integration. Use an **include** filter to collect only matching Datadog metric names, or an **exclude** filter to collect all metric names except matching ones.
+
+Metric name filters apply after the namespace is enabled for metric collection. Each filter applies to one CloudWatch namespace, and each namespace can use only one filter mode: `include_only` or `exclude_only`.
+
+<div class="alert alert-info">
+Metric name filters cannot remove <code>aws.ec2.cpuutilization</code> or <code>aws.lambda.invocations</code>. Datadog always collects these required metrics.
+</div>
+
+## Before you begin
+
+You need:
+
+- A Datadog API key and application key with the `aws_configuration_read` and `aws_configuration_edit` permissions.
+- The AWS account ID for the integration you want to update.
+- Your Datadog site. Your site is {{< region-param key="dd_site" code="true" >}}.
+
+Set these environment variables before running the examples:
+
+```shell
+export DD_SITE="<DD_SITE>"
+export DD_API_KEY="<DATADOG_API_KEY>"
+export DD_APP_KEY="<DATADOG_APPLICATION_KEY>"
+export AWS_ACCOUNT_ID="<AWS_ACCOUNT_ID>"
+```
+
+## Find the AWS account config ID
+
+The update and preview endpoints use the Datadog AWS account config ID, not the AWS account ID. To find the config ID, call the [List all AWS integrations][1] endpoint and filter by AWS account ID:
+
+```shell
+curl -X GET "https://api.${DD_SITE}/api/v2/integration/aws/accounts?aws_account_id=${AWS_ACCOUNT_ID}" \
+-H "Accept: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
+```
+
+In the response, use the `data.id` value for the matching account config:
+
+```shell
+export AWS_ACCOUNT_CONFIG_ID="<AWS_ACCOUNT_CONFIG_ID>"
+```
+
+## Preview saved filters
+
+To preview the effect of the filters already saved on an account config, call the [Get AWS metric name filter preview][2] endpoint:
+
+```shell
+curl -X GET "https://api.${DD_SITE}/api/v2/integration/aws/accounts/${AWS_ACCOUNT_CONFIG_ID}/metric_name_filter_preview" \
+-H "Accept: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
+```
+
+The response lists each affected namespace, the filter patterns that matched metric names, and whether each resulting Datadog metric name is filtered.
+
+## Preview a proposed filter
+
+To preview filters before saving them, call the [Preview AWS metric name filter][3] endpoint. This request does not update the account config.
+
+The following example previews an include filter for EC2 network metrics:
+
+```shell
+curl -X POST "https://api.${DD_SITE}/api/v2/integration/aws/accounts/${AWS_ACCOUNT_CONFIG_ID}/metric_name_filter_preview" \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+-d @- << EOF
+{
+  "data": {
+    "type": "metric_name_filter_preview",
+    "attributes": {
+      "metric_name_filters": [
+        {
+          "namespace": "AWS/EC2",
+          "include_only": [
+            "aws.ec2.network_*"
+          ]
+        }
+      ]
+    }
+  }
+}
+EOF
+```
+
+Use `exclude_only` instead of `include_only` to preview collecting all metric names for a namespace except matching patterns:
+
+```json
+{
+  "namespace": "AWS/EC2",
+  "exclude_only": [
+    "aws.ec2.network_*"
+  ]
+}
+```
+
+Filter patterns support lowercase letters, numbers, `.`, `_`, and `*`.
+
+## Save metric name filters
+
+To save filters, update the AWS account integration config and set `data.attributes.metrics_config.metric_name_filters`.
+
+The following example saves an include filter for EC2 network metrics:
+
+```shell
+curl -X PATCH "https://api.${DD_SITE}/api/v2/integration/aws/accounts/${AWS_ACCOUNT_CONFIG_ID}" \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+-d @- << EOF
+{
+  "data": {
+    "type": "account",
+    "attributes": {
+      "aws_account_id": "${AWS_ACCOUNT_ID}",
+      "metrics_config": {
+        "metric_name_filters": [
+          {
+            "namespace": "AWS/EC2",
+            "include_only": [
+              "aws.ec2.network_*"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+```
+
+When updating an existing account config, preserve any existing `metrics_config` fields you want to keep in the request body.
+
+## Verify the saved filters
+
+After saving the filters, call the [Get AWS metric name filter preview][2] endpoint again to confirm which metric names are filtered:
+
+```shell
+curl -X GET "https://api.${DD_SITE}/api/v2/integration/aws/accounts/${AWS_ACCOUNT_CONFIG_ID}/metric_name_filter_preview" \
+-H "Accept: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}"
+```
+
+You can also call the [Get an AWS integration by config ID][4] endpoint and confirm the saved filters are present under `data.attributes.metrics_config.metric_name_filters`.
+
+[1]: /api/latest/aws-integration/#list-all-aws-integrations
+[2]: /api/latest/aws-integration/#get-aws-metric-name-filter-preview
+[3]: /api/latest/aws-integration/#preview-aws-metric-name-filter
+[4]: /api/latest/aws-integration/#get-an-aws-integration-by-config-id


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds an API guide for configuring AWS metric name filters.

- Documents how to find the AWS account config ID.
- Shows saved and proposed filter previews.
- Shows how to update `metrics_config.metric_name_filters`.
- Links the guide from AWS setup docs and FAQ.
