### PR TITLE
Clarify JavaScript unskippable test setup

### DIFF
--- a/content/en/tests/test_impact_analysis/setup/javascript.md
+++ b/content/en/tests/test_impact_analysis/setup/javascript.md
@@ -117,6 +117,22 @@ describe('context', () => {
 })
 ```
 
+The following example is invalid because the docblock appears after code and attempts to mark only one test as unskippable:
+
+```javascript
+it('can sum', () => {
+  expect(1 + 2).to.equal(3)
+})
+
+// THIS IS INVALID: The docblock cannot mark an individual test as unskippable.
+/**
+ * @datadog {"unskippable": true}
+ */
+it('can subtract', () => {
+  expect(3 - 2).to.equal(1)
+})
+```
+
 [1]: https://jestjs.io/docs/configuration#testenvironmentoptions-object
 {{% /tab %}}
 {{% tab "Cucumber" %}}

--- a/content/en/tests/test_impact_analysis/setup/javascript.md
+++ b/content/en/tests/test_impact_analysis/setup/javascript.md
@@ -95,15 +95,17 @@ Examples include:
 * Tests that read data from text files
 * Tests that interact with APIs outside of the code being tested (such as remote REST APIs)
 
-Designating tests as unskippable ensures that Test Impact Analysis runs them regardless of coverage data.
+Designating tests as unskippable helps Test Impact Analysis run them regardless of coverage data.
 
 ### Marking tests as unskippable
 
 {{< tabs >}}
 {{% tab "Jest/Mocha/Cypress" %}}
-You can use the following docblock at the top of your test file to mark a suite as unskippable. This prevents any of the tests defined in the test file from being skipped by Test Impact Analysis. This is similar to jest's [`testEnvironmentOptions`][1].
+You can use the following docblock to mark an entire test file as unskippable. You cannot mark individual tests as unskippable. Place the docblock at the top of the file, before any code; only other comments can appear before it. This prevents any of the tests defined in the test file from being skipped by Test Impact Analysis. This is similar to jest's [`testEnvironmentOptions`][1].
 
 ```javascript
+// Other comments can appear above the docblock.
+
 /**
  * @datadog {"unskippable": true}
  */


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies that JavaScript tests can only be marked as unskippable at the file level. Updates the example to show that the Datadog docblock must appear before code and that only comments can precede it.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Codex to draft and validate the documentation update.

### Additional notes

Vale passed with zero errors, warnings, or suggestions.

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->