### PR TITLE
Document pgx driver latency caveat with full DBM propagation mode

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -201,6 +201,10 @@ func main() {
 
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
+<div class="alert alert-warning">
+The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. Datadog recommends using <code>service</code> mode with the <code>pgx</code> driver.
+</div>
+
 {{% /tab %}}
 
 {{% tab "Java" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a callout to the Go tab of Connect DBM and APM warning about a latency regression when using the `pgx` driver with `full` propagation mode.

`pgx` caches prepared statements by query text. Because `full` mode injects unique trace context into each query, it defeats this cache and forces the database to re-plan every query. Recommends `service` mode as a workaround.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes