### PR TITLE
Document OTel service-level DBM correlation

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -201,10 +201,6 @@ func main() {
 
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
-<div class="alert alert-warning">
-The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. Datadog recommends using <code>service</code> mode with the <code>pgx</code> driver.
-</div>
-
 {{% /tab %}}
 
 {{% tab "Java" %}}

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -202,7 +202,7 @@ func main() {
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
 <div class="alert alert-warning">
-The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. This can significantly increase latency. If your application uses <code>pgx</code> (directly or through <code>database/sql</code>) and you observe this, switch to <code>service</code> mode.
+The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. Datadog recommends using <code>service</code> mode with the <code>pgx</code> driver.
 </div>
 
 {{% /tab %}}

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -201,6 +201,10 @@ func main() {
 
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
+<div class="alert alert-warning">
+If your application uses the <code>pgx</code> driver (directly or through <code>database/sql</code>), enabling <code>full</code> propagation mode can cause a significant increase in query latency. The <code>pgx</code> driver caches prepared statements by query text. The trace context that <code>full</code> mode injects into each query makes every query text unique. This defeats the cache and forces the database to re-plan each query. If you observe increased latency after enabling <code>full</code> mode with <code>pgx</code>, switch to <code>service</code> mode.
+</div>
+
 {{% /tab %}}
 
 {{% tab "Java" %}}

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -202,7 +202,7 @@ func main() {
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
 <div class="alert alert-warning">
-If your application uses the <code>pgx</code> driver (directly or through <code>database/sql</code>), enabling <code>full</code> propagation mode can cause a significant increase in query latency. The <code>pgx</code> driver caches prepared statements by query text. The trace context that <code>full</code> mode injects into each query makes every query text unique. This defeats the cache and forces the database to re-plan each query. If you observe increased latency after enabling <code>full</code> mode with <code>pgx</code>, switch to <code>service</code> mode.
+The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. This can significantly increase latency. If your application uses <code>pgx</code> (directly or through <code>database/sql</code>) and you observe this, switch to <code>service</code> mode.
 </div>
 
 {{% /tab %}}

--- a/content/en/opentelemetry/correlate/dbm_and_traces.md
+++ b/content/en/opentelemetry/correlate/dbm_and_traces.md
@@ -156,11 +156,9 @@ After your application is sending traces, you can see the correlation in the APM
 DBM correlation for OpenTelemetry traces works at two levels:
 
 - **Statement-level correlation**: Links a query sample or execution plan to the query signature computed from `db.statement`. This works automatically after you complete the setup steps above.
-- **Service-level correlation**: Populates the {{< ui >}}Databases{{< /ui >}} tab and {{< ui >}}Calling Services{{< /ui >}} list on a database instance page, so DBM can associate a query with the specific service that issued it. This requires the query to carry a SQL comment with the service metadata.
+- **Service-level correlation**: Populates the {{< ui >}}Databases{{< /ui >}} tab and {{< ui >}}Calling Services{{< /ui >}} list on a database instance page, linking a query to the service that issued it. This requires a SQL comment containing service metadata on the query.
 
-Datadog SDKs add this comment automatically. OpenTelemetry auto-instrumentation doesn't add it. Service-level correlation doesn't happen by default for OpenTelemetry, even when statement-level correlation is working. If your database instance shows no calling services, or your APM service page shows no database section, this is expected. Add the comment yourself to enable service-level correlation.
-
-To enable service-level correlation, wrap your query text in a comment that includes your service metadata:
+Datadog SDKs add this comment automatically. OpenTelemetry auto-instrumentation doesn't, so service-level correlation requires adding the comment manually:
 
 ```
 /*dddbs='<service>',dde='<env>',ddps='<service>',ddpv='<version>'*/ SELECT * FROM users WHERE id = ?
@@ -173,9 +171,11 @@ To enable service-level correlation, wrap your query text in a comment that incl
 | `ddps`  | The parent service name.           |
 | `ddpv`  | The version of the service.        |
 
+Without this comment, a database instance shows no calling services. The APM service page shows no database section, even when statement-level correlation is working.
+
 ### Stored procedures
 
-Correlation isn't supported for stored procedure calls (for example, `CALL my_procedure()`). The span records the procedure call itself, while DBM captures the individual SQL statements the procedure runs internally. Because these two representations don't match, DBM can't link the span to the statements executed inside the procedure.
+Correlation isn't supported for stored procedure calls (for example, `CALL my_procedure()`). The span records the procedure call itself, while DBM captures the individual SQL statements the procedure runs internally. These two representations don't match, so DBM can't link the span to the statements the procedure runs.
 
 ## Troubleshooting
 
@@ -185,7 +185,7 @@ If you don't see the expected correlation between your APM traces and DBM, it's 
 - **Incorrect unified service tagging**: The `service` tag on your database spans must be set. Verify that [unified service tagging][1] is configured correctly.
 - **The SQL query may not be parsable**: The correlation relies on Datadog's ability to parse the SQL query from the `db.statement` attribute. If the query uses non-standard or complex syntax, parsing may fail. If you suspect this is the case, [contact Datadog support][5] for assistance.
 - **The correct feature gates must be enabled** for your specific trace ingestion path as described in the setup steps.
-- **No calling services or empty database section on the APM service page**: See [Correlation levels](#correlation-levels) above. This is expected for OpenTelemetry setups unless you add the service metadata comment manually.
+- **No calling services or empty database section on the APM service page**: OpenTelemetry doesn't inject SQL comments automatically. See [Correlation levels](#correlation-levels) to add them manually.
 
 ## Further reading
 

--- a/content/en/opentelemetry/correlate/dbm_and_traces.md
+++ b/content/en/opentelemetry/correlate/dbm_and_traces.md
@@ -151,6 +151,32 @@ After your application is sending traces, you can see the correlation in the APM
 3. In the trace's flame graph, select a database span (for example, a span with `span.type: sql`)
 4. In the details panel, click the {{< ui >}}SQL Queries{{< /ui >}} tab. You should see performance metrics and execution plans for the query.
 
+## Correlation levels
+
+DBM correlation for OpenTelemetry traces works at two levels:
+
+- **Statement-level correlation**: Links a query sample or execution plan to the query signature computed from `db.statement`. This works automatically after you complete the setup steps above.
+- **Service-level correlation**: Populates the {{< ui >}}Databases{{< /ui >}} tab and {{< ui >}}Calling Services{{< /ui >}} list on a database instance page, so DBM can associate a query with the specific service that issued it. This requires the query to carry a SQL comment with the service metadata.
+
+Datadog SDKs add this comment automatically. OpenTelemetry auto-instrumentation doesn't add it. Service-level correlation doesn't happen by default for OpenTelemetry, even when statement-level correlation is working. If your database instance shows no calling services, or your APM service page shows no database section, this is expected. Add the comment yourself to enable service-level correlation.
+
+To enable service-level correlation, wrap your query text in a comment that includes your service metadata:
+
+```
+/*dddbs='<service>',dde='<env>',ddps='<service>',ddpv='<version>'*/ SELECT * FROM users WHERE id = ?
+```
+
+| Field   | Description                       |
+|---------|------------------------------------|
+| `dddbs` | The name of the service issuing the query. |
+| `dde`   | The environment of the service.    |
+| `ddps`  | The parent service name.           |
+| `ddpv`  | The version of the service.        |
+
+### Stored procedures
+
+Correlation isn't supported for stored procedure calls (for example, `CALL my_procedure()`). The span records the procedure call itself, while DBM captures the individual SQL statements the procedure runs internally. Because these two representations don't match, DBM can't link the span to the statements executed inside the procedure.
+
 ## Troubleshooting
 
 If you don't see the expected correlation between your APM traces and DBM, it's typically due to a missing or incorrect configuration. Check the following common causes:
@@ -159,6 +185,7 @@ If you don't see the expected correlation between your APM traces and DBM, it's 
 - **Incorrect unified service tagging**: The `service` tag on your database spans must be set. Verify that [unified service tagging][1] is configured correctly.
 - **The SQL query may not be parsable**: The correlation relies on Datadog's ability to parse the SQL query from the `db.statement` attribute. If the query uses non-standard or complex syntax, parsing may fail. If you suspect this is the case, [contact Datadog support][5] for assistance.
 - **The correct feature gates must be enabled** for your specific trace ingestion path as described in the setup steps.
+- **No calling services or empty database section on the APM service page**: See [Correlation levels](#correlation-levels) above. This is expected for OpenTelemetry setups unless you add the service metadata comment manually.
 
 ## Further reading
 

--- a/content/en/opentelemetry/correlate/dbm_and_traces.md
+++ b/content/en/opentelemetry/correlate/dbm_and_traces.md
@@ -160,7 +160,7 @@ DBM correlation for OpenTelemetry traces works at two levels:
 
 Datadog SDKs add this comment automatically. OpenTelemetry auto-instrumentation doesn't, so service-level correlation requires adding the comment manually:
 
-```
+```sql
 /*dddbs='<service>',dde='<env>',ddps='<service>',ddpv='<version>'*/ SELECT * FROM users WHERE id = ?
 ```
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for OpenTelemetry service-level vs. statement-level APM<>DBM correlation, which wasn't previously covered in public docs.

Clarifies that statement-level correlation works automatically for OTel setups, but service-level correlation (Calling Services, Databases tab) requires a SQL comment with service metadata that OTel auto-instrumentation doesn't add by default. Documents the comment format needed to enable it manually, and notes that stored procedure calls aren't supported for correlation.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes