### PR TITLE
Document troubleshooting for persistent Firehose destination errors

### DIFF
--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -162,6 +162,32 @@ Once the resources are deleted, wait for five minutes for Datadog to recognize t
 
 To resolve any issues encountered while setting up Metric Streams or the associated resources, see [AWS Troubleshooting][6].
 
+### Persistent Firehose destination errors
+
+If CloudWatch metrics stop appearing in Datadog, the CloudWatch Metric Stream and Amazon Data Firehose delivery stream may still show a `running` state even when Firehose is no longer delivering records.
+
+This can happen when Firehose cannot deliver records to the Datadog HTTP endpoint before its [retry period][8] expires and it also cannot write the failed records to its S3 backup. When both delivery paths fail, the delivery stream may not automatically resume HTTP delivery after the endpoint becomes available again.
+
+To diagnose and restore delivery:
+
+1. Locate the Firehose delivery stream associated with the affected CloudWatch Metric Stream. To do this with the AWS CLI, run the following command and find the `FirehoseArn` in the response:
+
+   ```shell
+   aws cloudwatch get-metric-stream \
+     --name <METRIC_STREAM_NAME> \
+     --region <AWS_REGION>
+   ```
+
+2. Review the [Firehose delivery error logs][9] in CloudWatch Logs. If delivery error logging is not enabled, enable it to capture subsequent delivery errors. Relevant errors include `HttpEndpoint.DestinationException`, such as HTTP 408 responses, and `S3.AccessDenied`.
+3. Inspect the [Firehose CloudWatch metrics][10], including `DeliveryToHttpEndpoint.Success`, `DeliveryToHttpEndpoint.DataFreshness`, `DeliveryToHttpEndpoint.Records`, and `IncomingRecords`.
+4. If Firehose receives records but does not deliver them, verify the S3 backup configuration and IAM role. Ensure Firehose can assume the configured role and write to the backup bucket. Check that the bucket policy, permissions boundary, service control policies (SCPs), and KMS key policy do not deny the required access. If the logs show an S3 permissions error, correct it before continuing.
+5. Make and save a valid update to the Firehose HTTP destination configuration, such as updating its retry duration. A configuration update can restart a stalled destination. You can use the Firehose [`UpdateDestination` API][11].
+6. Confirm that `DeliveryToHttpEndpoint.Success` recovers, data freshness decreases, and new AWS metrics appear in Datadog.
+
+If delivery does not recover, contact [Datadog Support][12] and provide the AWS account ID and region, the CloudWatch Metric Stream and Firehose delivery stream ARNs, the approximate time delivery stopped, and relevant Firehose error logs.
+
+Restarting delivery affects new records and does not automatically recover a historical gap. Records written to the S3 backup are not automatically ingested into Datadog.
+
 ## Further Reading
  {{< partial name="whats-next/whats-next.html" >}}
 
@@ -172,3 +198,8 @@ To resolve any issues encountered while setting up Metric Streams or the associa
 [5]: https://app.datadoghq.com/integrations/amazon-web-services
 [6]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-troubleshoot.html
 [7]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html
+[8]: https://docs.aws.amazon.com/firehose/latest/dev/retry.html
+[9]: https://docs.aws.amazon.com/firehose/latest/dev/monitoring-with-cloudwatch-logs.html
+[10]: https://docs.aws.amazon.com/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html#fh-http-metrics
+[11]: https://docs.aws.amazon.com/firehose/latest/APIReference/API_UpdateDestination.html
+[12]: /help/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds customer-facing troubleshooting guidance for CloudWatch Metric Streams when an Amazon Data Firehose destination remains stalled after HTTP and S3 backup delivery failures.

Added after https://app.datadoghq.com/incidents/56319 so that we have a place to point customers to if this happens again. 

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

AI-assisted incident research and structuring message, content was manually written out, then AI refined.

### Additional notes

