### PR TITLE
[RUM] Add resource OOTB metrics to RUM without Limits metrics table

### DIFF
--- a/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -35,8 +35,8 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.error.anr` | Count of ANRs (an Android freeze) | Default, Is Crash, View Name | Mobile only |
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |
 | `rum.measure.error.hang.duration` | Duration of hangs (an iOS freeze) | Default, View Name | Mobile only |
-| `rum.measure.resource` | Count of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
-| `rum.measure.resource.duration` | Duration of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource` | Count of resources | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource.duration` | Duration of resources | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
 | `rum.measure.session` | Count of sessions | Default | Mobile & Browser |
 | `rum.measure.session.action` | Count of actions | Default | Mobile & Browser |
 | `rum.measure.session.crash_free` | Count of crash-free sessions | Default | Mobile only |

--- a/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -35,6 +35,8 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.error.anr` | Count of ANRs (an Android freeze) | Default, Is Crash, View Name | Mobile only |
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |
 | `rum.measure.error.hang.duration` | Duration of hangs (an iOS freeze) | Default, View Name | Mobile only |
+| `rum.measure.resource` | Count of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource.duration` | Duration of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
 | `rum.measure.session` | Count of sessions | Default | Mobile & Browser |
 | `rum.measure.session.action` | Count of actions | Default | Mobile & Browser |
 | `rum.measure.session.crash_free` | Count of crash-free sessions | Default | Mobile only |


### PR DESCRIPTION
### What does this PR do?

Adds two new out-of-the-box metrics to the [RUM without Limits metrics table](https://docs.datadoghq.com/real_user_monitoring/rum_without_limits/metrics):

- `rum.measure.resource` — Count of resources (REST and GraphQL network calls)
- `rum.measure.resource.duration` — Duration of resources (REST and GraphQL network calls)

These are the first OOTB metrics targeting resources. Both are available on Mobile & Browser and share the same dimensions:

- Default
- Status Code (`resource.status_code`)
- URL Path Group (`resource.url_path_group`)
- Resource Type (`resource.type`)
- GraphQL Operation Name (`resource.graphql.operationName`)
- GraphQL Operation Type (`resource.graphql.operationType`)
- GraphQL Has Errors (`resource.graphql.has_errors`)

### Motivation

These metrics are going GA. Documenting them alongside the existing OOTB RUM metrics.

### Additional Notes

Rows inserted in alphabetical order (after `rum.measure.error.*`, before `rum.measure.session`), matching the table's existing ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)