### PR TITLE
fix(WEB-9713): prevent IME Enter from submitting Docs AI prompts

### DIFF
--- a/assets/scripts/components/conversational-search/index.js
+++ b/assets/scripts/components/conversational-search/index.js
@@ -286,7 +286,9 @@ class ConversationalSearch {
         this.sendBtn.addEventListener('click', () => this.sendMessage());
 
         this.input.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
+            // Safari can end composition before dispatching the IME-confirming Enter keydown.
+            const isImeComposition = e.isComposing || e.keyCode === 229;
+            if (e.key === 'Enter' && !e.shiftKey && !isImeComposition) {
                 e.preventDefault();
                 this.sendMessage();
             }

--- a/e2e/components/conversational-search/cdocs-conversational-search.spec.ts
+++ b/e2e/components/conversational-search/cdocs-conversational-search.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Locator } from '@playwright/test';
+
+const PAGE_URL = '/getting_started/';
+
+async function dispatchEnter(
+    input: Locator,
+    { isComposing = false, keyCode = 13 }: { isComposing?: boolean; keyCode?: number } = {}
+) {
+    await input.evaluate(
+        (element, options) => {
+            const event = new KeyboardEvent('keydown', {
+                bubbles: true,
+                cancelable: true,
+                code: 'Enter',
+                isComposing: options.isComposing,
+                key: 'Enter'
+            });
+            Object.defineProperty(event, 'keyCode', { value: options.keyCode });
+            element.dispatchEvent(event);
+        },
+        { isComposing, keyCode }
+    );
+}
+
+test.describe('Docs AI conversational search', () => {
+    test('does not submit Enter used to confirm IME composition', async ({ page }) => {
+        let chatRequests = 0;
+        await page.route('**/*', async (route) => {
+            const url = new URL(route.request().url());
+            if (url.pathname.endsWith('/api/unstable/docs-ai/chat')) {
+                chatRequests += 1;
+                await route.fulfill({
+                    body: 'data: [DONE]\n\n',
+                    contentType: 'text/event-stream',
+                    status: 200
+                });
+                return;
+            }
+            if (url.hostname !== 'localhost') {
+                await route.abort();
+                return;
+            }
+            await route.continue();
+        });
+
+        await page.goto(PAGE_URL);
+        await page.locator('.conv-search-float-btn').click();
+
+        const input = page.locator('.conv-search-input');
+        await input.fill('にほん');
+
+        await dispatchEnter(input, { isComposing: true });
+        await expect(input).toHaveValue('にほん');
+        await expect(page.locator('.conv-search-message-user')).toHaveCount(0);
+        expect(chatRequests).toBe(0);
+
+        // Safari can report isComposing=false for the Enter that ends composition,
+        // while retaining the IME process key code.
+        await dispatchEnter(input, { keyCode: 229 });
+        await expect(input).toHaveValue('にほん');
+        await expect(page.locator('.conv-search-message-user')).toHaveCount(0);
+        expect(chatRequests).toBe(0);
+
+        await input.press('Enter');
+        await expect(input).toHaveValue('');
+        await expect(page.locator('.conv-search-message-user .conv-search-message-content')).toHaveText('にほん');
+        await expect.poll(() => chatRequests).toBe(1);
+    });
+});


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

  
  **what:** Pressing Enter to confirm IME character conversion **incorrectly submits** the Docs AI prompt.
   Tested for Japanese + korean IME.

   **Fix**: Prevents Docs AI from submitting prompts during IME composition, including Safari handling.
  Adds end-to-end coverage confirming regular Enter still submits.
  
  https://docs-staging.datadoghq.com/reda.elissati/WEB-9713-fix-ime-submit-bug/

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
