### PR TITLE
[OTAGENT-1177] Add cumulativetodelta processor to DDOT sample configurations

### DIFF
--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -276,7 +276,7 @@ processors:
 
 Finally, add it to the `processors` list on your metrics pipelines.
 
-**Note**: The cumulative-to-delta processor does not support exponential histograms. Also, some fields, such as the minimum and maximum, can't be recovered with this approach. Instead, use the OpenTelemetry SDK approach whenever possible.
+**Note**: Some fields, such as the minimum and maximum, can't be recovered with this approach. Use the OpenTelemetry SDK approach whenever possible.
 
 ## Further reading
 

--- a/content/en/opentelemetry/migrate/ddot_collector.md
+++ b/content/en/opentelemetry/migrate/ddot_collector.md
@@ -74,6 +74,7 @@ processors:
       - include: system.cpu.usage
         action: insert
         new_name: host.cpu.utilization
+  cumulativetodelta:
 connectors:
   datadog/connector:
     traces:
@@ -85,7 +86,7 @@ service:
       exporters: [datadog/connector, datadog]
     metrics:
       receivers: [otlp, datadog/connector]
-      processors: [metricstransform, infraattributes, batch]
+      processors: [metricstransform, infraattributes, batch, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]
@@ -120,6 +121,7 @@ processors:
     cardinality: 2
   batch:
     timeout: 10s
+  cumulativetodelta:
 connectors:
   datadog/connector:
     traces:
@@ -131,7 +133,7 @@ service:
       exporters: [datadog/connector, datadog]
     metrics:
       receivers: [otlp, datadog/connector]
-      processors: [infraattributes, batch]
+      processors: [infraattributes, batch, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/custom_components/kubernetes.md
+++ b/content/en/opentelemetry/setup/ddot_collector/custom_components/kubernetes.md
@@ -179,7 +179,7 @@ Create a sample configuration file and run your custom DDOT Collector (Agent) to
          exporters: [datadog, datadog/connector]
        metrics:
          receivers: [otlp, datadog/connector, prometheus]
-         processors: [metricstransform, infraattributes]
+         processors: [metricstransform, infraattributes, cumulativetodelta]
          exporters: [datadog]
        logs:
          receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/custom_components/linux.md
+++ b/content/en/opentelemetry/setup/ddot_collector/custom_components/linux.md
@@ -211,6 +211,7 @@ After the build completes, verify the custom `otel-agent` binary includes your a
            new_name: system.cpu.usage_time
      infraattributes:
        cardinality: 2
+     cumulativetodelta:
    connectors:
      datadog/connector:
        traces:
@@ -225,7 +226,7 @@ After the build completes, verify the custom `otel-agent` binary includes your a
          exporters: [datadog, datadog/connector]
        metrics:
          receivers: [otlp, datadog/connector, prometheus]
-         processors: [metricstransform, infraattributes]
+         processors: [metricstransform, infraattributes, cumulativetodelta]
          exporters: [datadog]
        logs:
          receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/custom_components/windows.md
+++ b/content/en/opentelemetry/setup/ddot_collector/custom_components/windows.md
@@ -214,6 +214,7 @@ After the build completes, verify the custom `otel-agent.exe` binary includes yo
            new_name: system.cpu.usage_time
      infraattributes:
        cardinality: 2
+     cumulativetodelta:
    connectors:
      datadog/connector:
        traces:
@@ -228,7 +229,7 @@ After the build completes, verify the custom `otel-agent.exe` binary includes yo
          exporters: [datadog, datadog/connector]
        metrics:
          receivers: [otlp, datadog/connector, prometheus]
-         processors: [metricstransform, infraattributes]
+         processors: [metricstransform, infraattributes, cumulativetodelta]
          exporters: [datadog]
        logs:
          receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/install/eks_fargate.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/eks_fargate.md
@@ -136,7 +136,7 @@ service:
       exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector]
-      processors: [resourcedetection, infraattributes]
+      processors: [resourcedetection, infraattributes, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_daemonset.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_daemonset.md
@@ -336,6 +336,7 @@ In the snippet below, the Collector configuration is placed directly under the `
           processors:
             infraattributes:
               cardinality: 2
+            cumulativetodelta:
           connectors:
             datadog/connector:
               traces:
@@ -347,7 +348,7 @@ In the snippet below, the Collector configuration is placed directly under the `
                 exporters: [debug, datadog, datadog/connector]
               metrics:
                 receivers: [otlp, datadog/connector, prometheus]
-                processors: [infraattributes]
+                processors: [infraattributes, cumulativetodelta]
                 exporters: [debug, datadog]
               logs:
                 receivers: [otlp]
@@ -428,6 +429,7 @@ spec:
           processors:
             infraattributes:
               cardinality: 2
+            cumulativetodelta:
           connectors:
             datadog/connector:
               traces:
@@ -439,7 +441,7 @@ spec:
                 exporters: [debug, datadog, datadog/connector]
               metrics:
                 receivers: [otlp, datadog/connector, prometheus]
-                processors: [infraattributes]
+                processors: [infraattributes, cumulativetodelta]
                 exporters: [debug, datadog]
               logs:
                 receivers: [otlp]
@@ -490,6 +492,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
     connectors:
       datadog/connector:
         traces:
@@ -501,7 +504,7 @@ data:
           exporters: [debug, datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector, prometheus]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [debug, datadog]
         logs:
           receivers: [otlp]
@@ -610,6 +613,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
     connectors:
       datadog/connector:
         traces:
@@ -621,7 +625,7 @@ data:
           exporters: [debug, datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector, prometheus]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [debug, datadog]
         logs:
           receivers: [otlp]
@@ -664,6 +668,7 @@ exporters:
 processors:
   infraattributes:
     cardinality: 2
+  cumulativetodelta:
 connectors:
   datadog/connector:
     traces:
@@ -675,7 +680,7 @@ service:
       exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector, prometheus]
-      processors: [infraattributes]
+      processors: [infraattributes, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/install/linux.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/linux.md
@@ -154,6 +154,7 @@ exporters:
 processors:
   infraattributes:
     cardinality: 2
+  cumulativetodelta:
 connectors:
   datadog/connector:
     traces:
@@ -168,7 +169,7 @@ service:
       exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector, prometheus]
-      processors: [infraattributes]
+      processors: [infraattributes, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]

--- a/content/en/opentelemetry/setup/ddot_collector/install/windows.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/windows.md
@@ -156,6 +156,7 @@ exporters:
 processors:
   infraattributes:
     cardinality: 2
+  cumulativetodelta:
 connectors:
   datadog/connector:
     traces:
@@ -170,7 +171,7 @@ service:
       exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector, prometheus]
-      processors: [infraattributes]
+      processors: [infraattributes, cumulativetodelta]
       exporters: [datadog]
     logs:
       receivers: [otlp]


### PR DESCRIPTION
### What does this PR do? What is the motivation?

[OTAGENT-1177]

- Adds the `cumulativetodelta` processor to the DDOT Collector sample configurations (metrics pipelines) on the install, custom components, and migration pages.
- Updates the *Producing Delta Temporality Metrics with OpenTelemetry* guide: the `cumulativetodelta` processor supports exponential histograms (removes an outdated note).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

The DDOT gateway install page is not included in this change.

https://datadoghq.atlassian.net/browse/OTAGENT-1177

[OTAGENT-1177]: https://datadoghq.atlassian.net/browse/OTAGENT-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ