### PR TITLE
Add Learning Center course cross-reference: Getting Started with the Datadog AWS Integration

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -29,6 +29,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/monitor-aws-graviton3-with-datadog/'
       tag: 'Blog'
       text: 'Monitor your Graviton3-powered EC2 instances with Datadog'
+    - link: 'https://learn.datadoghq.com/courses/getting-started-aws-integration'
+      tag: 'Learning Center'
+      text: 'Getting Started with the Datadog AWS Integration'
 ---
 
 ## Overview

--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -29,7 +29,7 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/monitor-aws-graviton3-with-datadog/'
       tag: 'Blog'
       text: 'Monitor your Graviton3-powered EC2 instances with Datadog'
-    - link: 'https://learn.datadoghq.com/courses/getting-started-aws-integration'
+    - link: 'https://learn.datadoghq.com/courses/getting-started-with-the-datadog-aws-integration'
       tag: 'Learning Center'
       text: 'Getting Started with the Datadog AWS Integration'
 ---


### PR DESCRIPTION
## Summary

Adds a `further_reading` link to the [Getting Started with the Datadog AWS Integration](https://learn.datadoghq.com/courses/getting-started-aws-integration) Learning Center course on the following documentation page:

- Getting Started with AWS — `content/en/getting_started/integrations/aws.md`

## Motivation

Cross-linking the Learning Center course from the AWS integration getting-started page helps readers find hands-on practice with the same CloudFormation setup, metric collection, and tag-based filtering the page documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)