### PR TITLE
Add missing Case Management integrations

### DIFF
--- a/content/en/incident_response/case_management/create_case.md
+++ b/content/en/incident_response/case_management/create_case.md
@@ -39,6 +39,13 @@ You can also create cases manually from the following products:
 | Cloud Cost Management | Click into a cost recommendation to open its side panel. Then, click **Create case**. |
 | Sensitive Data Scanner | Click **Create case** next to a Sensitive Data Scanner issue.  |
 | Slack  | Click the **Create Case** button under a monitor notification in Slack.  |
+| Continuous Profiler | Click into a profiling insight to open its detail panel. Then, click **Add Case**. |
+| APM Recommendations | Click into a recommendation to open its side panel. Then, click **Add Case**. |
+| Database Monitoring | Click into a database recommendation to open its side panel. Click the **Actions** dropdown menu and select **Create Case**. |
+| CI Visibility | In the flaky tests table, click a test's actions menu and select **Create Case**. |
+| Code Security | Click **Add Ticket** next to a vulnerability, and select **Case Management** from the ticketing app list. |
+| Cloud Network Monitoring | In Cloud Network, click into a table row (for example, under DNS, TLS Certificates, or Security Groups) to open its side panel. Then, click **Create Case**. |
+| Cloud SIEM | On the Cloud SIEM **Cases** page, click **New Case**. |
 
 ## Automatic case creation
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

A number of Datadog products have recently integrated with Case Management and are missing from the documentation.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used this initial prompt:
>  I noticed that the "You can also create cases manually from the following products" section of Datadog's documentation about case management (https://docs.datadoghq.com/incident_response/case_management/create_case/) was missing some products, for example Continuous Profiler. Could you fill out missing entries in that table by going through all products that have integrated with Case Management? Check the web-ui code to figure out missing products and corresponding instructions, and modify the documentation file. Both repositories are checked out in my workspace.

Manually reviewed and edited product-specific instructions.
