### PR TITLE
Update Bits Security Analyst supported sources

### DIFF
--- a/content/en/bits_ai/bits_security_analyst.md
+++ b/content/en/bits_ai/bits_security_analyst.md
@@ -47,18 +47,22 @@ Additionally, when you use Cloud SIEM notifications to send new signal alerts to
 
 Bits AI can run investigations on the following Security log sources:
 - Amazon GuardDuty
-  - [Finding categories][6] include anomalous IAM behavior, EC2 credential exfiltration and misuse, S3 data exposure, CloudTrail or S3 defense evasion, and attack sequences correlating IAM credential and S3 data compromise
+  - Supported [finding types][6] cover anomalous and compromised IAM credentials; EC2 and resource credential exfiltration and misuse; Bedrock logging changes, anomalous model invocation, cost harvesting, and direct prompt injection; compromised EKS and ECS cluster attack sequences; Kubernetes credential access, anomalous behavior, execution, privilege escalation, persistence, policy changes, and malicious callers; S3 anomalous behavior, data exposure, malicious callers, and penetration test activity; CloudTrail or S3 defense evasion; and attack sequences correlating IAM credential and S3 data compromise.
 - AWS CloudTrail
 - Azure
+- Cloudflare
 - GCP
 - Kubernetes
 - Microsoft Entra ID
 - Okta
 - Google Workspace
 - Microsoft 365
+- GitLab
 - GitHub
+- Slack
 - Snowflake
 - SentinelOne
+- Windows
 - Email phishing
 
 ## Set up Bits Security Analyst


### PR DESCRIPTION
## What changed

- Add Cloudflare, Windows, Slack, and GitLab to the supported Security log sources for Bits Security Analyst.
- Expand the Amazon GuardDuty coverage description to include the existing finding types plus the new IAM, Bedrock, EKS, ECS, Kubernetes, and S3 finding coverage.

## Why

Bits Security Analyst supports additional log sources and GuardDuty finding types that are not represented in the current documentation.

## Impact

Customers can see a more complete and accurate view of the sources and GuardDuty findings that Bits Security Analyst can investigate.

## Validation

- Confirmed the branch is one commit ahead of `master`.
- Confirmed the diff changes only `content/en/bits_ai/bits_security_analyst.md`.
- Reviewed the rendered Markdown list structure and source names.