### PR TITLE
Link to OpenTelemetry feature compatibility in LLM Observability OTel setup

### DIFF
--- a/content/en/llm_observability/instrumentation/otel_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/otel_instrumentation.md
@@ -56,6 +56,8 @@ with tracer.start_as_current_span("chat gpt-4o", links=[link]) as llm_span:
 
 ## Setup
 
+Any method Datadog supports for ingesting OpenTelemetry traces works with Agent Observability. For the full list of supported ingestion paths, see [OpenTelemetry feature compatibility][10]. The following is one way to configure it.
+
 To send OpenTelemetry traces to Agent Observability, configure your OpenTelemetry exporter with the following settings:
 
 ### Configuration
@@ -640,4 +642,5 @@ with tracer.start_as_current_span("my-span") as span:
 [7]: https://strandsagents.com/latest/
 [8]: /account_management/rbac/data_access/
 [9]: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+[10]: /opentelemetry/compatibility/#feature-compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a note at the top of the **Setup** section of the LLM Observability OpenTelemetry Instrumentation page clarifying that any method Datadog supports for ingesting OpenTelemetry traces works with Agent Observability, with a link to the [OpenTelemetry feature compatibility](https://docs.datadoghq.com/opentelemetry/compatibility/#feature-compatibility) page. The existing configuration is presented as one way to set it up.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes