### PR TITLE
[DOCS-XXXXX] Flag DDSQL and calculated fields as unsupported in BYOC Logs

### DIFF
--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -46,6 +46,5 @@ Feature support is actively evolving. The following are not currently supported:
 - **Notebooks**: Log data from BYOC Logs cannot be used in Notebooks.
 - **Federated search**: Searching across multiple BYOC Logs clusters from a single query is not supported.
 - **LiveTail**: Real-time log streaming is not available for BYOC Logs indexes.
-- **Log context view**: Viewing surrounding logs in context is not yet supported.
 
 [1]: /api/latest/logs-restriction-queries/

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -39,6 +39,8 @@ The following log features are supported:
 
 Feature support is actively evolving. The following are not currently supported:
 
+- **DDSQL**: Querying BYOC Logs data with DDSQL is not supported.
+- **Calculated fields**: Defining calculated fields on BYOC Logs data is not supported.
 - **SIEM**: Not available for BYOC Logs data.
 - **Watchdog**: Not available for BYOC Logs data.
 - **Notebooks**: Log data from BYOC Logs cannot be used in Notebooks.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX <!-- TODO: add Jira ticket -->

Adds **DDSQL** and **Calculated fields** to the list of unsupported features on the BYOC Logs "Supported Features" page (`/byoc-logs/introduction/features/`), reflecting that neither is available for BYOC Logs data.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

