### PR TITLE
[codex] Clarify supported BYOC Logs platforms

### DIFF
--- a/content/en/byoc-logs/_index.md
+++ b/content/en/byoc-logs/_index.md
@@ -17,7 +17,7 @@ BYOC (Bring Your Own Cloud) Logs is Datadog's log management solution for organi
 {{< whatsnext desc="Follow our guides to get BYOC Logs up and running:">}}
   {{< nextlink href="/byoc-logs/introduction/" >}}What is BYOC Logs?{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/quickstart/" >}}Quickstart: Run BYOC Logs locally in 5 minutes{{< /nextlink >}}
-  {{< nextlink href="/byoc-logs/install/" >}}Installation - Deploy BYOC Logs on AWS, Azure, or custom Kubernetes{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/install/" >}}Installation - Deploy BYOC Logs on AWS, GCP, or Azure{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/ingest/agent/" >}}Ingest Logs - Configure the Datadog Agent to send logs to BYOC Logs{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/search_logs" >}}Search Logs - Explore your logs in the Datadog Log Explorer{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/guides/" >}}Guides - Step-by-step guides for BYOC Logs features and integrations{{< /nextlink >}}

--- a/content/en/byoc-logs/install/_index.md
+++ b/content/en/byoc-logs/install/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 ## Overview
 
-BYOC (Bring Your Own Cloud) Logs requires **Kubernetes** for production deployments. It is supported on cloud-managed Kubernetes services (EKS, GKE, AKS) and self-managed Kubernetes clusters. A [Docker installation][2] is also available for local evaluation and testing only.
+BYOC (Bring Your Own Cloud) Logs requires **Kubernetes** for production deployments. It is supported on Amazon EKS, Google GKE, and Azure AKS. A [Docker installation][2] is also available for local evaluation and testing only.
 
 <div class="alert alert-warning">
 <strong>Docker is for evaluation only.</strong> The Docker installation method is designed for exploring BYOC Logs features locally. For production workloads, deploy on a supported Kubernetes platform.
@@ -24,7 +24,7 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 | Requirement            | Details                                                                                  |
 |------------------------|------------------------------------------------------------------------------------------|
 | **Kubernetes Version** | 1.25 or higher                                                                           |
-| **Supported Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br>- Self-managed Kubernetes (NGINX Ingress Controller or AWS Load Balancer Controller)<br><br>OpenShift and OCI (Oracle Cloud) are not currently tested or supported. |
+| **Supported Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br><br>Self-managed Kubernetes, OpenShift, and OCI (Oracle Cloud) are not currently tested or supported. |
 | **Metadata Storage**   | PostgreSQL database                                                                      |
 | **Recommended PostgreSQL Options** | - AWS: RDS PostgreSQL<br>- GCP: Cloud SQL for PostgreSQL<br>- Azure: Azure Database for PostgreSQL<br>- Self-hosted: PostgreSQL with persistent storage |
 

--- a/content/en/byoc-logs/install/_index.md
+++ b/content/en/byoc-logs/install/_index.md
@@ -24,7 +24,7 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 | Requirement            | Details                                                                                  |
 |------------------------|------------------------------------------------------------------------------------------|
 | **Kubernetes Version** | 1.25 or higher                                                                           |
-| **Supported Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br><br>Self-managed Kubernetes, OpenShift, and OCI (Oracle Cloud) are not currently tested or supported. |
+| **Supported Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br><br>Self-managed Kubernetes, OpenShift, and OCI (Oracle Cloud) are not tested or supported. |
 | **Metadata Storage**   | PostgreSQL database                                                                      |
 | **Recommended PostgreSQL Options** | - AWS: RDS PostgreSQL<br>- GCP: Cloud SQL for PostgreSQL<br>- Azure: Azure Database for PostgreSQL<br>- Self-hosted: PostgreSQL with persistent storage |
 

--- a/content/en/byoc-logs/install/docker.md
+++ b/content/en/byoc-logs/install/docker.md
@@ -16,7 +16,7 @@ aliases:
 ## Overview
 
 <div class="alert alert-warning">
-<strong>This installation method is for local evaluation only.</strong> Docker is not supported for production deployments. For production workloads, deploy BYOC Logs on a <a href="/byoc-logs/install/">supported Kubernetes platform</a> (EKS, GKE, AKS, or self-managed Kubernetes).
+<strong>This installation method is for local evaluation only.</strong> Docker is not supported for production deployments. For production workloads, deploy BYOC Logs on a <a href="/byoc-logs/install/">supported Kubernetes platform</a> (EKS, GKE, or AKS).
 </div>
 
 This installation guide shows you how to run Datadog BYOC (Bring Your Own Cloud) Logs locally using either standalone Docker containers or Docker Compose. Follow these steps to deploy a minimal BYOC Logs environment on your machine, ideal for exploring BYOC Logs features and testing log ingestion with Datadog.

--- a/content/en/byoc-logs/introduction/_index.md
+++ b/content/en/byoc-logs/introduction/_index.md
@@ -18,7 +18,7 @@ Here is a high-level overview of how BYOC Logs works:
 The diagram illustrates the BYOC Logs hybrid architecture, highlighting how data is processed and stored within your infrastructure:
 
 *   **Ingestion**: Logs are collected from Datadog Agents and other sources using standard protocols.
-*   **Your Infrastructure**: The BYOC Logs platform runs entirely inside your infrastructure. It processes and stores logs in your own storage (S3, Azure Blob Storage, Google Cloud Storage, MinIO, Ceph, or any S3-compatible storage).
+*   **Your Infrastructure**: The BYOC Logs platform runs entirely inside your infrastructure. It processes and stores logs in your own object storage (Amazon S3, Google Cloud Storage, or Azure Blob Storage).
 *   **Datadog SaaS**: The Datadog platform is BYOC Logs' Control Plane. It hosts the Datadog UI and communicates with BYOC Logs through a secure connection to send log queries and receive results.
 
 {{< whatsnext desc="Explore BYOC Logs' architecture and capabilities:">}}
@@ -31,7 +31,6 @@ The diagram illustrates the BYOC Logs hybrid architecture, highlighting how data
 
 {{< whatsnext desc="Ready to deploy BYOC Logs? Follow these guides:">}}
   {{< nextlink href="/byoc-logs/quickstart/" >}}Quickstart - Run BYOC Logs locally in 5 minutes{{< /nextlink >}}
-  {{< nextlink href="/byoc-logs/install/" >}}Installation - Deploy BYOC Logs on AWS, GCP, Azure, or custom Kubernetes{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/install/" >}}Installation - Deploy BYOC Logs on AWS, GCP, or Azure{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/ingest/agent/" >}}Ingest Logs - Configure the Datadog Agent to send logs to BYOC Logs{{< /nextlink >}}
 {{< /whatsnext >}}
-


### PR DESCRIPTION
## What changed

- Align the BYOC Logs overview and installation pages with the supported Kubernetes platforms: EKS, GKE, and AKS.
- Limit the documented object storage options to Amazon S3, Google Cloud Storage, and Azure Blob Storage.
- Remove active references to MinIO, Ceph, generic S3-compatible storage, and custom or self-managed Kubernetes.
- Keep the existing private, archived MinIO installation guide unchanged as historical content.

## Why

Visible BYOC Logs pages described MinIO, generic S3-compatible storage, and self-managed Kubernetes as supported, while the installation guidance and current product support scope are limited to cloud-managed Kubernetes and native object storage on AWS, GCP, and Azure. This inconsistency could lead customers and sales engineers to assume unsupported deployments are covered.

## User impact

Customers and field teams now see a consistent support matrix across the BYOC Logs landing, introduction, installation, and Docker evaluation pages.

## Validation

- `git diff --check`
- Targeted search for remaining MinIO, S3-compatible, and custom/self-managed Kubernetes claims; remaining MinIO references are confined to the private archived guide.