### PR TITLE
docs(llm-obs): combine Patterns setup docs for new Model/Runs on UI + scheduling

### DIFF
--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -47,20 +47,25 @@ Each topic shows its interaction volume and share of total traffic. Interactions
 
 ## Set up a Pattern
 
-1. Click **+ New Pattern**
-2. Enter a **Name**
-3. Under **Model**, click the **Model** button to open the **Model configuration** modal, then select your LLM Provider, Account, and Model. These are used to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic. Supported providers are **OpenAI**, **Azure OpenAI**, and **Amazon Bedrock**.
-4. Under **Runs on**, use the **Application** multi-selector to choose one or more LLM applications whose spans to include. Selecting applications automatically updates the underlying span filter query, and editing the query updates the selected applications. Also set the **Sampling Rate**: the percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap. For finer-grained scoping, click the filter icon next to the **Application** selector to open the **Advanced** popover, which exposes:
-   - **Which spans do you want to cluster?:** The raw span filter query for scoping by environment, span type, or other tags.
-   - **Time window:** The lookback period for interactions to analyze.
-5. Under **What should we detect Patterns on?**, enter a template that defines what gets sent to the model for analysis. Use {{variable}} syntax to reference any span field — for example, {{meta.input.value}} to analyze patterns by user input, or {{meta.span.kind}} to analyze by span kind. Click {{< ui >}}Template Examples{{< /ui >}} to see common configurations. As you type, the right panel previews matching spans and shows what percentage of interactions have values for the variables you've referenced.
-6. Under **How often should we run Patterns?**, choose how the Pattern runs:
+1. In Datadog, navigate to **AI Observability** > **Agent Observability** > [**Patterns**][4].
+1. Click **+ New Pattern**.
+1. Enter a **Name**.
+1. Click **Select a model**. The Model configuration window opens, where you can add details that Agent Observability uses to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic:
+   - **LLM Provider**: Supported providers are OpenAI, Amazon Bedrock, and Azure OpenAI
+   - **Account**
+   - **Model**
+1. Click **Confirm** to save your changes and close the window.
+1. Under **Runs**:
+   1. Use the **Application** multi-selector to choose one or more LLM applications to include spans for. Selecting applications automatically updates the underlying span filter query, and editing the query updates the selected applications. For finer-grained scoping, click the filter icon next to the selector to open the **Advanced** popover, which exposes:
+      - **Which spans do you want to cluster?:** The raw span filter query for scoping by environment, span type, or other tags.
+      - **Time window:** The lookback period for interactions to analyze.
+   1. Set the **Sampling Rate**: The percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, Agent Observability randomly samples records until it reaches that number.
+1. Under **What should we detect Patterns on?**, enter a template that defines what gets sent to the model for analysis. Use `{{variable}}` syntax to reference any span field; for example, `{{meta.input.value}}` to analyze patterns by user input, or `{{meta.span.kind}}` to analyze by span kind. Click {{< ui >}}Template Examples{{< /ui >}} to see common configurations. As you type, the right panel previews matching spans and shows what percentage of interactions have values for the variables you've referenced.
+1. Under **How often should we run Patterns?**, choose how the Pattern runs. Scheduled times use your Datadog timezone preference. Scheduled runs use the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
    - **On demand** (default): Run the Pattern manually.
    - **Daily**, **Weekdays**, or **Weekly**: Run automatically at a time (and, for weekly, a day) you choose.
    - **Custom**: Run automatically every 1 to 7 days.
-
-   Scheduled times use your Datadog timezone preference. Scheduled runs use the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
-7. Click **Save**
+1. Click **Create and Run Pattern**, or **Create Pattern** to create it without running it.
 
 ## Explore your Patterns
 
@@ -141,3 +146,4 @@ Re-run your Pattern periodically and use the {{< ui >}}Compare to{{< /ui >}} dro
 [1]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/connect_to_account/
 [2]: /llm_observability/experiments/datasets/
 [3]: /llm_observability/annotation_queues/
+[4]: https://app.datadoghq.com/llm/patterns

--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -55,7 +55,7 @@ Each topic shows its interaction volume and share of total traffic. Interactions
    - **Account**
    - **Model**
 1. Click **Confirm** to save your changes and close the window.
-1. Under **Runs**:
+1. Under **Runs on**:
    1. Use the **Application** multi-selector to choose one or more LLM applications to include spans for. Selecting applications automatically updates the underlying span filter query, and editing the query updates the selected applications. For finer-grained scoping, click the filter icon next to the selector to open the **Advanced** popover, which exposes:
       - **Which spans do you want to cluster?:** The raw span filter query for scoping by environment, span type, or other tags.
       - **Time window:** The lookback period for interactions to analyze.

--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -48,14 +48,19 @@ Each topic shows its interaction volume and share of total traffic. Interactions
 ## Set up a Pattern
 
 1. Click **+ New Pattern**
-2. Enter a **Pattern Name**
-3. Under **Clustering model**, select your LLM Provider, Account, and Model. These are used to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic. Supported providers are **OpenAI**, **Azure OpenAI**, and **Amazon Bedrock**.
-4. Under **Scope**, configure:
-   - **Time window:** The lookback period for interactions to analyze
-   - **Which spans do you want to cluster?:** Filter by application, environment, span type, or other tags to scope the Pattern to a specific slice of traffic.
-   - **Sampling Rate:** The percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap.
+2. Enter a **Name**
+3. Under **Model**, click the **Model** button to open the **Model configuration** modal, then select your LLM Provider, Account, and Model. These are used to generate topic names, summaries, topic hierarchy, and to attribute each interaction to a topic. Supported providers are **OpenAI**, **Azure OpenAI**, and **Amazon Bedrock**.
+4. Under **Runs on**, use the **Application** multi-selector to choose one or more LLM applications whose spans to include. Selecting applications automatically updates the underlying span filter query, and editing the query updates the selected applications. Also set the **Sampling Rate**: the percentage of matching interactions to include. Patterns processes up to 10,000 records per run; if your filter matches more than that, records are randomly sampled down to the cap. For finer-grained scoping, click the filter icon next to the **Application** selector to open the **Advanced** popover, which exposes:
+   - **Which spans do you want to cluster?:** The raw span filter query for scoping by environment, span type, or other tags.
+   - **Time window:** The lookback period for interactions to analyze.
 5. Under **What should we detect Patterns on?**, enter a template that defines what gets sent to the model for analysis. Use {{variable}} syntax to reference any span field — for example, {{meta.input.value}} to analyze patterns by user input, or {{meta.span.kind}} to analyze by span kind. Click {{< ui >}}Template Examples{{< /ui >}} to see common configurations. As you type, the right panel previews matching spans and shows what percentage of interactions have values for the variables you've referenced.
-6. Click **Save**
+6. Under **How often should we run Patterns?**, choose how the Pattern runs:
+   - **On demand** (default): Run the Pattern manually.
+   - **Daily**, **Weekdays**, or **Weekly**: Run automatically at a time (and, for weekly, a day) you choose.
+   - **Custom**: Run automatically every 1 to 7 days.
+
+   Scheduled times use your Datadog timezone preference. Scheduled runs use the same pipeline as a manual run, so results appear in the same place, and the Patterns page always shows your most recent run.
+7. Click **Save**
 
 ## Explore your Patterns
 


### PR DESCRIPTION
## Summary
- Combines the doc changes from #37951 (Pattern run scheduling) and #38524 (revamped Model / Runs on config UI) into a single, correctly-renumbered "Set up a Pattern" walkthrough.
- Uses "Runs on" (not "Runs") to match the just-shipped web-ui label rename (DataDog/web-ui#334514).

Supersedes #37951 and #38524 — those remain open pending doc-team review but their content now lives here combined and renumbered.