### PR TITLE
Remove Test Parallelization preview CTA

### DIFF
--- a/content/en/tests/test_parallelization/_index.md
+++ b/content/en/tests/test_parallelization/_index.md
@@ -3,10 +3,6 @@ title: Test Parallelization
 description: Reduce CI testing time by distributing test files across CI nodes or workers with Test Optimization data.
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/test-parallelization/" btn_hidden="false" header="Join the Preview!" >}}
-Test Parallelization is in Preview. Complete the form to request access.
-{{< /callout >}}
-
 ## Overview
 
 Test Parallelization helps you reduce CI testing time by distributing test files across CI nodes or local workers. It uses Test Optimization data to detect which test files should run, estimate their duration, and create an execution plan.

--- a/content/en/tests/test_parallelization/best_practices.md
+++ b/content/en/tests/test_parallelization/best_practices.md
@@ -13,10 +13,6 @@ further_reading:
     text: "Troubleshooting Test Parallelization"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/test-parallelization/" btn_hidden="false" header="Join the Preview!" >}}
-Test Parallelization is in Preview. Complete the form to request access.
-{{< /callout >}}
-
 ## Optimize the planning step
 
 Test Parallelization adds a planning step that discovers tests before execution. For example, RSpec projects use dry-run discovery, pytest projects use collection, and Jest projects use `--listTests`. Keep this step lightweight so the time saved by parallel execution is not offset by planning overhead.

--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -13,10 +13,6 @@ further_reading:
     text: "Test Parallelization Best Practices"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/test-parallelization/" btn_hidden="false" header="Join the Preview!" >}}
-Test Parallelization is in Preview. Complete the form to request access.
-{{< /callout >}}
-
 ## Environment variables
 
 Most `ddtest` settings can be passed as a CLI flag or as an environment variable. CLI flags take precedence over environment variables.

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -16,10 +16,6 @@ further_reading:
     text: "Set up Test Optimization"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/test-parallelization/" btn_hidden="false" header="Join the Preview!" >}}
-Test Parallelization is in Preview. Complete the form to request access.
-{{< /callout >}}
-
 ## Prerequisites
 
 Before setting up Test Parallelization:

--- a/content/en/tests/test_parallelization/troubleshooting.md
+++ b/content/en/tests/test_parallelization/troubleshooting.md
@@ -13,10 +13,6 @@ further_reading:
     text: "Troubleshooting Test Optimization"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/test-parallelization/" btn_hidden="false" header="Join the Preview!" >}}
-Test Parallelization is in Preview. Complete the form to request access.
-{{< /callout >}}
-
 ## Missing or invalid plan artifacts
 
 If `ddtest run --ci-node <N>` cannot find assigned test files, confirm that the `.testoptimization/` directory from the planning job is available in the test job.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the preview CTA from all Test Parallelization documentation pages. The feature is now GA.

### Merge instructions

Merge readiness:
- [x] Ready for merge
