### PR TITLE
Update homepage AI navtile title to Agent Observability

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -103,7 +103,7 @@ nav_sections:
         link: watchdog/
         icon: watchdog
         desc: Detect and surface application and infrastructure anomalies
-      - title: LLM Observability
+      - title: Agent Observability
         link: llm_observability/
         icon: llm-observability
         desc: Trace, monitor, and secure your LLM applications


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the "LLM Observability" navtile on the docs homepage to "Agent Observability" to match the current product name.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes