### PR TITLE
Update minimum Datadog Agent version to v7.80

### DIFF
--- a/content/en/gpu_monitoring/setup.md
+++ b/content/en/gpu_monitoring/setup.md
@@ -26,7 +26,7 @@ To begin using Datadog's GPU Monitoring, your environment must meet the followin
 
 #### Minimum version requirements
 
-- **Datadog Agent**: v7.74
+- **Datadog Agent**: v7.80
 - **Operating system**: Linux
 - **Linux kernel**: 5.8 and above
 - **NVIDIA driver**: version 450.51


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the minimum Datadog Agent version for GPU Monitoring from v7.74 to v7.80 (skips the buggy v7.79). Keeps the public setup docs in lockstep with the web-ui product gate.

Paired with the web-ui change: https://github.com/DataDog/web-ui/pull/330951

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Claude Code to make the two-repo version bump and open both PRs.
