### PR TITLE
[DOCS] AI Guard: document disabling APM tracing and update supported libraries

### DIFF
--- a/content/en/security/ai_guard/setup/_index.md
+++ b/content/en/security/ai_guard/setup/_index.md
@@ -52,18 +52,19 @@ The [AI Guard SDK][12] provides language-specific libraries (Python, JavaScript,
 
 [Automatic integrations][10] provide out-of-the-box AI Guard protection for supported frameworks. When you run your application with the Datadog SDK, AI Guard evaluations are automatically performed without requiring any code changes.
 
-| Language   | Supported Frameworks |
-|------------|---------------------|
-| Python     | LangChain           |
-| Node.js    | AI SDK              |
+| Language | Supported Frameworks         |
+|----------|------------------------------|
+| Python   | LangChain, OpenAI, Anthropic |
+| Node.js  | AI SDK, OpenAI, Anthropic    |
+| Ruby     | RubyLLM                      |
 
 ### Manual integrations
 
 [Manual integrations][11] require additional configuration to enable AI Guard protection for supported frameworks.
 
-| Language   | Supported Frameworks        |
-|------------|-----------------------------|
-| Python     | Amazon Strands, LiteLLM Proxy |
+| Language   | Supported Frameworks           |
+|------------|--------------------------------|
+| Python     | Amazon Strands, LiteLLM Proxy  |
 
 ### HTTP API
 
@@ -174,6 +175,17 @@ Do not use the system prompt to override AI Guard's security checks or to instru
 ## 6. (Optional) Limit access to AI Guard spans {#limit-access}
 
 To restrict access to AI Guard spans for specific users, you can use [Data Access Control][9]. Follow the linked instructions to create a restricted dataset, scoped to **APM data**, with the `resource_name:ai_guard` filter applied. Then, you can grant access to the dataset to specific roles or teams.
+
+## Disable APM tracing
+
+To disable APM tracing on the tracer while keeping AI Guard enabled, set `DD_APM_TRACING_ENABLED=false`:
+
+{{< code-block lang="bash" >}}
+DD_AI_GUARD_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+DD_SERVICE=<YOUR_SERVICE_NAME>
+DD_ENV=<YOUR_ENVIRONMENT>
+{{< /code-block >}}
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes APPSEC-69383

Updates the AI Guard setup docs:
- Adds a **Disable APM tracing** section explaining how to keep AI Guard enabled while turning off APM tracing (`DD_APM_TRACING_ENABLED=false`, `DD_AI_GUARD_ENABLED=true`) to avoid APM host billing.
- Updates the AI Guard supported libraries tables:
  - Automatic integrations: adds OpenAI and Anthropic for Python and Node.js, and adds Ruby (RubyLLM).
  - Manual integrations: Python (Amazon Strands, LiteLLM Proxy).

Part of the AI Guard without APM billing epic ([APPSEC-61460](https://datadoghq.atlassian.net/browse/APPSEC-61460)).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

[APPSEC-61460]: https://datadoghq.atlassian.net/browse/APPSEC-61460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ