### PR TITLE
[DOCS-15066] Add gov/gov2 site-support banner to Amazon Security Lake integration

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -287,6 +287,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  amazon-security-lake: [gov, gov2]
   resource_catalog_policies: [gov, gov2]
   runtime_prioritization_engine: [gov, gov2]
   ai_agents_console: [gov, gov2]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15066

Amazon Security Lake is not supported on US1-FED (gov) or US2-FED (gov2). Adds `amazon-security-lake` to `unsupported_sites` in `config/_default/params.yaml` so the standard site-support banner renders at the top of the integration page for those sites.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes