### PR TITLE
Synthetics: document use-site variable filters ({{ var | filter }})

### DIFF
--- a/layouts/shortcodes/synthetics-variables.en.md
+++ b/layouts/shortcodes/synthetics-variables.en.md
@@ -27,3 +27,21 @@ To create a local variable, click **+ All steps > Variables**. You can select on
 : Injects the Result ID of your test run.
 
 To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.
+
+### Apply filters to variable values
+
+When you reference a variable, you can transform its resolved value by appending a filter with a pipe (`|`). Use the syntax &#x7b;&#x7b; VARIABLE_NAME | filter &#x7d;&#x7d; anywhere a variable is accepted, such as the URL, request body, headers, and assertions. The following filters are available:
+
+&#x7b;&#x7b; VARIABLE_NAME | urlEncode &#x7d;&#x7d;
+: URL-encodes the variable's value. For example, `hello world` becomes `hello%20world`.
+
+&#x7b;&#x7b; VARIABLE_NAME | urlDecode &#x7d;&#x7d;
+: URL-decodes the variable's value. For example, `hello%20world` becomes `hello world`.
+
+&#x7b;&#x7b; VARIABLE_NAME | base64Encode &#x7d;&#x7d;
+: Base64-encodes the variable's value. For example, `hello` becomes `aGVsbG8=`.
+
+&#x7b;&#x7b; VARIABLE_NAME | base64Decode &#x7d;&#x7d;
+: Base64-decodes the variable's value. For example, `aGVsbG8=` becomes `hello`.
+
+Filters apply to both local and global variables. You can apply one filter per reference, and filter names are case-sensitive.

--- a/layouts/shortcodes/synthetics-variables.en.md
+++ b/layouts/shortcodes/synthetics-variables.en.md
@@ -26,7 +26,7 @@ To create a local variable, click **+ All steps > Variables**. You can select on
 &#x7b;&#x7b; result-id &#x7d;&#x7d;
 : Injects the Result ID of your test run.
 
-To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.
+To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. After you have defined the variable string, click **Add Variable**.
 
 ### Apply filters to variable values
 


### PR DESCRIPTION
[Direct link to PREVIEW
](https://docs-staging.datadoghq.com/francesco.infante/synthetics-variable-filters/synthetics/api_tests/http_tests/?tab=requestoptions#apply-filters-to-variable-values)

### What does this PR do? What is the motivation?

Documents a new Synthetic Monitoring capability: **use-site variable filters**. When you reference a variable in a test, you can now pipe its resolved value through a filter to transform it before it is injected into the request — for example `{{ TOKEN | urlEncode }}`.

Four filters are supported: `urlEncode`, `urlDecode`, `base64Encode`, and `base64Decode`. They work for both local and global variables and across all test types, which is why the docs live in the shared `synthetics-variables` shortcode (included by the HTTP, multistep, browser, mobile, gRPC, SSL, TCP, UDP, WebSocket, DNS, and ICMP test pages).

### Merge readiness

- [x] Ready for merge
<!-- Hold until the feature is generally available in production. Frontend enablement: DataDog/web-ui#325187. -->
