### PR TITLE
Add Windows 11 to Private Location worker supported OS list

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -85,7 +85,7 @@ This machine's requirements are listed in the table below. PowerShell scripting 
 
 | System | Requirements |
 |---|---|
-| OS | Windows Server 2022, Windows Server 2019, Windows Server 2016, or Windows 10. |
+| OS | Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows 11, or Windows 10. |
 | RAM | 4GB minimum. 8GB recommended. |
 | CPU | Intel or AMD processor with 64-bit support. 2.8 GHz or faster processor recommended. |
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds Windows 11 to the list of supported operating systems for the Synthetics Private Location worker (Windows MSI install method). Windows 11 is supported but was missing from the requirements table, which only listed Windows Server 2016/2019/2022 and Windows 10.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the requirements table and make the one-line edit.

### Additional notes

Single-line change to `content/en/synthetics/platform/private_locations/_index.md` (Windows tab requirements table).
