### PR TITLE
Document Vertex AI multi-region locations

### DIFF
--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -49,7 +49,7 @@ Learn more about the [compatibility requirements][6].
 1. Configure the model:
     1. Select the {{< ui >}}Account{{< /ui >}} dropdown menu to select the LLM provider and corresponding account to use for your LLM judge. To connect a new account, see [connect an LLM provider][2].
         - If you select an {{< ui >}}Amazon Bedrock{{< /ui >}} account, choose a region the account is configured for. You can then select a model name or provide the inference profile ARN.
-        - If you select a {{< ui >}}Vertex{{< /ui >}} account, choose a project and location.
+        - If you select a {{< ui >}}Vertex{{< /ui >}} account, choose a project and location. The {{< ui >}}Location{{< /ui >}} dropdown includes `us (multi-region)` and `eu (multi-region)` options, which route requests to Google's jurisdictional (REP) endpoints and keep data within the US or EU respectively. All other entries are single-region or global locations.
     1. Use the {{< ui >}}Model{{< /ui >}} dropdown menu to select a model.
 1. In {{< ui >}}Runs On{{< /ui >}}, select the application you want to evaluate, what you want to evaluate on (span, trace, or session), and the sampling rate. You can add more filtering criteria by selecting the button to the right of the sampling rate.
 1. In the {{< ui >}}Template{{< /ui >}} section, use the dropdown menu:

--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -49,7 +49,7 @@ Learn more about the [compatibility requirements][6].
 1. Configure the model:
     1. Select the {{< ui >}}Account{{< /ui >}} dropdown menu to select the LLM provider and corresponding account to use for your LLM judge. To connect a new account, see [connect an LLM provider][2].
         - If you select an {{< ui >}}Amazon Bedrock{{< /ui >}} account, choose a region the account is configured for. You can then select a model name or provide the inference profile ARN.
-        - If you select a {{< ui >}}Vertex{{< /ui >}} account, choose a project and location. The {{< ui >}}Location{{< /ui >}} dropdown includes `us (multi-region)` and `eu (multi-region)` options, which route requests to Google's jurisdictional (REP) endpoints and keep data within the US or EU respectively. All other entries are single-region or global locations.
+        - If you select a {{< ui >}}Vertex{{< /ui >}} account, choose a project and location. The {{< ui >}}Location{{< /ui >}} dropdown includes single-region, multi-region, and global options. For details on each option, see [Google's Vertex AI locations documentation][18].
     1. Use the {{< ui >}}Model{{< /ui >}} dropdown menu to select a model.
 1. In {{< ui >}}Runs On{{< /ui >}}, select the application you want to evaluate, what you want to evaluate on (span, trace, or session), and the sampling rate. You can add more filtering criteria by selecting the button to the right of the sampling rate.
 1. In the {{< ui >}}Template{{< /ui >}} section, use the dropdown menu:
@@ -609,4 +609,5 @@ You can use basic CRUD operations to manipulate managed evaluation configs, afte
 [15]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/prompt_templating
 [16]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/trace_level_evaluations
 [17]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/session_level_evaluations
+[18]: https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations
 

--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account.md
@@ -101,11 +101,12 @@ Connect Vertex AI to Agent Observability with your Google Cloud Platform account
 
 {{< img src="llm_observability/configuration/vertex-ai-pint.png" alt="The Vertex AI onboarding workflow. Follow steps to configure your GCP service account with the right Vertex AI permissions for use with Agent Observability." style="width:100%;" >}}
 
-**Note**: When you run evaluations, the location selector offers `us (multi-region)` and `eu (multi-region)` options for jurisdictional data residency, keeping requests within the US or EU respectively, in addition to single-region and global locations.
+**Note**: When you run evaluations, the location selector offers single-region, multi-region, and global options. For details on each option, see [Google's Vertex AI locations documentation][4].
 
 [1]: https://app.datadoghq.com/llm/settings/integrations
 [2]: https://docs.cloud.google.com/vertex-ai/docs/general/access-control#aiplatform.user
 [3]: https://console.cloud.google.com/apis/library/aiplatform.googleapis.com
+[4]: https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations
 {{% /tab %}}
 
 {{% tab "AI Gateway" %}}

--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account.md
@@ -101,6 +101,8 @@ Connect Vertex AI to Agent Observability with your Google Cloud Platform account
 
 {{< img src="llm_observability/configuration/vertex-ai-pint.png" alt="The Vertex AI onboarding workflow. Follow steps to configure your GCP service account with the right Vertex AI permissions for use with Agent Observability." style="width:100%;" >}}
 
+**Note**: When you run evaluations, the location selector offers `us (multi-region)` and `eu (multi-region)` options for jurisdictional data residency, keeping requests within the US or EU respectively, in addition to single-region and global locations.
+
 [1]: https://app.datadoghq.com/llm/settings/integrations
 [2]: https://docs.cloud.google.com/vertex-ai/docs/general/access-control#aiplatform.user
 [3]: https://console.cloud.google.com/apis/library/aiplatform.googleapis.com


### PR DESCRIPTION
<!-- dd-meta {"pullId":"01b711cd-6459-495c-b148-88c13a237d11","source":"chat","resourceId":"c400e827-bf8d-410e-b025-f7dc453cc673","workflowId":"b9ea2f61-b05e-4250-aa6f-5fdcfa56bf32","codeChangeId":"b9ea2f61-b05e-4250-aa6f-5fdcfa56bf32","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Vertex AI location selector in custom LLM-as-a-judge evaluations now includes multi-region options (such as `us (multi-region)` and `eu (multi-region)`) in addition to single-region and global locations. The docs did not mention that the location dropdown has these options, so customers had no way to know they exist.

Rather than duplicating and maintaining Google-owned location details, these pages now note that single-region, multi-region, and global options are available and link customers to Google's own Vertex AI locations documentation for specifics.

This PR updates the two relevant pages:
- The "Configure the model" step, which describes choosing a project and location.
- The GCP Vertex AI onboarding tab, which previously said nothing about the location selector.

Source PRs that introduced this behavior:
- https://github.com/ddoghq/dd-source/pull/27562
- https://github.com/DataDog/web-ui/pull/331891

### Changes

- `content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md`: Expanded the Vertex AI bullet in step 4 ("Configure the model") to note that the Location dropdown includes single-region, multi-region, and global options, linking to Google's Vertex AI locations documentation for details.
- `content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account.md`: Added a note to the GCP Vertex AI tab that the location selector offers single-region, multi-region, and global options, linking to Google's Vertex AI locations documentation for details.

### Testing / validation

Verified the edits render correctly within their existing list and tab shortcode scopes and that the new reference links resolve (`[18]` in `_index.md`, `[4]` in the GCP Vertex AI tab). Confirmed the wording follows the Datadog style guide (no banned terms such as "ensure", "once you", or temporal words). Vale is not available in this environment, so a Vale check should be run before merge.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Datadog AI agent) based on the linked source PRs.

### Additional notes

<!-- Anything else we should know when reviewing?-->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c400e827-bf8d-410e-b025-f7dc453cc673)

Comment @datadog to request changes