### PR TITLE
Update Patterns setup docs for new config UI

### DIFF
--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -48,12 +48,11 @@ Each topic shows its interaction volume and share of total traffic. Interactions
 ## Set up a Pattern
 
 1. Click **+ New Pattern**
-2. Enter a **Pattern Name**
-3. Under **Clustering model**, select your LLM Provider, Account, and Model. These are used to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic. Supported providers are **OpenAI**, **Azure OpenAI**, and **Amazon Bedrock**.
-4. Under **Scope**, configure:
-   - **Time window:** The lookback period for interactions to analyze
-   - **Which spans do you want to cluster?:** Filter by application, environment, span type, or other tags to scope the Pattern to a specific slice of traffic.
-   - **Sampling Rate:** The percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap.
+2. Enter a **Name**
+3. Under **Model**, click the **Model** button to open the **Model configuration** modal, then select your LLM Provider, Account, and Model. These are used to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic. Supported providers are **OpenAI**, **Azure OpenAI**, and **Amazon Bedrock**.
+4. Under **Runs**, use the **Application** multi-selector to choose one or more LLM applications whose spans to include. Selecting applications automatically updates the underlying span filter query, and editing the query updates the selected applications. Also set the **Sampling Rate**: the percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap. For finer-grained scoping, click the filter icon next to the **Application** selector to open the **Advanced** popover, which exposes:
+   - **Which spans do you want to cluster?:** The raw span filter query for scoping by environment, span type, or other tags.
+   - **Time window:** The lookback period for interactions to analyze.
 5. Under **What should we detect Patterns on?**, enter a template that defines what gets sent to the model for analysis. Use {{variable}} syntax to reference any span field — for example, {{meta.input.value}} to analyze patterns by user input, or {{meta.span.kind}} to analyze by span kind. Click {{< ui >}}Template Examples{{< /ui >}} to see common configurations. As you type, the right panel previews matching spans and shows what percentage of interactions have values for the variables you've referenced.
 6. Click **Save**
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"77b65df9-7414-4fd4-a403-62bf8e4cbfda","source":"chat","resourceId":"3bcb066a-1339-4dd8-8a8b-3dd29dcf8283","workflowId":"d64a4e46-b94e-4987-a9c1-46deee425873","codeChangeId":"d64a4e46-b94e-4987-a9c1-46deee425873","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

Updates the LLM Observability Patterns setup documentation to match the revamped Patterns configuration page UI.

Why: The Patterns configuration page was redesigned (see source PR below), which renamed fields and reorganized where the model and scope settings live. The existing docs describe UI that no longer matches the product.

What changed (all within the "Set up a Pattern" section of content/en/llm_observability/monitoring/patterns.md):
- Renamed the "Pattern Name" field to "Name".
- Reworked the model step: the "Clustering model" section is now "Model", and Provider/Account/Model are now selected inside a "Model configuration" modal opened via the "Model" button. The fields themselves (including Azure OpenAI and Amazon Bedrock) are unchanged.
- Replaced the old top-level "Scope" section with the new "Runs" section: an "Application" multi-selector kept in sync with the underlying span filter query, the retained "Sampling Rate", and an "Advanced" popover (filter icon) that houses the raw span filter query ("Which spans do you want to cluster?") and "Time window".

The rest of the page (overview, how it works, explore, trigger a run, use topics) is unchanged.

Source PR requiring these doc changes: https://github.com/DataDog/web-ui/pull/333397

### Testing

Reviewed the rendered Markdown locally and confirmed the numbered steps in "Set up a Pattern" read correctly and that no other sections were modified. A Datadog preview build will generate a live preview of the page for reviewers.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code). The assistant made the targeted edits to patterns.md based on the UI changes described in the source PR and wrote this PR description.

### Additional notes

No changes outside content/en/llm_observability/monitoring/patterns.md.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3bcb066a-1339-4dd8-8a8b-3dd29dcf8283)

Comment @datadog to request changes