### PR TITLE
[DOCS-15096] Fix spelling typos in Code Security docs

### DIFF
--- a/content/en/security/code_security/iast/setup/nodejs.md
+++ b/content/en/security/code_security/iast/setup/nodejs.md
@@ -118,7 +118,7 @@ esbuild.build({
   entryPoints: ['app.js'],
   bundle: true,
   outfile: 'out.js',
-  sourcemap: true, // required for correct vulnearability location
+  sourcemap: true, // required for correct vulnerability location
   plugins: [ddPlugin],
   platform: 'node', // allows built-in modules to be required
   target: ['node18'],

--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/dotnet.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/dotnet.md
@@ -32,7 +32,7 @@ The minimum tracer version to get all supported application security capabilitie
 
 ### Supported .NET versions
 
-For a list of supported platforms and operating systems, see [.NET Framework Compatibility][2] and [.NET/.NET Core Compatiblity][1].
+For a list of supported platforms and operating systems, see [.NET Framework Compatibility][2] and [.NET/.NET Core Compatibility][1].
 
 ### Web framework compatibility
 

--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -111,7 +111,7 @@ AI-native SAST detects the following vulnerability types:
 
 Code Security SAST provides AI-powered detection for vulnerabilities in source code. AI-powered detection is built on top of Datadog's default static analyzer tool, `datadog-static-analyzer`. The AI-powered layer enhances detection for semantically complex or cross-file vulnerabilities
 
-AI-powered detection is provided in [Vulernabilities][6] and [Repositories][7]. Use the query `@static_analysis.tool.name:datadog-saist` to use AI-powered detection.
+AI-powered detection is provided in [Vulnerabilities][6] and [Repositories][7]. Use the query `@static_analysis.tool.name:datadog-saist` to use AI-powered detection.
 
 ### How the AI layer works
 

--- a/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/content/en/security/code_security/static_analysis/setup/_index.md
@@ -246,7 +246,7 @@ When ingesting SARIF files, Datadog maps SARIF severities into CVSS severities u
 
 ## Data Retention
 
-Datadog stores findings in accordance with our [Data Rentention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
+Datadog stores findings in accordance with our [Data Retention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
 
 <!-- ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15096

Fixes 4 spelling typos in the Code Security documentation:
- `vulnearability` → `vulnerability`
- `Compatiblity` → `Compatibility`
- `Vulernabilities` → `Vulnerabilities`
- `Rentention` → `Retention`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code for the full change: identifying and fixing the typos, running Vale, and creating this PR.

### Additional notes