### PR TITLE
Fix sticky filter CSS to account for the missing top docs banner

### DIFF
--- a/assets/styles/components/_multifilter-search.scss
+++ b/assets/styles/components/_multifilter-search.scss
@@ -1,10 +1,16 @@
+.announcement .multifilter-search-component {
+    #multifilter-search-nav {
+        top: 95px;
+    }
+}
+
 .multifilter-search-component {
     [x-cloak] {
         display: none !important;
     }
     #multifilter-search-nav {
         position: sticky;
-        top: 95px;
+        top: 65px;
         align-self: flex-start;
         z-index: 2;
         background-color: white;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adjusts the filter CSS to account for cases when the docs site doesn't have a banner. If you scroll down on this prod page, you can see the issue: https://docs.datadoghq.com/tracing/recommendations/. The filter is sitting too low, so scrolling content is visible above it.

You can see the issue is resolved [in staging](https://docs-staging.datadoghq.com/jen.gilbert/WEB-9662-sticky-filters-fix/tracing/recommendations/).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
