### PR TITLE
[APPSEC-68621] Document current AAP MCP tools

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1882,12 +1882,11 @@ Retrieves one App & API Protection (AAP) custom WAF rule by ID or lists custom r
 
 - List custom WAF rules that apply to service "checkout-service" in production.
 - Get AAP custom rule "rule-xyz-123".
-- Show me custom security response rules that block traffic.
 
 ### `upsert_datadog_security_aap_custom_rule`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Write`*\
-Creates or updates an AAP custom WAF rule in the attack attempt, business logic, or security response category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
+Creates or updates an AAP custom WAF rule in the attack attempt or business logic category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
 
 - Create a monitoring custom WAF rule for requests to path "/admin".
 - Update AAP custom rule "rule-xyz-123" to block matching traffic.

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -1823,7 +1823,7 @@ Moves an automation rule up or down in the list. Rules are applied in order, so 
 - Move the mute rule `abc-123-def` to the top of the list.
 - Lower the priority of this due-date rule by two positions.
 
-### `get_datadog_security_passlist`
+### `get_datadog_security_trace_passlist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Read`*\
 Returns all WAF exclusion filter (passlist) entries for the organization to review existing suppressions.
@@ -1832,7 +1832,7 @@ Returns all WAF exclusion filter (passlist) entries for the organization to revi
 - Show me active WAF exclusion filters.
 - Check existing passlist suppressions before I add a new one.
 
-### `upsert_datadog_security_passlist`
+### `upsert_datadog_security_trace_passlist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Write`*\
 Creates or updates a WAF exclusion filter (passlist) entry to suppress noisy rules on a specific service or endpoint.
@@ -1841,7 +1841,7 @@ Creates or updates a WAF exclusion filter (passlist) entry to suppress noisy rul
 - Update the exclusion filter to suppress rule "xss-rule" for service "auth-api".
 - Create an AppSec passlist entry that matches rule ID "lfi-attack" on "/v1/users".
 
-### `delete_datadog_security_passlist`
+### `delete_datadog_security_trace_passlist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Write`*\
 Deletes an existing WAF exclusion filter (passlist) entry.
@@ -1849,7 +1849,7 @@ Deletes an existing WAF exclusion filter (passlist) entry.
 - Delete WAF exclusion filter "passlist-abc-123".
 - Remove the passlist entry that matches rule "sqli-detection" on "/api/pay".
 
-### `get_datadog_security_denylist`
+### `get_datadog_security_aap_denylist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Read`*\
 Lists blocked IPs, users, and user agents (denylist entries), with optional filtering.
@@ -1858,7 +1858,7 @@ Lists blocked IPs, users, and user agents (denylist entries), with optional filt
 - Show me blocked IP addresses from yesterday.
 - Check if IP "198.51.100.42" is on the security denylist.
 
-### `upsert_datadog_security_denylist_entry`
+### `upsert_datadog_security_aap_denylist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Write`*\
 Adds or updates a denylist block for an IP, user, or user agent with an expiration.
@@ -1867,13 +1867,48 @@ Adds or updates a denylist block for an IP, user, or user agent with an expirati
 - Add user "attacker_user_99" to the blocked entities denylist.
 - Create a denylist entry for user-agent "MaliciousScanner/1.0" with an expiration set to next week.
 
-### `delete_datadog_security_denylist_entry`
+### `unblock_datadog_security_aap_denylist`
 *Toolset: **security***\
 *Permissions Required: `Application Security Management Protect Write`*\
 Unblocks a previously denylisted entity by setting its expiration in the past.
 
 - Unblock IP "198.51.100.42" on the denylist.
 - Remove user "attacker_user_99" from the blocked entities list.
+
+### `get_datadog_security_aap_custom_rules`
+*Toolset: **security***\
+*Permissions Required: `Application Security Management Protect Read`*\
+Retrieves one App & API Protection (AAP) custom WAF rule by ID or lists custom rules. Supports filtering by category, status, service, and environment.
+
+- List custom WAF rules that apply to service "checkout-service" in production.
+- Get AAP custom rule "rule-xyz-123".
+- Show me custom security response rules that block traffic.
+
+### `upsert_datadog_security_aap_custom_rule`
+*Toolset: **security***\
+*Permissions Required: `Application Security Management Protect Write`*\
+Creates or updates an AAP custom WAF rule in the attack attempt, business logic, or security response category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
+
+- Create a monitoring custom WAF rule for requests to path "/admin".
+- Update AAP custom rule "rule-xyz-123" to block matching traffic.
+- Disable custom rule "rule-xyz-123" without deleting it.
+
+### `delete_datadog_security_aap_custom_rule`
+*Toolset: **security***\
+*Permissions Required: `Application Security Management Protect Write`*\
+Permanently deletes an AAP custom WAF rule by ID.
+
+- Delete custom WAF rule "rule-xyz-123".
+- Remove the AAP custom rule that monitors requests to "/admin".
+
+### `get_datadog_security_aap_blocking_config`
+*Toolset: **security***\
+*Permissions Required: `Application Security Management Protect Read`*\
+Retrieves the organization-wide AAP blocking and denylist enforcement settings.
+
+- Is AAP blocking enabled for the organization?
+- Is the AAP denylist enforced?
+- Show me the AAP blocking configuration.
 
 ## Session Replay
 

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -45,7 +45,7 @@ You can use the `security` toolset to:
 - **Correlate signals and findings**: Cross-reference active security signals with open findings to determine whether an alert is tied to a known posture issue.
 - **Inspect and manage detection rules**: List, retrieve, create, update, and delete detection rules to understand and manage the logic generating signals.
 - **Manage suppressions**: Create, update, and delete suppressions to silence noisy rules for specific conditions without disabling them entirely.
-- **Respond to attacks with App & API Protection**: Block or unblock IPs, users, and user agents on the denylist, and suppress false positives with passlist exclusion filters.
+- **Respond to attacks with App & API Protection**: Block or unblock IPs, users, and user agents on the denylist; suppress false positives with passlist exclusion filters; and create, update, or delete custom WAF rules to protect a specific service or endpoint.
 - **Remediate vulnerabilities with an AI agent**: Pull library vulnerability findings, including code location and remediation guidance, and pass them to your AI agent to apply patches directly in your codebase.
 - **Investigate indicators of compromise (IoCs)**: Search and retrieve IP addresses, domains, URLs, and file hashes matched against threat intelligence feeds. Review individual indicators and update their triage state.
 
@@ -201,29 +201,45 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 
 ### App & API Protection
 
-`get_datadog_security_passlist`
+`get_datadog_security_trace_passlist`
 : Returns all WAF exclusion filter (passlist) entries for the organization to review existing suppressions.
 : *Permissions required: `Application Security Management Protect Read`*
 
-`upsert_datadog_security_passlist`
+`upsert_datadog_security_trace_passlist`
 : Creates or updates a WAF exclusion filter (passlist) entry to suppress noisy rules on a specific service or endpoint.
 : *Permissions required: `Application Security Management Protect Write`*
 
-`delete_datadog_security_passlist`
+`delete_datadog_security_trace_passlist`
 : Deletes an existing WAF exclusion filter (passlist) entry.
 : *Permissions required: `Application Security Management Protect Write`*
 
-`get_datadog_security_denylist`
+`get_datadog_security_aap_denylist`
 : Lists blocked IPs, users, and user agents (denylist entries), with optional filtering.
 : *Permissions required: `Application Security Management Protect Read`*
 
-`upsert_datadog_security_denylist_entry`
+`upsert_datadog_security_aap_denylist`
 : Adds or updates a denylist block for an IP, user, or user agent with an expiration.
 : *Permissions required: `Application Security Management Protect Write`*
 
-`delete_datadog_security_denylist_entry`
+`unblock_datadog_security_aap_denylist`
 : Unblocks a previously denylisted entity by setting its expiration in the past.
 : *Permissions required: `Application Security Management Protect Write`*
+
+`get_datadog_security_aap_custom_rules`
+: Retrieves one App & API Protection (AAP) custom WAF rule by ID or lists custom rules. Supports filtering by category, status, service, and environment.
+: *Permissions required: `Application Security Management Protect Read`*
+
+`upsert_datadog_security_aap_custom_rule`
+: Creates or updates an AAP custom WAF rule in the attack attempt, business logic, or security response category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
+: *Permissions required: `Application Security Management Protect Write`*
+
+`delete_datadog_security_aap_custom_rule`
+: Permanently deletes an AAP custom WAF rule by ID.
+: *Permissions required: `Application Security Management Protect Write`*
+
+`get_datadog_security_aap_blocking_config`
+: Retrieves the organization-wide AAP blocking and denylist enforcement settings.
+: *Permissions required: `Application Security Management Protect Read`*
 
 ## Further reading
 

--- a/content/en/security/mcp_server.md
+++ b/content/en/security/mcp_server.md
@@ -230,7 +230,7 @@ The `security` toolset exposes the following tools to your AI client. Each tool 
 : *Permissions required: `Application Security Management Protect Read`*
 
 `upsert_datadog_security_aap_custom_rule`
-: Creates or updates an AAP custom WAF rule in the attack attempt, business logic, or security response category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
+: Creates or updates an AAP custom WAF rule in the attack attempt or business logic category. New rules cannot block traffic: create the rule in monitoring mode, then update it to blocking mode after confirming its matches.
 : *Permissions required: `Application Security Management Protect Write`*
 
 `delete_datadog_security_aap_custom_rule`


### PR DESCRIPTION
## Summary

Document the new AAP custom-rule and blocking-configuration MCP tools, update tool name so they match the real tool names.

## Testing

- [x] Tool names verified against `dd-source`
- [x] Documentation preview passed

Created with OpenAI Codex.