### PR TITLE
(DOCS-14511) Add site support banner to Azure DevOps Source Code integration

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -308,6 +308,7 @@ unsupported_sites:
   application_security: [gov,gov2]
   autocomplete_search: [gov,gov2]
   azure-automated-log-forwarding: [gov,gov2]
+  azure-devops-source-code: [gov, gov2]
   azure-private-link: [us,us5,eu,gov,gov2,ap1,ap2,uk1]
   backstage: [gov,gov2]
   bits_ai: [gov,gov2]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Fixes DOCS-14511, resolving request from TSE to add unsupported banner for FED sites.


preview:
- https://docs-staging.datadoghq.com/jeff.morgan/DOCS-14511-azure-banner/integrations/azure-devops-source-code/?site=gov

- https://docs-staging.datadoghq.com/jeff.morgan/DOCS-14511-azure-banner/integrations/azure-devops-source-code/?site=gov2

### Merge readiness

- [X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
