### PR TITLE
observability pipelines: update pipeline_usage_metrics.md

### DIFF
--- a/content/en/observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics.md
+++ b/content/en/observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics.md
@@ -134,14 +134,6 @@ Worker reloads
 : **Metric**: `pipelines.reloaded_total`
 : **Description:** The number of times the Worker instance has been reloaded, such as after a configuration change.
 
-Worker starts
-: **Metric**: `pipelines.started_total`
-: **Description:** The number of times the Worker instance has been started.
-
-Worker stops
-: **Metric**: `pipelines.stopped_total`
-: **Description:** The number of times the Worker instance has been stopped.
-
 ## Component metrics
 
 These metrics are available for sources, processors, and destinations.


### PR DESCRIPTION
pipelines.started_total and stopped_total are actually not exported from OP workers, because of a limitation of the worker internal metrics collector which always miss the first datapoint of a metric (and those ones only produce one datapoint per worker).

so we should not document them.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
