### PR TITLE
Fix stale feature flag reference in OTel span type mapping docs

### DIFF
--- a/content/en/opentelemetry/mapping/semantic_mapping.md
+++ b/content/en/opentelemetry/mapping/semantic_mapping.md
@@ -174,7 +174,7 @@ Based on the attributes included in your span, the Datadog Agent and Datadog Ope
 
 ### Map OpenTelemetry span attribute to Datadog span type
 
-The following table shows the span type mapping logic that is used if the feature flag `enable_receive_resource_spans_v2` is set in the Datadog Agent or both the Datadog Exporter and Connector, if using the OpenTelemetry Collector. The chart lists mappings in order of precedence.  
+The following table shows the default span type mapping logic. This behavior is used unless the feature flag `disable_receive_resource_spans_v2` is set in the Datadog Agent, or in the Datadog Exporter and Connector if using OpenTelemetry Collector. The chart lists mappings in order of precedence.  
 | # | Span Attribute | Datadog span.type |
 |---|----------------|-------------------|
 | 1 | `span.type` | `span.type` attribute value |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The span type mapping page referenced `enable_receive_resource_spans_v2` as an opt-in feature flag. That flag was renamed and its polarity flipped to `disable_receive_resource_spans_v2` — the v2 span type mapping logic is now the default (opt-out) behavior, not something you opt into. This updates the docs to match current behavior.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes