### PR TITLE
[DOIO-12] Add Hightouch to Data Observability documentation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5366,6 +5366,11 @@ menu:
       identifier: elt_integrations_fivetran
       parent: elt_integrations
       weight: 1000000
+    - name: Hightouch
+      url: data_observability/quality_monitoring/elt/hightouch
+      identifier: elt_integrations_hightouch
+      parent: elt_integrations
+      weight: 1500000
     - name: Business Intelligence Integrations
       url: data_observability/quality_monitoring/business_intelligence
       identifier: business_intelligence_integrations

--- a/content/en/data_observability/lineage.md
+++ b/content/en/data_observability/lineage.md
@@ -23,7 +23,7 @@ further_reading:
 
 Lineage shows how data flows through your stack—from source systems and warehouse tables, through transformations and jobs, to the dashboards and applications that consume it. Use it to trace quality issues to their root cause, assess the blast radius of a failing job or a planned schema change, and route incidents to the right owner.
 
-Datadog builds lineage automatically from metadata collected through your [Quality Monitoring][1] and [Jobs Monitoring][2] integrations (Snowflake, BigQuery, Databricks, dbt, Airflow, Fivetran, Looker, Tableau, and others). Anything in the Data Observability Catalog can appear in the graph.
+Datadog builds lineage automatically from metadata collected through your [Quality Monitoring][1] and [Jobs Monitoring][2] integrations (Snowflake, BigQuery, Databricks, dbt, Airflow, Fivetran, Hightouch, Looker, Tableau, and others). Anything in the Data Observability Catalog can appear in the graph.
 
 {{< img src="data_observability/lineage/lineage-overview.png" alt="The Lineage page showing upstream and downstream dependencies for an anchored Snowflake table" style="width:100%;" >}}
 

--- a/content/en/data_observability/quality_monitoring/_index.md
+++ b/content/en/data_observability/quality_monitoring/_index.md
@@ -59,6 +59,7 @@ With Quality Monitoring, you can:
 {{< whatsnext desc="Trace lineage from these ELT tools:" >}}
    {{< nextlink href="data_observability/quality_monitoring/elt/airbyte" >}}Airbyte{{< /nextlink >}}
    {{< nextlink href="data_observability/quality_monitoring/elt/fivetran" >}}Fivetran{{< /nextlink >}}
+   {{< nextlink href="data_observability/quality_monitoring/elt/hightouch" >}}Hightouch{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Track downstream impact in these BI tools:" >}}

--- a/content/en/data_observability/quality_monitoring/elt/_index.md
+++ b/content/en/data_observability/quality_monitoring/elt/_index.md
@@ -11,7 +11,7 @@ further_reading:
 
 Datadog Data Observability connects to your ELT (Extract, Load, Transform) tools to help you understand how data flows from external sources into your data warehouse.
 
-By integrating with tools like Fivetran and Airbyte, Datadog automatically ingests metadata about connectors and schema mappings, and builds end-to-end column-level lineage between your source systems and destination warehouse tables. This enables data teams to trace data quality issues back to their origin and understand the impact of upstream source changes.
+By integrating with tools like Fivetran and Airbyte, Datadog automatically ingests metadata about connectors and schema mappings, and builds end-to-end column-level lineage between your source systems and destination warehouse tables. Reverse-ETL tools like Hightouch flow in the opposite direction: Datadog ingests metadata about their syncs and destinations to trace lineage from your warehouse tables out to downstream systems. Together, these integrations enable data teams to trace data quality issues back to their origin and understand the impact of upstream source changes.
 
 Use these integrations to:
 - **Visualize lineage** from source tables and columns to destination warehouse tables for impact analysis
@@ -21,6 +21,7 @@ Use these integrations to:
 {{< whatsnext desc="Connect to these ELT tools:" >}}
    {{< nextlink href="data_observability/quality_monitoring/elt/airbyte" >}}Airbyte{{< /nextlink >}}
    {{< nextlink href="data_observability/quality_monitoring/elt/fivetran" >}}Fivetran{{< /nextlink >}}
+   {{< nextlink href="data_observability/quality_monitoring/elt/hightouch" >}}Hightouch{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further reading

--- a/content/en/data_observability/quality_monitoring/elt/hightouch.md
+++ b/content/en/data_observability/quality_monitoring/elt/hightouch.md
@@ -1,0 +1,54 @@
+---
+title: Hightouch
+description: Connect Hightouch to Datadog Data Observability to trace lineage from your data warehouse to downstream destinations.
+further_reading:
+  - link: '/data_observability/'
+    tag: 'Documentation'
+    text: 'Learn about Data Observability'
+---
+
+## Overview
+
+Datadog's Hightouch integration helps data teams understand how data flows from their data warehouse to downstream business tools and trace quality issues back to upstream sources. When Datadog connects, it:
+
+- Pulls metadata from your Hightouch workspace, including syncs, models, and destinations
+- Generates lineage between source warehouse tables and destination objects across all active syncs
+
+Lineage granularity depends on the sync's model type:
+
+- **Table-selector models** produce column-level lineage from the sync's field mappings.
+- **dbt models** and **raw SQL models** produce table-level lineage.
+
+Lineage is derived from all [supported data warehouse sources][4].
+
+## Connect Hightouch
+
+### Generate an API key
+
+Follow the [Hightouch API documentation][1] to generate an API key with read access to your workspace.
+
+### Add the Hightouch integration
+
+To connect Hightouch to Datadog:
+
+1. Navigate to the [Hightouch integration tile][2].
+2. Enter an **Account Name** to identify this Hightouch account in Datadog. This can be any name you choose.
+3. Enter your **API Key**.
+4. Click {{< ui >}}Save{{< /ui >}}.
+
+## What's next
+
+After your Hightouch workspace is successfully connected, Datadog refreshes Hightouch metadata every 60 minutes and derives lineage from source warehouse tables to your destination objects across all active syncs.
+
+After the initial setup, it can take up to 60 minutes for data to appear.
+
+After the metadata refresh completes, you can explore your Hightouch destinations and their upstream dependencies in the [Data Observability Catalog][3].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://hightouch.com/docs/developer-tools/api-guide#create-an-api-key
+[2]: https://app.datadoghq.com/integrations/hightouch
+[3]: https://app.datadoghq.com/data-obs/catalog
+[4]: /data_observability/quality_monitoring/data_warehouses

--- a/content/en/data_observability/quality_monitoring/elt/hightouch.md
+++ b/content/en/data_observability/quality_monitoring/elt/hightouch.md
@@ -4,7 +4,7 @@ description: Connect Hightouch to Datadog Data Observability to trace lineage fr
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
-    text: 'Learn about Data Observability'
+    text: 'Data Observability Overview'
 ---
 
 ## Overview
@@ -19,7 +19,7 @@ Lineage granularity depends on the sync's model type:
 - **Table-selector models** produce column-level lineage from the sync's field mappings.
 - **dbt models** and **raw SQL models** produce table-level lineage.
 
-Lineage is derived from all [supported data warehouse sources][4].
+Datadog derives lineage from all [supported data warehouse sources][4].
 
 ## Connect Hightouch
 
@@ -31,10 +31,10 @@ Follow the [Hightouch API documentation][1] to generate an API key with read acc
 
 To connect Hightouch to Datadog:
 
-1. Navigate to the [Hightouch integration tile][2].
-2. Enter an **Account Name** to identify this Hightouch account in Datadog. This can be any name you choose.
+1. In Datadog, navigate to the [Hightouch integration tile][2], then go to the **Configuration** tab.
+2. Enter an **Account name** to identify this Hightouch account in Datadog. This can be any name you choose.
 3. Enter your **API Key**.
-4. Click {{< ui >}}Save{{< /ui >}}.
+4. Click {{< ui >}}Create Account{{< /ui >}}.
 
 ## What's next
 
@@ -50,5 +50,5 @@ After the metadata refresh completes, you can explore your Hightouch destination
 
 [1]: https://hightouch.com/docs/developer-tools/api-guide#create-an-api-key
 [2]: https://app.datadoghq.com/integrations/hightouch
-[3]: https://app.datadoghq.com/data-obs/catalog
+[3]: https://app.datadoghq.com/data-obs/catalog?platform=hightouch
 [4]: /data_observability/quality_monitoring/data_warehouses


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOIO-12

Adds Hightouch as a supported ELT integration in the Data Observability documentation:

- **New**: `content/en/data_observability/quality_monitoring/elt/hightouch.md` — dedicated integration page (overview, API key setup, tile connection, lineage granularity by model type).
- **Modified**: `elt/_index.md` — adds a Hightouch nextlink and describes reverse-ETL lineage direction.
- **Modified**: `quality_monitoring/_index.md` — adds a Hightouch nextlink under the ELT tools section.
- **Modified**: `lineage.md` — adds Hightouch to the example integrations list.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes