### PR TITLE
Document Okta SCIM role attribute mapping

### DIFF
--- a/content/en/account_management/scim/okta.md
+++ b/content/en/account_management/scim/okta.md
@@ -78,8 +78,11 @@ Datadog's SCIM role support follows the SCIM multi-valued attribute convention d
     - {{< ui >}}Display name{{< /ui >}}: **Roles**
     - {{< ui >}}Variable name{{< /ui >}}: **roles**
     - For {{< ui >}}Enum{{< /ui >}}, select {{< ui >}}Define enumerated list of values{{< /ui >}} and add one entry per Datadog role, using the role name as the display name and the role UUID as the value. You can find a role's UUID in the role's URL on your [Organization Settings][9] page. Add any custom roles the same way.
-2. In your Datadog application's {{< ui >}}Provisioning{{< /ui >}} > {{< ui >}}To App{{< /ui >}} settings, map the Okta `roles` attribute to the Datadog `roles` attribute.
-3. In the app's {{< ui >}}Assignments{{< /ui >}} tab, assign each user the appropriate role from the dropdown.
+2. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the Datadog application (or SCIM test app), then create a custom app attribute for the role. Configure the custom attribute as follows:
+    - {{< ui >}}External namespace{{< /ui >}}: `urn:ietf:params:scim:schemas:core:2.0:User`
+    - {{< ui >}}External name{{< /ui >}}: `roles.^[primary==true].value`
+3. In your Datadog application's {{< ui >}}Provisioning{{< /ui >}} > {{< ui >}}To App{{< /ui >}} settings, map the Okta `roles` attribute to the custom app attribute.
+4. In the app's {{< ui >}}Assignments{{< /ui >}} tab, assign each user the appropriate role from the dropdown.
 
 If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
 

--- a/content/en/account_management/scim/okta.md
+++ b/content/en/account_management/scim/okta.md
@@ -77,12 +77,11 @@ Datadog's SCIM role support follows the SCIM multi-valued attribute convention d
     - {{< ui >}}Data type{{< /ui >}}: **string**
     - {{< ui >}}Display name{{< /ui >}}: **Roles**
     - {{< ui >}}Variable name{{< /ui >}}: **roles**
-    - For {{< ui >}}Enum{{< /ui >}}, select {{< ui >}}Define enumerated list of values{{< /ui >}} and add one entry per Datadog role, using the role name as the display name and the role UUID as the value. You can find a role's UUID in the role's URL on your [Organization Settings][9] page. Add any custom roles the same way.
-2. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the Datadog application (or SCIM test app), then create a custom app attribute for the role. Configure the custom attribute as follows:
     - {{< ui >}}External namespace{{< /ui >}}: `urn:ietf:params:scim:schemas:core:2.0:User`
     - {{< ui >}}External name{{< /ui >}}: `roles.^[primary==true].value`
-3. In your Datadog application's {{< ui >}}Provisioning{{< /ui >}} > {{< ui >}}To App{{< /ui >}} settings, map the Okta `roles` attribute to the custom app attribute.
-4. In the app's {{< ui >}}Assignments{{< /ui >}} tab, assign each user the appropriate role from the dropdown.
+    - For {{< ui >}}Enum{{< /ui >}}, select {{< ui >}}Define enumerated list of values{{< /ui >}} and add one entry per Datadog role, using the role name as the display name and the role UUID as the value. You can find a role's UUID in the role's URL on your [Organization Settings][9] page. Add any custom roles the same way.
+2. In your Datadog application's {{< ui >}}Provisioning{{< /ui >}} > {{< ui >}}To App{{< /ui >}} settings, map the Okta `roles` attribute to the Datadog `roles` attribute.
+3. In the app's {{< ui >}}Assignments{{< /ui >}} tab, assign each user the appropriate role from the dropdown.
 
 If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
 

--- a/content/en/account_management/scim/okta.md
+++ b/content/en/account_management/scim/okta.md
@@ -77,8 +77,8 @@ Datadog's SCIM role support follows the SCIM multi-valued attribute convention d
     - {{< ui >}}Data type{{< /ui >}}: **string**
     - {{< ui >}}Display name{{< /ui >}}: **Roles**
     - {{< ui >}}Variable name{{< /ui >}}: **roles**
-    - {{< ui >}}External namespace{{< /ui >}}: `urn:ietf:params:scim:schemas:core:2.0:User`
     - {{< ui >}}External name{{< /ui >}}: `roles.^[primary==true].value`
+    - {{< ui >}}External namespace{{< /ui >}}: `urn:ietf:params:scim:schemas:core:2.0:User`
     - For {{< ui >}}Enum{{< /ui >}}, select {{< ui >}}Define enumerated list of values{{< /ui >}} and add one entry per Datadog role, using the role name as the display name and the role UUID as the value. You can find a role's UUID in the role's URL on your [Organization Settings][9] page. Add any custom roles the same way.
 2. In your Datadog application's {{< ui >}}Provisioning{{< /ui >}} > {{< ui >}}To App{{< /ui >}} settings, map the Okta `roles` attribute to the Datadog `roles` attribute.
 3. In the app's {{< ui >}}Assignments{{< /ui >}} tab, assign each user the appropriate role from the dropdown.


### PR DESCRIPTION
## What changed

Adds the missing SCIM external-attribute configuration for Okta role provisioning:

- `External namespace`: `urn:ietf:params:scim:schemas:core:2.0:User`
- `External name`: `roles.^[primary==true].value`

These settings appear with the other `roles` attribute fields in the first configuration step.

## Why

The role-provisioning instructions did not specify the external SCIM mapping required for the `roles` attribute.

## User impact

Okta administrators can configure the `roles` attribute needed to provision a user's primary Datadog role through SCIM.

## Validation

- `git diff --check`
- Reviewed the rendered Markdown structure
- Vale was not available in the local checkout
