### PR TITLE
chore: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately rather than opening a public issue.
+
+Please include as much of the following information as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof-of-concept if you have one
+- The affected version(s) or commit hash
+- Any suggested mitigation
+
+You can expect an initial response within a few days. Please do not disclose
+the vulnerability publicly until it has been addressed.
+
+## Supported Versions
+
+Only the latest released version is actively maintained. If you're on an older
+version, please try to reproduce the issue on the latest before reporting.


### PR DESCRIPTION
Small addition: a `SECURITY.md` file so security researchers know how to report vulnerabilities privately. GitHub surfaces this file prominently on the repo's Security tab.

Happy to adjust the wording if you have a preferred reporting channel.