### PR TITLE
[DOCS-14995] Add gov/gov2 banner to Trace Pipeline Processing pipelines section

### DIFF
--- a/content/en/tracing/trace_pipeline/_index.md
+++ b/content/en/tracing/trace_pipeline/_index.md
@@ -33,6 +33,10 @@ The [Ingestion Control page][3] overviews ingestion volumes and configuration se
 
 ## Processing pipelines
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-warning">Processing Pipelines are not supported in {{< region-param key="dd_site_name" >}}.</div>
+{{< /site-region >}}
+
 Transform, normalize, and enrich span attributes after ingestion with [Processing Pipelines][7]. Standardize attribute naming across services, consolidate inconsistent keys, and extract structured data from span values, without modifying application code.
 
 {{< img src="tracing/processing_pipelines/manage_pipelines.png" style="width:100%;" alt="Processing Pipelines" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14995

Adds the standard US1-FED/US2-FED unsupported banner to the Processing pipelines section of The Trace Pipeline overview page. The dedicated Processing Pipelines child page already shows this banner via `site_support_id: apm_processing_pipelines`, but the overview page's anchor section did not.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes