### PR TITLE
Update BYOC Logs feature parity list

### DIFF
--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -11,9 +11,8 @@ Datadog BYOC (Bring Your Own Cloud) Logs brings core Log Explorer capabilities t
 
 ## Supported features
 
-The following log features are supported:
+### Search and visualization
 
-**Search and visualization**
 - Full text search on any log attributes
 - List, Timeseries, Top List, Table, Tree Map, Pie Chart, Scatter Plot visualizations
 - Group into Fields and Patterns (except monthly timeshift)
@@ -24,26 +23,32 @@ The following log features are supported:
 - Pagination
 - Notebooks (Preview)
 
-**Dashboards and monitors**
+### Dashboards and monitors
+
 - Dashboards with BYOC Logs data
 - Log monitors on BYOC Logs indexes
 
-**Index management**
+### Index management
+
 - Multiple indexes with independent retention periods and routing rules
 
-**Access control**
+### Access control
+
 - RBAC through [Log Restriction Queries][1]
 
-**Correlation**
+### Correlation
+
 - Correlation from a log in BYOC Logs to metrics sent to Datadog SaaS
 - Correlation from a log in BYOC Logs to traces sent to Datadog SaaS
 - Correlation from a log in BYOC Logs to processes sent to Datadog SaaS
 
-**Processing**
+### Processing
+
 - Configurable processing pipelines through Observability Pipelines
 - Observability Pipeline connection
 
-**AI features**
+### AI features
+
 - Bits Investigation (Preview)
 - MCP Server (Preview)
 

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -51,17 +51,17 @@ The following log features are supported:
 
 Feature support is actively evolving. The following are not supported:
 
-- **SIEM**
-- **Watchdog**
-- **Federated search**
-- **LiveTail**
-- **Log context view**
+- SIEM
+- Watchdog
+- Federated search
+- LiveTail
+- Log context view
 
 ### Unsupported query capabilities
 
-- **CIDR query**
-- **Group by transactions**
-- **Advanced query capabilities**:
+- CIDR query
+- Group by transactions
+- Advanced query capabilities:
   - Calculated fields
   - Grok extraction (query-time parsing)
 

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -17,13 +17,15 @@ The following log features are supported:
 - Full text search on any log attributes
 - List, Timeseries, Top List, Table, Tree Map, Pie Chart, Scatter Plot visualizations
 - Group by into Fields and Patterns (except monthly timeshift)
+- Group by sort by, including group by sort by with count unique
+- Flat group queries
 - Facet-based filtering and drill-down
 - Download CSV
+- Pagination
 
 **Dashboards and monitors**
 - Dashboards with BYOC Logs data
 - Log monitors on BYOC Logs indexes
-- Bits Investigation
 
 **Index management**
 - Multiple indexes with independent retention periods and routing rules
@@ -34,16 +36,40 @@ The following log features are supported:
 **Correlation**
 - Correlation from a log in BYOC Logs to metrics sent to Datadog SaaS
 - Correlation from a log in BYOC Logs to traces sent to Datadog SaaS
+- Correlation from a log in BYOC Logs to processes sent to Datadog SaaS
+
+**Processing**
+- Configurable processing pipelines through Observability Pipelines
+- Observability Pipeline connection
+
+**AI features**
+- Bits Investigation (Preview)
+- MCP Server (Preview)
+- Notebooks (Preview)
 
 ## Unsupported features
 
 Feature support is actively evolving. The following are not currently supported:
 
-- **SIEM**: Not available for BYOC Logs data.
-- **Watchdog**: Not available for BYOC Logs data.
-- **Notebooks**: Log data from BYOC Logs cannot be used in Notebooks.
-- **Federated search**: Searching across multiple BYOC Logs clusters from a single query is not supported.
-- **LiveTail**: Real-time log streaming is not available for BYOC Logs indexes.
-- **Log context view**: Viewing surrounding logs in context is not yet supported.
+- **SIEM**
+- **Watchdog**
+- **Federated search**
+- **LiveTail**
+- **Log context view**
+
+### Query capabilities not currently supported
+
+The following query capabilities are not supported by ddSQL:
+
+- **CIDR query**
+- **Sorting by text field**
+- **Group by transactions**
+- **Advanced query capabilities**:
+  - Calculated fields
+  - Grok extraction (query-time parsing)
+  - Formula
+  - Join
+  - Filter on reference tables
+  - Filter with subquery
 
 [1]: /api/latest/logs-restriction-queries/

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -22,6 +22,7 @@ The following log features are supported:
 - Facet-based filtering and drill-down
 - Download CSV
 - Pagination
+- Notebooks (Preview)
 
 **Dashboards and monitors**
 - Dashboards with BYOC Logs data
@@ -45,7 +46,6 @@ The following log features are supported:
 **AI features**
 - Bits Investigation (Preview)
 - MCP Server (Preview)
-- Notebooks (Preview)
 
 ## Unsupported features
 
@@ -62,7 +62,6 @@ Feature support is actively evolving. The following are not currently supported:
 The following query capabilities are not supported by ddSQL:
 
 - **CIDR query**
-- **Sorting by text field**
 - **Group by transactions**
 - **Advanced query capabilities**:
   - Calculated fields

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -16,8 +16,8 @@ The following log features are supported:
 **Search and visualization**
 - Full text search on any log attributes
 - List, Timeseries, Top List, Table, Tree Map, Pie Chart, Scatter Plot visualizations
-- Group by into Fields and Patterns (except monthly timeshift)
-- Group by sort by, including group by sort by with count unique
+- Group into Fields and Patterns (except monthly timeshift)
+- Group and sort, including group and sort with count unique
 - Flat group queries
 - Facet-based filtering and drill-down
 - Download CSV

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -54,7 +54,7 @@ Datadog BYOC (Bring Your Own Cloud) Logs brings core Log Explorer capabilities t
 
 ## Unsupported features
 
-The following are not supported:
+BYOC Logs does not support the following features:
 
 - SIEM
 - Watchdog

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -49,7 +49,7 @@ The following log features are supported:
 
 ## Unsupported features
 
-Feature support is actively evolving. The following are not currently supported:
+Feature support is actively evolving. The following are not supported:
 
 - **SIEM**
 - **Watchdog**
@@ -57,7 +57,7 @@ Feature support is actively evolving. The following are not currently supported:
 - **LiveTail**
 - **Log context view**
 
-### Query capabilities not currently supported
+### Unsupported query capabilities
 
 - **CIDR query**
 - **Group by transactions**

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -49,7 +49,7 @@ The following log features are supported:
 
 ## Unsupported features
 
-Feature support is actively evolving. The following are not supported:
+The following are not supported:
 
 - SIEM
 - Watchdog

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -59,8 +59,6 @@ Feature support is actively evolving. The following are not currently supported:
 
 ### Query capabilities not currently supported
 
-The following query capabilities are not supported by ddSQL:
-
 - **CIDR query**
 - **Group by transactions**
 - **Advanced query capabilities**:
@@ -70,5 +68,6 @@ The following query capabilities are not supported by ddSQL:
   - Join
   - Filter on reference tables
   - Filter with subquery
+  - DDSQL
 
 [1]: /api/latest/logs-restriction-queries/

--- a/content/en/byoc-logs/introduction/features.md
+++ b/content/en/byoc-logs/introduction/features.md
@@ -64,10 +64,5 @@ Feature support is actively evolving. The following are not currently supported:
 - **Advanced query capabilities**:
   - Calculated fields
   - Grok extraction (query-time parsing)
-  - Formula
-  - Join
-  - Filter on reference tables
-  - Filter with subquery
-  - DDSQL
 
 [1]: /api/latest/logs-restriction-queries/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the BYOC Logs supported/unsupported features list to reflect the current feature parity matrix.

- Adds previously missing supported features: pagination, flat group queries, group by sort by (including count unique), MCP Server, and correlation to processes.
- Adds a new **Processing** section for configurable processing pipelines and Observability Pipeline connection.
- Adds a new **AI features** section, moving Bits Investigation and MCP Server here and marking them, along with Notebooks, as Preview.
- Reorganizes the Unsupported Features section: removes redundant explanatory text, and adds a **Query capabilities not currently supported** subsection covering ddSQL-specific limitations (CIDR query, sorting by text field, group by transactions, and advanced query capabilities such as calculated fields, Grok extraction, formula, join, filter on reference tables, and filter with subquery).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes