### PR TITLE
[reorg fix] [TEST] New page with nav link (base edited the same menu line) (not auto-fixable)

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -1,5 +1,9 @@
 menu:
   main:
+    - name: Example Feature
+      identifier: example_feature_heading
+      url: /getting_started/example_feature/
+      weight: 500000
     - name: Essentials
       identifier: essentials_heading
       weight: 1000000

--- a/hugo/content/en/getting_started/example_feature/_index.md
+++ b/hugo/content/en/getting_started/example_feature/_index.md
@@ -1,0 +1,5 @@
+---
+title: Example Feature
+---
+
+Placeholder page for exercising the astro reorg tooling.


### PR DESCRIPTION
🤖 Auto-generated fix for #38237.

This PR replays the commits from #38237 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38237) has been closed.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

Test PR for exercising the astro reorg tooling. Adds a new page and a nav menu entry linking to it. The base branch renames that same menu heading, so the auto-fix can't replay the menu change and the PR should be labeled for manual review.

Do not merge.