### PR TITLE
Update Reorder tag indexing rules description

### DIFF
--- a/data/api/v2/full_spec.yaml
+++ b/data/api/v2/full_spec.yaml
@@ -160624,6 +160624,7 @@ paths:
       description: |-
         Atomically re-sequence the tag indexing rules for an org to match the supplied list of rule UUIDs.
         The server assigns `rule_order` 1, 2, … matching each rule UUID by position in the list.
+        The UUIDs of all active rules must be provided; omitting any active rule UUID returns a 400 error.
         Requires the `Manage Tags for Metrics` permission.
       operationId: ReorderTagIndexingRules
       requestBody:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the description for the `POST /api/v2/metrics/tag-indexing-rules/order` endpoint to clarify that all active rule UUIDs must be included in the request. Omitting any active rule UUID returns a 400 error.