### PR TITLE
[DOCS-15077] Enable RDS backups for BYOC AWS install

### DIFF
--- a/content/en/byoc-logs/install/aws_eks.md
+++ b/content/en/byoc-logs/install/aws_eks.md
@@ -144,10 +144,12 @@ aws rds create-db-instance \
   --db-subnet-group-name <DB-SUBNET-GROUP-NAME> \
   --vpc-security-group-ids <EKS-CLUSTER-SECURITY-GROUP-ID> \
   --db-name byoclogs \
-  --backup-retention-period 0 \
+  --backup-retention-period 7 \
   --region <AWS_REGION> \
   --no-multi-az
 ```
+
+The `--backup-retention-period 7` flag enables automated backups with a 7-day retention period. Enable backups for disaster recovery in production deployments.
 
 You can retrieve RDS information by executing the following shell commands. The below commands retrieve information for the RDS instance created above:
 

--- a/content/en/byoc-logs/operate/best_practices.md
+++ b/content/en/byoc-logs/operate/best_practices.md
@@ -53,6 +53,8 @@ Indexers use a write-ahead log (WAL) to temporarily buffer data before uploading
 **Note**: Local SSDs are not recommended because the WAL is not replicated. Ephemeral disks can result in data loss if the disk fails. Use network-attached storage for built-in redundancy, and always enable persistent volumes for production deployments.
 
 Example Helm values:
+Example Helm values:
+
 ```yaml
 indexer:
   persistentVolume:

--- a/content/en/byoc-logs/operate/best_practices.md
+++ b/content/en/byoc-logs/operate/best_practices.md
@@ -61,6 +61,12 @@ indexer:
     storageClass: gp3
 ```
 
+## Enable automated backups on your metastore database
+
+BYOC Logs stores metadata in a PostgreSQL database (Amazon RDS, Cloud SQL, or Azure Database for PostgreSQL, depending on your cloud provider). Enable automated backups on this database for disaster recovery.
+
+For example, on AWS, set a nonzero `--backup-retention-period` when you create the RDS instance. See [Create an RDS database][5] for an example command.
+
 ## Monitor disk capacity on indexers
 
 Indexer disk usage grows as the WAL accumulates data and during merge operations. If disk space runs out, indexers stop ingesting logs.
@@ -117,3 +123,4 @@ helm search repo datadog/cloudprem --versions
 [2]: /byoc-logs/operate/monitoring/
 [3]: /byoc-logs/operate/sizing/#helm-chart-sizing-tiers
 [4]: /byoc-logs/configure/lambda/
+[5]: /byoc-logs/install/aws_eks/#create-an-rds-database


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15077

The BYOC Logs AWS install docs create the RDS instance with `--backup-retention-period 0`, which disables automated backups. This PR:
- Changes the retention period to 7 days so the example command enables backups.
- Adds a best practice section on enabling automated metastore database backups for disaster recovery.

### Merge readiness

- [X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to diagnose the ticket and draft the doc changes.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
