### PR TITLE
Document sourceCodeLocation facet requirement for dbt Core CI/CD

### DIFF
--- a/content/en/data_observability/cicd.md
+++ b/content/en/data_observability/cicd.md
@@ -78,6 +78,8 @@ Impact lineage generates a graph of the downstream assets that may be affected b
 
 Drift detection compares the current state of your data on the branch to a baseline and flags any deviations. For Datadog to understand which models ran as part of a CI pipeline, you must send OpenLineage events from your CI job. Datadog uses these events as triggers for drift detection checks. See the [OpenLineage setup documentation][6] for instructions on how to set up OpenLineage.
 
+For **dbt Core**, drift detection also requires the pull request number to be attached to your OpenLineage events through the `sourceCodeLocation` facet. This requires `openlineage-dbt` version 1.46.0 or later and the `OPENLINEAGE__FACETS__SOURCE_CODE_LOCATION__DISABLED=false` environment variable. See [Set the environment variables][7].
+
 ##### General settings
 
 | Setting                            | Description                                                                                                                                                   |

--- a/content/en/data_observability/jobs_monitoring/dbt.md
+++ b/content/en/data_observability/jobs_monitoring/dbt.md
@@ -117,6 +117,18 @@ Follow the steps below to connect dbt Core to Datadog.
 
    # Optional, for debugging purposes
    export OPENLINEAGE_CLIENT_LOGGING=DEBUG
+
+   # Required for CI/CD Drift Detection (requires openlineage-dbt >= 1.46.0).
+   # Attaches the sourceCodeLocation facet (repository URL, commit SHA, and pull
+   # request number) so Datadog can associate the dbt run with a pull request.
+   # Disabled by default; not required for job monitoring alone.
+   export OPENLINEAGE__FACETS__SOURCE_CODE_LOCATION__DISABLED=false
+   ```
+
+   For [CI/CD checks][8], the pull request number is detected automatically when the run exposes `GITHUB_REF` (GitHub Actions workflows triggered by a pull request) or `CI_MERGE_REQUEST_IID` (GitLab merge request pipelines). If neither variable is present, set the pull request number explicitly:
+
+   ```shell
+   export OPENLINEAGE__FACETS__SOURCE_CODE_LOCATION__PULL_REQUEST_NUMBER=<PR_NUMBER>
    ```
 
 ## Update the dbt invocation
@@ -148,6 +160,7 @@ After your next dbt job run, you should start seeing job run and lineage data in
 [5]: https://openlineage.io/docs/client/python/#predefined-datadog-sites
 [6]: https://app.datadoghq.com/data-obs/catalog?integration=dbt
 [7]: https://docs.getdbt.com/docs/running-a-dbt-project/run-your-dbt-projects
+[8]: /data_observability/cicd/
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Drift Detection for **dbt Core** requires the `sourceCodeLocation` facet (carrying the pull request number) on the OpenLineage events sent from CI. That facet is **opt-in** in `openlineage-dbt` >= 1.46.0 (`disabled=true` by default), so without configuration no facet is emitted and drift checks never run. The docs didn't mention this.

This PR documents:
- The required `OPENLINEAGE__FACETS__SOURCE_CODE_LOCATION__DISABLED=false` environment variable (and the >= 1.46.0 version requirement) in the dbt Core setup.
- How the pull request number is resolved: auto-detected from `GITHUB_REF` (GitHub Actions PR workflows) or `CI_MERGE_REQUEST_IID` (GitLab MR pipelines), or set explicitly via `OPENLINEAGE__FACETS__SOURCE_CODE_LOCATION__PULL_REQUEST_NUMBER`.
- A note in the CI/CD Drift Detection section pointing dbt Core users to the requirement.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Investigation, root-cause analysis, and initial draft with Claude Code; reviewed and edited manually.