### PR TITLE
[DOCS-13784] Clarify AWS commercial-partition principal on Gov sites

### DIFF
--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -91,6 +91,7 @@ Datadog assumes this role to collect data on your behalf.
 {{< /site-region >}}
 {{< site-region region="gov,gov2" >}}
 3. If the AWS account you want to integrate is a GovCloud account, enter {{< region-param key="aws_customer_access_govcloud_id" code="true" >}} as the `Account ID`, otherwise enter {{< region-param key="aws_customer_access_id" code="true" >}}. This is Datadog's account ID, and grants Datadog access to your AWS data.
+   **Note**: On US1-FED and US2-FED, Datadog assumes roles in commercial AWS accounts from a dedicated account operated by Datadog for Government in the AWS commercial partition. This account ID differs from the one used on Datadog commercial sites, so it appears as the assuming principal in your CloudTrail logs.
 {{< /site-region >}}
 **Note**: Ensure that the **DATADOG SITE** selector on the right of this documentation page is set to your Datadog site before copying the account ID above.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13784

Adds a clarifying note to the GovCloud (US1-FED and US2-FED) section of the AWS manual setup guide. On these sites, Datadog assumes roles in commercial AWS accounts from a dedicated account operated by Datadog for Government in the AWS commercial partition. Because that account ID differs from the account used on Datadog commercial sites, it appears as the assuming principal in the customer's CloudTrail logs. The note preempts confusion when customers see this account rather than the standard commercial account.

The account IDs and conditional logic already on the page are correct and match the backend role-assumption behavior; no factual correction was needed.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

