### PR TITLE
Document the workflow run-as identity, including run as initiator

### DIFF
--- a/content/en/actions/workflows/access_and_auth.md
+++ b/content/en/actions/workflows/access_and_auth.md
@@ -36,10 +36,10 @@ A workflow can run as one of the following identities:
 : The workflow runs as its owner, and any editor of the workflow can access the same resources as the owner. A new workflow runs as its owner by default.
 
 {{< ui >}}Initiator{{< /ui >}}
-: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for triggers that have an end user.
+: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for [triggers][4] that have an end user.
 
 {{< ui >}}Service Account{{< /ui >}}
-: The workflow runs as a service account associated with the workflow. Use a service account for workflows with [automated triggers][4], so that runs don't depend on the permissions of an individual user.
+: The workflow runs as a service account associated with the workflow. Use a service account to control the exact permissions a run has, with roles you choose for the workflow.
 
 ### Set the workflow identity
 
@@ -70,9 +70,11 @@ The initiator resolves the connections defined in the workflow actions. Each use
 
 ### Run as a service account
 
-When a workflow runs as a service account, every run uses that account's identity, whoever triggers it. Attach an existing service account to the workflow, or create a service account when you set the identity. A service account you create adopts your roles and permissions. For more information, see [Service accounts][2] or [Role based access control][3].
+When a workflow runs as a service account, every run uses that account's identity, whoever triggers it. Because you choose which roles the service account has, you control the exact permissions a run has, independently of any user's permissions.
 
-The service account resolves the connections defined in the workflow actions. It needs the `connections_resolve` permission, plus {{< ui >}}Resolver{{< /ui >}} access to each connection the workflow uses.
+Attach an existing service account to the workflow, or create a service account when you set the identity. When you create one, you select its roles. You can assign any subset of the roles you have. With the {{< ui >}}User Access Manage{{< /ui >}} permission, you can assign any role in your organization. For more information, see [Service accounts][2] or [Role based access control][3].
+
+The service account resolves the connections defined in the workflow actions. It needs a role with the `workflows_run` and `connections_resolve` permissions, plus {{< ui >}}Resolver{{< /ui >}} access to each connection the workflow uses.
 
 ## Action credentials
 

--- a/content/en/actions/workflows/access_and_auth.md
+++ b/content/en/actions/workflows/access_and_auth.md
@@ -33,13 +33,13 @@ Every run of a workflow uses a single Datadog identity, controlled by the workfl
 A workflow can run as one of the following identities:
 
 {{< ui >}}Owner{{< /ui >}}
-: The workflow runs as its owner, and any editor of the workflow can access the same resources as the owner. If ownership of the workflow is transferred, the identity changes with it. A new workflow runs as its owner by default.
+: The workflow runs as its owner, and any editor of the workflow can access the same resources as the owner. A new workflow runs as its owner by default.
 
 {{< ui >}}Initiator{{< /ui >}}
-: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for triggers that identify a user.
+: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for triggers that have an end user.
 
 {{< ui >}}Service Account{{< /ui >}}
-: The workflow runs as a service account associated with the workflow. Use a service account for workflows with automated triggers, so that runs don't depend on the permissions of an individual user.
+: The workflow runs as a service account associated with the workflow. Use a service account for workflows with [automated triggers][4], so that runs don't depend on the permissions of an individual user.
 
 ### Set the workflow identity
 
@@ -54,64 +54,25 @@ The following restrictions apply:
 - Only the owner of the workflow can select {{< ui >}}Owner{{< /ui >}} or {{< ui >}}Initiator{{< /ui >}}.
 - To select {{< ui >}}Service Account{{< /ui >}}, you need either the Datadog admin role, or a custom role with the {{< ui >}}Service Account Write{{< /ui >}} permission.
 
-To see the identity a workflow uses, hover over the workflow name in the editor and read the {{< ui >}}Run as{{< /ui >}} field. For a workflow that runs as the initiator, the field reads {{< ui >}}Run as initiator{{< /ui >}}, because the identity is resolved at runtime.
+To see the identity a workflow uses, hover over the workflow name in the editor and read the {{< ui >}}Run as{{< /ui >}} field.
+
+### Run as the owner
+
+When a workflow runs as its owner, every run uses the owner's identity, whoever triggers it. A run can use the connections and Datadog resources the owner can access, even when the user who triggered it cannot access them.
+
+The owner resolves the connections defined in the workflow actions. The owner needs the `connections_resolve` permission, plus {{< ui >}}Resolver{{< /ui >}} access to each connection the workflow uses.
 
 ### Run as the initiator
 
-When a workflow runs as the initiator, each run uses the identity of the user who triggered it. The run can only use the connections and Datadog resources that this user can access, and the actions the workflow takes are attributed to them. For example, if the workflow declares an incident, the incident is created by the user who triggered the workflow.
+When a workflow runs as the initiator, each run uses the identity of the user who triggered it. A run can only use the connections and Datadog resources that this user can access, and the actions the workflow takes are attributed to them. For example, if the workflow declares an incident, the incident is created by the user who triggered the workflow.
 
-The initiator resolves the connections defined in the workflow actions. Therefore, each user who triggers the workflow needs the `connections_resolve` permission, as well as {{< ui >}}Resolver{{< /ui >}} access to every connection the workflow uses. The Datadog Admin Role and the Datadog Standard Role include the `connections_resolve` permission.
+The initiator resolves the connections defined in the workflow actions. Each user who triggers the workflow needs the `connections_resolve` permission, plus {{< ui >}}Resolver{{< /ui >}} access to each connection the workflow uses.
 
-Set a workflow to run as the initiator only if each of its [triggers][11] identifies a user:
-- Manual runs, where a user clicks {{< ui >}}Run{{< /ui >}} on the workflow
-- Dashboard, notebook, Software Catalog, and Database Monitoring triggers
-- Slack messages and emoji reactions
-- API triggers, where the initiator is the owner of the application key used in the request
-- [App Builder][12] apps and custom agents in [Bits Agent Builder][13], where the initiator is the identity the app or agent runs as
-- AI agents using the [Datadog MCP server][14]
+### Run as a service account
 
-Every other trigger can start a run without a user, and a run without an initiator fails. This includes schedules, incoming webhooks, monitor notifications, security notification rules, incident automation, case automation, On-Call events, and Cloud Cost Management automation. [Forms][15] are also unsupported, because a user who isn't a member of your Datadog organization can submit a form. Keep workflows with those triggers set to {{< ui >}}Owner{{< /ui >}} or {{< ui >}}Service Account{{< /ui >}}.
+When a workflow runs as a service account, every run uses that account's identity, whoever triggers it. Attach an existing service account to the workflow, or create a service account when you set the identity. A service account you create adopts your roles and permissions. For more information, see [Service accounts][2] or [Role based access control][3].
 
-### Use a service account
-
-A service account can be associated with a workflow and act as the identity of the workflow when it runs. A service account can:
-- resolve the connections defined in the workflow actions at runtime
-- provide an identity for workflow executions
-- provide an identity for workflow [audit trails][1]
-
-To create a service account for a workflow, you must have either the Datadog admin role, or a custom role with the {{< ui >}}Service Account Write{{< /ui >}} permission. The service account you create adopts your role and permissions. For more information on service accounts and permissions, see [Service accounts][2] or [Role based access control][3].
-
-#### Associate a service account with a workflow
-
-You can dynamically create a service account for your workflow, for example when you [add an automatic trigger][4].
-
-1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Edit permissions{{< /ui >}}.
-1. Under {{< ui >}}Run as{{< /ui >}}, click {{< ui >}}Service Account{{< /ui >}}.
-1. In the {{< ui >}}Create or Select Service account{{< /ui >}} dialog, select one or more roles for your service account user and click {{< ui >}}Create{{< /ui >}}. To use an existing service account instead, click {{< ui >}}Existing Service Account{{< /ui >}}, select the account, and click {{< ui >}}Select{{< /ui >}}.
-1. Click {{< ui >}}Save{{< /ui >}} to save the service account and apply the changes.
-
-When you run a workflow, the service account user resolves the connections defined in the workflow actions. Therefore, the service account user needs the `connections_resolve` permission. The Datadog Admin Role and the Datadog Standard Role include the `connections_resolve` permission.
-
-#### View service account details
-
-1. In the workflow editor, hover over the workflow name.
-1. Click your service account under {{< ui >}}Run as{{< /ui >}}.
-
-#### Change the service account associated with a workflow
-
-1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Edit permissions{{< /ui >}}.
-1. Under {{< ui >}}Run as{{< /ui >}}, click {{< ui >}}Change{{< /ui >}}.
-1. Select another service account and click {{< ui >}}Select{{< /ui >}}.
-1. Click {{< ui >}}Save{{< /ui >}}.
-
-#### Remove a service account associated with a workflow
-
-1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Edit permissions{{< /ui >}}.
-1. Under {{< ui >}}Run as{{< /ui >}}, select {{< ui >}}Owner{{< /ui >}}.
-1. Click {{< ui >}}Save{{< /ui >}}.
+The service account resolves the connections defined in the workflow actions. It needs the `connections_resolve` permission, plus {{< ui >}}Resolver{{< /ui >}} access to each connection the workflow uses.
 
 ## Action credentials
 
@@ -207,8 +168,3 @@ You can restrict access on a specific workflow either from the workflow list pag
 [8]: https://app.datadoghq.com/workflow
 [9]: https://chat.datadoghq.com/
 [10]: /actions/private_actions/
-[11]: /actions/workflows/trigger/
-[12]: /actions/app_builder/
-[13]: /actions/agents/
-[14]: /mcp_server/
-[15]: /actions/forms/

--- a/content/en/actions/workflows/access_and_auth.md
+++ b/content/en/actions/workflows/access_and_auth.md
@@ -25,7 +25,52 @@ A few tools control access and authentication for workflows and their components
 
 ## Workflow identity
 
-A workflow can run using the identity of the owner of the workflow, or a service account associated with the workflow. By default, a workflow uses the Datadog user identity of its author.
+Every run of a workflow uses a single Datadog identity, controlled by the workflow's {{< ui >}}Run as{{< /ui >}} setting. That identity determines:
+- which [connections][6] a run can resolve, including connections that use [private action runners][10]
+- which Datadog resources a run can read and modify
+- which user the actions in a run are attributed to, in [audit trails][1] and in the products those actions touch
+
+A workflow can run as one of the following identities:
+
+{{< ui >}}Owner{{< /ui >}}
+: The workflow runs as its owner, and any editor of the workflow can access the same resources as the owner. If ownership of the workflow is transferred, the identity changes with it. A new workflow runs as its owner by default.
+
+{{< ui >}}Initiator{{< /ui >}}
+: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for triggers that identify a user.
+
+{{< ui >}}Service Account{{< /ui >}}
+: The workflow runs as a service account associated with the workflow. Use a service account for workflows with automated triggers, so that runs don't depend on the permissions of an individual user.
+
+### Set the workflow identity
+
+Select an identity when you publish a workflow, or change it at any time:
+
+1. In the workflow editor, click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
+1. Click {{< ui >}}Edit permissions{{< /ui >}}.
+1. Under {{< ui >}}Run as{{< /ui >}}, select {{< ui >}}Owner{{< /ui >}}, {{< ui >}}Initiator{{< /ui >}}, or {{< ui >}}Service Account{{< /ui >}}.
+1. Click {{< ui >}}Save{{< /ui >}}.
+
+The following restrictions apply:
+- Only the owner of the workflow can select {{< ui >}}Owner{{< /ui >}} or {{< ui >}}Initiator{{< /ui >}}.
+- To select {{< ui >}}Service Account{{< /ui >}}, you need either the Datadog admin role, or a custom role with the {{< ui >}}Service Account Write{{< /ui >}} permission.
+
+To see the identity a workflow uses, hover over the workflow name in the editor and read the {{< ui >}}Run as{{< /ui >}} field. For a workflow that runs as the initiator, the field reads {{< ui >}}Run as initiator{{< /ui >}}, because the identity is resolved at runtime.
+
+### Run as the initiator
+
+When a workflow runs as the initiator, each run uses the identity of the user who triggered it. The run can only use the connections and Datadog resources that this user can access, and the actions the workflow takes are attributed to them. For example, if the workflow declares an incident, the incident is created by the user who triggered the workflow.
+
+The initiator resolves the connections defined in the workflow actions. Therefore, each user who triggers the workflow needs the `connections_resolve` permission, as well as {{< ui >}}Resolver{{< /ui >}} access to every connection the workflow uses. The Datadog Admin Role and the Datadog Standard Role include the `connections_resolve` permission.
+
+Set a workflow to run as the initiator only if each of its [triggers][11] identifies a user:
+- Manual runs, where a user clicks {{< ui >}}Run{{< /ui >}} on the workflow
+- Dashboard, notebook, Software Catalog, and Database Monitoring triggers
+- Slack messages and emoji reactions
+- API triggers, where the initiator is the owner of the application key used in the request
+- [App Builder][12] apps and custom agents in [Bits Agent Builder][13], where the initiator is the identity the app or agent runs as
+- AI agents using the [Datadog MCP server][14]
+
+Every other trigger can start a run without a user, and a run without an initiator fails. This includes schedules, incoming webhooks, monitor notifications, security notification rules, incident automation, case automation, On-Call events, and Cloud Cost Management automation. [Forms][15] are also unsupported, because a user who isn't a member of your Datadog organization can submit a form. Keep workflows with those triggers set to {{< ui >}}Owner{{< /ui >}} or {{< ui >}}Service Account{{< /ui >}}.
 
 ### Use a service account
 
@@ -38,27 +83,35 @@ To create a service account for a workflow, you must have either the Datadog adm
 
 #### Associate a service account with a workflow
 
-You can dynamically create a service account for your workflow when you [add an automatic trigger][4].
+You can dynamically create a service account for your workflow, for example when you [add an automatic trigger][4].
 
 1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Manage ownership and identity{{< /ui >}}.
-1. Click {{< ui >}}Run as Service Account{{< /ui >}}.
-1. Select a role for your service account user or select an existing Service Account.
+1. Click {{< ui >}}Edit permissions{{< /ui >}}.
+1. Under {{< ui >}}Run as{{< /ui >}}, click {{< ui >}}Service Account{{< /ui >}}.
+1. In the {{< ui >}}Create or Select Service account{{< /ui >}} dialog, select one or more roles for your service account user and click {{< ui >}}Create{{< /ui >}}. To use an existing service account instead, click {{< ui >}}Existing Service Account{{< /ui >}}, select the account, and click {{< ui >}}Select{{< /ui >}}.
 1. Click {{< ui >}}Save{{< /ui >}} to save the service account and apply the changes.
 
 When you run a workflow, the service account user resolves the connections defined in the workflow actions. Therefore, the service account user needs the `connections_resolve` permission. The Datadog Admin Role and the Datadog Standard Role include the `connections_resolve` permission.
 
 #### View service account details
 
+1. In the workflow editor, hover over the workflow name.
+1. Click your service account under {{< ui >}}Run as{{< /ui >}}.
+
+#### Change the service account associated with a workflow
+
 1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Manage ownership and identity{{< /ui >}}.
-1. Click on your service account next to *Run As*.
+1. Click {{< ui >}}Edit permissions{{< /ui >}}.
+1. Under {{< ui >}}Run as{{< /ui >}}, click {{< ui >}}Change{{< /ui >}}.
+1. Select another service account and click {{< ui >}}Select{{< /ui >}}.
+1. Click {{< ui >}}Save{{< /ui >}}.
 
 #### Remove a service account associated with a workflow
 
 1. Click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Click {{< ui >}}Manage ownership and identity{{< /ui >}}.
-1. Click {{< ui >}}Change service account{{< /ui >}}.
+1. Click {{< ui >}}Edit permissions{{< /ui >}}.
+1. Under {{< ui >}}Run as{{< /ui >}}, select {{< ui >}}Owner{{< /ui >}}.
+1. Click {{< ui >}}Save{{< /ui >}}.
 
 ## Action credentials
 
@@ -120,7 +173,7 @@ You can restrict access on a specific workflow either from the workflow list pag
 
 **Restricting permissions from the workflow list page**
 1. Navigate to the [Workflow Automation page][8].
-1. Hover over the workflow on which you would like to set granular permissions. {{< ui >}}Edit{{< /ui >}}, {{< ui >}}Permissions{{< /ui >}}, and {{< ui >}}Delete{{< /ui >}} icons appear on the right.
+1. Hover over the workflow on which you would like to set granular permissions. Action icons, including {{< ui >}}Permissions{{< /ui >}}, appear on the right.
 1. Click the padlock ({{< ui >}}Permissions{{< /ui >}}) icon.
 1. Select {{< ui >}}Restrict Access{{< /ui >}}.
 1. Select a role from the dropdown menu. Click {{< ui >}}Add{{< /ui >}}. The role you selected populates into the bottom of the dialog box.
@@ -129,13 +182,14 @@ You can restrict access on a specific workflow either from the workflow list pag
 1. Click {{< ui >}}Save{{< /ui >}}.
 
 **Restricting permissions from the workflow editor**
-1. In the workflow editor click on the cog ({{< ui >}}Settings{{< /ui >}}) icon.
-1. Select {{< ui >}}Edit Permissions{{< /ui >}} from the dropdown.
+1. In the workflow editor, click the cog ({{< ui >}}Settings{{< /ui >}}) icon.
+1. Select {{< ui >}}Edit permissions{{< /ui >}} from the dropdown.
+1. Under {{< ui >}}Who has access{{< /ui >}}, select {{< ui >}}Custom{{< /ui >}}.
 1. Select {{< ui >}}Restrict Access{{< /ui >}}.
 1. Select a role from the dropdown menu. Click {{< ui >}}Add{{< /ui >}}. The role you selected populates into the bottom of the dialog box.
 1. Next to the role name, select your desired permission from the dropdown menu.
 1. If you would like to remove access from a role, click the trash can icon to the right of the role name.
-1. Click {{< ui >}}Save{{< /ui >}}.
+1. Click {{< ui >}}Done{{< /ui >}}, then click {{< ui >}}Save{{< /ui >}}.
 
 ## Further Reading
 
@@ -152,3 +206,9 @@ You can restrict access on a specific workflow either from the workflow list pag
 [7]: /account_management/rbac/permissions/#workflow-automation
 [8]: https://app.datadoghq.com/workflow
 [9]: https://chat.datadoghq.com/
+[10]: /actions/private_actions/
+[11]: /actions/workflows/trigger/
+[12]: /actions/app_builder/
+[13]: /actions/agents/
+[14]: /mcp_server/
+[15]: /actions/forms/

--- a/content/en/actions/workflows/access_and_auth.md
+++ b/content/en/actions/workflows/access_and_auth.md
@@ -26,9 +26,9 @@ A few tools control access and authentication for workflows and their components
 ## Workflow identity
 
 Every run of a workflow uses a single Datadog identity, controlled by the workflow's {{< ui >}}Run as{{< /ui >}} setting. That identity determines:
-- which [connections][6] a run can resolve, including connections that use [private action runners][10]
-- which Datadog resources a run can read and modify
-- which user the actions in a run are attributed to, in [audit trails][1] and in the products those actions touch
+- Which [connections][6] a run can resolve, including connections that use [private action runners][10]
+- Which Datadog resources a run can read and modify
+- Which user a run's actions are attributed to, in [audit trails][1] and in the products those actions touch
 
 A workflow can run as one of the following identities:
 
@@ -36,7 +36,7 @@ A workflow can run as one of the following identities:
 : The workflow runs as its owner, and any editor of the workflow can access the same resources as the owner. A new workflow runs as its owner by default.
 
 {{< ui >}}Initiator{{< /ui >}}
-: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. Supported for [triggers][4] that have an end user.
+: The workflow runs as the user who triggered the run, so each run is limited to the resources that user can access. The Initiator identity is only supported for [triggers][4] that have an end user.
 
 {{< ui >}}Service Account{{< /ui >}}
 : The workflow runs as a service account associated with the workflow. Use a service account to control the exact permissions a run has, with roles you choose for the workflow.
@@ -52,7 +52,7 @@ Select an identity when you publish a workflow, or change it at any time:
 
 The following restrictions apply:
 - Only the owner of the workflow can select {{< ui >}}Owner{{< /ui >}} or {{< ui >}}Initiator{{< /ui >}}.
-- To select {{< ui >}}Service Account{{< /ui >}}, you need either the Datadog admin role, or a custom role with the {{< ui >}}Service Account Write{{< /ui >}} permission.
+- To select {{< ui >}}Service Account{{< /ui >}}, you need either the Datadog Admin Role or a custom role with the {{< ui >}}Service Account Write{{< /ui >}} permission.
 
 To see the identity a workflow uses, hover over the workflow name in the editor and read the {{< ui >}}Run as{{< /ui >}} field.
 

--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -14,9 +14,9 @@ further_reading:
 - link: "/getting_started/workflow_automation/"
   tag: "Documentation"
   text: "Getting Started with Workflow Automation"
-- link: "/actions/workflows/access_and_auth/#use-a-service-account"
+- link: "/actions/workflows/access_and_auth/#workflow-identity"
   tag: "Documentation"
-  text: "Find out more about Service Accounts for workflows"
+  text: "Find out more about the identity a workflow runs as"
 - link: "dashboards"
   tag: "Documentation"
   text: "Find out more about setting up a dashboard"
@@ -33,7 +33,7 @@ further_reading:
 
 You can trigger a workflow manually or automatically and a workflow can have multiple triggers. This allows you to trigger a workflow from a variety of different sources, like a Datadog monitor and a Datadog dashboard.
 
-A workflow can either run with the identity of the user who owns it, or with the identity of a service account associated with the workflow. For more information on service accounts, see [Service accounts for Workflow Automation][1].
+A workflow runs with the identity of its owner, the user who triggered the run, or an associated service account. Triggers that fire without a user, such as schedules and webhooks, require the owner or a service account. For more information, see [Workflow identity][1].
 
 {{< img src="actions/workflows/trigger/multiple-triggers.png" alt="A workflow with multiple triggers" style="width:100%;" >}}
 
@@ -262,7 +262,7 @@ In later steps of your workflow, use `Source.api.requestBody` to reference the p
 
 To schedule a workflow run:
 1. On the workflow canvas, click {{< ui >}}Add an Automated Trigger{{< /ui >}} and select {{< ui >}}Schedule{{< /ui >}}.
-1. Click {{< ui >}}Create{{< /ui >}} to create a service account. For more information, see [Use a service account][1].
+1. Click {{< ui >}}Create{{< /ui >}} to create a service account. For more information, see [Use a service account][17].
 1. Enter a time and frequency for the run.
 1. (Optional) Enter a description for the workflow in the {{< ui >}}Memo{{< /ui >}} field.
 1. Click {{< ui >}}Save{{< /ui >}}.
@@ -292,7 +292,7 @@ After you trigger a workflow, the workflow page switches to the workflow's {{< u
 
 <br>Do you have questions or feedback? Join the {{< ui >}}#workflows{{< /ui >}} channel on the [Datadog Community Slack][7].
 
-[1]: /actions/workflows/access_and_auth/#use-a-service-account
+[1]: /actions/workflows/access_and_auth/#workflow-identity
 [2]: https://app.datadoghq.com/monitors/manage
 [3]: https://app.datadoghq.com/security/configuration/notification-rules
 [4]: /security/cloud_security_management/workflows
@@ -308,3 +308,4 @@ After you trigger a workflow, the workflow page switches to the workflow's {{< u
 [14]: https://app.datadoghq.com/software
 [15]: /incident_response/incident_management/setup_and_configuration/automations
 [16]: /incident_response/incident_management/setup_and_configuration/notification_rules/
+[17]: /actions/workflows/access_and_auth/#use-a-service-account

--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -16,7 +16,7 @@ further_reading:
   text: "Getting Started with Workflow Automation"
 - link: "/actions/workflows/access_and_auth/#workflow-identity"
   tag: "Documentation"
-  text: "Find out more about the identity a workflow runs as"
+  text: "Find out more about the identity used to run a workflow"
 - link: "dashboards"
   tag: "Documentation"
   text: "Find out more about setting up a dashboard"

--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -262,7 +262,7 @@ In later steps of your workflow, use `Source.api.requestBody` to reference the p
 
 To schedule a workflow run:
 1. On the workflow canvas, click {{< ui >}}Add an Automated Trigger{{< /ui >}} and select {{< ui >}}Schedule{{< /ui >}}.
-1. Click {{< ui >}}Create{{< /ui >}} to create a service account. For more information, see [Use a service account][17].
+1. Click {{< ui >}}Create{{< /ui >}} to create a service account. For more information, see [Run as a service account][17].
 1. Enter a time and frequency for the run.
 1. (Optional) Enter a description for the workflow in the {{< ui >}}Memo{{< /ui >}} field.
 1. Click {{< ui >}}Save{{< /ui >}}.
@@ -308,4 +308,4 @@ After you trigger a workflow, the workflow page switches to the workflow's {{< u
 [14]: https://app.datadoghq.com/software
 [15]: /incident_response/incident_management/setup_and_configuration/automations
 [16]: /incident_response/incident_management/setup_and_configuration/notification_rules/
-[17]: /actions/workflows/access_and_auth/#use-a-service-account
+[17]: /actions/workflows/access_and_auth/#run-as-a-service-account


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Updates the Workflow Automation **Workflow identity** documentation for the release that lets a workflow run as the person who triggered it. The page described only two identities (owner and service account) and a settings menu that no longer exists.

`content/en/actions/workflows/access_and_auth.md`:
- Rewrites the **Workflow identity** intro to explain what the `Run as` identity controls (connection resolution, resource access, attribution), and summarizes the three identities: `Owner` (the default), `Initiator`, and `Service Account`.
- Adds **Set the workflow identity**, covering the current path (cog icon > `Edit permissions` > `Run as`), who can select each option, and where the active identity appears in the editor.
- Adds a parallel section for each identity: **Run as the owner**, **Run as the initiator**, and **Run as a service account**. Each one explains whose permissions a run uses and which permissions that identity needs to resolve the workflow's connections.
- Replaces the service account step lists (`Associate`, `View`, `Change`, `Remove`) with the single set of instructions in **Set the workflow identity**, because the service account is now attached in the same `Edit permissions` modal. The old `Manage ownership and identity` > `Run as Service Account` menu is no longer reachable from the workflow editor.
- Updates the workflow permissions steps for the editor, where granular access now lives under `Who has access` > `Custom`.

`content/en/actions/workflows/trigger.md`:
- Updates the workflow identity sentence and the further reading link, which both described only the owner and service account identities.

Anchor change to be aware of: `#use-a-service-account` becomes `#run-as-a-service-account`, so that the three identity sections read consistently. The in-repo link in `trigger.md` is updated. `#workflow-identity`, `#workflow-permissions`, `#restrict-access-on-a-specific-connection`, and `#restrict-access-on-a-specific-workflow` are unchanged.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- Branch name follows the `<name>/<description>` convention.

### AI assistance

Drafted with Pi (AI-assisted research, manually reviewed). The wording was checked against the workflow run-as implementation and the current workflow editor UI strings.

### Additional notes

The French translation of `trigger.md` still links to `#use-a-service-account`; that link now lands at the top of the page until translations are refreshed.

No Jira ticket is linked yet; happy to add one and rename the PR title to `[DOCS-XXXXX] ...` if the docs team wants it tracked.
