### PR TITLE
[SEC-34751] Add Security Signals to DAC supported telemetry

### DIFF
--- a/content/en/account_management/rbac/data_access.md
+++ b/content/en/account_management/rbac/data_access.md
@@ -46,7 +46,7 @@ Name Dataset
 : A descriptive name to help users understand what data is contained in the dataset.
 
 Select data to be included in this Dataset
-: The boundary definition that describes which data to restrict to a specific set of users. Boundaries are query statements with limitations that allow an access manager to define the scope of sensitive data to be protected. The [supported telemetry types][10] are custom metrics, RUM sessions, APM traces, logs, cloud costs, error tracking issues, Software Delivery repository info (CI Visibility pipelines), Workload Protection Agent Events, and Security Signals (only Cloud SIEM signals are currently supported).
+: The boundary definition that describes which data to restrict to a specific set of users. Boundaries are query statements with limitations that allow an access manager to define the scope of sensitive data to be protected. The [supported telemetry types][10] are custom metrics, RUM sessions, APM traces, logs, cloud costs, error tracking issues, Software Delivery repository info (CI Visibility pipelines), Workload Protection Agent Events, and security signals (Cloud SIEM signals only).
 
 Grant access
 : Select one or more teams or roles that may access the content bound in the Restricted Dataset. Any users who are not members of these groups are blocked from accessing this data.
@@ -65,7 +65,7 @@ You may create a maximum of 100 Restricted Datasets under the Enterprise plan, a
 - Error Tracking issues
 - Logs
 - RUM sessions
-- Security Signals (only Cloud SIEM signals are currently supported)
+- Security signals (Cloud SIEM signals only)
 - Software Delivery repository info (in CI Visibility pipelines)
 - Workload Protection Agent Events
 

--- a/content/en/account_management/rbac/data_access.md
+++ b/content/en/account_management/rbac/data_access.md
@@ -46,7 +46,7 @@ Name Dataset
 : A descriptive name to help users understand what data is contained in the dataset.
 
 Select data to be included in this Dataset
-: The boundary definition that describes which data to restrict to a specific set of users. Boundaries are query statements with limitations that allow an access manager to define the scope of sensitive data to be protected. The [supported telemetry types][10] are custom metrics, RUM sessions, APM traces, logs, cloud costs, error tracking issues, Software Delivery repository info (CI Visibility pipelines), and Workload Protection Agent Events.
+: The boundary definition that describes which data to restrict to a specific set of users. Boundaries are query statements with limitations that allow an access manager to define the scope of sensitive data to be protected. The [supported telemetry types][10] are custom metrics, RUM sessions, APM traces, logs, cloud costs, error tracking issues, Software Delivery repository info (CI Visibility pipelines), Workload Protection Agent Events, and Security Signals (only Cloud SIEM signals are currently supported).
 
 Grant access
 : Select one or more teams or roles that may access the content bound in the Restricted Dataset. Any users who are not members of these groups are blocked from accessing this data.
@@ -65,6 +65,7 @@ You may create a maximum of 100 Restricted Datasets under the Enterprise plan, a
 - Error Tracking issues
 - Logs
 - RUM sessions
+- Security Signals (only Cloud SIEM signals are currently supported)
 - Software Delivery repository info (in CI Visibility pipelines)
 - Workload Protection Agent Events
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds Security Signals (Cloud SIEM signals) to the Data Access Controls supported telemetry types list.

Updated two locations in `content/en/account_management/rbac/data_access.md`:
- The inline field description under "Select data to be included in this Dataset"
- The `### Supported telemetry types` list

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft the wording and open this PR.

### Additional notes

Companion API spec change: https://github.com/DataDog/datadog-api-spec/pull/6218