### PR TITLE
[DOCS-14178] Finish BYOC Logs rename cleanup

### DIFF
--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -21,8 +21,6 @@ Use the `search_datadog_logs` tool on the [Datadog MCP (Model Context Protocol) 
 
 **Note**: BYOC Logs indexes are supported only by `search_datadog_logs`. The `analyze_datadog_logs` tool and the `datadog/querying-patterns` skill do not support BYOC Logs indexes.
 
-With `search_datadog_logs`, you can use natural-language prompts to generate and run log queries without needing to remember the query syntax.
-
 ## Prerequisites
 
 - A running BYOC Logs deployment with logs ingested.

--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -1,6 +1,6 @@
 ---
 title: Query BYOC Logs with the Datadog MCP Server
-description: Learn how to query logs stored in BYOC Logs indexes using the Datadog MCP server
+description: Learn how to query logs stored in BYOC Logs indexes with the search_datadog_logs tool on the Datadog MCP server
 further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-remote-mcp-server/"
   tag: "Blog"
@@ -17,10 +17,11 @@ aliases:
 
 ## Overview
 
-The [Datadog MCP (Model Context Protocol) server][1] allows you to query your Datadog logs, including logs stored in BYOC (Bring Your Own Cloud) Logs indexes, directly through AI-powered tools and integrations. Querying BYOC Logs with the Datadog MCP server unlocks several valuable capabilities, including:
+Use the `search_datadog_logs` tool on the [Datadog MCP (Model Context Protocol) server][1] to query logs stored in BYOC (Bring Your Own Cloud) Logs indexes. You can access the tool through AI-powered tools and integrations.
 
-- **Unified, Context-Aware Troubleshooting**: Query and correlate logs, metrics, and traces from any environment in one place, and pivot across telemetry types to identify root causes faster.
-- **Natural Language Interaction**: Ask plain-language questions, and let AI generate the appropriate log queries without needing to remember syntax.
+**Note**: BYOC Logs indexes are supported only by `search_datadog_logs`. The `analyze_datadog_logs` tool and the `datadog/querying-patterns` skill do not support BYOC Logs indexes.
+
+With `search_datadog_logs`, you can use natural-language prompts to generate and run log queries without needing to remember the query syntax.
 
 ## Prerequisites
 
@@ -30,18 +31,18 @@ The [Datadog MCP (Model Context Protocol) server][1] allows you to query your Da
 
 ## Querying BYOC Logs
 
-To query logs stored in BYOC Logs indexes, specify your BYOC Logs index name in addition to your standard log query:
+To query logs stored in BYOC Logs indexes, use `search_datadog_logs` and specify your BYOC Logs index name in addition to your standard log query:
 
 - (Required) **`indexes`**: The name(s) of your BYOC Logs index(es).
 
-The MCP server identifies BYOC Logs indexes by their names and routes queries to the appropriate storage tier automatically. Without the `indexes` parameter, queries default to searching standard Datadog log indexes instead of BYOC Logs.
+The `search_datadog_logs` tool identifies BYOC Logs indexes by their names and routes queries to the appropriate storage tier automatically. Without the `indexes` parameter, queries default to searching standard Datadog log indexes instead of BYOC Logs.
 
 For best results, your prompt **should also include**:
 - (Recommended) Time range (for example, "in the last hour", "from the last 24 hours").
 - (Recommended) Query filters (service, status, log content).
 
 ### Query parameters
-The following table describes the key parameters used when querying logs with the MCP server:
+The following table describes the key parameters used with `search_datadog_logs`:
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
@@ -65,7 +66,7 @@ You can also find your index names in the [BYOC Logs console][3] by selecting a 
 
 ## Advanced query examples
 
-When using AI-powered tools with the Datadog MCP server, you can ask questions in natural language. The MCP server will automatically translate these into properly formatted BYOC Logs queries.
+When using AI-powered tools with `search_datadog_logs`, you can ask questions in natural language. The tool translates these into properly formatted BYOC Logs queries.
 
 ### Error logs from a specific service
 **Prompt**:

--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -30,12 +30,11 @@ The [Datadog MCP (Model Context Protocol) server][1] allows you to query your Da
 
 ## Querying BYOC Logs
 
-To query logs stored in BYOC Logs indexes, you **must** specify two critical parameters in addition to your standard log query:
+To query logs stored in BYOC Logs indexes, specify your BYOC Logs index name in addition to your standard log query:
 
 - (Required) **`indexes`**: The name(s) of your BYOC Logs index(es).
-- (Required) **`storage_tier`**: Must be set to `"cloudprem"`.
 
-Without both parameters, queries will default to searching standard Datadog log indexes instead of BYOC Logs.
+The MCP server identifies BYOC Logs indexes by their names and routes queries to the appropriate storage tier automatically. Without the `indexes` parameter, queries default to searching standard Datadog log indexes instead of BYOC Logs.
 
 For best results, your prompt **should also include**:
 - (Recommended) Time range (for example, "in the last hour", "from the last 24 hours").
@@ -48,7 +47,6 @@ The following table describes the key parameters used when querying logs with th
 |-----------|-------------|---------|
 | `query` | Log search query using Datadog query syntax | `"*"` (all logs), `"service:web"`, `"status:error"` |
 | `indexes` | Array of BYOC Logs index names to search | `["byoc--dev--main"]` |
-| `storage_tier` | Storage tier to query (must be `"cloudprem"` for BYOC Logs) | `"cloudprem"` |
 | `from` | Start time for the query | `"now-1h"`, `"now-24h"`, `"2024-01-15T00:00:00Z"` |
 | `to` | End time for the query | `"now"`, `"2024-01-15T23:59:59Z"` |
 | `sort` | Sort order for results | `"-timestamp"` (descending), `"timestamp"` (ascending) |
@@ -78,7 +76,6 @@ When using AI-powered tools with the Datadog MCP server, you can ask questions i
 {
   "query": "service:nginx status:error",
   "indexes": ["byoc--dev--main"],
-  "storage_tier": "cloudprem",
   "from": "now-1h",
   "to": "now"
 }
@@ -93,7 +90,6 @@ When using AI-powered tools with the Datadog MCP server, you can ask questions i
 {
   "query": "service:api \"connection timeout\"",
   "indexes": ["byoc--prod--main"],
-  "storage_tier": "cloudprem",
   "from": "now-24h",
   "to": "now"
 }
@@ -108,7 +104,6 @@ When using AI-powered tools with the Datadog MCP server, you can ask questions i
 {
   "query": "status:500",
   "indexes": ["byoc--prod--main"],
-  "storage_tier": "cloudprem",
   "from": "now-1d",
   "to": "now"
 }
@@ -116,8 +111,7 @@ When using AI-powered tools with the Datadog MCP server, you can ask questions i
 
 ## Important notes
 
-- **Both `storage_tier` and `indexes` are required** when querying BYOC Logs. Without these parameters, queries will search standard Datadog indexes instead.
-- `storage_tier` must always be set to `"cloudprem"`.
+- The `indexes` parameter is required when querying BYOC Logs. Without it, queries search standard Datadog indexes instead.
 - The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<cluster_name>--<index_name>`).
 - When using natural language queries, explicitly mention your BYOC Logs index name in your prompt.
 - BYOC Logs data is queryable in real-time as soon as it is indexed.

--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -1,6 +1,6 @@
 ---
 title: Query BYOC Logs with the Datadog MCP Server
-description: Learn how to query logs stored in BYOC Logs indexes with the search_datadog_logs tool on the Datadog MCP server
+description: Learn how to query logs stored in BYOC Logs indexes using the Datadog MCP server
 further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-remote-mcp-server/"
   tag: "Blog"

--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -29,9 +29,7 @@ Use the `search_datadog_logs` tool on the [Datadog MCP (Model Context Protocol) 
 
 ## Querying BYOC Logs
 
-To query logs stored in BYOC Logs indexes, use `search_datadog_logs` and specify your BYOC Logs index name in addition to your standard log query:
-
-- (Required) **`indexes`**: The name(s) of your BYOC Logs index(es).
+To query logs stored in BYOC Logs indexes, use `search_datadog_logs` and specify your BYOC Logs index name in addition to your standard log query.
 
 For best results, your prompt **should also include**:
 - (Recommended) Time range (for example, "in the last hour", "from the last 24 hours").

--- a/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -35,8 +35,6 @@ To query logs stored in BYOC Logs indexes, use `search_datadog_logs` and specify
 
 - (Required) **`indexes`**: The name(s) of your BYOC Logs index(es).
 
-The `search_datadog_logs` tool identifies BYOC Logs indexes by their names and routes queries to the appropriate storage tier automatically. Without the `indexes` parameter, queries default to searching standard Datadog log indexes instead of BYOC Logs.
-
 For best results, your prompt **should also include**:
 - (Recommended) Time range (for example, "in the last hour", "from the last 24 hours").
 - (Recommended) Query filters (service, status, log content).
@@ -112,7 +110,6 @@ When using AI-powered tools with `search_datadog_logs`, you can ask questions in
 
 ## Important notes
 
-- The `indexes` parameter is required when querying BYOC Logs. Without it, queries search standard Datadog indexes instead.
 - The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<cluster_name>--<index_name>`).
 - When using natural language queries, explicitly mention your BYOC Logs index name in your prompt.
 - BYOC Logs data is queryable in real-time as soon as it is indexed.

--- a/content/en/byoc-logs/ingest/_index.md
+++ b/content/en/byoc-logs/ingest/_index.md
@@ -39,7 +39,7 @@ BYOC Logs accepts logs as **JSON objects** sent to the `/api/v2/logs` endpoint. 
 The [Datadog Lambda Forwarder][1] can send AWS CloudWatch Logs to BYOC Logs by setting the `DD_URL` environment variable to your BYOC Logs endpoint:
 
 ```
-DD_URL=<CLOUDPREM_HOST>
+DD_URL=<BYOC_LOGS_HOST>
 ```
 
 The forwarder sends logs to `https://<DD_URL>:443/api/v2/logs`. 

--- a/content/en/byoc-logs/install/docker.md
+++ b/content/en/byoc-logs/install/docker.md
@@ -186,7 +186,7 @@ curl -X POST "http://localhost:7280/api/v2/logs" \
 
 ### Search your local logs from the Log Explorer
 
-After verifying that BYOC Logs is running, you can search and analyze your logs in the Logs Explorer by searching into the `cloudprem` index!
+Verify that BYOC Logs is running. In the Log Explorer, select your BYOC Logs index to search and analyze your logs.
 
 ## Further reading
 

--- a/content/en/byoc-logs/introduction/network.md
+++ b/content/en/byoc-logs/introduction/network.md
@@ -41,7 +41,7 @@ Only **searcher** pods establish the reverse connection. Indexers, the control p
 
 It is also possible to configure BYOC Logs to deploy a public ingress so Datadog can establish the connection in the other direction.
 
-The public ingress enables Datadog's control plane and query service to manage and query BYOC Logs clusters over the public internet. It provides secure access to the BYOC Logs gRPC API using mTLS authentication. You can find more information about BYOC Logs ingress in its [configuration page](/cloudprem/configure/ingress/).
+The public ingress enables Datadog's control plane and query service to manage and query BYOC Logs clusters over the public internet. It provides secure access to the BYOC Logs gRPC API using mTLS authentication. You can find more information about BYOC Logs ingress in its [configuration page](/byoc-logs/configure/ingress/).
 
 ## Further reading
 

--- a/content/en/byoc-logs/operate/monitoring.md
+++ b/content/en/byoc-logs/operate/monitoring.md
@@ -53,4 +53,4 @@ Configure either option with your organization's API key to export these metrics
 Coming soon. -->
 
 [1]: https://docs.datadoghq.com/extend/dogstatsd/?tab=hostagent
-[2]: https://app.datadoghq.com/dashboard/lists?q=cloudprem&p=1
+[2]: https://app.datadoghq.com/dashboard/lists?q=byoc&p=1

--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -56,12 +56,12 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 #### Changed
 - Reduces search CPU time for nested date histogram queries by up to 20%, with the largest gains on seven-day windows.
-- Adds a dedicated health check listener on port `7284` for BYOC Logs component liveness and readiness checks.
+- Adds a dedicated health check listener on port `7284` for CloudPrem component liveness and readiness checks.
 
 #### Helm chart changes
-- Adds global `volumes` and `volumeMounts` values that apply to all BYOC Logs components and merge with existing per-component `extraVolumes` and `extraVolumeMounts`.
-- Adds global `topologySpreadConstraints` support, merged with per-component constraints, to spread BYOC Logs workload pods across topology domains.
-- Updates BYOC Logs services and AWS ALB internal ingress health checks to use the dedicated health endpoint.
+- Adds global `volumes` and `volumeMounts` values that apply to all CloudPrem components and merge with existing per-component `extraVolumes` and `extraVolumeMounts`.
+- Adds global `topologySpreadConstraints` support, merged with per-component constraints, to spread CloudPrem workload pods across topology domains.
+- Updates CloudPrem services and AWS ALB internal ingress health checks to use the dedicated health endpoint.
 
 ### v0.1.29 — 2026-06-05
 

--- a/content/en/byoc-logs/release_notes.md
+++ b/content/en/byoc-logs/release_notes.md
@@ -56,12 +56,12 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs][2] for the 
 
 #### Changed
 - Reduces search CPU time for nested date histogram queries by up to 20%, with the largest gains on seven-day windows.
-- Adds a dedicated health check listener on port `7284` for CloudPrem component liveness and readiness checks.
+- Adds a dedicated health check listener on port `7284` for BYOC Logs component liveness and readiness checks.
 
 #### Helm chart changes
-- Adds global `volumes` and `volumeMounts` values that apply to all CloudPrem components and merge with existing per-component `extraVolumes` and `extraVolumeMounts`.
-- Adds global `topologySpreadConstraints` support, merged with per-component constraints, to spread CloudPrem workload pods across topology domains.
-- Updates CloudPrem services and AWS ALB internal ingress health checks to use the dedicated health endpoint.
+- Adds global `volumes` and `volumeMounts` values that apply to all BYOC Logs components and merge with existing per-component `extraVolumes` and `extraVolumeMounts`.
+- Adds global `topologySpreadConstraints` support, merged with per-component constraints, to spread BYOC Logs workload pods across topology domains.
+- Updates BYOC Logs services and AWS ALB internal ingress health checks to use the dedicated health endpoint.
 
 ### v0.1.29 — 2026-06-05
 

--- a/content/en/observability_pipelines/destinations/datadog_byoc_logs.md
+++ b/content/en/observability_pipelines/destinations/datadog_byoc_logs.md
@@ -42,7 +42,7 @@ After you select the BYOC Logs destination in the pipeline UI, you can configure
 - BYOC Logs endpoint URL identifier:
 	- References the intake endpoint to which Observability Pipelines sends logs.
 	- In your secrets manager:
-		- Define the cluster URL, such as `http://cloudprem.acme.internal:7280`. **Note**: The URL must include the port.
+		- Define the cluster URL, such as `http://byoc-logs.acme.internal:7280`. **Note**: The URL must include the port.
 		- The Worker appends `/api/v2/logs` and `/api/v1/validate` to the endpoint URL, so these endpoints must be allowed if you are using forwarding or firewall rules.
 	- The default identifier is `DESTINATION_CLOUDPREM_ENDPOINT_URL`.
 
@@ -53,7 +53,7 @@ After you select the BYOC Logs destination in the pipeline UI, you can configure
 {{< img src="observability_pipelines/destinations/cloudprem_env_vars.png" alt="The install page showing the BYOC Logs environment variable field" style="width:75%;" >}}
 
 - BYOC Logs endpoint URL
-	- Observability Pipelines sends logs to the BYOC Logs intake endpoint. Define the cluster URL, such as `http://cloudprem.acme.internal:7280`. **Note**: The URL must include the port.
+	- Observability Pipelines sends logs to the BYOC Logs intake endpoint. Define the cluster URL, such as `http://byoc-logs.acme.internal:7280`. **Note**: The URL must include the port.
 	- The Worker appends `/api/v2/logs` and `/api/v1/validate` to the endpoint URL, so these endpoints must be allowed if you are using forwarding or firewall rules.
   - Stored as the environment variable: `DD_OP_DESTINATION_CLOUDPREM_ENDPOINT_URL`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14178

Updates the BYOC Logs documentation to:

- Document that BYOC Logs indexes are supported by `search_datadog_logs`, not `analyze_datadog_logs` or the `datadog/querying-patterns` skill.
- Update the `search_datadog_logs` examples to use `indexes` without the obsolete `storage_tier` parameter.
- Replace obsolete CloudPrem placeholders, example hostnames, and user-facing index references.
- Update the BYOC Logs ingress link and dashboard search URL.

Technical identifiers that still use `cloudprem` remain unchanged.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Vale completed with no errors. Existing warnings on unchanged lines remain.
