### PR TITLE
Document create_llmobs_experiment MCP tool

### DIFF
--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -410,12 +410,11 @@ The `llmobs` toolset includes the following tools:
 
 ### Experiment analysis
 
-1. **Create**: Use `create_llmobs_experiment` to register a new experiment object in a project before submitting events or metrics against it.
-2. **Summarize**: Use `get_llmobs_experiment_summary` to get overall statistics and discover available metrics and dimensions.
-3. **Browse events**: Use `list_llmobs_experiment_events` to find events of interest, filtering by dimension or sorting by metric.
-4. **Inspect events**: Use `get_llmobs_experiment_event` to view full details for a specific event.
-5. **Analyze metrics**: Use `get_llmobs_experiment_metric_values` to get percentile distributions, true/false rates, or compare across dimension segments.
-6. **Discover dimensions**: Use `get_llmobs_experiment_dimension_values` to find valid filter and segment values.
+1. **Summarize**: Use `get_llmobs_experiment_summary` to get overall statistics and discover available metrics and dimensions.
+2. **Browse events**: Use `list_llmobs_experiment_events` to find events of interest, filtering by dimension or sorting by metric.
+3. **Inspect events**: Use `get_llmobs_experiment_event` to view full details for a specific event.
+4. **Analyze metrics**: Use `get_llmobs_experiment_metric_values` to get percentile distributions, true/false rates, or compare across dimension segments.
+5. **Discover dimensions**: Use `get_llmobs_experiment_dimension_values` to find valid filter and segment values.
 
 ### Dataset management
 

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -283,6 +283,7 @@ The Agent Observability MCP tools enable AI-assisted workflows for:
 - **Analyzing trace structure**: Visualize the full span tree of a trace to understand how agents, LLMs, tools, and retrievals interact.
 - **Investigating agent loops**: Review an agent's step-by-step execution loop to understand decision-making and tool invocation patterns.
 - **Evaluating experiments**: Get summary statistics for experiment metrics, compare results across dimension segments, and inspect individual events.
+- **Creating experiments**: Register a new experiment object with `create_llmobs_experiment` to record experiment metadata (project, dataset, description, config) without running model inference. Attach evaluation metrics afterward with `submit_llmobs_experiment_events`.
 - **Discovering experiment patterns**: Filter and sort experiment events by metric performance to find the best and worst-performing cases.
 - **Managing evaluators**: List, inspect, create, update, and delete evaluator configurations across an ML application or the entire organization.
 - **Exploring Patterns**: List pattern configurations, check run status, and browse the discovered topic hierarchy to understand what users are asking and how traffic is distributed.
@@ -316,6 +317,9 @@ The `llmobs` toolset includes the following tools:
 : Get a chronological view of an agent's execution loop, showing each step (LLM calls, tool invocations, decisions) in order.
 
 ### Experiment tools
+
+`create_llmobs_experiment`
+: Create a new LLM Observability experiment object in a project. Records the experiment (so events and metrics can be reported against it) without running any model inference. Requires `project_id` and `experiment_name`. Returns the created `experiment_id` and its resolved name. Use `submit_llmobs_experiment_events` to attach evaluation metrics, or `update_llmobs_experiment` to change its properties.
 
 `get_llmobs_experiment_summary`
 : Get a high-level experiment summary with pre-computed statistics for all evaluation metrics. Start here before using other experiment tools.
@@ -406,11 +410,12 @@ The `llmobs` toolset includes the following tools:
 
 ### Experiment analysis
 
-1. **Summarize**: Use `get_llmobs_experiment_summary` to get overall statistics and discover available metrics and dimensions.
-2. **Browse events**: Use `list_llmobs_experiment_events` to find events of interest, filtering by dimension or sorting by metric.
-3. **Inspect events**: Use `get_llmobs_experiment_event` to view full details for a specific event.
-4. **Analyze metrics**: Use `get_llmobs_experiment_metric_values` to get percentile distributions, true/false rates, or compare across dimension segments.
-5. **Discover dimensions**: Use `get_llmobs_experiment_dimension_values` to find valid filter and segment values.
+1. **Create**: Use `create_llmobs_experiment` to register a new experiment object in a project before submitting events or metrics against it.
+2. **Summarize**: Use `get_llmobs_experiment_summary` to get overall statistics and discover available metrics and dimensions.
+3. **Browse events**: Use `list_llmobs_experiment_events` to find events of interest, filtering by dimension or sorting by metric.
+4. **Inspect events**: Use `get_llmobs_experiment_event` to view full details for a specific event.
+5. **Analyze metrics**: Use `get_llmobs_experiment_metric_values` to get percentile distributions, true/false rates, or compare across dimension segments.
+6. **Discover dimensions**: Use `get_llmobs_experiment_dimension_values` to find valid filter and segment values.
 
 ### Dataset management
 
@@ -440,6 +445,7 @@ After connecting, try prompts like:
 - Analyze experiment `exp-456` and generate a markdown table of the worst-performing dimensions broken down by evaluation scores. Include any other relevant columns that help me understand where and why performance is degrading.
 - Compare experiment `exp-123` (baseline) against experiment `exp-456`. Summarize what improved, what regressed, and by how much. Give me a recommendation on whether the changes are worth shipping.
 - Summarize experiment `exp-456` and identify the top 5 lowest-scoring events. For each, show the input, output, and which evaluations failed.
+- Create a new experiment called "prompt-v2-test" in my project `my-chatbot-project` and return its experiment ID so I can attach evaluation metrics to it.
 - List the datasets in my `my-project` project and show me a sample of records from the dataset named `qa-golden-set`, including its schema.
 - I have a CSV of new test cases. Add them to the `qa-golden-set` dataset in `my-project` as a new version. Show me a preview first.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"dbb0ca98-a5a6-49d4-b8bc-7349cd78aa2a","workflowId":"112355c1-0f79-49f6-b4ad-a4a4ecdf1081","codeChangeId":"112355c1-0f79-49f6-b4ad-a4a4ecdf1081","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

**Motivation (WHY):** The `llmobs` MCP toolset gained a new `create_llmobs_experiment` tool (added in https://github.com/ddoghq/dd-source/pull/27417), but it was not documented anywhere in the LLM Observability MCP Server docs. This PR adds that coverage so users know the tool exists and how it fits into the experiment workflow.

**Changes (WHAT):** All edits are in `content/en/llm_observability/mcp_server.md`:

- **Available tools → Experiment tools:** Added `create_llmobs_experiment` as the first entry (before `get_llmobs_experiment_summary`), since it is the creation step that precedes analysis.
- **Use cases:** Added a **Creating experiments** bullet after **Evaluating experiments**.
- **Example prompts:** Added a prompt demonstrating experiment creation.

The **Recommended workflows → Experiment analysis** list is left unchanged (a proposed "Create" step was dropped as redundant with the tool-list entry and the Use cases bullet).

No changes to `content/en/mcp_server/tools.md`: that file has no dedicated `llmobs` section or per-tool entry (the toolset's tools are documented in the LLM Observability page), so there was nothing to update there.

**Testing (HOW verified):** Verified with `grep` that the new tool name appears in the Experiment tools list and the Use cases section, and confirmed `tools.md` contains no `llmobs` section or tool entry. Changes are documentation-only (Markdown/definition-list formatting matching surrounding entries).

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`).
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): applied the specified documentation edits and verified them.

### Additional notes

Source PR that made these doc changes necessary: https://github.com/ddoghq/dd-source/pull/27417

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/dbb0ca98-a5a6-49d4-b8bc-7349cd78aa2a)

Comment @datadog to request changes