### PR TITLE
[TEST] Non-reorg conflict on a top-level file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Datadog documentation style guide
 
-This guide explains how to write and edit content for the [Datadog documentation][7]. While it's helpful for standardizing large bodies of work with multiple contributors, a style guide can't tell you how to write for your specific context. If you find that these guidelines get in the way of writing clearly, break the rules! Just do so thoughtfully.
+This guide explains how to write and revise content for the [Datadog documentation][7]. While it's helpful for standardizing large bodies of work with multiple contributors, a style guide can't tell you how to write for your specific context. If you find that these guidelines get in the way of writing clearly, break the rules! Just do so thoughtfully.
 
 The Datadog documentation [implementation of the Vale linter][4] has rules corresponding to some of these guidelines. After you make a PR, check its **Files changed** tab to see and fix warnings and errors it flagged.
 

--- a/astro_reorg/config.yaml
+++ b/astro_reorg/config.yaml
@@ -132,7 +132,7 @@ ignore:
 test:
   # Stand-in for post-reorg master: the branch that has the reorg applied. Test
   # PRs target it, and resolve_pr_conflicts.py treats it as the base by default.
-  mock_reorged_master_branch: jen.gilbert/astro-reorg-demo-7-10-22047
+  mock_reorged_master_branch: mock-reorged-master-122011
   # Frozen snapshot of master that test PRs branch off, so each PR's diff stays
   # small (a PR shows every commit in its head that isn't in the base branch).
   branch_from: jen.gilbert/astro-reorg-scripts


### PR DESCRIPTION
Test PR for exercising the astro reorg tooling. Creates a conflict on a top-level file that the reorg doesn't move, so it isn't a reorg conflict and should go straight to manual review.

Do not merge.