### PR TITLE
Widgets: better oneOf schema support

### DIFF
--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -838,6 +838,14 @@ const descColumn = (key, value) => {
   return `<div class="col-6 column">${descHtml}${def}</div>`.trim();
 };
 
+/**
+ * @param {array} items - oneOf items
+ * @returns {object} object keyed by item name
+ */
+const getOneOfChildData = (items) => Object.fromEntries(
+  items.map((item, i) => [`Object ${i}`, item])
+);
+
 
 /**
  * Takes a application/json schema for request or response and outputs a table
@@ -881,11 +889,7 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
             }
             // for items -> oneOf
             if (value.items.oneOf && value.items.oneOf instanceof Array && value.items.oneOf.length < oneOfLimit) {
-              childData = value.items.oneOf
-              .map((obj, indx) => {
-                return {[`Option ${indx + 1}`]: value.items.oneOf[indx]}
-              })
-              .reduce((obj, item) => ({...obj, ...item}), {});
+              childData = getOneOfChildData(value.items.oneOf);
             }
           } else if(typeof value.items === 'string') {
             if(value.items === '[Circular]') {
@@ -904,11 +908,7 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
         } else if (typeof value === 'object' && "oneOf" in value) {
           // for properties -> oneOf
           if(value.oneOf instanceof Array && value.oneOf.length < oneOfLimit) {
-            childData = value.oneOf
-              .map((obj, indx) => {
-                return {[`Option ${indx + 1}`]: value.oneOf[indx]}
-              })
-              .reduce((obj, item) => ({...obj, ...item}), {});
+            childData = getOneOfChildData(value.oneOf);
           }
         }
         // for widgets

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -863,7 +863,11 @@ const groupBy = (items, keyFn) => {
 /**
  * Returns "<type=c>" if `item` is an object schema with a const `type` field
  * @param {object} schema
- * @returns "<type=c>" if the schema is a const or 1-value string enum
+ * Returns `<discriminant=c>` when `item.properties[discriminant]` is a
+ * single-value string enum.
+ * @param {object} item - schema object
+ * @param {string} discriminant - property name to inspect
+ * @returns {string|undefined} formatted label, or undefined if not a const
  */
 const getMaybeConstTypeName = (item, discriminant) => {
   const type = item.properties?.[discriminant];

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -880,7 +880,7 @@ const getMaybeConstTypeName = (item, discriminant) => {
     return `&lt;${discriminant}=${type.enum[0]}&gt;`;
   }
   return undefined;
-}
+};
 
 /**
  * Auto-detects the best discriminant property across a set of oneOf branches.
@@ -930,7 +930,7 @@ const getBestDiscriminant = (items) => {
   }
 
   return undefined;
-}
+};
 
 /**
  * @param {array} items - oneOf items
@@ -945,7 +945,7 @@ const getOneOfChildData = (items) => {
     [name && byName.get(name)?.length === 1 ? name : `Object ${i + 1}`, item]
   );
   return Object.fromEntries(entries);
-}
+};
 
 
 /**

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -1103,12 +1103,17 @@ const processSpecs = (specs) => {
           if(deref.components.schemas && deref.components.schemas.WidgetDefinition && deref.components.schemas.WidgetDefinition.oneOf) {
             const jsonData = {};
             const pageDir = `./content/en/api/${version}/dashboards/`;
-            deref.components.schemas.WidgetDefinition.oneOf.forEach((widget) => {
+            const addWidget = (widget) => {
+              if (widget.oneOf) {
+                widget.oneOf.forEach(addWidget);
+                return;
+              }
               const requestJson = filterExampleJson("request", widget);
               const requestCurlJson = filterExampleJson("curl", widget);
               const html = schemaTable("request", widget);
               jsonData[widget.properties.type.default] = {"json_curl": requestCurlJson, "json": requestJson, "html": html};
-            });
+            };
+            deref.components.schemas.WidgetDefinition.oneOf.forEach(addWidget);
             fs.writeFileSync(`${pageDir}widgets.json`, safeJsonStringify(jsonData, null, 2), 'utf-8');
           }
 

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -938,7 +938,7 @@ const getOneOfChildData = (items) => {
   const byName = groupBy(namedEntries, ([name]) => name);
   const entries = namedEntries.map(([name, item], i) =>
     // if name is unique, use it; otherwise, use "Object 3"
-    [name && byName.get(name)?.length === 1 ? name : `Object ${i}`, item]
+    [name && byName.get(name)?.length === 1 ? name : `Object ${i + 1}`, item]
   );
   return Object.fromEntries(entries);
 }
@@ -1258,6 +1258,7 @@ const init = () => {
 
 module.exports = {
   init,
+  getBestDiscriminant,
   isTagMatch,
   isReadOnlyRow,
   descColumn,

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -839,12 +839,109 @@ const descColumn = (key, value) => {
 };
 
 /**
+ * Shim for Map.groupBy(), which is only available in Node 21+ (this repo
+ * targets Node 20).
+ *
+ * @param {Iterable} items - items to group
+ * @param {function} keyFn - maps an item to its group key
+ * @returns {Map} map of key to array of items
+ */
+const groupBy = (items, keyFn) => {
+  const map = new Map();
+  items.forEach((item, i) => {
+    const key = keyFn(item, i);
+    const group = map.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  });
+  return map;
+};
+
+/**
+ * Returns "<type=c>" if `item` is an object schema with a const `type` field
+ * @param {object} schema
+ * @returns "<type=c>" if the schema is a const or 1-value string enum
+ */
+const getMaybeConstTypeName = (item, discriminant) => {
+  const type = item.properties?.[discriminant];
+  if (
+    type
+    && type.type === 'string'
+    && type.enum
+    && type.enum.length === 1
+  ) {
+    return `&lt;${discriminant}=${type.enum[0]}&gt;`;
+  }
+  return undefined;
+}
+
+/**
+ * Auto-detects the best discriminant property across a set of oneOf branches.
+ *
+ * A property is a candidate discriminant when every branch either omits it or
+ * defines it as a string enum.
+ *
+ * Preference order:
+ *  1. The first candidate that covers every branch (all-defined + unique).
+ *  2. Otherwise, the candidate covering the most branches, provided it covers
+ *     all-but-one branch or at least 75% of branches.
+ *
+ * @param {array} items - oneOf items
+ * @returns {string|undefined} the discriminant property name, or undefined
+ */
+const getBestDiscriminant = (items) => {
+  const candidates = Array.from(new Set(
+    items.flatMap((item) => Object.keys(item.properties ?? {}))
+  ));
+  const enumCandidates = candidates.filter((d) => items.some((item) => {
+    const prop = item.properties?.[d];
+    return prop && prop.type === 'string' && prop.enum?.length === 1;
+  }));
+  const onlyEnumCandidates = enumCandidates.filter((d) => !items.some((item) => {
+    const prop = item.properties?.[d];
+    return prop && (prop.type !== 'string' || !prop.enum);
+  }));
+
+  const countedCandidates = onlyEnumCandidates.map((d) => {
+    const byName = groupBy(items, (item) => getMaybeConstTypeName(item, d));
+    const nUnique = [...byName].reduce(
+      (acc, [value, arr]) => acc + ((value && arr.length === 1) ? 1 : 0),
+      0,
+    );
+    return { name: d, nUnique };
+  });
+  countedCandidates.sort((a, b) => b.nUnique - a.nUnique);
+
+  const bestCandidate = countedCandidates[0];
+  if (!bestCandidate) {
+    return undefined;
+  }
+
+  const { name, nUnique } = bestCandidate;
+  if (nUnique >= items.length - 1 || (nUnique / items.length) >= 0.75) {
+    return name;
+  }
+
+  return undefined;
+}
+
+/**
  * @param {array} items - oneOf items
  * @returns {object} object keyed by item name
  */
-const getOneOfChildData = (items) => Object.fromEntries(
-  items.map((item, i) => [`Object ${i}`, item])
-);
+const getOneOfChildData = (items) => {
+  const discriminant = getBestDiscriminant(items);
+  const namedEntries = items.map((item) => [discriminant ? getMaybeConstTypeName(item, discriminant) : undefined, item]);
+  const byName = groupBy(namedEntries, ([name]) => name);
+  const entries = namedEntries.map(([name, item], i) =>
+    // if name is unique, use it; otherwise, use "Object 3"
+    [name && byName.get(name)?.length === 1 ? name : `Object ${i}`, item]
+  );
+  return Object.fromEntries(entries);
+}
 
 
 /**

--- a/assets/scripts/tests/build-api-pages.test.js
+++ b/assets/scripts/tests/build-api-pages.test.js
@@ -1,5 +1,7 @@
 import * as bp from '../build-api-pages';
 import fs from 'fs';
+import yaml from 'js-yaml';
+import $RefParser from '@apidevtools/json-schema-ref-parser';
 
 describe(`updateMenu`, () => {
 
@@ -2807,6 +2809,27 @@ describe(`schemaTable`, () => {
         </div>
       </div>`.trim();
     expect(actual).toEqual(expected);
+  });
+
+});
+
+describe(`getBestDiscriminant`, () => {
+
+  let schemas;
+  beforeAll(async () => {
+    const spec = yaml.safeLoad(fs.readFileSync('./data/api/v1/full_spec.yaml', 'utf8'));
+    const deref = await $RefParser.dereference(spec, { resolve: { external: false } });
+    schemas = deref.components.schemas;
+  });
+
+  it('discriminates WidgetDefinition on `type`', () => {
+    expect(bp.getBestDiscriminant(schemas.WidgetDefinition.oneOf)).toEqual('type');
+  });
+
+  it('discriminates timeseries requests[].queries[] on `data_source`', () => {
+    const queries = schemas.TimeseriesWidgetRequest.properties.queries.items;
+    expect(queries).toBe(schemas.FormulaAndFunctionQueryDefinition);
+    expect(bp.getBestDiscriminant(queries.oneOf)).toEqual('data_source');
   });
 
 });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Supports generating widget documentation once we introduce nested `oneOf`. See https://github.com/DataDog/datadog-api-spec/pull/5974 -- this [failed build](https://github.com/DataDog/datadog-api-spec/actions/runs/29511325539/job/87673255575?pr=5974)

Also: I found it hard to "see" my change in the widget list, so I scratched an itch and changed the "Option 1", "Option 2", etc. to: `<type=foo>` and `<type=bar>`. This affects a _bunch_ of documents.

| Before | After |
|--------|--------|
| <img width="1256" height="571" alt="image" src="https://github.com/user-attachments/assets/3d637a1d-633b-4568-ac62-13d98c656f0a" /> | <img width="1256" height="571" alt="image" src="https://github.com/user-attachments/assets/63d521c3-a9c1-4b78-9982-4475cf926cdd" /> |
| <img width="1261" height="641" alt="image" src="https://github.com/user-attachments/assets/b8fcb500-eb0d-4557-bcc1-3e7e61090415" /> | <img width="1261" height="641" alt="image" src="https://github.com/user-attachments/assets/514f1911-ebf8-4ef1-8866-deb4341e41ea" /> |
| <img width="1240" height="312" alt="image" src="https://github.com/user-attachments/assets/9fc29c2e-9575-4f96-b6ec-3f8515991cd6" /> | <img width="1240" height="312" alt="image" src="https://github.com/user-attachments/assets/5739707b-58ff-4325-a989-9969258c2a7e" /> |

How we find a discriminant (e.g., `type` or `data_source`):

- In every `oneOf` branch, the discriminant must be a string enum
- For every discriminant, count _unique_ enum values: i.e., the branch has a single-value enum (a const), and no other branch has a single-value enum with the same value.
- Pick the best discriminant. If there's no perfect match (e.g., FormulaEventsDataSource isn't unique; nor is widget type), ensure the discriminant is _good_ -- i.e., it'll render something useful for _most_ options.

How we _render_ an item (e.g., `<type=timeseries>`):

- If the discriminant points to a single-value enum, render that
- Otherwise, fallback to what we have today: "Object 3", etc

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

I flipped back and forth with Opus 4.8. Most of the code is mine.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
