### PR TITLE
[documentation] Add Cursor and Amazon Bedrock to Cost Anomalies provider list

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-Datadog Cloud Cost Management (CCM) continuously monitors your environment to detect and prioritize unexpected cost changes, enabling you to share, investigate, and resolve anomalies. Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, and OpenAI and do not require any additional setup after CCM is set up.
+Datadog Cloud Cost Management (CCM) continuously monitors your environment to detect and prioritize unexpected cost changes, enabling you to share, investigate, and resolve anomalies. Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, OpenAI, Cursor, and Amazon Bedrock and do not require any additional setup after CCM is set up.
 
 {{< img src="cloud_cost/anomalies/anomalies-overview.png" alt="List of cost anomalies showing service names, usage types, and cost impacts" style="width:80;" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Cursor and Amazon Bedrock cost anomaly detection are now GA, but the **Overview** section of the Cost Anomalies doc doesn't list them yet.

### Merge instructions

This is a copy-only change (adds two providers to one sentence); no restructuring or link changes.

**Diff:**
```diff
- Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, and OpenAI and do not require any additional setup after CCM is set up.
+ Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, OpenAI, Cursor, and Amazon Bedrock and do not require any additional setup after CCM is set up.
```