### PR TITLE
[DOCS-15218] Incorporate feedback on Configure Custom Logs page

### DIFF
--- a/content/en/agent/fleet_automation/configure_agents.md
+++ b/content/en/agent/fleet_automation/configure_agents.md
@@ -16,7 +16,7 @@ Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at 
 ## Prerequisites
 
 - [Remote Configuration][9] enabled for your organization
-- Agent version 7.73+ for Agent and OTel Collector configuration (version 7.76+ for configuring integrations and secrets)
+- Agent version 7.73+ for Agent and OTel Collector configuration (version 7.76+ for configuring integrations and secrets). To upgrade your Agents, see [Upgrade Agents][10].
 - Linux VMs installed with the install script or Ansible Datadog Role, or Windows VMs
 
 <div class="alert alert-info">
@@ -97,3 +97,4 @@ For instructions on using mirrored or air-gapped repositories, see:
 [7]: /containers/guide/sync_container_images/
 [8]: /agent/guide/installing-the-agent-on-a-server-with-limited-internet-connectivity/
 [9]: /agent/guide/setup_remote_config
+[10]: /agent/fleet_automation/upgrade_agents/

--- a/content/en/agent/fleet_automation/configure_integrations.md
+++ b/content/en/agent/fleet_automation/configure_integrations.md
@@ -34,7 +34,7 @@ Custom checks are **not** supported.
 
 ## Configure integrations across multiple Agents
 
-<div class="alert alert-tip">As you step through the configuration wizard, the <strong>Configuration Summary</strong> panel shows your current selected scope of Agents. Use this to check how a change would affect an Agent by previewing configuration diffs on a specific Agent in scope.</a></div>
+<div class="alert alert-tip">As you step through the configuration wizard, the <strong>Configuration Summary</strong> panel shows your current selected scope of Agents. Use this to check how a change would affect an Agent by previewing configuration diffs on a specific Agent in scope.</div>
 
 1. In Fleet Automation, open the [{{< ui >}}Configuration{{< /ui >}}][3] tab and click {{< ui >}}Configure Agents{{< /ui >}}.
 1. Scope the configuration to the target Agents. Filter by host information or tags to target a specific group.

--- a/content/en/agent/fleet_automation/configure_integrations.md
+++ b/content/en/agent/fleet_automation/configure_integrations.md
@@ -19,7 +19,7 @@ Fleet Automation can deploy, update, and remove [integration][1] configuration f
 ## Prerequisites
 
 - [Remote Configuration][2] enabled for your organization
-- Agent version 7.76 or later
+- Agent version 7.76 or later. To upgrade your Agents, see [Upgrade Agents][6].
 - Linux VMs (installed with the install script or the Ansible Datadog Role) or Windows VMs
 
 <div class="alert alert-info">
@@ -77,3 +77,4 @@ Each operation applies changes to the integration's `conf.d` configuration file 
 [3]: https://app.datadoghq.com/fleet/agent-management
 [4]: https://app.datadoghq.com/fleet/deployments
 [5]: https://www.rfc-editor.org/rfc/rfc7386
+[6]: /agent/fleet_automation/upgrade_agents/

--- a/content/en/agent/fleet_automation/configure_logs.md
+++ b/content/en/agent/fleet_automation/configure_logs.md
@@ -30,6 +30,7 @@ Use [Fleet Automation][2] to manage [custom log collection][4] settings on your 
 - [Remote Configuration][1] enabled for your organization
 - Agent version 7.76 or later. To upgrade your Agents, see [Upgrade Agents][5].
 - Linux VMs (installed with the install script or the Ansible Datadog Role) or Windows VMs
+- Log collection enabled on the target Agents (`logs_enabled: true` in `datadog.yaml`). Fleet Automation deploys the configuration file either way, but the Agent does not start collecting logs until log collection is enabled. See [Host Agent Log Collection][8].
 
 <div class="alert alert-info">
 Configuring custom logs on Agents in containerized workloads is not supported. For containerized environments, see <a href="/containers/kubernetes/log/">Kubernetes Log Collection</a>.
@@ -67,8 +68,8 @@ Each operation applies changes to custom log collection on an Agent differently:
 
 After you deploy a configuration:
 
-1. <TODO>
-2. ...
+1. In [Fleet Automation][9], open the details page for one of the targeted Agents.
+1. In the {{< ui >}}Configuration{{< /ui >}} tab, confirm that the new or updated custom log configuration file is listed with no error status. This means the configuration was pushed and applied successfully.
 
 If the deployment succeeded but no logs arrive, see the [Log Collection Troubleshooting Guide][7].
 
@@ -83,3 +84,5 @@ If the deployment succeeded but no logs arrive, see the [Log Collection Troubles
 [5]: /agent/fleet_automation/upgrade_agents/
 [6]: /getting_started/tagging/assigning_tags/
 [7]: /logs/guide/log-collection-troubleshooting-guide/
+[8]: /agent/logs/
+[9]: https://app.datadoghq.com/fleet

--- a/content/en/agent/fleet_automation/configure_logs.md
+++ b/content/en/agent/fleet_automation/configure_logs.md
@@ -1,7 +1,6 @@
 ---
 title: Configure Custom Logs
 description: "Remotely configure custom log collection at scale with Fleet Automation."
-private: true
 further_reading:
 - link: "/agent/fleet_automation/"
   tag: "Documentation"
@@ -15,31 +14,37 @@ further_reading:
 - link: "/api/latest/fleet-automation/"
   tag: "Documentation"
   text: "Fleet Automation API"
+- link: "/agent/logs/"
+  tag: "Documentation"
+  text: "Host Agent Log Collection"
+- link: "/logs/guide/log-collection-troubleshooting-guide/"
+  tag: "Documentation"
+  text: "Log Collection Troubleshooting Guide"
 site_support_id: fleet-automation-standard-features
 ---
 
-Use [Fleet Automation][2] to manage custom log collection settings on your Agents remotely at scale.
+Use [Fleet Automation][2] to manage [custom log collection][4] settings on your Agents remotely at scale. Instead of editing `conf.d` configuration files host by host, scope a change by host information or tag and deploy it to all matching Agents at once. Before deploying, review the configuration diff for each Agent in scope.
 
 ## Prerequisites
 
 - [Remote Configuration][1] enabled for your organization
-- Agent version 7.76 or later
+- Agent version 7.76 or later. To upgrade your Agents, see [Upgrade Agents][5].
 - Linux VMs (installed with the install script or the Ansible Datadog Role) or Windows VMs
 
 <div class="alert alert-info">
-Configuring custom logs on Agents in containerized workloads is not supported.
+Configuring custom logs on Agents in containerized workloads is not supported. For containerized environments, see <a href="/containers/kubernetes/log/">Kubernetes Log Collection</a>.
 </div>
 
 ## Configure custom logs across multiple Agents
 
-<div class="alert alert-tip">As you step through the configuration wizard, the <strong>Configuration Summary</strong> panel shows your current selected scope of Agents. Use this to check how a change would affect an Agent by previewing configuration diffs on a specific Agent in scope.</a></div>
+<div class="alert alert-tip">As you step through the configuration wizard, the <strong>Configuration Summary</strong> panel shows your current selected scope of Agents. Use this to check how a change would affect an Agent by previewing configuration diffs on a specific Agent in scope.</div>
 
 1. In Fleet Automation, open the [{{< ui >}}Configuration{{< /ui >}}][2] tab and click {{< ui >}}Configure Agents{{< /ui >}}.
 1. Scope the configuration to the target Agents. Filter by host information or tags to target a specific group.
 1. Choose {{< ui >}}Custom Logs{{< /ui >}}.
 1. Select an operation (for more information, see [How configuration changes are applied](#how-configuration-changes-are-applied)):
 
-    - {{< ui >}}Add New{{< /ui >}}. Specify the filename for the new configuration file, and fill in the configuration as prompted. You can add additional log collection settings by clicking {{< ui >}}+ Add Log Collection{{< /ui >}}.
+    - {{< ui >}}Add New{{< /ui >}}. Specify the filename for the new configuration file, and fill in the configuration as prompted. For an explanation of the log collection fields, see [Custom log collection][4]. Use the {{< ui >}}Tags{{< /ui >}} field to attach [tags][6] to the collected logs. Click {{< ui >}}+ Add Log Collection{{< /ui >}} to add more log collection settings.
     - {{< ui >}}Edit & Replace{{< /ui >}}. Click {{< ui >}}Select a File{{< /ui >}} and choose the configuration file you want to replace, then update the log collection settings.
     - {{< ui >}}Delete{{< /ui >}}. Click {{< ui >}}Select a File to Delete{{< /ui >}}.
 
@@ -58,6 +63,15 @@ Each operation applies changes to custom log collection on an Agent differently:
 
 - {{< ui >}}Delete{{< /ui >}}: Removes the configuration file from the target Agents.
 
+## Verify log collection
+
+After you deploy a configuration:
+
+1. <TODO>
+2. ...
+
+If the deployment succeeded but no logs arrive, see the [Log Collection Troubleshooting Guide][7].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -65,3 +79,7 @@ Each operation applies changes to custom log collection on an Agent differently:
 [1]: /agent/guide/setup_remote_config
 [2]: https://app.datadoghq.com/fleet/agent-management
 [3]: https://app.datadoghq.com/fleet/deployments
+[4]: /agent/logs/?tab=tailfiles#custom-log-collection
+[5]: /agent/fleet_automation/upgrade_agents/
+[6]: /getting_started/tagging/assigning_tags/
+[7]: /logs/guide/log-collection-troubleshooting-guide/

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -63,6 +63,8 @@ Datadog Agent v6 can collect logs and forward them to Datadog from files, the ne
 
 If there are permission errors, see [Permission issues tailing log files][10] to troubleshoot.
 
+To deploy custom log collection configuration to multiple Agents at once without editing files on each host, see [Configure Custom Logs][15] with Fleet Automation.
+
 Below are examples of custom log collection setup:
 
 {{< tabs >}}
@@ -264,3 +266,4 @@ For both file and journald tailer types, if an `end` or `beginning` position is 
 [12]: /getting_started/tagging/unified_service_tagging
 [13]: /metrics/custom_metrics/#overview
 [14]: /getting_started/tagging/
+[15]: /agent/fleet_automation/configure_logs/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15218

Incorporates some post-merge feedback on the new [Configure Custom Logs](https://docs.datadoghq.com/agent/fleet_automation/configure_logs/) topic from https://github.com/DataDog/documentation/pull/38049. 

- Added some extra context to the intro
- Added backlinks for context: 
    - Link from a few places to how to upgrade your Agents
    - Link to learn more about what the different log collection fields do
    - In the warning that containerized workflows aren't supported, link to docs on Kubernetes log collection
- Added steps for verifying that log collection config deploy worked
- (small) Removed a couple stray `</a>` tags that I noticed

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[RESOLVED - thanks all!] Open questions (cc @ethandebnath7702):

~~- Does the Agent need a restart after Fleet Automation pushes log configuration, the way the manual `conf.d` flow does?~~
~~- Does a pushed configuration take effect on an Agent that still has `logs_enabled: false`? If not, log collection belongs in Prerequisites.~~