### PR TITLE
[DOCS-15198] Fix stale assertion table for API HTTP tests

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -185,7 +185,7 @@ If a test contains an assertion on the response body and the timeout limit is re
 [4]: https://restfulapi.net/json-jsonpath/
 [5]: https://www.w3schools.com/xml/xpath_syntax.asp
 [6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[18]: https://json-schema.org/
+[7]: https://json-schema.org/
 
 {{% /tab %}}
 {{% tab "JavaScript" %}}

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -162,7 +162,7 @@ Assertions define what an expected test result is. After you click {{< ui >}}Tes
 
 | Type          | Operator                                                                                               | Value type                                                      |
 |---------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| body          | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> [`jsonpath`][4], [`xpath`][5], <br> [`jsonschema`][18] | _String_ <br> _[Regex][6]_ <br> _String_, _[Regex][6]_ <br> _String_ |
+| body          | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> [`jsonpath`][4], [`xpath`][5], <br> [`jsonschema`][7] | _String_ <br> _[Regex][6]_ <br> _String_, _[Regex][6]_ <br> _String_ |
 | body hash     | `md5`, `sha1`, `sha256`                                                                                 | _String_                                                        |
 | header        | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> `does not exist`, <br> `is less than`, `is less than or equal`, `is more than`, `is more than or equal` | _String_ <br> _[Regex][6]_ <br> _None_ <br> _Integer_ |
 | response time | `is less than`                                                                                         | _Integer (ms)_                                                  |

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -162,8 +162,9 @@ Assertions define what an expected test result is. After you click {{< ui >}}Tes
 
 | Type          | Operator                                                                                               | Value type                                                      |
 |---------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| body          | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> [`jsonpath`][4], [`xpath`][5] | _String_ <br> _[Regex][6]_ |
-| header        | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`                       | _String_ <br> _[Regex][6]_                                      |
+| body          | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> [`jsonpath`][4], [`xpath`][5], <br> [`jsonschema`][18] | _String_ <br> _[Regex][6]_ <br> _String_, _[Regex][6]_ <br> _String_ |
+| body hash     | `md5`, `sha1`, `sha256`                                                                                 | _String_                                                        |
+| header        | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, `does not exist`, <br> `is less than`, `is less than or equal`, <br> `is more than`, `is more than or equal` | _String_ <br> _[Regex][6]_ <br> _Integer_ |
 | response time | `is less than`                                                                                         | _Integer (ms)_                                                  |
 | status code   | `is`, `is not`, <br> `matches`, `does not match`                                                                                         | _Integer_ <br> _[Regex][6]_                                                     |
 
@@ -184,6 +185,7 @@ If a test contains an assertion on the response body and the timeout limit is re
 [4]: https://restfulapi.net/json-jsonpath/
 [5]: https://www.w3schools.com/xml/xpath_syntax.asp
 [6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[18]: https://json-schema.org/
 
 {{% /tab %}}
 {{% tab "JavaScript" %}}

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -164,7 +164,7 @@ Assertions define what an expected test result is. After you click {{< ui >}}Tes
 |---------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
 | body          | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> [`jsonpath`][4], [`xpath`][5], <br> [`jsonschema`][18] | _String_ <br> _[Regex][6]_ <br> _String_, _[Regex][6]_ <br> _String_ |
 | body hash     | `md5`, `sha1`, `sha256`                                                                                 | _String_                                                        |
-| header        | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, `does not exist`, <br> `is less than`, `is less than or equal`, <br> `is more than`, `is more than or equal` | _String_ <br> _[Regex][6]_ <br> _Integer_ |
+| header        | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`, <br> `does not exist`, <br> `is less than`, `is less than or equal`, `is more than`, `is more than or equal` | _String_ <br> _[Regex][6]_ <br> _None_ <br> _Integer_ |
 | response time | `is less than`                                                                                         | _Integer (ms)_                                                  |
 | status code   | `is`, `is not`, <br> `matches`, `does not match`                                                                                         | _Integer_ <br> _[Regex][6]_                                                     |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Response Assertions table for HTTP API tests was out of date. Updated it to match current product behavior:

- `body`: added the `jsonschema` operator.
- `body hash`: added this assertion type (`md5`, `sha1`, `sha256`), which was missing entirely.
- `header`: added the `does not exist` operator and the numeric operators (`is less than`, `is less than or equal`, `is more than`, `is more than or equal`), with the operator and value-type rows aligned.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`).
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to verify the operator set against current product behavior and edit the table.

### Additional notes

These assertion capabilities have existed in the product for a long time; this is a documentation correction, not a new feature.