### PR TITLE
[TEST] New page with nav link (base edited the same menu line)

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1,5 +1,9 @@
 menu:
   main:
+    - name: Example Feature
+      identifier: example_feature_heading
+      url: /getting_started/example_feature/
+      weight: 500000
     - name: Essentials
       identifier: essentials_heading
       weight: 1000000

--- a/content/en/getting_started/example_feature/_index.md
+++ b/content/en/getting_started/example_feature/_index.md
@@ -1,0 +1,5 @@
+---
+title: Example Feature
+---
+
+Placeholder page for exercising the astro reorg tooling.


### PR DESCRIPTION
Test PR for exercising the astro reorg tooling. Adds a new page and a nav menu entry linking to it. The base branch renames that same menu heading, so the auto-fix can't replay the menu change and the PR should be labeled for manual review.

Do not merge.