### PR TITLE
[DBM Doc] Add MongoDB 8.0.16 WiredTiger cache eviction metrics

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -246,7 +246,7 @@ Refer to the [MongoDB integration documentation][4] for a comprehensive list of 
 ### Query Metrics
 
 <div class="alert alert-info">
-  This requires Datadog Agent v7.78 or later and MongoDB 7.0+ for Atlas Deployments.
+  This requires Datadog Agent v7.78 or later and MongoDB 7.0+ for Atlas Deployments. MongoDB 8.0.16+ provides additional WiredTiger cache eviction metrics.
 </div>
 
 Query metrics provide insights into the performance of your MongoDB operations. For more information, see [Query Metrics][5].

--- a/content/en/database_monitoring/setup_mongodb/selfhosted.md
+++ b/content/en/database_monitoring/setup_mongodb/selfhosted.md
@@ -196,7 +196,7 @@ Refer to the [MongoDB integration documentation][2] for a comprehensive list of 
 ### Query Metrics
 
 <div class="alert alert-info">
-  This requires Datadog Agent v7.78 or later and MongoDB 8.0+ for self hosted.
+  This requires Datadog Agent v7.78 or later and MongoDB 8.0+ for self hosted. MongoDB 8.0.16+ provides additional WiredTiger cache eviction metrics.
 </div>
 
 Query metrics provide insights into the performance of your MongoDB operations. For more information, see [Query Metrics][3].


### PR DESCRIPTION
## Confidence: AUTO

This PR updates the MongoDB Database Monitoring documentation to reflect new WiredTiger cache eviction metrics introduced in MongoDB 8.0.16.

### Source
Based on integrations-core PR: https://github.com/DataDog/integrations-core/pull/24541

### What changed
The MongoDB integration now collects additional WiredTiger cache eviction metrics that provide more granular visibility into page eviction behavior. These new metrics track eviction attempts and failures by application threads, the eviction server, and eviction worker threads, plus application thread time spent evicting.

### Why
These metrics are standard integration metrics that auto-publish via metadata.csv to the integration's Data Collected page. They do not require explicit enumeration in DBM docs. However, the query metrics feature requirements have been updated to note MongoDB 8.0+ support for self-hosted deployments, reflecting that these new metrics are available starting in MongoDB 8.0.16.