### PR TITLE
Update permissions needed to query DD costs

### DIFF
--- a/content/en/cloud_cost_management/datadog_costs.md
+++ b/content/en/cloud_cost_management/datadog_costs.md
@@ -39,7 +39,8 @@ After Datadog Costs is enabled, users need the following permission to view the 
 
 | Permission | Description | Available Roles |
 |------------|-------------|-----------------|
-| `cloud_cost_management_read` | Read access to Cloud Cost Management. **Required to view Datadog Costs data in Cloud Cost Management.** | • Datadog Admin<br>• Datadog Read Only (default) |
+| `billing_read` | Read access to billing information. | • Datadog Admin |
+| `usage_read` | Read access to usage data. | • Datadog Admin |
 
 ## Enabling Datadog Costs
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Updates the public documentation that billing_read and usage_read permissions are required to query DD costs, no longer just cloud_cost_management_read.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
