### PR TITLE
[MCPS-498] Remove outdated further reading link from MCP Server setup doc

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -13,9 +13,6 @@ further_reading:
 - link: "mcp_server/tools"
   tag: "Documentation"
   text: "Datadog MCP Server Tools"
-- link: "ide_plugins/vscode/?tab=cursor"
-  tag: "Documentation"
-  text: "Datadog Extension for Cursor"
 ---
 
 Learn how to set up and configure the Datadog MCP Server, which lets you retrieve telemetry insights and manage platform features directly from AI-powered clients. Select your client:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes MCPS-498

Removes an outdated further reading link from the MCP Server setup doc.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes