### PR TITLE
Clarify Custom Costs prerequisite

### DIFF
--- a/content/en/cloud_cost_management/setup/custom.md
+++ b/content/en/cloud_cost_management/setup/custom.md
@@ -41,7 +41,7 @@ Additionally, all dates are transformed into UTC timestamps. For example, "2024-
 
 ## Setup
 
-To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] for either a cloud provider (AWS, Azure, Google Cloud, or Oracle Cloud) or a SaaS provider, even if your custom costs are not related to any of these cloud providers. This configuration is required to enable the Custom Costs feature.
+To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] for either a cloud provider (AWS, Azure, Google Cloud, or Oracle Cloud) or a SaaS provider, even if your custom costs are not related to any of these providers. This configuration is required to enable the Custom Costs feature.
 
 ### Collect the required fields
 

--- a/content/en/cloud_cost_management/setup/custom.md
+++ b/content/en/cloud_cost_management/setup/custom.md
@@ -41,8 +41,6 @@ Additionally, all dates are transformed into UTC timestamps. For example, "2024-
 
 ## Setup
 
-To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] for either AWS, Azure, Google Cloud, Oracle Cloud, or a SaaS/AI provider, even if your custom costs are not related to any of these providers. This configuration is required to enable the Custom Costs feature.
-
 ### Collect the required fields
 
 | Parameter | Description | Valid example | Invalid example | Additional Requirements |
@@ -289,7 +287,6 @@ You can view custom costs data on the [**Cloud Cost Explorer** page][6], the [Cl
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/cloud_cost_management
 [2]: https://focus.finops.org/#specification
 [3]: https://app.datadoghq.com/cost/settings/cost-files
 [4]: https://www.ecma-international.org/publications-and-standards/standards/ecma-404/

--- a/content/en/cloud_cost_management/setup/custom.md
+++ b/content/en/cloud_cost_management/setup/custom.md
@@ -41,6 +41,8 @@ Additionally, all dates are transformed into UTC timestamps. For example, "2024-
 
 ## Setup
 
+To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] for either a cloud provider (AWS, Azure, Google Cloud, or Oracle Cloud) or a SaaS provider, even if your custom costs are not related to any of these cloud providers. This configuration is required to enable the Custom Costs feature.
+
 ### Collect the required fields
 
 | Parameter | Description | Valid example | Invalid example | Additional Requirements |
@@ -287,6 +289,7 @@ You can view custom costs data on the [**Cloud Cost Explorer** page][6], the [Cl
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+[1]: https://docs.datadoghq.com/cloud_cost_management
 [2]: https://focus.finops.org/#specification
 [3]: https://app.datadoghq.com/cost/settings/cost-files
 [4]: https://www.ecma-international.org/publications-and-standards/standards/ecma-404/


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6f4e01e2-169e-4a54-956d-79d0dab2d631","source":"chat","resourceId":"fb53f033-f2da-43e5-a660-6902d4bd096e","workflowId":"d59da26f-54d8-4eb4-b1c3-eb38f90f35f9","codeChangeId":"d59da26f-54d8-4eb4-b1c3-eb38f90f35f9","sourceType":"assistant"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies the Custom Costs setup prerequisite so the documentation states that customers can enable Cloud Cost Management through either a supported cloud provider or a SaaS provider before using Custom Costs.

Changes:
- Updated the Custom Costs setup prerequisite in content/en/cloud_cost_management/setup/custom.md to include SaaS providers.
- Refined the prerequisite wording to refer to custom costs that are not related to any of the configured provider types.

### Testing/Validation

- Confirmed the updated prerequisite text is present and no longer refers only to cloud providers in the final clause.
- Ran `git diff --check -- content/en/cloud_cost_management/setup/custom.md`.
- Attempted `vale content/en/cloud_cost_management/setup/custom.md`, but Vale is not installed in this sandbox.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code for this documentation update.

### Additional notes

None.

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/fb53f033-f2da-43e5-a660-6902d4bd096e)

Comment @datadog to request changes