### PR TITLE
[RUM] Remove Preview callout from Retention Quotas docs

### DIFF
--- a/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
+++ b/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
@@ -16,10 +16,6 @@ further_reading:
     text: Retention Filter Best Practices
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/rum-retention-quotas/" btn_hidden="false" header="Join the Preview">}}
-Retention Quotas are in Preview.
-{{< /callout >}}
-
 ## Overview
 
 Retention quotas let you cap the number of sessions retained per day across your retention filters.


### PR DESCRIPTION
## What does this PR do?

Removes the "Join the Preview" form callout from the RUM Retention Quotas documentation, since Retention Quotas is now GA.

## Motivation

Retention Quotas has moved from Preview to GA. The preview sign-up form is no longer relevant and should not appear in the docs.

## Additional Notes

- Single-file change: `content/en/real_user_monitoring/rum_without_limits/retention_quotas.md`
- No remaining references to the `product-preview/rum-retention-quotas` form anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)