### PR TITLE
[reorg fix] [TEST] Minor wording tweak in getting started intro (auto-fixable)

### DIFF
--- a/hugo/content/en/getting_started/_index.md
+++ b/hugo/content/en/getting_started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Introduction to Datadog's observability platform with guides for installation, configuration, and getting started with key features.
+description: Introduction to Datadog's observability platform with guides for setup, configuration, and getting started with key features.
 disable_sidebar: true
 aliases:
     - /overview


### PR DESCRIPTION
🤖 Auto-generated fix for #38264.

@jhgilbert — the [docs repo reorg](https://github.com/DataDog/documentation/blob/jen.gilbert/astro-reorg-scripts/REPO_REORG.md) created merge conflicts in your PR #38264. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38264 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38264) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

Test PR for exercising the astro reorg tooling. Makes a minor, non-material wording change in the getting started page description.

Do not merge.