### PR TITLE
Make LLM Obs MCP setup commands site-aware

### DIFF
--- a/content/en/llm_observability/guide/claude_code_skills.md
+++ b/content/en/llm_observability/guide/claude_code_skills.md
@@ -58,10 +58,14 @@ The skills are available in any Claude Code session after copying.
 
 To use the Datadog MCP server option, connect the Agent Observability MCP server to your Claude Code session:
 
-```shell
-claude mcp add --scope user --transport http datadog-llmo-mcp \
-  'https://mcp.datadoghq.com/v1/mcp?toolsets=llmobs'
-```
+{{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}
+<pre><code>claude mcp add --scope user --transport http datadog-llmo-mcp \
+  '{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core'</code></pre>
+{{< /site-region >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 All skills detect the MCP server automatically at startup and use it throughout.
 

--- a/content/en/llm_observability/mcp_server.md
+++ b/content/en/llm_observability/mcp_server.md
@@ -170,10 +170,14 @@ npx skills add datadog-labs/agent-skills --skill agent-observability --full-dept
 
 The skills require the `llmobs` MCP toolset to be connected. If you have not already connected it, run:
 
-```shell
-claude mcp add --scope user --transport http "datadog-llmo-mcp" \
-  'https://mcp.datadoghq.com/v1/mcp?toolsets=llmobs'
-```
+{{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}
+<pre><code>claude mcp add --scope user --transport http "datadog-llmo-mcp" \
+  '{{< region-param key="mcp_server_endpoint" >}}?toolsets=llmobs,core'</code></pre>
+{{< /site-region >}}
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">This product is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 Restart Claude Code after running both commands for the skills to appear.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0def1525-d419-44d1-b6ef-4d744020ad5b","source":"chat","resourceId":"4cd35760-bec0-4010-a85e-66f0c3aa10b9","workflowId":"82e248e9-4fe6-4204-829b-288d933d299d","codeChangeId":"82e248e9-4fe6-4204-829b-288d933d299d","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The in-product MCP setup commands were changed by https://github.com/DataDog/web-ui/pull/330414 from a hardcoded US1-only URL (`https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=llmobs,core`) to a site-aware dynamic URL pattern (`https://mcp.{site}/v1/mcp?toolsets=llmobs,core`), and the UI now always emits the `core` toolset alongside `llmobs`. This updates the docs to match.

### Changes

- `content/en/llm_observability/mcp_server.md` (Agent skills → Install): replaced the hardcoded US1 `claude mcp add` command with a `{{< region-param key="mcp_server_endpoint" >}}`-based command wrapped in a `{{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}` block, updated the toolsets query string to `llmobs,core`, and added a `{{< site-region region="gov,gov2" >}}` unsupported-site alert — consistent with the rest of the page.
- `content/en/llm_observability/guide/claude_code_skills.md` (Datadog MCP server): applied the same site-region–aware command, `llmobs,core` toolsets, and gov/gov2 unsupported-site alert.

### Testing / validation

- Verified the new blocks use the exact `<pre><code>` + `{{< region-param >}}` + `{{< site-region >}}` shortcode convention already used elsewhere on `mcp_server.md` (so the endpoint renders per selected Datadog site rather than being hardcoded).
- Confirmed no remaining hardcoded `mcp.datadoghq.com` MCP URLs in the two edited sections.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Datadog's AI coding agent), reviewed manually.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4cd35760-bec0-4010-a85e-66f0c3aa10b9)

Comment @datadog to request changes