### PR TITLE
[DOCS-15167] Configure BYOC Logs disk buffer durability

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7648,16 +7648,21 @@ menu:
       parent: cloudprem_operate
       identifier: cloudprem_operate_best_practices
       weight: 603
+    - name: Disk Buffer Durability
+      url: /byoc-logs/operate/disk_buffer_durability
+      parent: cloudprem_operate
+      identifier: cloudprem_operate_disk_buffer_durability
+      weight: 604
     - name: Releases and Updates
       url: /byoc-logs/operate/updates
       parent: cloudprem_operate
       identifier: cloudprem_operate_updates
-      weight: 604
+      weight: 605
     - name: Troubleshooting
       url: /byoc-logs/operate/troubleshooting
       parent: cloudprem_operate
       identifier: cloudprem_operate_troubleshooting
-      weight: 605
+      weight: 606
     - name: Guides
       url: /byoc-logs/guides/
       parent: cloudprem

--- a/content/en/byoc-logs/operate/_index.md
+++ b/content/en/byoc-logs/operate/_index.md
@@ -14,6 +14,7 @@ Manage your BYOC (Bring Your Own Cloud) Logs deployment with guides on sizing, m
   {{< nextlink href="/byoc-logs/operate/monitoring/" >}}Monitor BYOC Logs{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/search_logs/" >}}Search Logs{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/best_practices/" >}}Production Best Practices{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/operate/disk_buffer_durability/" >}}Configure Disk Buffer Durability{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/updates/" >}}Releases and Updates{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/troubleshooting/" >}}Troubleshooting{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -16,6 +16,8 @@ further_reading:
   text: "Monitor BYOC Logs"
 ---
 
+{{< jqmath-vanilla >}}
+
 {{< img src="cloudprem/operate/disk-buffer-durability.svg" alt="Diagram of durable BYOC Logs ingestion using Observability Pipelines disk buffers and the BYOC Logs engine." style="width:100%;" >}}
 
 ## Overview
@@ -42,13 +44,8 @@ A useful starting point is to decide how long Workers need to retain logs if the
 
 For example, consider a total ingress of 50 TB/day, 25 Workers, and a one-hour BYOC Logs engine outage:
 
-```text
-total backlog = 50 TB × 1 hour ÷ 24 hours
-              = 2.08 TB
-
-buffer per Worker = 2.08 TB ÷ 25 Workers
-                  = 83 GB per Worker
-```
+1. **Total backlog:** `50 TB × 1 hour ÷ 24 hours = 2.08 TB`
+2. **Buffer per Worker:** `2.08 TB ÷ 25 Workers ≈ 83 GB`
 
 Rounding up the result leaves capacity for a longer incident or a higher ingress rate. With a 100 GB buffer on each Worker, the 25 Workers provide 2.5 TB of total buffer capacity. This retains approximately 1.2 hours of logs at 50 TB/day.
 
@@ -101,20 +98,14 @@ Two settings give the Worker time to empty its buffer before exiting:
 
 The shorter of these two limits determines how long the buffer has to drain. You can estimate the required time from the drain throughput measured in your environment:
 
-```text
-drain time = configured buffer size in MB ÷ measured drain throughput in MB/s
-termination grace period = drain time × safety factor
-```
+$$\text"drain time" = {\text"buffer size (MB)"} / {\text"drain throughput (MB/s)"}$$
+
+$$\text"termination grace period" = \text"drain time" × \text"safety factor"$$
 
 For a Worker draining a 100 GB buffer at 120 MB/s, a safety factor of `1.2` gives:
 
-```text
-drain time = 100,000 MB ÷ 120 MB/s
-           = 833 seconds
-
-termination grace period = 833 seconds × 1.2
-                         ≈ 1,000 seconds
-```
+1. **Drain time:** `100,000 MB ÷ 120 MB/s ≈ 833 seconds`
+2. **Termination grace period:** `833 seconds × 1.2 ≈ 1000 seconds`
 
 Although the estimate is approximately 1000 seconds, this example sets both shutdown limits to 3600 seconds to provide additional margin:
 

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -1,6 +1,6 @@
 ---
 title: Configure disk buffers for durable BYOC Logs ingestion
-description: Configure persistent disk buffers to retain logs when the BYOC Engine is unavailable or cannot accept logs fast enough.
+description: Configure persistent disk buffers to retain logs when the BYOC Logs engine is unavailable or cannot accept logs fast enough.
 aliases:
 - /cloudprem/operate/durable_autoscaling/
 - /byoc-logs/operate/durable_autoscaling/
@@ -16,11 +16,11 @@ further_reading:
   text: "Monitor BYOC Logs"
 ---
 
-{{< img src="cloudprem/operate/disk-buffer-durability.svg" alt="Diagram of durable BYOC Logs ingestion using Observability Pipelines disk buffers and the BYOC Engine." style="width:100%;" >}}
+{{< img src="cloudprem/operate/disk-buffer-durability.svg" alt="Diagram of durable BYOC Logs ingestion using Observability Pipelines disk buffers and the BYOC Logs engine." style="width:100%;" >}}
 
 ## Overview
 
-BYOC Logs combines Observability Pipelines with the BYOC Engine. Observability Pipelines Workers can store logs in persistent disk buffers when the BYOC Engine is unavailable or cannot keep up with the incoming rate. This gives the ingestion path time to recover without immediately dropping logs.
+BYOC Logs combines Observability Pipelines with the BYOC Logs engine. Observability Pipelines Workers can store logs in persistent disk buffers when the BYOC Logs engine is unavailable or cannot keep up with the incoming rate. This gives the ingestion path time to recover without immediately dropping logs.
 
 A durable setup has four parts:
 
@@ -34,13 +34,13 @@ A durable setup has four parts:
 This guide assumes that you have a BYOC Logs deployment with:
 
 - Observability Pipelines configured with a [BYOC Logs destination][1]
-- A [BYOC Engine deployment][2]
+- A [BYOC Logs engine deployment][2]
 
 ## Size the disk buffer
 
-A useful starting point is to decide how long Workers need to retain logs if the BYOC Engine is unavailable. The expected backlog can then be divided across the minimum number of Workers that remain active.
+A useful starting point is to decide how long Workers need to retain logs if the BYOC Logs engine is unavailable. The expected backlog can then be divided across the minimum number of Workers that remain active.
 
-For example, consider a total ingress of 50 TB/day, 25 Workers, and a one-hour BYOC Engine outage:
+For example, consider a total ingress of 50 TB/day, 25 Workers, and a one-hour BYOC Logs engine outage:
 
 ```text
 total backlog = 50 TB × 1 hour ÷ 24 hours
@@ -92,7 +92,7 @@ The persistent volume keeps buffered logs if a Worker pod restarts. The `Retain`
 
 ## Draining Workers before shutdown
 
-During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume until a replacement Worker reattaches that volume.
+During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Logs engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume until a replacement Worker reattaches that volume.
 
 Two settings give the Worker time to empty its buffer before exiting:
 

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-BYOC Logs combines Observability Pipelines with the BYOC Engine. Observability Pipelines Workers can store logs in persistent disk buffers when the BYOC Engine is unavailable or cannot accept logs as fast as they arrive. This gives the ingestion path time to recover without immediately dropping logs.
+BYOC Logs combines Observability Pipelines with the BYOC Engine. Observability Pipelines Workers can store logs in persistent disk buffers when the BYOC Engine is unavailable or cannot keep up with the incoming rate. This gives the ingestion path time to recover without immediately dropping logs.
 
 A durable setup has four parts:
 
@@ -33,8 +33,8 @@ A durable setup has four parts:
 
 This guide assumes that you have a BYOC Logs deployment with:
 
-- Observability Pipelines configured with a [BYOC Logs destination](/observability_pipelines/destinations/datadog_byoc_logs/)
-- A [BYOC Engine deployment](/byoc-logs/install/)
+- Observability Pipelines configured with a [BYOC Logs destination][1]
+- A [BYOC Engine deployment][2]
 
 ## Size the disk buffer
 
@@ -50,7 +50,7 @@ buffer per Worker = 2.08 TB ÷ 25 Workers
                   = 83 GB per Worker
 ```
 
-Rounding up the result leaves capacity for a longer incident or a higher ingress rate. With a 100 GB buffer on each Worker, the 25 Workers provide 2.5 TB of total buffer capacity and can retain approximately 1.2 hours of logs at 50 TB/day.
+Rounding up the result leaves capacity for a longer incident or a higher ingress rate. With a 100 GB buffer on each Worker, the 25 Workers provide 2.5 TB of total buffer capacity. This retains approximately 1.2 hours of logs at 50 TB/day.
 
 ## Disk buffer configuration
 
@@ -74,7 +74,7 @@ The `max_size` value is expressed in bytes (100 GB = 100,000,000,000 bytes). Whe
 
 ## Persistent storage for the buffer
 
-Disk buffering is durable only when the storage outlives the Worker pod. In the 100 GB buffer example, the following Helm values assign a 120 GiB (about 129 GB) persistent volume to each Worker to leave headroom above the buffer capacity:
+Disk buffering is durable only when the storage outlives the Worker pod. In the 100 GB buffer example, the following Helm values assign a 120 GiB (about 129 GB) persistent volume to each Worker. The extra capacity leaves headroom above the buffer size:
 
 ```yaml
 persistence:
@@ -116,7 +116,7 @@ termination grace period = 833 seconds × 1.2
                          ≈ 1,000 seconds
 ```
 
-Although the estimate is approximately 1,000 seconds, this example sets both shutdown limits to 3,600 seconds to provide additional margin:
+Although the estimate is approximately 1000 seconds, this example sets both shutdown limits to 3600 seconds to provide additional margin:
 
 ```yaml
 env:
@@ -129,3 +129,6 @@ terminationGracePeriodSeconds: 3600
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /observability_pipelines/destinations/datadog_byoc_logs/
+[2]: /byoc-logs/install/

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -70,11 +70,11 @@ For the 25-Worker example, the destination configuration looks like this:
 }
 ```
 
-The `max_size` value is expressed in bytes. When the buffer is full, `block` keeps the Worker from discarding logs and allows backpressure to propagate to upstream applications.
+The `max_size` value is expressed in bytes (100 GB = 100,000,000,000 bytes). When the buffer is full, `block` keeps the Worker from discarding logs and allows backpressure to propagate to upstream applications.
 
 ## Persistent storage for the buffer
 
-Disk buffering is durable only when the storage outlives the Worker pod. In the 100 GB buffer example, the following Helm values assign a 120 GiB persistent volume to each Worker:
+Disk buffering is durable only when the storage outlives the Worker pod. In the 100 GB buffer example, the following Helm values assign a 120 GiB (about 129 GB) persistent volume to each Worker to leave headroom above the buffer capacity:
 
 ```yaml
 persistence:
@@ -90,9 +90,9 @@ persistence:
 
 The persistent volume keeps buffered logs if a Worker pod restarts. The `Retain` policies also keep the volume when its Worker is scaled down or the StatefulSet is deleted.
 
-## Draining OP Workers before shutdown
+## Draining Workers before shutdown
 
-During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume and are not sent until a Worker reattaches that volume.
+During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume until a replacement Worker reattaches that volume.
 
 The `terminationGracePeriodSeconds` value gives the Worker time to empty its buffer before exiting. You can estimate the required time from the drain throughput measured in your environment:
 

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -94,7 +94,12 @@ The persistent volume keeps buffered logs if a Worker pod restarts. The `Retain`
 
 During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume until a replacement Worker reattaches that volume.
 
-The `terminationGracePeriodSeconds` value gives the Worker time to empty its buffer before exiting. You can estimate the required time from the drain throughput measured in your environment:
+Two settings give the Worker time to empty its buffer before exiting:
+
+- `terminationGracePeriodSeconds` controls how long Kubernetes waits before terminating the pod.
+- `DD_OP_GRACEFUL_SHUTDOWN_LIMIT_SECS` controls how long the Worker waits before forcing its own shutdown.
+
+The shorter of these two limits determines how long the buffer has to drain. You can estimate the required time from the drain throughput measured in your environment:
 
 ```text
 drain time = configured buffer size in MB ÷ measured drain throughput in MB/s
@@ -111,9 +116,13 @@ termination grace period = 833 seconds × 1.2
                          ≈ 1,000 seconds
 ```
 
-Although the estimate is approximately 1,000 seconds, this example uses a 3,600-second termination grace period to provide additional margin:
+Although the estimate is approximately 1,000 seconds, this example sets both shutdown limits to 3,600 seconds to provide additional margin:
 
 ```yaml
+env:
+  - name: DD_OP_GRACEFUL_SHUTDOWN_LIMIT_SECS
+    value: "3600"
+
 terminationGracePeriodSeconds: 3600
 ```
 

--- a/content/en/byoc-logs/operate/disk_buffer_durability.md
+++ b/content/en/byoc-logs/operate/disk_buffer_durability.md
@@ -1,0 +1,122 @@
+---
+title: Configure disk buffers for durable BYOC Logs ingestion
+description: Configure persistent disk buffers to retain logs when the BYOC Engine is unavailable or cannot accept logs fast enough.
+aliases:
+- /cloudprem/operate/durable_autoscaling/
+- /byoc-logs/operate/durable_autoscaling/
+further_reading:
+- link: "/byoc-logs/operate/sizing/"
+  tag: "Documentation"
+  text: "Cluster Sizing"
+- link: "/observability_pipelines/scaling_and_performance/buffering_and_backpressure/"
+  tag: "Documentation"
+  text: "Observability Pipelines Buffering and Backpressure"
+- link: "/byoc-logs/operate/monitoring/"
+  tag: "Documentation"
+  text: "Monitor BYOC Logs"
+---
+
+{{< img src="cloudprem/operate/disk-buffer-durability.svg" alt="Diagram of durable BYOC Logs ingestion using Observability Pipelines disk buffers and the BYOC Engine." style="width:100%;" >}}
+
+## Overview
+
+BYOC Logs combines Observability Pipelines with the BYOC Engine. Observability Pipelines Workers can store logs in persistent disk buffers when the BYOC Engine is unavailable or cannot accept logs as fast as they arrive. This gives the ingestion path time to recover without immediately dropping logs.
+
+A durable setup has four parts:
+
+- Enough buffer capacity for the backlog you want to retain
+- Disk buffering on the BYOC Logs destination
+- A persistent volume for each Worker's buffer
+- Enough time for a terminating Worker to drain its buffer
+
+## Before you begin
+
+This guide assumes that you have a BYOC Logs deployment with:
+
+- Observability Pipelines configured with a [BYOC Logs destination](/observability_pipelines/destinations/datadog_byoc_logs/)
+- A [BYOC Engine deployment](/byoc-logs/install/)
+
+## Size the disk buffer
+
+A useful starting point is to decide how long Workers need to retain logs if the BYOC Engine is unavailable. The expected backlog can then be divided across the minimum number of Workers that remain active.
+
+For example, consider a total ingress of 50 TB/day, 25 Workers, and a one-hour BYOC Engine outage:
+
+```text
+total backlog = 50 TB × 1 hour ÷ 24 hours
+              = 2.08 TB
+
+buffer per Worker = 2.08 TB ÷ 25 Workers
+                  = 83 GB per Worker
+```
+
+Rounding up the result leaves capacity for a longer incident or a higher ingress rate. With a 100 GB buffer on each Worker, the 25 Workers provide 2.5 TB of total buffer capacity and can retain approximately 1.2 hours of logs at 50 TB/day.
+
+## Disk buffer configuration
+
+The following buffering options are available when editing the BYOC Logs destination in the Observability Pipelines UI or through the API:
+
+- **Buffer type**: Disk
+- **Buffer size**: The per-Worker capacity from your calculation
+- **Behavior on full buffer**: Block
+
+For the 25-Worker example, the destination configuration looks like this:
+
+```json
+"buffer": {
+  "type": "disk",
+  "max_size": 100000000000,
+  "when_full": "block"
+}
+```
+
+The `max_size` value is expressed in bytes. When the buffer is full, `block` keeps the Worker from discarding logs and allows backpressure to propagate to upstream applications.
+
+## Persistent storage for the buffer
+
+Disk buffering is durable only when the storage outlives the Worker pod. In the 100 GB buffer example, the following Helm values assign a 120 GiB persistent volume to each Worker:
+
+```yaml
+persistence:
+  enabled: true
+  storageClassName: "<STORAGE_CLASS>"
+  accessModes:
+    - ReadWriteOnce
+  size: 120Gi
+  retentionPolicy:
+    whenScaled: Retain
+    whenDeleted: Retain
+```
+
+The persistent volume keeps buffered logs if a Worker pod restarts. The `Retain` policies also keep the volume when its Worker is scaled down or the StatefulSet is deleted.
+
+## Draining OP Workers before shutdown
+
+During a scale-down or rollout, a Worker stops accepting new logs and sends its buffered logs to the BYOC Engine. If the Worker exits before the buffer is empty, the logs remain on its persistent volume and are not sent until a Worker reattaches that volume.
+
+The `terminationGracePeriodSeconds` value gives the Worker time to empty its buffer before exiting. You can estimate the required time from the drain throughput measured in your environment:
+
+```text
+drain time = configured buffer size in MB ÷ measured drain throughput in MB/s
+termination grace period = drain time × safety factor
+```
+
+For a Worker draining a 100 GB buffer at 120 MB/s, a safety factor of `1.2` gives:
+
+```text
+drain time = 100,000 MB ÷ 120 MB/s
+           = 833 seconds
+
+termination grace period = 833 seconds × 1.2
+                         ≈ 1,000 seconds
+```
+
+Although the estimate is approximately 1,000 seconds, this example uses a 3,600-second termination grace period to provide additional margin:
+
+```yaml
+terminationGracePeriodSeconds: 3600
+```
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/static/images/cloudprem/operate/disk-buffer-durability.svg
+++ b/static/images/cloudprem/operate/disk-buffer-durability.svg
@@ -95,7 +95,7 @@
   <rect x="375" y="563" width="505" height="76" rx="8" fill="#DDF8E8" stroke="#00C875" stroke-width="2"/>
   <text x="397" y="588" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">SCALE DOWN</text>
   <text x="397" y="609" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13">Stop intake → drain disk buffer → exit</text>
-  <text x="397" y="629" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">terminationGracePeriodSeconds: 3,600</text>
+  <text x="397" y="629" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">Kubernetes and Worker shutdown limits: 3,600 seconds</text>
 
   <!-- OP to BYOC Engine -->
   <path d="M905 355h59" fill="none" stroke="#111111" stroke-width="3" marker-end="url(#arrowBlack)"/>

--- a/static/images/cloudprem/operate/disk-buffer-durability.svg
+++ b/static/images/cloudprem/operate/disk-buffer-durability.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title description">
+  <title id="title">Durable BYOC Logs ingestion architecture with disk buffers</title>
+  <desc id="description">BYOC Logs combines Observability Pipelines with the BYOC Engine. At 50 terabytes per day, a one-hour BYOC Engine outage creates a 2.08 terabyte backlog. Log sources send data to 25 Observability Pipelines Workers, each with a 100 gigabyte persistent disk buffer. After a Worker stops accepting new logs, it drains to BYOC Engine indexers at up to 120 megabytes per second. Each indexer uses a persistent write-ahead log before uploading index files to object storage. Scale-down grace periods allow both buffers and write-ahead logs to drain before pods exit.</desc>
+
+  <defs>
+    <linearGradient id="datadogGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F5008B"/>
+      <stop offset="1" stop-color="#8A00FF"/>
+    </linearGradient>
+    <marker id="arrowBlack" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0L10 5L0 10Z" fill="#111111"/>
+    </marker>
+    <symbol id="pod" viewBox="0 0 72 72">
+      <path d="M20 5h32l16 27-16 28H20L4 32Z" fill="#2E6FE8"/>
+      <path d="M25 25l11-6 11 6v14l-11 7-11-7Z" fill="#FFFFFF"/>
+      <path d="M25 25l11 7 11-7M36 32v14" fill="none" stroke="#2E6FE8" stroke-width="2"/>
+    </symbol>
+    <symbol id="disk" viewBox="0 0 110 70">
+      <ellipse cx="55" cy="15" rx="48" ry="13" fill="#E8D8F8" stroke="#7B3FB1" stroke-width="2"/>
+      <path d="M7 15v35c0 8 21 14 48 14s48-6 48-14V15" fill="#F6EFFC" stroke="#7B3FB1" stroke-width="2"/>
+      <ellipse cx="55" cy="50" rx="48" ry="14" fill="#E8D8F8" stroke="#7B3FB1" stroke-width="2"/>
+    </symbol>
+    <symbol id="wal" viewBox="0 0 84 62">
+      <ellipse cx="42" cy="13" rx="35" ry="10" fill="#D8EFFA" stroke="#2E6FE8" stroke-width="2"/>
+      <path d="M7 13v31c0 7 16 12 35 12s35-5 35-12V13" fill="#EFF9FD" stroke="#2E6FE8" stroke-width="2"/>
+      <ellipse cx="42" cy="44" rx="35" ry="12" fill="#D8EFFA" stroke="#2E6FE8" stroke-width="2"/>
+    </symbol>
+  </defs>
+
+  <rect width="1600" height="900" fill="#F3F3F3"/>
+  <rect x="32" y="28" width="1536" height="842" rx="28" fill="#FFFFFF" stroke="#111111" stroke-width="3" stroke-dasharray="15 12"/>
+
+  <text x="58" y="72" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="27" font-weight="700">USER ENVIRONMENT</text>
+  <text x="58" y="111" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700">DURABLE BYOC LOGS INGESTION</text>
+  <text x="430" y="111" fill="#4D4D4D" font-family="Arial, Helvetica, sans-serif" font-size="15">Persistent queues protect log data during downstream incidents and scale-down events.</text>
+
+  <!-- Log sources -->
+  <rect x="66" y="172" width="208" height="364" rx="18" fill="url(#datadogGradient)"/>
+  <text x="170" y="229" text-anchor="middle" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="17" font-weight="700">LOG SOURCES</text>
+  <path d="M105 262h130" stroke="#FFFFFF" stroke-opacity="0.5" stroke-width="2"/>
+  <rect x="101" y="292" width="38" height="47" rx="5" fill="none" stroke="#FFFFFF" stroke-width="3"/>
+  <circle cx="120" cy="306" r="5" fill="#FFFFFF"/>
+  <path d="M110 323h20M110 331h14" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+  <text x="153" y="311" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="17" font-weight="700">DATADOG</text>
+  <text x="153" y="334" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="17" font-weight="700">AGENTS</text>
+  <circle cx="120" cy="405" r="21" fill="none" stroke="#FFFFFF" stroke-width="3"/>
+  <circle cx="120" cy="405" r="6" fill="#FFFFFF"/>
+  <path d="M120 376v15M120 419v15M91 405h15M134 405h15" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+  <text x="153" y="397" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">APPS AND</text>
+  <text x="153" y="419" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">OTLP</text>
+  <text x="153" y="441" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">COLLECTORS</text>
+
+  <rect x="66" y="566" width="208" height="143" rx="14" fill="#FFDDEB" stroke="#F50068" stroke-width="2.5"/>
+  <text x="170" y="598" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">WORST-CASE BACKLOG</text>
+  <text x="170" y="630" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="16">50 TB/day × 1 hour</text>
+  <path d="M91 647h158" stroke="#F50068" stroke-width="2"/>
+  <text x="170" y="682" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">2.08 TB TOTAL</text>
+
+  <!-- Kubernetes -->
+  <rect x="320" y="142" width="1010" height="564" rx="19" fill="#D9F4FF" stroke="#0875FF" stroke-width="3"/>
+  <text x="347" y="181" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700">KUBERNETES</text>
+
+  <!-- Source to OP -->
+  <path d="M274 355h76" fill="none" stroke="#111111" stroke-width="3" marker-end="url(#arrowBlack)"/>
+  <text x="312" y="338" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="14">LOGS</text>
+
+  <!-- Observability Pipelines -->
+  <rect x="350" y="204" width="555" height="463" rx="10" fill="#FFFFFF" stroke="#BEBEBE" stroke-width="2"/>
+  <text x="375" y="244" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="23" font-weight="700">OBSERVABILITY PIPELINES</text>
+  <text x="375" y="270" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">WORKER STATEFULSET</text>
+  <rect x="747" y="225" width="132" height="31" rx="4" fill="#FFFFFF" stroke="#0875FF" stroke-width="2"/>
+  <text x="813" y="246" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">25 WORKERS</text>
+
+  <text x="453" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">WORKER 0</text>
+  <text x="627" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">WORKER 1</text>
+  <text x="801" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">WORKER N</text>
+  <use href="#pod" x="417" y="318" width="72" height="72"/>
+  <use href="#pod" x="591" y="318" width="72" height="72"/>
+  <use href="#pod" x="765" y="318" width="72" height="72"/>
+  <path d="M489 354h102M663 354h102" fill="none" stroke="#2E6FE8" stroke-width="2" stroke-dasharray="5 6"/>
+
+  <use href="#disk" x="398" y="401" width="110" height="70"/>
+  <use href="#disk" x="572" y="401" width="110" height="70"/>
+  <use href="#disk" x="746" y="401" width="110" height="70"/>
+  <text x="453" y="431" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">DISK BUFFER</text>
+  <text x="453" y="448" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">100 GB</text>
+  <text x="627" y="431" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">DISK BUFFER</text>
+  <text x="627" y="448" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">100 GB</text>
+  <text x="801" y="431" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">DISK BUFFER</text>
+  <text x="801" y="448" text-anchor="middle" fill="#5A267D" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">100 GB</text>
+
+  <rect x="375" y="492" width="505" height="53" rx="8" fill="#FFDDEB" stroke="#F50068" stroke-width="2"/>
+  <text x="397" y="516" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">ONE-HOUR OUTAGE</text>
+  <text x="397" y="536" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13">2.08 TB buffered across 25 Workers</text>
+  <rect x="375" y="563" width="505" height="76" rx="8" fill="#DDF8E8" stroke="#00C875" stroke-width="2"/>
+  <text x="397" y="588" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">SCALE DOWN</text>
+  <text x="397" y="609" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13">Stop intake → drain disk buffer → exit</text>
+  <text x="397" y="629" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">terminationGracePeriodSeconds: 3,600</text>
+
+  <!-- OP to BYOC Engine -->
+  <path d="M905 355h59" fill="none" stroke="#111111" stroke-width="3" marker-end="url(#arrowBlack)"/>
+  <text x="934" y="313" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="700">HTTPS / mTLS</text>
+  <text x="934" y="331" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="10">120 MB/s</text>
+  <text x="934" y="347" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="9">PER WORKER</text>
+  <path d="M964 421c-22 22-38 22-59 0" fill="none" stroke="#111111" stroke-width="2.5" stroke-dasharray="7 6" marker-end="url(#arrowBlack)"/>
+  <text x="934" y="459" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="9">429 / OUTAGE</text>
+
+  <!-- BYOC Engine -->
+  <rect x="964" y="204" width="335" height="463" rx="10" fill="#FFFFFF" stroke="#BEBEBE" stroke-width="2"/>
+  <text x="988" y="244" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="23" font-weight="700">BYOC ENGINE</text>
+  <text x="988" y="270" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700">CLOUDPREM INDEXERS</text>
+  <rect x="1163" y="225" width="112" height="31" rx="4" fill="#FFFFFF" stroke="#0875FF" stroke-width="2"/>
+  <text x="1219" y="246" text-anchor="middle" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">INDEXER POOL</text>
+
+  <text x="1023" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">INDEXER 0</text>
+  <text x="1132" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">INDEXER 1</text>
+  <text x="1241" y="305" text-anchor="middle" fill="#2E6FE8" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">INDEXER N</text>
+  <use href="#pod" x="987" y="318" width="72" height="72"/>
+  <use href="#pod" x="1096" y="318" width="72" height="72"/>
+  <use href="#pod" x="1205" y="318" width="72" height="72"/>
+  <use href="#wal" x="981" y="405" width="84" height="62"/>
+  <use href="#wal" x="1090" y="405" width="84" height="62"/>
+  <use href="#wal" x="1199" y="405" width="84" height="62"/>
+  <text x="1023" y="434" text-anchor="middle" fill="#1B5CB0" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">WAL PVC</text>
+  <text x="1132" y="434" text-anchor="middle" fill="#1B5CB0" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">WAL PVC</text>
+  <text x="1241" y="434" text-anchor="middle" fill="#1B5CB0" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">WAL PVC</text>
+
+  <rect x="988" y="492" width="287" height="53" rx="8" fill="#DDF3FF" stroke="#0875FF" stroke-width="2"/>
+  <text x="1008" y="516" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">PERSISTENT WAL</text>
+  <text x="1008" y="536" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">Absorbs pending indexing work</text>
+  <rect x="988" y="563" width="287" height="76" rx="8" fill="#DDF8E8" stroke="#00C875" stroke-width="2"/>
+  <text x="1008" y="588" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">SCALE DOWN</text>
+  <text x="1008" y="609" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">Drain WAL → exit</text>
+  <text x="1008" y="629" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">Termination grace: at least 300 seconds</text>
+
+  <!-- Durable destination and scale-down rule -->
+  <path d="M1132 667v73" fill="none" stroke="#111111" stroke-width="3" marker-end="url(#arrowBlack)"/>
+  <text x="1150" y="712" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="12">SPLITS</text>
+
+  <rect x="964" y="749" width="335" height="86" rx="12" fill="#FFDDEB" stroke="#F50068" stroke-width="2.5"/>
+  <text x="990" y="778" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700">OBJECT STORAGE</text>
+  <g fill="#FF5B00">
+    <rect x="990" y="794" width="7" height="24"/><rect x="1002" y="794" width="7" height="24"/><rect x="1014" y="794" width="7" height="24"/>
+    <rect x="1026" y="794" width="7" height="24"/><rect x="1038" y="794" width="7" height="24"/><rect x="1050" y="794" width="7" height="24"/>
+    <rect x="1062" y="794" width="7" height="24"/><rect x="1074" y="794" width="7" height="24"/><rect x="1086" y="794" width="7" height="24"/>
+  </g>
+  <text x="1120" y="812" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">DURABLE INDEX FILES</text>
+
+  <rect x="320" y="749" width="585" height="86" rx="12" fill="#FFFFFF" stroke="#111111" stroke-width="2"/>
+  <circle cx="351" cy="792" r="12" fill="#F5008B"/>
+  <text x="379" y="779" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">SCALE-DOWN INVARIANT</text>
+  <text x="379" y="802" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13">A pod exits only after its local durable queue is empty,</text>
+  <text x="379" y="823" fill="#0A0A0A" font-family="Arial, Helvetica, sans-serif" font-size="13">or after its configured termination grace period expires.</text>
+</svg>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15167

Adds a focused guide for configuring persistent Observability Pipelines disk buffers for durable BYOC Logs ingestion. The guide explains how to size buffers for a one-hour BYOC Engine outage, retain Worker volumes, and allow buffered logs to drain before shutdown. It also adds an architecture diagram and navigation links.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- `xmllint` validates the SVG.
- `git diff --check` passes.
- Vale could not run because the configured `datadog-vale/styles` directory is not available in this checkout.
