### PR TITLE
Add missing DDOT collector components to included components list

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/_index.md
+++ b/content/en/opentelemetry/setup/ddot_collector/_index.md
@@ -86,11 +86,15 @@ By default, the DDOT Collector ships with the following Collector components. Yo
 
 {{% collapse-content title="Receivers" level="p" %}}
 
+- [dockerstatsreceiver][58] (available since version 7.56.0)
 - [filelogreceiver][16]
 - [fluentforwardreceiver][17]
 - [hostmetricsreceiver][18]
 - [jaegerreceiver][19]
+- [k8sobjectsreceiver][59] (available since version 7.56.0)
+- [kubeletstatsreceiver][60] (available since version 7.56.0)
 - [otlpreceiver][20]
+- [podmanreceiver][61] (available since version 7.56.0)
 - [prometheusreceiver][21]
 - [receivercreator][22]
 - [zipkinreceiver][23]
@@ -138,9 +142,11 @@ By default, the DDOT Collector ships with the following Collector components. Yo
 
 {{% collapse-content title="Extensions" level="p" %}}
 
+- [datadogextension][62] (available since version 7.72.0)
 - [healthcheckextension][46]
 - [observer][47]
 - [pprofextension][48]
+- [storage/filestorage][63] (available since version 7.56.0)
 - [zpagesextension][49]
 
 {{% /collapse-content %}}
@@ -241,3 +247,9 @@ This guide helps you migrate from an existing OpenTelemetry Collector setup to t
 [55]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md
 [56]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/routingconnector/README.md
 [57]: /opentelemetry/compatibility/#support-levels
+[58]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/dockerstatsreceiver/README.md
+[59]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sobjectsreceiver/README.md
+[60]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/README.md
+[61]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/podmanreceiver/README.md
+[62]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/datadogextension/README.md
+[63]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/storage/filestorage/README.md


### PR DESCRIPTION
## Summary
- The DDOT Collector [manifest](https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/collector-contrib/impl/manifest.yaml) already ships several components that weren't listed on this page:
  - Receivers: `dockerstatsreceiver`, `k8sobjectsreceiver`, `kubeletstatsreceiver`, `podmanreceiver` (all since Agent 7.56.0)
  - Extensions: `storage/filestorage` (since 7.56.0), `datadogextension` (since 7.72.0)
- Added each with a link to its README and the Agent version it became available in, matching the existing `routingconnector` annotation style.
- Related to [OTAGENT-1174](https://datadoghq.atlassian.net/browse/OTAGENT-1174), which adds three new components (`k8sclusterreceiver`, `k8sleaderelector`, `countconnector`) via [datadog-agent#54016](https://github.com/DataDog/datadog-agent/pull/54016) — those are intentionally not included here and will be documented separately once merged.

## Test plan
- [x] Cross-referenced every component in `manifest.yaml` against this page's Receivers/Processors/Exporters/Connectors/Extensions lists
- [x] Verified addition versions via `git tag --contains <commit>` in datadog-agent for the commit that first added each component to the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OTAGENT-1174]: https://datadoghq.atlassian.net/browse/OTAGENT-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ