### PR TITLE
[CCT-1656] Remove Preview alert from Customize anomaly detection section

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -36,8 +36,6 @@ To distinguish between true anomalies and expected fluctuations, Datadog's algor
 
 ## Customize anomaly detection
 
-<div class="alert alert-danger">Custom anomaly detection is in Preview.</div>
-
 By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, and Oracle Cloud.
 
 To customize anomaly detection:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
[CCT-1656](https://datadoghq.atlassian.net/browse/CCT-1656)
Removes the "Custom anomaly detection is in Preview." alert from the **Customize anomaly detection** section of the Cost Anomalies doc, since the feature is no longer in Preview.

### Preview

https://docs-staging.datadoghq.com/bianca.catarau/CCT-1656/cloud_cost_management/cost_changes/anomalies/

### Merge instructions

This is a copy-only change (removes one alert callout); no restructuring or link changes.

**Diff:**
```diff
- <div class="alert alert-danger">Custom anomaly detection is in Preview.</div>
-
```


[CCT-1656]: https://datadoghq.atlassian.net/browse/CCT-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ