### PR TITLE
Add OPW 2.19 changelog to docs

### DIFF
--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -25,13 +25,6 @@ To upgrade to Worker version 2.19.0:
 
 Worker version 2.19.0 gives you access to the following:
 
-#### New features
-
-- The OpenTelemetry source and destination now support traces pipelines.
-- The Custom Processor is now available in traces pipelines.
-- The Sensitive Data Scanner processor is now available in traces pipelines.
-- Live Capture now supports traces pipelines.
-
 #### Enhancements
 
 - A `server_name` TLS option has been added to the BYOC Logs, HTTP Client, Socket, and Syslog destinations and to the HTTP Client source. It overrides the SNI and certificate hostname used for the TLS handshake, which is applicable when the dialed address does not match the certificate's Common Name or Subject Alternative Name.
@@ -66,7 +59,6 @@ Worker version 2.18.0 gives you access to the following:
 - The `run` command now supports a `--log-format` flag, also configurable using the `DD_OP_LOG_FORMAT` environment variable, for selecting the format of the Worker's own `stdout` and `stderr` logs. The default `text` preserves the existing human-readable output, and `json` emits structured JSON logs that can be tailed and parsed directly without additional parsing rules.
 - The Tag Cardinality Limit processor now supports a `tracking_mode` option. `exact_fingerprint` tracks tag values exactly using 64-bit fingerprints, which uses less memory than the previous method of storing raw values, and `probabilistic` uses a bloom filter for even lower memory usage in exchange for an occasional false positive. Probabilistic mode accepts a `false_positive_rate` field, which defaults to `0.001` (0.1%).
 - The WebSocket source is available for ingesting logs from a WebSocket endpoint, with support for `none`, `basic`, `bearer`, and `custom` authentication strategies, as well as TLS.
-- Trace pipelines now support the sample processor.
 - A new `generate_metrics` processor routes metrics to any supported metrics destination. Datadog recommends using it over the existing `generate_datadog_metrics` processor, although use of the latter is not affected.
 
 #### Enhancements

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade the Worker Guide
-description: Learn about new features, enhancements, and fixes for Worker versions 2.7 to 2.18.
+description: Learn about new features, enhancements, and fixes for Worker versions 2.7 to 2.19.
 disable_toc: false
 aliases:
     - /observability_pipelines/guide/upgrade_worker_2_7/
@@ -13,6 +13,42 @@ Datadog recommends updating the Observability Pipelines Worker (OPW) with every 
 </div>
 
 This guide goes over how to upgrade to a specific Worker version and the updates for that version.
+
+## Worker version 2.19.0
+
+To upgrade to Worker version 2.19.0:
+
+- Docker: Run the `docker pull` command for the [2.19.0 image][49].
+- Kubernetes: See the [Helm chart][2] and [Upgrade the Worker][37].
+- APT: Run the command `apt-get install observability-pipelines-worker=2.19.0`.
+- RPM: Run the command `sudo yum install observability-pipelines-worker-2.19.0`.
+
+Worker version 2.19.0 gives you access to the following:
+
+#### New features
+
+- The OpenTelemetry source and destination now support traces pipelines.
+- The Custom Processor is now available in traces pipelines.
+- The Sensitive Data Scanner processor is now available in traces pipelines.
+- Live Capture now supports traces pipelines.
+
+#### Enhancements
+
+- A `server_name` TLS option has been added to the BYOC Logs, HTTP Client, Socket, and Syslog destinations and to the HTTP Client source. It overrides the SNI and certificate hostname used for the TLS handshake, which is applicable when the dialed address does not match the certificate's Common Name or Subject Alternative Name.
+- The Splunk TCP source now supports hot-reloading TLS certificates, so certificate rotations are applied without restarting the Worker.
+- The BYOC Logs destination now supports hot-reloading mTLS files.
+- The Worker now supports a configurable graceful shutdown limit.
+- The Amazon S3 destination now supports SSE-KMS encryption using the `server_side_encryption` and `ssekms_key_id` options.
+
+#### Fixes
+
+- Fixed an issue in the Reduce processor where a timestamp field whose name requires quoting in a path (for example, `"created.at"` or `"event-time"`) had its `_end` companion field silently dropped from the reduced event. The companion field is now placed correctly next to the base field.
+- Fixed a configuration reload issue. If a reload changed a component's type while keeping the same name, such as replacing a source named `X` with a processor named `X`, any downstream processor or destination still reading from `X` now reconnects to the new component.
+- Fixed an issue in the Syslog source (TCP mode) to handle over-length, length-prefixed message split across multiple reads.
+- Fixed an issue in the Logstash source to acknowledge only completed windows instead of sometimes sending a partial acknowledgment. Partial acknowledgments could confuse proxies that expect a single acknowledgment per window and cause errors on subsequent batches.
+- The Logstash source now rejects a window-size frame that arrives before the current window has received all of its advertised events, closing the connection with a fatal decode error instead of continuing.
+- Fixed the Syslog codec silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
+- Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines of 65,535 bytes or more.
 
 ## Worker version 2.18.0
 
@@ -629,3 +665,4 @@ Worker version 2.7.0 gives you access to the following:
 [46]: https://hub.docker.com/r/datadog/observability-pipelines-worker/tags?name=2.17.0
 [47]: /observability_pipelines/destinations/databricks/
 [48]: https://hub.docker.com/r/datadog/observability-pipelines-worker/tags?name=2.18.0
+[49]: https://hub.docker.com/r/datadog/observability-pipelines-worker/tags?name=2.19.0

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -41,7 +41,7 @@ Worker version 2.19.0 gives you access to the following:
 - The Logstash source has been fixed to acknowledge only completed windows instead of sometimes sending a partial acknowledgment.
 - The Logstash source now rejects a window-size frame that arrives before the current window has received all of its advertised events, closing the connection with a fatal decode error instead of continuing.
 - Fixed the Syslog codec that was silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
-- Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines of 65,535 bytes or more.
+- Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` that had inputs with lines of 65,535 bytes or more.
 
 ## Worker version 2.18.0
 

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -37,7 +37,7 @@ Worker version 2.19.0 gives you access to the following:
 
 - Fixed an issue in the Reduce processor where a timestamp field whose name requires quoting in a path (for example, `"created.at"` or `"event-time"`) had its `_end` companion field silently dropped from the reduced event. The companion field is now placed correctly next to the base field.
 - Fixed a configuration reload issue. If a reload changed a component's type while keeping the same name, such as replacing a source named `X` with a processor named `X`, any downstream processor or destination still reading from `X` now reconnects to the new component.
-- The Syslog source (TCP mode) has been fixed to handle over-length, length-prefixed message split across multiple reads.
+- The Syslog source (TCP mode) has been fixed to handle an over-length, length-prefixed message split across multiple reads.
 - The Logstash source has been fixed to acknowledge only completed windows instead of sometimes sending a partial acknowledgment.
 - The Logstash source now rejects a window-size frame that arrives before the current window has received all of its advertised events, closing the connection with a fatal decode error instead of continuing.
 - Fixed the Syslog codec that was silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -39,7 +39,7 @@ Worker version 2.19.0 gives you access to the following:
 - Fixed a configuration reload issue. If a reload changed a component's type while keeping the same name, such as replacing a source named `X` with a processor named `X`, any downstream processor or destination still reading from `X` now reconnects to the new component.
 - The Syslog source (TCP mode) has been fixed to handle an over-length, length-prefixed message split across multiple reads.
 - The Logstash source has been fixed to acknowledge only completed windows instead of sometimes sending a partial acknowledgment.
-- The Logstash source now rejects a window-size frame that arrives before the current window has received all of its advertised events, closing the connection with a fatal decode error instead of continuing.
+- The Logstash source now rejects a batch of events that arrives before all events in the current batch has been received, closing the connection with a fatal decode error instead of continuing.
 - Fixed the Syslog codec that was silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
 - Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` that had inputs with lines of 65,535 bytes or more.
 

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -27,7 +27,7 @@ Worker version 2.19.0 gives you access to the following:
 
 #### Enhancements
 
-- A `server_name` TLS option has been added to the BYOC Logs, HTTP Client, Socket, and Syslog destinations and to the HTTP Client source. It overrides the SNI and certificate hostname used for the TLS handshake, which is applicable when the dialed address does not match the certificate's Common Name or Subject Alternative Name.
+- A `server_name` TLS option has been added to the BYOC Logs, HTTP Client, Socket, and Syslog destinations, and to the HTTP Client source. It overrides the SNI and certificate hostname used for the TLS handshake, which is applicable when the dialed address does not match the certificate's Common Name or Subject Alternative Name.
 - The Splunk TCP source now supports hot-reloading TLS certificates, so certificate rotations are applied without restarting the Worker.
 - The BYOC Logs destination now supports hot-reloading mTLS files.
 - The Worker now supports a configurable graceful shutdown limit.
@@ -37,10 +37,10 @@ Worker version 2.19.0 gives you access to the following:
 
 - Fixed an issue in the Reduce processor where a timestamp field whose name requires quoting in a path (for example, `"created.at"` or `"event-time"`) had its `_end` companion field silently dropped from the reduced event. The companion field is now placed correctly next to the base field.
 - Fixed a configuration reload issue. If a reload changed a component's type while keeping the same name, such as replacing a source named `X` with a processor named `X`, any downstream processor or destination still reading from `X` now reconnects to the new component.
-- Fixed an issue in the Syslog source (TCP mode) to handle over-length, length-prefixed message split across multiple reads.
-- Fixed an issue in the Logstash source to acknowledge only completed windows instead of sometimes sending a partial acknowledgment. Partial acknowledgments could confuse proxies that expect a single acknowledgment per window and cause errors on subsequent batches.
+- The Syslog source (TCP mode) has been fixed to handle over-length, length-prefixed message split across multiple reads.
+- The Logstash source has been fixed to acknowledge only completed windows instead of sometimes sending a partial acknowledgment.
 - The Logstash source now rejects a window-size frame that arrives before the current window has received all of its advertised events, closing the connection with a fatal decode error instead of continuing.
-- Fixed the Syslog codec silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
+- Fixed the Syslog codec that was silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
 - Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines of 65,535 bytes or more.
 
 ## Worker version 2.18.0

--- a/content/en/observability_pipelines/guide/upgrade_worker.md
+++ b/content/en/observability_pipelines/guide/upgrade_worker.md
@@ -38,7 +38,7 @@ Worker version 2.19.0 gives you access to the following:
 - Fixed an issue in the Reduce processor where a timestamp field whose name requires quoting in a path (for example, `"created.at"` or `"event-time"`) had its `_end` companion field silently dropped from the reduced event. The companion field is now placed correctly next to the base field.
 - Fixed a configuration reload issue. If a reload changed a component's type while keeping the same name, such as replacing a source named `X` with a processor named `X`, any downstream processor or destination still reading from `X` now reconnects to the new component.
 - The Syslog source (TCP mode) has been fixed to handle an over-length, length-prefixed message split across multiple reads.
-- The Logstash source has been fixed to acknowledge only completed windows instead of sometimes sending a partial acknowledgment.
+- The Logstash source has been fixed to only send an acknowledgment when all events of a batch are received instead of sending a partial acknowledgment.
 - The Logstash source now rejects a batch of events that arrives before all events in the current batch has been received, closing the connection with a fatal decode error instead of continuing.
 - Fixed the Syslog codec that was silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and defaulting to `informational`. Both short-form and full-form severity names are now accepted.
 - Fixed an issue in the Custom Processor functions `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` that had inputs with lines of 65,535 bytes or more.


### PR DESCRIPTION
Add changelog entries from OPW 2.19 to docs https://github.com/DataDog/observability-pipelines-worker/blob/cb2579df7a725016b44d50dd9a06154865d511c9/CHANGELOG.md