### PR TITLE
Clarify Lambda Extension env var naming for HTTP obfuscation settings

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -397,10 +397,9 @@ apm_config:
 * `remove_query_string` or environment variable `DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`: If true, obfuscates query strings in URLs (`http.url`).
 * `remove_paths_with_digits` or environment variable `DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`: If true, path segments in URLs (`http.url`) containing one or more digits are replaced by "?".
 
-**Note**: If you are using the [Datadog Lambda Extension][2], set `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING` and `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS` instead.
+**Note**: If you are using the Datadog Lambda Extension, set `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING` and `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS` instead.
 
 [1]: /tracing/glossary/#spans
-[2]: /serverless/libraries_integrations/extension/
 {{% /tab %}}
 {{% tab "Stack Traces" %}}
 

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -397,7 +397,10 @@ apm_config:
 * `remove_query_string` or environment variable `DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`: If true, obfuscates query strings in URLs (`http.url`).
 * `remove_paths_with_digits` or environment variable `DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`: If true, path segments in URLs (`http.url`) containing one or more digits are replaced by "?".
 
+**Note**: If you are using the [Datadog Lambda Extension][2], set `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING` and `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS` instead.
+
 [1]: /tracing/glossary/#spans
+[2]: /serverless/libraries_integrations/extension/
 {{% /tab %}}
 {{% tab "Stack Traces" %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The `remove_query_string` and `remove_paths_with_digits` HTTP obfuscation settings are documented with the following environment variable names:

- `DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`
- `DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`

These names are correct for the host Datadog Agent, but they have no effect when set on an AWS Lambda function using the Datadog Lambda Extension. The Lambda Extension internally reads a different set of names for these two settings, with an added `_CONFIG_` segment:

- `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`
- `DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`

Source reference confirming the Lambda Extension's internal variable names: [serverless-components / datadog-agent-config / env.rs#L206](https://github.com/DataDog/serverless-components/blob/56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627/crates/datadog-agent-config/src/sources/env.rs#L206)

This gap is not documented anywhere, and it is difficult for customers to self-diagnose since there is no error or warning when the host Agent variable name is set on Lambda, it simply has no effect. Two support tickets independently ran into this exact issue:

- Ticket 2920198 (resolved): customer set `DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING=true` on Lambda, `http.url` remained unobfuscated. Root cause found by reading the Lambda Extension source code.
- Ticket 2953229: same issue, plus a question about `DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`. Both variables were verified end-to-end on a live Lambda function for this PR.

**Testing:** Verified on AWS Lambda (Python 3.14, `ap-northeast-1`) with the `Datadog-Extension` and `Datadog-Python314` layers, using a test function that calls a URL with a query string and a numeric path segment, and inspecting the resulting span's `http.url` tag.

- With the host Agent variable names set: no effect, `http.url` unobfuscated.
<img width="2000" height="882" alt="image" src="https://github.com/user-attachments/assets/709c514a-11be-4a90-a812-a34f630a3beb" />

- With the `_CONFIG_` variable names set: both settings take effect, query string removed and numeric path segment replaced with `?`.
<img width="2000" height="1108" alt="image" src="https://github.com/user-attachments/assets/8174754e-2e9e-48d4-ab1a-5e911565c672" />

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code for investigation (reading Lambda Extension source) and initial PR draft. Ran the verification Lambda function, content reviewed and edited by me before submission.

### Additional notes

Open question for reviewers: does this `_CONFIG_` naming difference apply only to these two HTTP obfuscation settings, or to other `DD_APM_OBFUSCATION_*` settings as well (MongoDB, Elasticsearch, Redis, etc.)? Only the two HTTP settings were tested for this PR.