### PR TITLE
Fix continuous profiler link on MCP server setup page [DOCS-15080]

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -926,10 +926,10 @@ Local authentication is recommended for Cline and when remote authentication is 
 [55]: https://claude.com/plugins/datadog
 [56]: https://claude.ai/directory/connectors/datadog
 [57]: /real_user_monitoring/
-[58]: https://partners.datadoghq.com/s/login/SelfRegister
+[58]: /getting_started/profiler/
 [59]: https://chatgpt.com/
 [60]: https://www.datadoghq.com/product-preview/mcp-codexec/
-[61]: /getting_started/profiler/
+[61]: https://partners.datadoghq.com/s/login/SelfRegister
 [62]: https://www.datadoghq.com/product-preview/datadog-agent-mcp/
 [63]: /cloud_cost_management/
 [64]: https://github.com/features/copilot/cli


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15080

The "Continuous Profiler" link and the "Technology Partner Signup" link on the MCP server setup page had swapped destinations. This updates them so each points to the correct target.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify and fix the swapped reference links.

### Additional notes