### PR TITLE
Restore Public User note for RUM advanced configuration (SDK 6.4.0+)

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -714,6 +714,8 @@ In versions 6.4.0 and above, the following attributes are available:
 | `usr.id`    | String | Yes | Unique user identifier.                                                                                  |
 | `usr.name`  | String | No | User friendly name, displayed by default in the RUM UI.                                                  |
 | `usr.email` | String | No | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+
+**Note**: 'Public User' is displayed in the RUM UI when `usr.name` is not set, even if `usr.email` and `usr.id` are defined.
 {% /if %}
 <!-- ends  6.4.0 -->
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The Advanced Configuration page for the RUM Browser SDK previously included a note explaining that 'Public User' is displayed in the RUM UI when `usr.name` is not set, even if `usr.email` and `usr.id` are defined.

A later content restructure split the user session attributes section into two version-conditional blocks (SDK versions before 6.4.0, and 6.4.0 and above). The note only carried over into the pre-6.4.0 block, so it stopped appearing for the default, current view of the page.

This PR adds the same note to the 6.4.0-and-above block so it's visible again for current SDK versions.

### Pages changed

- `content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes