### PR TITLE
[DOCS-12502] Add billing plans section to Pricing doc

### DIFF
--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -13,10 +13,10 @@ Datadog has many pricing plans to fit your needs. For more information, see the 
 
 Datadog offers two billing plans for host-based products, such as Infrastructure Monitoring, APM, and Database Monitoring:
 
-- **High watermark plan (HWMP)**: Datadog meters your host count each hour. At the end of the month, Datadog bills you on the maximum count (high-water mark) of the lower 99 percent of those hourly readings, excluding the top 1 percent to reduce the impact of short usage spikes on your bill. This plan is well-suited to environments with stable usage throughout the month.
+- **High watermark plan (HWMP)**: Datadog meters your host count each hour. At the end of the month, Datadog bills you on the maximum count (high-water mark) of the lower 99% of those hourly readings, excluding the top 1% to reduce the impact of short usage spikes on your bill. This plan is well-suited to environments with stable usage throughout the month.
 - **Hybrid monthly/hourly plan (MHP)**: You commit to a monthly minimum, and any host hours above that commitment are billed at an hourly rate. Because usage above the commitment is billed hourly, this plan is well-suited to ephemeral environments, such as autoscaling fleets or short-lived workloads.
 
-The following sections describe the most common pricing units for each product:
+The following sections describe the most common pricing units for each product.
 
 ## Infrastructure monitoring
 

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -7,7 +7,16 @@ further_reading:
   text: "Datadog Pricing"
 ---
 
-Datadog has many pricing plans to fit your needs. For more information, see the [Pricing][1] page. Unless otherwise stated in your order, Datadog calculates fees based on product usage during each calendar month. Here are the most common pricing units:
+Datadog has many pricing plans to fit your needs. For more information, see the [Pricing][1] page. Unless otherwise stated in your order, Datadog calculates fees based on product usage during each calendar month.
+
+## Billing plans
+
+Datadog offers two billing plans for host-based products, such as Infrastructure Monitoring, APM, and Database Monitoring:
+
+- **High watermark plan (HWMP)**: Datadog meters your host count each hour. At the end of the month, Datadog bills you on the maximum count (high-water mark) of the lower 99 percent of those hourly readings, excluding the top 1 percent to reduce the impact of short usage spikes on your bill. This plan is well-suited to environments with stable usage throughout the month.
+- **Hybrid monthly/hourly plan (MHP)**: You commit to a monthly minimum, and any host hours above that commitment are billed at an hourly rate. Because usage above the commitment is billed hourly, this plan is well-suited to ephemeral environments, such as autoscaling fleets or short-lived workloads.
+
+The following sections describe the most common pricing units for each product:
 
 ## Infrastructure monitoring
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Resolves https://datadoghq.atlassian.net/browse/DOCS-12502

Adds a **Billing plans** section near the top of the Pricing page that defines the two billing plans for host-based products (Infrastructure Monitoring, APM, and Database Monitoring) up front:

- **High watermark plan (HWMP)**,  noted as suited to environments with stable usage
- **Hybrid monthly/hourly plan (MHP)**, noted as suited to ephemeral environments

This makes hourly billing visible as a standard option and frames when each plan fits, rather than leaving the plan definitions buried in per-product pricing details.

The existing inline plan definitions under the Infrastructure Monitoring, APM, and Database Monitoring sections are left in place. A possible follow-up is to de-duplicate those into references to the new section.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code to help research who to contact for more info on billing, draft the initial wording for the page update, and make a draft PR.

