### PR TITLE
Remove enable_receive_resource_spans_v2 feature flag reference

### DIFF
--- a/content/en/opentelemetry/mapping/semantic_mapping.md
+++ b/content/en/opentelemetry/mapping/semantic_mapping.md
@@ -174,7 +174,7 @@ Based on the attributes included in your span, the Datadog Agent and Datadog Ope
 
 ### Map OpenTelemetry span attribute to Datadog span type
 
-The following table shows the span type mapping logic that is used if the feature flag `enable_receive_resource_spans_v2` is set in the Datadog Agent or both the Datadog Exporter and Connector, if using the OpenTelemetry Collector. The chart lists mappings in order of precedence.  
+The following table shows the span type mapping logic. The chart lists mappings in order of precedence.  
 | # | Span Attribute | Datadog span.type |
 |---|----------------|-------------------|
 | 1 | `span.type` | `span.type` attribute value |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the reference to the `enable_receive_resource_spans_v2` feature flag on the [OpenTelemetry semantic mapping page](https://docs.datadoghq.com/opentelemetry/mapping/semantic_mapping/?tab=datadogexporter#map-opentelemetry-span-attribute-to-datadog-span-type).

The span type mapping logic previously described as gated behind this feature flag now applies by default, so the conditional wording no longer applies.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
