### PR TITLE
[WEB-9711] Update Zendesk ticket retention policy language

### DIFF
--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -84,6 +84,10 @@ Korean language support is available Monday to Friday from 9am to 5pm Korea Stan
 
 When support in your preferred language is not available, you can continue working with Datadog Support in English.
 
+## Ticket retention policy
+
+Our retention policy changed on June 12, 2026: closed tickets, including their attachments, are now deleted 15 months after their last update. Reach out to us with any questions.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes WEB-9711

Adds a **Ticket retention policy** section to the Getting Started with Datadog Support page describing the updated Zendesk retention policy that took effect on June 12, 2026.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The support portal banner (help.datadoghq.com) and the dedicated 404 page for deleted Zendesk tickets are Zendesk-side configurations outside this repository and are not addressed here.