### PR TITLE
[DOCS-14951] Limit reached for Archive Search rehydration

### DIFF
--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -173,9 +173,7 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 - {{< ui >}}Rehydration retention periods{{< /ui >}}: Choose which retention periods are available when rehydrating results. Only the selected durations (for example, 3, 7, 15, 30, 45, 60, 90, or 180 days) appear in the dropdown menu when selecting how long logs should remain searchable in Datadog.
 
-### Identify a rehydration that reached its limit
-
-When an Archive Search in {{< ui >}}Search & Rehydration{{< /ui >}} mode reaches its volume limit, rehydration stops and the status changes to {{< ui >}}Limit reached{{< /ui >}}. Already rehydrated logs remain accessible, but not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
+When an Archive Search in {{< ui >}}Search & Rehydration{{< /ui >}} mode reaches the volume limit, its status changes to {{< ui >}}Limit reached{{< /ui >}}, indicating that not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
 
 ## Cloud-specific permissions
 

--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -173,6 +173,10 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 - {{< ui >}}Rehydration retention periods{{< /ui >}}: Choose which retention periods are available when rehydrating results. Only the selected durations (for example, 3, 7, 15, 30, 45, 60, 90, or 180 days) appear in the dropdown menu when selecting how long logs should remain searchable in Datadog.
 
+### Identifying a rehydration that reached its limit
+
+When a {{< ui >}}Search & Rehydration{{< /ui >}} reaches its volume limit, rehydration stops and the Archive Search status changes to {{< ui >}}Limit reached{{< /ui >}}. Already rehydrated logs remain accessible, but not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
+
 ## Cloud-specific permissions
 
 Datadog requires the permission to read your archives to search content from them. This permission can be changed at any time.

--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -173,7 +173,7 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 - {{< ui >}}Rehydration retention periods{{< /ui >}}: Choose which retention periods are available when rehydrating results. Only the selected durations (for example, 3, 7, 15, 30, 45, 60, 90, or 180 days) appear in the dropdown menu when selecting how long logs should remain searchable in Datadog.
 
-### Identifying a rehydration that reached its limit
+### Identify a rehydration that reached its limit
 
 When an Archive Search in {{< ui >}}Search & Rehydration{{< /ui >}} mode reaches its volume limit, rehydration stops and the status changes to {{< ui >}}Limit reached{{< /ui >}}. Already rehydrated logs remain accessible, but not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
 

--- a/content/en/logs/explorer/archive_search.md
+++ b/content/en/logs/explorer/archive_search.md
@@ -175,7 +175,7 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 ### Identifying a rehydration that reached its limit
 
-When a {{< ui >}}Search & Rehydration{{< /ui >}} reaches its volume limit, rehydration stops and the Archive Search status changes to {{< ui >}}Limit reached{{< /ui >}}. Already rehydrated logs remain accessible, but not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
+When an Archive Search in {{< ui >}}Search & Rehydration{{< /ui >}} mode reaches its volume limit, rehydration stops and the status changes to {{< ui >}}Limit reached{{< /ui >}}. Already rehydrated logs remain accessible, but not all logs matching your query and time range were rehydrated. To rehydrate the remaining logs, run a new Archive Search with a higher volume limit, or with a narrower query or time range.
 
 ## Cloud-specific permissions
 

--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -124,15 +124,6 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 - {{< ui >}}Rehydration retention periods{{< /ui >}}: Choose which retention periods are available when creating rehydrations. Only the selected durations (for example, 3, 7, 15, 30, 45, 60, 90, or 180 days) appear in the dropdown menu when selecting how long logs should remain searchable in Datadog.
 
-### Detecting when a rehydration reaches its volume limit
-
-A historical view becomes `ACTIVE` whether it rehydrates all matching logs or stops early after reaching its volume limit. To confirm whether a view stopped because it reached the limit, compare the number of rehydrated logs against the configured volume limit:
-
-- The completion event for each rehydration reports the total number of rehydrated logs in the `{{number_of_indexed_logs}}` template variable. You can view this completion event in your [Events Explorer][7].
-- If the number of rehydrated logs matches the volume limit, the rehydration reached its limit. This means not all matching logs in the selected time range were rehydrated.
-
-When a view reaches its limit, rehydrate the remaining logs by creating a historical view with a higher volume limit, or with a narrower query or time range.
-
 ### Cloud-specific permissions
 
 Datadog requires the permission to read from your archives to rehydrate content from them. This permission can be changed at any time.

--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -128,19 +128,19 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 A historical view becomes `ACTIVE` whether it rehydrates all matching logs or stops early after reaching its volume limit. To confirm whether a view stopped because it reached the limit, compare the number of rehydrated logs against the configured volume limit:
 
-- The completion event for each rehydration reports the total number of rehydrated logs in the `{{number_of_indexed_logs}}` template variable, and is available in your [Events Explorer][7].
-- If the number of rehydrated logs matches the volume limit, the rehydration reached its limit and not all matching logs in the selected time range were rehydrated.
+- The completion event for each rehydration reports the total number of rehydrated logs in the `{{number_of_indexed_logs}}` template variable. You can view this completion event in your [Events Explorer][7].
+- If the number of rehydrated logs matches the volume limit, the rehydration reached its limit. This means not all matching logs in the selected time range were rehydrated.
 
-When a view reaches its limit, rehydrate the remaining logs by creating a new historical view with a higher volume limit, or with a narrower query or time range.
+When a view reaches its limit, rehydrate the remaining logs by creating a historical view with a higher volume limit, or with a narrower query or time range.
 
 ### Cloud-specific permissions
 
-Datadog requires the permission to read from your archives in order to rehydrate content from them. This permission can be changed at any time.
+Datadog requires the permission to read from your archives to rehydrate content from them. This permission can be changed at any time.
 
 {{< tabs >}}
 {{% tab "Amazon S3" %}}
 
-In order to rehydrate log events from your archives, Datadog uses the IAM Role in your AWS account that you configured for [your AWS integration][1]. If you have not yet created that Role, [follow these steps to do so][2]. To allow that Role to rehydrate log events from your archives, add the following permission statement to its IAM policies. Be sure to edit the bucket names and, if desired, specify the paths that contain your log archives.
+To rehydrate log events from your archives, Datadog uses the IAM Role in your AWS account that you configured for [your AWS integration][1]. If you have not yet created that Role, [follow these steps to do so][2]. To allow that Role to rehydrate log events from your archives, add the following permission statement to its IAM policies. Be sure to edit the bucket names and, if desired, specify the paths that contain your log archives.
 
 ```json
 {
@@ -170,7 +170,7 @@ In order to rehydrate log events from your archives, Datadog uses the IAM Role i
 
 #### Adding role delegation to S3 archives
 
-Datadog only supports rehydrating from archives that have been configured to use role delegation to grant access. Once you have modified your Datadog IAM role to include the IAM policy above, ensure that each archive in your [archive configuration page][3] has the correct AWS Account + Role combination.
+Datadog only supports rehydrating from archives that have been configured to use role delegation to grant access. After you have modified your Datadog IAM role to include the IAM policy above, ensure that each archive in your [archive configuration page][3] has the correct AWS Account + Role combination.
 
 {{< img src="logs/archives/log_archives_rehydrate_configure_s3.png" alt="Adding role delegation to S3 archives" style="width:75%;">}}
 
@@ -191,7 +191,7 @@ Datadog uses an Azure AD group with the Storage Blob Data Contributor role scope
 
 {{% tab "Google Cloud Storage" %}}
 
-In order to rehydrate log events from your archives, Datadog uses a service account with the Storage Object Viewer role. You can grant this role to your Datadog service account from the [Google Cloud IAM Admin page][1] by editing the service account's permissions, adding another role, and then selecting {{< ui >}}Storage{{< /ui >}} > {{< ui >}}Storage Object Viewer{{< /ui >}}.
+To rehydrate log events from your archives, Datadog uses a service account with the Storage Object Viewer role. You can grant this role to your Datadog service account from the [Google Cloud IAM Admin page][1] by editing the service account's permissions, adding another role, and then selecting {{< ui >}}Storage{{< /ui >}} > {{< ui >}}Storage Object Viewer{{< /ui >}}.
 
 {{< img src="logs/archives/log_archives_gcs_role.png" alt="Rehydration from GCS requires the Storage Object Viewer role" style="width:75%;">}}
 

--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -124,6 +124,15 @@ Admins with the `Logs Write Archives` permission can configure default controls 
 
 - {{< ui >}}Rehydration retention periods{{< /ui >}}: Choose which retention periods are available when creating rehydrations. Only the selected durations (for example, 3, 7, 15, 30, 45, 60, 90, or 180 days) appear in the dropdown menu when selecting how long logs should remain searchable in Datadog.
 
+### Detecting when a rehydration reaches its volume limit
+
+A historical view becomes `ACTIVE` whether it rehydrates all matching logs or stops early after reaching its volume limit. To confirm whether a view stopped because it reached the limit, compare the number of rehydrated logs against the configured volume limit:
+
+- The completion event for each rehydration reports the total number of rehydrated logs in the `{{number_of_indexed_logs}}` template variable, and is available in your [Events Explorer][7].
+- If the number of rehydrated logs matches the volume limit, the rehydration reached its limit and not all matching logs in the selected time range were rehydrated.
+
+When a view reaches its limit, rehydrate the remaining logs by creating a new historical view with a higher volume limit, or with a narrower query or time range.
+
 ### Cloud-specific permissions
 
 Datadog requires the permission to read from your archives in order to rehydrate content from them. This permission can be changed at any time.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-14951

Adds a subsection to the Archive Search page explaining how to tell when a Search & Rehydration was cut off by its volume limit: the Archive Search status changes to **Limit reached**. This answers a docs feedback question about whether users are notified when logs are cut off at the volume limit, and how to identify the missing logs.

Archive Search is the current recommended way to rehydrate, so the content lives there rather than on the Rehydrating from Archives page.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code. Behavior confirmed with the Log Management team (the Limit reached status).

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
