### PR TITLE
Update datastore limits in docs

### DIFF
--- a/content/en/actions/datastores/create.md
+++ b/content/en/actions/datastores/create.md
@@ -85,7 +85,7 @@ The {{< ui >}}Table Options{{< /ui >}} button allows you to:
 Datastores have the following limitations:
 
 - Your organization can have up to 50 datastores.
-- A datastore can contain up to 5,000 rows.
+- A datastore can contain up to 100,000 rows.
 - A primary key column of type `string` is required and must uniquely identify each row.
 - Each row can be up to 100 KB in size.
 - The primary-key value is immutable, it cannot be changed after the row is created.

--- a/content/en/actions/datastores/create.md
+++ b/content/en/actions/datastores/create.md
@@ -84,7 +84,6 @@ The {{< ui >}}Table Options{{< /ui >}} button allows you to:
 
 Datastores have the following limitations:
 
-- Your organization can have up to 50 datastores.
 - A datastore can contain up to 100,000 rows.
 - A primary key column of type `string` is required and must uniquely identify each row.
 - Each row can be up to 100 KB in size.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3e03383a-09ce-421f-9595-919b27e032aa","source":"chat","resourceId":"7a732b68-814e-4549-9b2e-df23c1a8afa8","workflowId":"3b5b34ad-3a00-4418-bb9f-417bab438d0b","codeChangeId":"3b5b34ad-3a00-4418-bb9f-417bab438d0b","sourceType":"slack"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The documented datastore limits were out of date after two code changes, causing customer confusion. This PR updates the Datastores "Limitations" section in `content/en/actions/datastores/create.md` to match current behavior:

- The per-table row limit was raised to 100,000 for all organizations (was 5,000).
- The 50-datastores-per-organization limit was removed entirely.

**Changes:**
- Update the row limit from 5,000 to 100,000 rows per datastore.
- Remove the "Your organization can have up to 50 datastores." bullet, since that limit no longer exists.

**Testing / validation:**
- Docs-only change. Verified via repo-wide search that `create.md` was the only page documenting either the datastore row limit or the per-org datastore cap. The other "5,000" and "50" mentions in the docs (wildcard widget, Observability Pipelines enrichment table, workflow run limits, DORA commits, RBAC restriction queries, Synthetics test runs) are unrelated and left untouched. The remaining datastore limits (100 KB per row, required string primary key, immutable primary key) were not changed.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): located the single source of each limit statement and updated it.

### Additional notes

Confirmed in Slack that both changes apply to all customers, not a single org.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7a732b68-814e-4549-9b2e-df23c1a8afa8)

Comment @datadog to request changes