### PR TITLE
[DOCS-15057] Move App and API Protection from unsupported to Preview on US1-FED

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -306,6 +306,7 @@ unsupported_sites:
   apm_processing_pipelines: [gov,gov2]
   apm_recommendations: [gov,gov2]
   application_security: [gov,gov2]
+  application_security_override: [gov2] # docs (content/en/security/application_security and content/en/getting_started/security/application_security.md cascades) — AAP is in Preview on gov
   autocomplete_search: [gov,gov2]
   azure-automated-log-forwarding: [gov,gov2]
   azure-private-link: [us,us5,eu,gov,gov2,ap1,ap2,uk1]

--- a/content/en/getting_started/security/application_security.md
+++ b/content/en/getting_started/security/application_security.md
@@ -20,8 +20,15 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/app-protection-block-attacks"
   tag: "Learning Center"
   text: "Block Application Attacks with Application & API Protection"
+site_support_id: application_security_override
 
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 ## Overview
 

--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -39,7 +39,16 @@ further_reading:
   text: "Block Application Attacks with Application & API Protection"
 algolia:
   tags: ["asm", "App and API Protection"]
+site_support_id: application_security_override
+cascade:
+    site_support_id: application_security_override
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 {{% site-region region="us,us3,us5,eu,ap1,ap2,uk1" %}}
 

--- a/content/en/security/application_security/api_posture/_index.md
+++ b/content/en/security/application_security/api_posture/_index.md
@@ -7,6 +7,12 @@ further_reading:
   text: "From discovery to defense: Securing APIs with Datadog App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Use API Posture in [App and API Protection][1] (AAP) to discover your APIs, assess the risks they expose, and track your security posture.
 
 To get started, [set up AAP][2] on your services to discover endpoints from your live traffic. Other data sources, such as Amazon API Gateway and source code, require additional setup; see [API Endpoints][3] for details.

--- a/content/en/security/application_security/api_posture/api_findings.md
+++ b/content/en/security/application_security/api_posture/api_findings.md
@@ -3,6 +3,12 @@ title: API Findings
 description: Triage detected API risks across definitions, gateways, and live traffic.
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The [API Findings][1] explorer provides a central triage view of the API risks detected across your definitions, gateways, and live traffic. Default rules detect common vulnerabilities and misconfigurations. You can also add [custom rules][2] for specific use cases.
 
 **API Findings** columns:

--- a/content/en/security/application_security/api_posture/api_inventory/_index.md
+++ b/content/en/security/application_security/api_posture/api_inventory/_index.md
@@ -9,6 +9,12 @@ further_reading:
   text: "Mitigate the primary API security risks"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 [API Inventory][1] is a continuously updated catalog of the API endpoints and services API Posture discovers across your environment. It shows security context for each endpoint, such as authentication status, public exposure, sensitive data flows, and associated findings.
 
 Inventory consists of two explorers:

--- a/content/en/security/application_security/api_posture/api_inventory/api_endpoints.md
+++ b/content/en/security/application_security/api_posture/api_inventory/api_endpoints.md
@@ -3,6 +3,12 @@ title: API Endpoints
 description: Monitor API traffic to assess endpoint risk, authentication, sensitive data flows, and exposure.
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The [API Endpoints][1] explorer monitors your API traffic to provide visibility into the security posture of your APIs, including:
 
 - **Authentication**: Whether the API enforces authentication.

--- a/content/en/security/application_security/api_posture/api_inventory/services.md
+++ b/content/en/security/application_security/api_posture/api_inventory/services.md
@@ -3,6 +3,12 @@ title: Services
 description: View where API findings, vulnerabilities, and runtime signals converge by service.
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The [Services][1] explorer aggregates findings, vulnerabilities, and runtime signals by service, so you can assess each service's risk and security coverage.
 
 Review your services for the following:

--- a/content/en/security/application_security/api_posture/compliance.md
+++ b/content/en/security/application_security/api_posture/compliance.md
@@ -10,6 +10,12 @@ further_reading:
   text: "OWASP API Security Top 10 2023"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 API Posture Compliance lets you continuously evaluate your API security posture against industry-standard frameworks. It maps Datadog's built-in API security detection rules to compliance framework controls and provides a real-time posture score showing which controls are passing or failing across your services.

--- a/content/en/security/application_security/api_posture/endpoint_scanning.md
+++ b/content/en/security/application_security/api_posture/endpoint_scanning.md
@@ -3,6 +3,12 @@ title: Endpoint Scanning
 description: Verify whether discovered API endpoints are publicly accessible and require authentication.
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-warning">Endpoint Scanning is in Preview and is subject to change.</div>
 
 Endpoint Scanning probes your API endpoints from outside your environment and records their HTTP responses, rather than inferring behavior from observed traffic. The results enrich the [API Inventory][2] with verified authentication and visibility data.

--- a/content/en/security/application_security/api_posture/overview.md
+++ b/content/en/security/application_security/api_posture/overview.md
@@ -10,6 +10,12 @@ further_reading:
   text: "Attack Summary"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The **API Posture** overview page gives you a security-focused view of your API estate. It surfaces how well your endpoints are covered, the open findings affecting them, the endpoints most exposed to risk, and the policies that protect them. The following sections describe each area of the page.
 
 {{< img src="security/application_security/overview/api_posture.png" alt="API Posture overview page" >}}

--- a/content/en/security/application_security/api_posture/sensitive_data.md
+++ b/content/en/security/application_security/api_posture/sensitive_data.md
@@ -3,6 +3,12 @@ title: Sensitive Data
 description: Detect and classify sensitive data processed by your API endpoints.
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 [App and API Protection][1] matches known patterns for sensitive data in API requests and responses. If it finds a match, the endpoint is tagged with the category and type of sensitive data processed and displayed in [API Endpoints][2].
 
 The matching occurs within your application, and none of the sensitive data is sent to Datadog.

--- a/content/en/security/application_security/attack_summary.md
+++ b/content/en/security/application_security/attack_summary.md
@@ -13,6 +13,12 @@ further_reading:
   text: "Threat Protection Overview"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <!-- {{< img src="security/application_security/threats/appsec-threat-overview-page-top.png" alt="Screenshot of the AAP Attack Summary page"  >}} -->
 
 The App and API Protection (AAP) [Attack Summary][2] provides a quick view of your application and API posture. It highlights trends, service exposure, attack traffic, and the impact on business logic. You can pivot from widgets to their related traces.

--- a/content/en/security/application_security/guide/_index.md
+++ b/content/en/security/application_security/guide/_index.md
@@ -4,6 +4,12 @@ private: true
 disable_toc: true
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< whatsnext desc="Getting Started" >}}
     {{< nextlink href="/getting_started/security/application_security/" >}}First steps with App and API Protection{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/security/application_security/guide/manage_account_theft_appsec.md
+++ b/content/en/security/application_security/guide/manage_account_theft_appsec.md
@@ -3,6 +3,12 @@ title: Managing Account Theft with AAP
 disable_toc: false
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Users are trusted entities in your systems with access to sensitive information and the ability to perform sensitive actions. Malicious actors have identified users as an opportunity to target websites and steal valuable data and resources.
 
 Datadog App and API Protection (AAP) provides [built-in][1] detection and protection capabilities to help you manage this threat. 

--- a/content/en/security/application_security/guide/standalone_application_security.md
+++ b/content/en/security/application_security/guide/standalone_application_security.md
@@ -3,6 +3,12 @@ title: Set Up App and API Protection Without APM or Infrastructure Monitoring
 disable_toc: false
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Datadog App and API Protection (AAP) is built on top of [APM][3] and runs alongside [Infrastructure Monitoring][7] by default. While Datadog recommends using AAP together with APM and Infrastructure Monitoring to adopt DevSecOps practices, you can also run AAP on its own. This configuration is referred to as Standalone App and API Protection.
 
 Running standalone allows to be billed primarily for App and API Protection. Some APM intake is still present to support AAP features (for example, security traces), and is expected to appear on your bill.

--- a/content/en/security/application_security/how-it-works/_index.md
+++ b/content/en/security/application_security/how-it-works/_index.md
@@ -7,6 +7,12 @@ aliases:
   - /security/guide/how-appsec-works/
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 Datadog App and API Protection (AAP) provides observability into application and API-level attacks that aim to exploit vulnerabilities and abuse app business logic, and observability into any bad actors targeting your systems. AAP performs actions such as the following:

--- a/content/en/security/application_security/how-it-works/add-user-info.md
+++ b/content/en/security/application_security/how-it-works/add-user-info.md
@@ -6,6 +6,12 @@ aliases:
   - /security/application_security/threats/add-user-info/
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 Instrument your services and track user activity to detect and block bad actors.

--- a/content/en/security/application_security/how-it-works/threat-intelligence.md
+++ b/content/en/security/application_security/how-it-works/threat-intelligence.md
@@ -10,6 +10,12 @@ further_reading:
 
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 This topic describes [threat intelligence][1] for App and API Protection (AAP).

--- a/content/en/security/application_security/how-it-works/trace_qualification.md
+++ b/content/en/security/application_security/how-it-works/trace_qualification.md
@@ -4,6 +4,12 @@ aliases:
   - /security/application_security/threats/trace_qualification
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 App and API Protection (AAP) provides observability into application-level attacks, and evaluates the conditions in which each trace was generated. AAP trace qualification then labels each attack as harmful or safe to help you take action on the most impactful attacks.

--- a/content/en/security/application_security/setup/_index.md
+++ b/content/en/security/application_security/setup/_index.md
@@ -11,6 +11,12 @@ disable_toc: false
 disable_sidebar: true
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to enable App and API Protection on all the following supported platforms and environments.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/aws/fargate/_index.md
+++ b/content/en/security/application_security/setup/aws/fargate/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your AWS Fargate tasks by selecting your task's programming language.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/aws/lambda/_index.md
+++ b/content/en/security/application_security/setup/aws/lambda/_index.md
@@ -22,6 +22,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to setup App and API Protection on your AWS Lambda functions by selecting the programming language your function is written with.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/aws/lambda/dotnet.md
+++ b/content/en/security/application_security/setup/aws/lambda/dotnet.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack and would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/lambda/go.md
+++ b/content/en/security/application_security/setup/aws/lambda/go.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/lambda/java.md
+++ b/content/en/security/application_security/setup/aws/lambda/java.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/lambda/nodejs.md
+++ b/content/en/security/application_security/setup/aws/lambda/nodejs.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/lambda/python.md
+++ b/content/en/security/application_security/setup/aws/lambda/python.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/lambda/ruby.md
+++ b/content/en/security/application_security/setup/aws/lambda/ruby.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Configuring App and API Protection for AWS Lambda involves:
 
 1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].

--- a/content/en/security/application_security/setup/aws/waf/_index.md
+++ b/content/en/security/application_security/setup/aws/waf/_index.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Monitor AWS WAF activity with Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 App and API Protection integrates with AWS Web Application Firewall (WAF) by:
 
 1. Converting logs to traces to gain visibility into monitored and blocked requests

--- a/content/en/security/application_security/setup/azure/app-service/_index.md
+++ b/content/en/security/application_security/setup/azure/app-service/_index.md
@@ -21,6 +21,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Only *web applications* are supported. Azure Functions are not supported.

--- a/content/en/security/application_security/setup/compatibility/envoy-gateway.md
+++ b/content/en/security/application_security/setup/compatibility/envoy-gateway.md
@@ -5,6 +5,12 @@ type: multi-code-lang
 code_lang_weight: 40
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The following table lists App and API Protection capabilities for the Envoy Gateway integration according to the specified Datadog External Processor image version:
 
 | App and API Protection capability              | Minimum Datadog External Processor image version  |

--- a/content/en/security/application_security/setup/compatibility/envoy.md
+++ b/content/en/security/application_security/setup/compatibility/envoy.md
@@ -7,6 +7,12 @@ aliases:
   - /security/application_security/threats/setup/compatibility/envoy
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The following table lists App and API Protection capabilities for the Envoy integration according to the specified Datadog External Processor image version:
 
 | App and API Protection capability              | Minimum Datadog External Processor image version  |

--- a/content/en/security/application_security/setup/compatibility/gcp-service-extensions.md
+++ b/content/en/security/application_security/setup/compatibility/gcp-service-extensions.md
@@ -7,6 +7,12 @@ aliases:
   - /security/application_security/threats/setup/compatibility/gcp-service-extensions
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The following table lists App and API Protection capabilities for GCP Service Extensions according to the specified Datadog Service Extensions callout image version:
 
 | App and API Protection capability        | Minimum App and API Protection Service Extensions callout image version  |

--- a/content/en/security/application_security/setup/compatibility/haproxy.md
+++ b/content/en/security/application_security/setup/compatibility/haproxy.md
@@ -5,6 +5,12 @@ type: multi-code-lang
 code_lang_weight: 40
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The following table lists App and API Protection capabilities for the HAProxy integration according to the specified Datadog HAProxy SPOA image version:
 
 | App and API Protection capability              | Minimum Datadog HAProxy SPOA image version |

--- a/content/en/security/application_security/setup/compatibility/istio.md
+++ b/content/en/security/application_security/setup/compatibility/istio.md
@@ -5,6 +5,12 @@ type: multi-code-lang
 code_lang_weight: 40
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The following table lists App and API Protection capabilities for the Istio integration according to the specified Datadog External Processor image version:
 
 | App and API Protection capability              | Minimum Datadog External Processor image version  |

--- a/content/en/security/application_security/setup/compatibility/nginx.md
+++ b/content/en/security/application_security/setup/compatibility/nginx.md
@@ -7,6 +7,12 @@ aliases:
   - /security/application_security/threats/setup/compatibility/nginx
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## App and API Protection capabilities support
 
 The following App and API Protection capabilities are supported in the nginx integration, for the

--- a/content/en/security/application_security/setup/compatibility/serverless.md
+++ b/content/en/security/application_security/setup/compatibility/serverless.md
@@ -7,6 +7,12 @@ aliases:
   - /security/application_security/threats/setup/compatibility/serverless
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 App and API Protection provides serverless capability for the following platforms and libraries:
 
 {{< card-grid card_width="225px" image_width="200" >}}

--- a/content/en/security/application_security/setup/docker/_index.md
+++ b/content/en/security/application_security/setup/docker/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your Docker containers by selecting the containerized service's programming language.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/dotnet/_index.md
+++ b/content/en/security/application_security/setup/dotnet/_index.md
@@ -25,6 +25,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 {{% aap/aap_and_api_protection_dotnet_overview showSetup="false"%}}

--- a/content/en/security/application_security/setup/dotnet/aws-fargate.md
+++ b/content/en/security/application_security/setup/dotnet/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_dotnet_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/dotnet/docker.md
+++ b/content/en/security/application_security/setup/dotnet/docker.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_dotnet_setup_options platform="docker" %}}
 {{% aap/aap_and_api_protection_dotnet_overview %}}
 

--- a/content/en/security/application_security/setup/dotnet/dotnet.md
+++ b/content/en/security/application_security/setup/dotnet/dotnet.md
@@ -25,6 +25,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 You can monitor App and API Protection for .NET apps running in Docker, Kubernetes, Amazon ECS, and AWS Fargate.
 
 {{% appsec-getstarted %}}

--- a/content/en/security/application_security/setup/dotnet/kubernetes.md
+++ b/content/en/security/application_security/setup/dotnet/kubernetes.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_dotnet_setup_options platform="kubernetes" %}}
 {{% aap/aap_and_api_protection_dotnet_overview %}}
 

--- a/content/en/security/application_security/setup/dotnet/linux.md
+++ b/content/en/security/application_security/setup/dotnet/linux.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_dotnet_setup_options platform="linux" %}}
 {{% aap/aap_and_api_protection_dotnet_overview %}}
 

--- a/content/en/security/application_security/setup/dotnet/troubleshooting.md
+++ b/content/en/security/application_security/setup/dotnet/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting .NET App and API Protection
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No Security Signals appear

--- a/content/en/security/application_security/setup/dotnet/windows.md
+++ b/content/en/security/application_security/setup/dotnet/windows.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_dotnet_setup_options platform="windows" %}}
 {{% aap/aap_and_api_protection_dotnet_overview %}}
 

--- a/content/en/security/application_security/setup/envoy.md
+++ b/content/en/security/application_security/setup/envoy.md
@@ -19,6 +19,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 You can enable App and API Protection for the Envoy proxy. The Datadog Envoy integration has support for threat detection and blocking.
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/gcp/cloud-run/_index.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to setup App and API Protection (AAP) on your Google Cloud Run functions by selecting the programming language your function is written with.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/gcp/cloud-run/dotnet.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/dotnet.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/cloud-run/go.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/go.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/cloud-run/java.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/java.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/cloud-run/nodejs.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/nodejs.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/cloud-run/php.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/php.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</div>
 
 See [compatibility requirements][4] for information about what AAP features are available for serverless functions.

--- a/content/en/security/application_security/setup/gcp/cloud-run/python.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/python.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/cloud-run/ruby.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/ruby.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Datadog Security extends compliance and threat protection capabilities for Google Cloud"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">AAP support for Google Cloud Run is in Preview.</a></div>
 
 ## How it works

--- a/content/en/security/application_security/setup/gcp/service-extensions.md
+++ b/content/en/security/application_security/setup/gcp/service-extensions.md
@@ -25,6 +25,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< callout url="#" btn_hidden="true" header="App and API Protection Service Extensions is in Preview" >}}
 To try the preview of App and API Protection Service Extensions for GCP, use the following setup instructions.
 {{< /callout >}}

--- a/content/en/security/application_security/setup/go/_index.md
+++ b/content/en/security/application_security/setup/go/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 App and API Protection (AAP) leverages the [Datadog Go library][5] to monitor and secure your Go service. The library integrates seamlessly into your workflow using [Orchestrion][6], an automatic compile-time instrumentation of Go code that does not require code changes.

--- a/content/en/security/application_security/setup/go/aws-fargate.md
+++ b/content/en/security/application_security/setup/go/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Prerequisites
 
 - AWS Fargate environment

--- a/content/en/security/application_security/setup/go/dockerfile.md
+++ b/content/en/security/application_security/setup/go/dockerfile.md
@@ -12,6 +12,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 App and API Protection for Go installation requirements can be abstract and the Go toolchain
 cross-compilation and CGO capabilities can make precise installation steps difficult to understand.
 

--- a/content/en/security/application_security/setup/go/sdk.md
+++ b/content/en/security/application_security/setup/go/sdk.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 If you need flexibility and features beyond those available when instrumenting your application automatically using [Orchestrion][12], Datadog provides an App and API Protection API located at [github.com/DataDog/dd-trace-go/v2/appsec][2]. This API improves flexibility and offers additional features.
 
 ## Error event handling

--- a/content/en/security/application_security/setup/go/setup.md
+++ b/content/en/security/application_security/setup/go/setup.md
@@ -26,6 +26,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Prerequisite
 
 - The [Datadog Agent][16] is installed and configured for your application's operating system or container, cloud, or virtual environment. 

--- a/content/en/security/application_security/setup/go/troubleshooting.md
+++ b/content/en/security/application_security/setup/go/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting App and API Protection for Go
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No security signals appearing

--- a/content/en/security/application_security/setup/haproxy.md
+++ b/content/en/security/application_security/setup/haproxy.md
@@ -17,6 +17,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< callout url="https://www.datadoghq.com/product-preview/haproxy-integration/">}}
 App and API Protection for HAProxy is in Preview. To sign up, click <strong>Request Access</strong> and complete the form.
 {{< /callout >}}

--- a/content/en/security/application_security/setup/java/_index.md
+++ b/content/en/security/application_security/setup/java/_index.md
@@ -25,6 +25,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 {{% app_and_api_protection_java_overview showSetup="false" %}}

--- a/content/en/security/application_security/setup/java/aws-fargate.md
+++ b/content/en/security/application_security/setup/java/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/java/docker.md
+++ b/content/en/security/application_security/setup/java/docker.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_setup_options platform="docker" %}}
 
 {{% app_and_api_protection_java_overview %}}

--- a/content/en/security/application_security/setup/java/kubernetes.md
+++ b/content/en/security/application_security/setup/java/kubernetes.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_setup_options platform="kubernetes" %}}
 
 {{% app_and_api_protection_java_overview %}}

--- a/content/en/security/application_security/setup/java/linux.md
+++ b/content/en/security/application_security/setup/java/linux.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_setup_options platform="linux" %}}
 
 {{% app_and_api_protection_java_overview %}}

--- a/content/en/security/application_security/setup/java/macos.md
+++ b/content/en/security/application_security/setup/java/macos.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/java/troubleshooting.md
+++ b/content/en/security/application_security/setup/java/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting Java App and API Protection
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No security signals appearing

--- a/content/en/security/application_security/setup/java/windows.md
+++ b/content/en/security/application_security/setup/java/windows.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_java_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/kubernetes/_index.md
+++ b/content/en/security/application_security/setup/kubernetes/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your Kubernetes clusters by selecting the Kubernetes integration that suits you best.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/kubernetes/envoy-gateway.md
+++ b/content/en/security/application_security/setup/kubernetes/envoy-gateway.md
@@ -16,6 +16,12 @@ further_reading:
     text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< callout url="#" btn_hidden="true" header="App and API Protection for Envoy Gateway is in Preview" >}}
 App and API Protection for Envoy Gateway is in Preview. Use the following instructions to try the preview.
 {{< /callout >}}

--- a/content/en/security/application_security/setup/kubernetes/gateway-api.md
+++ b/content/en/security/application_security/setup/kubernetes/gateway-api.md
@@ -16,6 +16,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-danger">
   AAP for Gateway API is experimental. Please follow the instructions below to try it out.
 </div>

--- a/content/en/security/application_security/setup/kubernetes/gke.md
+++ b/content/en/security/application_security/setup/kubernetes/gke.md
@@ -25,6 +25,12 @@ further_reading:
     text: "App and API Protection Service Extension source code"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< callout url="#" btn_hidden="true" header="App and API Protection for GKE is in Preview" >}}
 To try the Preview of App and API Protection for GKE, use the following setup instructions.
 {{< /callout >}}

--- a/content/en/security/application_security/setup/kubernetes/istio.md
+++ b/content/en/security/application_security/setup/kubernetes/istio.md
@@ -18,6 +18,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< callout url="#" btn_hidden="true" header="App and API Protection for Istio is in Preview" >}}
 To try the preview of App and API Protection for Istio, use the following setup instructions.
 {{< /callout >}}

--- a/content/en/security/application_security/setup/linux/_index.md
+++ b/content/en/security/application_security/setup/linux/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your Linux services by selecting the service's programming language.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/macos/_index.md
+++ b/content/en/security/application_security/setup/macos/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your macOS services by selecting the service's programming language.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/setup/nginx.md
+++ b/content/en/security/application_security/setup/nginx.md
@@ -3,3 +3,10 @@ title: Enabling App and API Protection for Nginx
 code_lang: nginx
 code_lang_weight: 50
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+

--- a/content/en/security/application_security/setup/nginx/_index.md
+++ b/content/en/security/application_security/setup/nginx/_index.md
@@ -14,6 +14,13 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 ## Overview

--- a/content/en/security/application_security/setup/nginx/ingress-controller.md
+++ b/content/en/security/application_security/setup/nginx/ingress-controller.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 # Ingress-nginx support for Datadog

--- a/content/en/security/application_security/setup/nginx/linux.md
+++ b/content/en/security/application_security/setup/nginx/linux.md
@@ -23,6 +23,12 @@ further_reading:
       text: "Standalone App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The Datadog nginx tracing module has experimental support for threat detection and blocking.
 
 ## Enabling threat detection

--- a/content/en/security/application_security/setup/nodejs/_index.md
+++ b/content/en/security/application_security/setup/nodejs/_index.md
@@ -23,6 +23,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 {{% aap/aap_and_api_protection_nodejs_overview showSetup="false" %}}

--- a/content/en/security/application_security/setup/nodejs/aws-fargate.md
+++ b/content/en/security/application_security/setup/nodejs/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/nodejs/docker.md
+++ b/content/en/security/application_security/setup/nodejs/docker.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_setup_options platform="docker" %}}
 
 {{% aap/aap_and_api_protection_nodejs_overview %}}

--- a/content/en/security/application_security/setup/nodejs/kubernetes.md
+++ b/content/en/security/application_security/setup/nodejs/kubernetes.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_setup_options platform="kubernetes" %}}
 
 {{% aap/aap_and_api_protection_nodejs_overview %}}

--- a/content/en/security/application_security/setup/nodejs/linux.md
+++ b/content/en/security/application_security/setup/nodejs/linux.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_setup_options platform="linux" %}}
 
 {{% aap/aap_and_api_protection_nodejs_overview %}}

--- a/content/en/security/application_security/setup/nodejs/macos.md
+++ b/content/en/security/application_security/setup/nodejs/macos.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/nodejs/troubleshooting.md
+++ b/content/en/security/application_security/setup/nodejs/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting Node.js App and API Protection
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No security signals appearing

--- a/content/en/security/application_security/setup/nodejs/windows.md
+++ b/content/en/security/application_security/setup/nodejs/windows.md
@@ -14,6 +14,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% aap/aap_and_api_protection_nodejs_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/php/_index.md
+++ b/content/en/security/application_security/setup/php/_index.md
@@ -11,6 +11,13 @@ aliases:
   - /security/application_security/enabling/compatibility/php
   - /security/application_security/setup/php/compatibility
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 {{% app_and_api_protection_php_overview showSetup="false" %}}

--- a/content/en/security/application_security/setup/php/aws-fargate.md
+++ b/content/en/security/application_security/setup/php/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_php_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/php/docker.md
+++ b/content/en/security/application_security/setup/php/docker.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_php_setup_options platform="docker" %}}
 
 {{% app_and_api_protection_php_overview %}}

--- a/content/en/security/application_security/setup/php/kubernetes.md
+++ b/content/en/security/application_security/setup/php/kubernetes.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_php_setup_options platform="kubernetes" %}}
 
 {{% app_and_api_protection_php_overview %}}

--- a/content/en/security/application_security/setup/php/linux.md
+++ b/content/en/security/application_security/setup/php/linux.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_php_setup_options platform="linux" %}}
 
 {{% app_and_api_protection_php_overview %}}

--- a/content/en/security/application_security/setup/php/troubleshooting.md
+++ b/content/en/security/application_security/setup/php/troubleshooting.md
@@ -12,6 +12,12 @@ further_reading:
     text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 This document provides diagnostic information for common issues and unexpected behavior with Datadog App and API Protection. If you continue to have trouble, reach out to [Datadog support][1] for further assistance.

--- a/content/en/security/application_security/setup/python/_index.md
+++ b/content/en/security/application_security/setup/python/_index.md
@@ -24,6 +24,13 @@ further_reading:
   tag: "Documentation"
   text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< partial name="app_and_api_protection/callout.html" >}}
 
 {{% app_and_api_protection_python_overview showSetup="false" %}}

--- a/content/en/security/application_security/setup/python/aws-fargate.md
+++ b/content/en/security/application_security/setup/python/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/python/docker.md
+++ b/content/en/security/application_security/setup/python/docker.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_setup_options platform="docker" %}}
 
 {{% app_and_api_protection_python_overview %}}

--- a/content/en/security/application_security/setup/python/kubernetes.md
+++ b/content/en/security/application_security/setup/python/kubernetes.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_setup_options platform="kubernetes" %}}
 
 {{% app_and_api_protection_python_overview %}}

--- a/content/en/security/application_security/setup/python/linux.md
+++ b/content/en/security/application_security/setup/python/linux.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_setup_options platform="linux" %}}
 
 {{% app_and_api_protection_python_overview %}}

--- a/content/en/security/application_security/setup/python/macos.md
+++ b/content/en/security/application_security/setup/python/macos.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/python/troubleshooting.md
+++ b/content/en/security/application_security/setup/python/troubleshooting.md
@@ -12,6 +12,12 @@ further_reading:
     text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No security signals appearing

--- a/content/en/security/application_security/setup/python/windows.md
+++ b/content/en/security/application_security/setup/python/windows.md
@@ -14,6 +14,13 @@ further_reading:
     tag: "Documentation"
     text: "Troubleshooting App and API Protection"
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app_and_api_protection_python_overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/ruby/_index.md
+++ b/content/en/security/application_security/setup/ruby/_index.md
@@ -26,6 +26,12 @@ further_reading:
       text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-overview showSetup="false" %}}
 
 ## Environments

--- a/content/en/security/application_security/setup/ruby/aws-fargate.md
+++ b/content/en/security/application_security/setup/ruby/aws-fargate.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/ruby/docker.md
+++ b/content/en/security/application_security/setup/ruby/docker.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-setup-options platform="linux" %}}
 
 {{% app-and-api-protection-ruby-overview %}}

--- a/content/en/security/application_security/setup/ruby/kubernetes.md
+++ b/content/en/security/application_security/setup/ruby/kubernetes.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-setup-options platform="kubernetes" %}}
 
 {{% app-and-api-protection-ruby-overview %}}

--- a/content/en/security/application_security/setup/ruby/linux.md
+++ b/content/en/security/application_security/setup/ruby/linux.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-setup-options platform="linux" %}}
 
 {{% app-and-api-protection-ruby-overview %}}

--- a/content/en/security/application_security/setup/ruby/macos.md
+++ b/content/en/security/application_security/setup/ruby/macos.md
@@ -15,6 +15,12 @@ further_reading:
   text: "Troubleshooting App and API Protection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{% app-and-api-protection-ruby-overview %}}
 
 ## Prerequisites

--- a/content/en/security/application_security/setup/ruby/troubleshooting.md
+++ b/content/en/security/application_security/setup/ruby/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting Ruby App and API Protection
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Common Issues
 
 ### No security signals appearing

--- a/content/en/security/application_security/setup/single_step/_index.md
+++ b/content/en/security/application_security/setup/single_step/_index.md
@@ -5,6 +5,12 @@ aliases:
   - /security/application_security/threats/setup/single_step
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Enabling AAP threat detection and protection using single step instrumentation is in Preview.</div>
 
 ## Requirements

--- a/content/en/security/application_security/setup/windows/_index.md
+++ b/content/en/security/application_security/setup/windows/_index.md
@@ -19,6 +19,12 @@ further_reading:
   text: "How Application & API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Learn how to set up App and API Protection (AAP) on your Windows services by selecting the service's programming language.
 
 <div class="alert alert-info">

--- a/content/en/security/application_security/terms.md
+++ b/content/en/security/application_security/terms.md
@@ -13,6 +13,12 @@ further_reading:
   text: "Accelerate security investigations with Datadog Threat Intelligence"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Datadog App and API Protection monitors threats and provides protection against application-level attacks that aim to exploit code-level vulnerabilities. It leverages runtime code execution context, trace and error data, and user attribution.
 
 ## General App and API Protection terms

--- a/content/en/security/application_security/threat_protection/_index.md
+++ b/content/en/security/application_security/threat_protection/_index.md
@@ -7,6 +7,12 @@ further_reading:
   text: "Protect your applications from zero-day attacks with Datadog Exploit Prevention"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Use Threat Protection in [App and API Protection][1] (AAP) to detect attacks against your applications and APIs, perform investigations, and block malicious traffic in real time.
 
 To get started, [set up AAP][2] on your services so they report security traces. AAP then detects threats from your live application traffic and lets you respond to them.

--- a/content/en/security/application_security/threat_protection/account_takeover_protection.md
+++ b/content/en/security/application_security/threat_protection/account_takeover_protection.md
@@ -16,6 +16,12 @@ further_reading:
   text: "App and API Protection Guides"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 App and API Protection (AAP) provides account takeover (ATO) protection to detect and mitigate account takeover attacks.
 
 ATO protection has the following benefits:

--- a/content/en/security/application_security/threat_protection/exploit-prevention.md
+++ b/content/en/security/application_security/threat_protection/exploit-prevention.md
@@ -19,6 +19,12 @@ further_reading:
   text: "Understanding your WAF: How to address common gaps in web application security"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 {{< learning-center-callout header="Get real-time security guardrails for your AI apps and agents" btn_title="Join the preview" hide_image="true" btn_url="https://www.datadoghq.com/product-preview/ai-security/">}}
   AI Guard helps secure your AI apps and agents in real time against prompt injection, jailbreaking, tool misuse, and sensitive data exfiltration attacks. Try it today!
 {{< /learning-center-callout >}}

--- a/content/en/security/application_security/threat_protection/overview.md
+++ b/content/en/security/application_security/threat_protection/overview.md
@@ -10,6 +10,12 @@ further_reading:
   text: "Attack Summary"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 The **Threat Protection** overview page shows how well your services are instrumented and protected against attacks, the security signals they generate, the services most exposed to threats, and the trends in attack activity. The following sections describe each area of the page.
 
 {{< img src="security/application_security/overview/threat_protection.png" alt="Threat Protection overview page" >}}

--- a/content/en/security/application_security/threat_protection/policies/_index.md
+++ b/content/en/security/application_security/threat_protection/policies/_index.md
@@ -6,6 +6,12 @@ aliases:
 disable_toc: false
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 If your service is running [an Agent with Remote Configuration enabled and an SDK version that supports it][2], you can block attacks and attackers from the Datadog UI without additional configuration of the Agent or SDKs.
 
 App and API Protection (AAP) Protect enables you to slow down attacks and attackers by _blocking_ them. Security traces are blocked in real-time by the Datadog SDKs. Blocks are saved in the Datadog platform, automatically and securely fetched by the Datadog Agent, deployed in your infrastructure, and applied to your services.

--- a/content/en/security/application_security/threat_protection/policies/custom_rules.md
+++ b/content/en/security/application_security/threat_protection/policies/custom_rules.md
@@ -23,6 +23,12 @@ further_reading:
   text: "Syntax for defining the AAP query"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 App and API Protection (AAP) comes with a set of [out-of-the-box detection rules][1] which aim to catch attack attempts, vulnerabilities found by attacker, and business logic abuse that impact your production systems.

--- a/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
+++ b/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
@@ -7,6 +7,12 @@ aliases:
   - /security/application_security/threats/inapp_waf_rules
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 With App and API Protection (AAP) enabled, the Datadog SDK actively monitors all web services and API requests for suspicious security activity.

--- a/content/en/security/application_security/threat_protection/policies/library_configuration.md
+++ b/content/en/security/application_security/threat_protection/policies/library_configuration.md
@@ -24,6 +24,11 @@ further_reading:
   text: "How App and API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 ## Configuring a client IP header
 

--- a/content/en/security/application_security/threat_protection/security_signals/_index.md
+++ b/content/en/security/application_security/threat_protection/security_signals/_index.md
@@ -15,6 +15,12 @@ further_reading:
     text: "AAP threat intelligence"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 AAP security signals are created when Datadog detects a threat based on a detection rule. View, search, filter, and investigate security signals in the [Signals Explorer][2], or configure [Notification Rules][8] to send signals to third-party tools.

--- a/content/en/security/application_security/threat_protection/security_signals/attacker-explorer.md
+++ b/content/en/security/application_security/threat_protection/security_signals/attacker-explorer.md
@@ -10,6 +10,13 @@ further_reading:
   text: "Protection"
 ---
  
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 This topic describes how to use {{< ui >}}Attackers Explorer{{< /ui >}} to investigate and block Flagged Attackers.
 
 ## Overview

--- a/content/en/security/application_security/threat_protection/security_signals/attacker_clustering.md
+++ b/content/en/security/application_security/threat_protection/security_signals/attacker_clustering.md
@@ -22,6 +22,11 @@ further_reading:
   text: "Detect and respond to evolving attacks with Attacker Clustering"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
 
 ## Overview
 

--- a/content/en/security/application_security/threat_protection/security_signals/attacker_fingerprint.md
+++ b/content/en/security/application_security/threat_protection/security_signals/attacker_fingerprint.md
@@ -10,6 +10,12 @@ further_reading:
   text: "Attacker Clustering"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 This topic describes a feature called **Datadog Attacker Fingerprint** to identify attackers beyond IP addresses.
 
 ## Overview

--- a/content/en/security/application_security/threat_protection/security_signals/users_explorer.md
+++ b/content/en/security/application_security/threat_protection/security_signals/users_explorer.md
@@ -5,6 +5,12 @@ title: Users Explorer
 disable_toc: false
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 This topic describes how to use the App and API Protection [Users explorer][1] to investigate the risks associated with the users tracked by security [traces][3].
 
 ## Overview

--- a/content/en/security/application_security/threat_protection/waf-integration.md
+++ b/content/en/security/application_security/threat_protection/waf-integration.md
@@ -10,6 +10,12 @@ further_reading:
   text: "Monitor AWS WAF activity with Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 Protecting web applications and APIs requires a multi-layered approach that combines in-app monitoring and perimeter defenses. These complementary strategies enable you to have a *defense-in-depth* App and API Protection approach that leverages AWS Web Application Firewall (WAF) as the first line of defense, followed by Exploit Prevention for blocking attacks that slip by the WAF.
 
 For details on how Exploit Prevention differs from In-App WAF, see [Exploit Prevention vs. In-App WAF][5].

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -11,6 +11,12 @@ further_reading:
   text: "How App and API Protection Works in Datadog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
 ## Overview
 
 If you experience unexpected behavior with Datadog App and API Protection (AAP), there are common issues you can investigate, as mentioned below. If you continue to have trouble, reach out to [Datadog support][1] for further assistance.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15057, DOCS-15058

App and API Protection (AAP) is moving from unsupported to Preview status on the US1-FED (gov) site. This PR:

- Removes the "not supported" banner for AAP on `gov` across `content/en/security/application_security/` and `content/en/getting_started/security/application_security.md`
- Adds a Preview banner on `gov`, matching the pattern used on [App Builder](https://docs.datadoghq.com/actions/app_builder/?site=gov)
- Keeps the existing unsupported banner in place for `gov2`

This isn't a great way of doing this. I may look into an automation for this

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes