### PR TITLE
Add Azure App Service to App Insights supported services

### DIFF
--- a/content/en/tracing/guide/serverless_enable_azure_app_insights.md
+++ b/content/en/tracing/guide/serverless_enable_azure_app_insights.md
@@ -42,6 +42,7 @@ Before you can use the Azure App Insights Integration, set up the following:
 Datadog enriches converted spans with Azure resource metadata for the following services:
 
 - Azure Functions
+- Azure App Service
 - Azure Storage
 - Azure Cosmos DB
 - Azure API Management


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds Azure App Service to the supported Azure services list in the Azure App Insights Integration guide.

Ticket: SVLS-9398

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

