### PR TITLE
Note Logs Findings explorer is not available on US1-FED/US2-FED

### DIFF
--- a/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -37,6 +37,10 @@ Navigate to the [Findings][1] page to see all sensitive data findings within the
 {{< tabs >}}
 {{% tab "Logs" %}}
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">The Logs Findings explorer is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 The Logs Findings explorer is an updated experience for investigating log findings. If you have at least one log finding, this explorer opens by default. APM, RUM, and Events findings are not available in this explorer. To view those findings, click {{< ui >}}Go back{{< /ui >}} in the banner at the top of the page.
 
 To investigate a log finding:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Logs Findings explorer (Sensitive Data Scanner) is not available on the Datadog for Government sites (US1-FED, US2-FED). This adds a `site-region` alert to the "Logs" tab of the Investigate Sensitive Data Findings guide so users on those sites see that this specific experience isn't available to them, following the same pattern used for other partially-restricted features (e.g. Workload Identity Federation for the Datadog Agent).

No ticket reference; this is docs-only cleanup requested directly by SDS product management.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes