### PR TITLE
[TEST] New page with nav link, no base conflict (auto-fixable)

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -51,6 +51,10 @@ menu:
       pre: hex-ringed
       parent: essentials_heading
       weight: 10000
+    - name: Example Auto Fix
+      identifier: example_auto_fix_heading
+      url: /getting_started/example_auto_fix/
+      weight: 500000
     - name: Agent
       identifier: getting_started_agent
       url: getting_started/agent/

--- a/content/en/getting_started/example_auto_fix/_index.md
+++ b/content/en/getting_started/example_auto_fix/_index.md
@@ -1,0 +1,5 @@
+---
+title: Example Auto Fix
+---
+
+Placeholder page for exercising the astro reorg tooling.


### PR DESCRIPTION
Test PR for exercising the astro reorg tooling. Adds a new page and a nav menu entry linking to it. The base branch does not touch that menu line, so the auto-fix should replay both changes cleanly.

Do not merge.