### PR TITLE
Add Learning Center course cross-reference: Getting Started with Product Analytics

### DIFF
--- a/content/en/product_analytics/_index.md
+++ b/content/en/product_analytics/_index.md
@@ -23,6 +23,9 @@ further_reading:
 - link: "/product_analytics/analytics_explorer/"
   tag: "Documentation"
   text: "Analytics Explorer"
+- link: https://learn.datadoghq.com/courses/getting-started-product-analytics
+  tag: Learning Center
+  text: Getting Started with Product Analytics
 ---
 
 ## Overview

--- a/content/en/product_analytics/charts/funnel_analysis.md
+++ b/content/en/product_analytics/charts/funnel_analysis.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "/product_analytics/analytics_explorer/"
   tag: "Documentation"
   text: "Analytics Explorer"
+- link: https://learn.datadoghq.com/courses/getting-started-product-analytics
+  tag: Learning Center
+  text: Getting Started with Product Analytics
 algolia:
   tags: ['funnel']
 ---

--- a/content/en/product_analytics/dashboards.md
+++ b/content/en/product_analytics/dashboards.md
@@ -5,6 +5,9 @@ further_reading:
 - link: "/product_analytics/"
   tag: "Documentation"
   text: "Product Analytics"
+- link: https://learn.datadoghq.com/courses/getting-started-product-analytics
+  tag: Learning Center
+  text: Getting Started with Product Analytics
 ---
 
 ## Overview

--- a/content/en/product_analytics/data_collected/_index.md
+++ b/content/en/product_analytics/data_collected/_index.md
@@ -14,6 +14,9 @@ further_reading:
 - link: "/product_analytics/data_collected/server_side_events/"
   tag: "Documentation"
   text: "Track Server-Side Events"
+- link: https://learn.datadoghq.com/courses/getting-started-product-analytics
+  tag: Learning Center
+  text: Getting Started with Product Analytics
 ---
 
 ## Overview

--- a/content/en/product_analytics/segmentation/_index.md
+++ b/content/en/product_analytics/segmentation/_index.md
@@ -5,6 +5,9 @@ further_reading:
 - link: "/product_analytics/"
   tag: "Documentation"
   text: "Product Analytics"
+- link: https://learn.datadoghq.com/courses/getting-started-product-analytics
+  tag: Learning Center
+  text: Getting Started with Product Analytics
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds `further_reading` links to the [Getting Started with Product Analytics](https://learn.datadoghq.com/courses/getting-started-product-analytics) Learning Center course on the following documentation pages:

- Product Analytics — `content/en/product_analytics/_index.md`
- Segments — `content/en/product_analytics/segmentation/_index.md`
- Product Analytics Data Collected — `content/en/product_analytics/data_collected/_index.md`
- Funnel Analysis — `content/en/product_analytics/charts/funnel_analysis.md`
- Dashboards — `content/en/product_analytics/dashboards.md`

## Motivation

Cross-linking the Learning Center course from the most relevant documentation pages helps readers find resources for hands-on practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)