### PR TITLE
Show ServiceNow Case Management as available in US1-FED

### DIFF
--- a/content/en/integrations/guide/servicenow-itom-itsm-setup.md
+++ b/content/en/integrations/guide/servicenow-itom-itsm-setup.md
@@ -231,7 +231,7 @@ sys_id from the templated handle passed in for user.
 
 ### Configure Datadog Case Management {#case-management}
 
-{{% site-region region="gov,gov2" %}}
+{{% site-region region="gov2" %}}
 <div class="alert alert-warning">
 Case Management integration is not supported in the {{< region-param key=dd_datacenter code="true" >}} site.
 </div>


### PR DESCRIPTION
## What changed

Scopes the ServiceNow ITOM/ITSM Case Management availability warning to US2-FED only.

## Why

US1-FED should no longer display the unsupported warning, while US2-FED remains marked unavailable.