### PR TITLE
Removes bold styling for header-text-inner class, used in collapsibles

### DIFF
--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -52,7 +52,6 @@
 .header-text-inner {
     margin: 0;
     line-height: 1.5;
-    font-weight: bold;
 }
 
 .header-content {


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removes bolding from the CSS class used to style collapsible titles, so headers display consistently!

### Merge readiness
Not ready; want to get feedback from docs team first
- [ ] Ready for merge

### AI assistance
Used Claude to investigate impact

### Additional notes
n/a
