### PR TITLE
[DOCS-XXXXX] Add IaC Security custom rules guide

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -8066,6 +8066,16 @@ menu:
       url: /security/code_security/iac_security/iac_rules/
       parent: code_security_iac_security
       weight: 100003
+    - name: Custom Rules
+      identifier: code_security_iac_security_custom_rules
+      url: /security/code_security/iac_security/custom_rules/
+      parent: code_security_iac_security
+      weight: 100004
+    - name: Custom Rule Creation Tutorial
+      identifier: code_security_iac_security_custom_rules_tutorial
+      url: /security/code_security/iac_security/custom_rules/tutorial/
+      parent: code_security_iac_security
+      weight: 100005
     - name: Developer Tool Integrations
       identifier: dev_tool_int
       url: /security/code_security/dev_tool_int/

--- a/content/en/security/code_security/iac_security/_index.md
+++ b/content/en/security/code_security/iac_security/_index.md
@@ -15,6 +15,9 @@ further_reading:
   - link: "/security/code_security/iac_security/iac_rules/"
     tag: "Documentation"
     text: "IaC Security Rules"
+  - link: "/security/code_security/iac_security/custom_rules/"
+    tag: "Documentation"
+    text: "IaC Security Custom Rules"
   - link: "/pr_gates/"
     tag: "Documentation"
     text: "PR Gates"
@@ -78,6 +81,10 @@ You can configure exclusions to prevent certain findings from appearing in scan 
 
 Exclusions are managed through a configuration file or inline comments in your IaC code. For supported formats and usage examples, see [Configure IaC Security][7].
 
+### Write custom rules
+
+In addition to Datadog's default rules, you can write your own rules for misconfigurations specific to your organization. See [IaC Security Custom Rules][14].
+
 ## Next steps
 
 1. [Set up IaC Security][1] in your environment.
@@ -101,3 +108,4 @@ Exclusions are managed through a configuration file or inline comments in your I
 [11]: /pr_gates/
 [12]: /pr_gates/setup
 [13]: /security/code_security/iac_security/iac_rules
+[14]: /security/code_security/iac_security/custom_rules/

--- a/content/en/security/code_security/iac_security/custom_rules/_index.md
+++ b/content/en/security/code_security/iac_security/custom_rules/_index.md
@@ -1,0 +1,90 @@
+---
+title: Infrastructure as Code (IaC) Security Custom Rules
+description: Write custom Rego rules to detect misconfigurations in your infrastructure-as-code files.
+further_reading:
+  - link: "/security/code_security/iac_security/custom_rules/tutorial/"
+    tag: "Documentation"
+    text: "IaC Security Custom Rule Creation Tutorial"
+  - link: "/security/code_security/iac_security/iac_rules/"
+    tag: "Documentation"
+    text: "IaC Security Rules"
+  - link: "/security/code_security/iac_security/configuration/"
+    tag: "Documentation"
+    text: "Configure IaC Security"
+---
+
+[IaC Security][1] scans your infrastructure-as-code files using [Rego][2], an open source policy language from the Open Policy Agent (OPA) project. In addition to Datadog's default rules, you can write your own custom rules to detect misconfigurations specific to your organization.
+
+## Where to write custom rules
+
+Create and manage custom IaC Security rules from [Detection Coverage][3] in Datadog. Custom rules run alongside default rules during every scan, and their findings appear in the same [Code Security Vulnerabilities][4] page.
+
+## The rule contract
+
+Every IaC Security rule, whether default or custom, is a Rego module that follows the same contract:
+
+- The module belongs to `package datadog`.
+- The module defines a partial set rule named `DatadogPolicy` that contains one object per violation.
+- Rego evaluates the rule against `input.document`, an array of the parsed infrastructure-as-code documents in the scanned file.
+
+```rego
+package datadog
+
+DatadogPolicy contains result if {
+	some i, name
+	instance := input.document[i].resource.aws_instance[name]
+	instance.associate_public_ip_address == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_instance",
+		"resourceName": name,
+		"searchKey": sprintf("aws_instance[%s].associate_public_ip_address", [name]),
+	}
+}
+```
+
+This rule flags any Terraform `aws_instance` resource that sets `associate_public_ip_address` to `true`.
+
+### Result fields
+
+Each object your rule adds to `DatadogPolicy` becomes one finding. Use the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `documentId` | Yes | The identifier of the source document the violation belongs to. Use `input.document[i].id`. |
+| `resourceType` | Yes | The type of resource that triggered the violation (for example, `aws_instance`). |
+| `resourceName` | Yes | The name of the specific resource instance that triggered the violation. |
+| `searchKey` | Yes | A string that locates the violation within the resource, used to attribute the finding to a line in the source file. |
+| `remediation` | No | A suggested fix, shown in the finding's remediation panel. |
+| `remediationType` | No | Either `addition` (the fix adds a missing attribute) or `replacement` (the fix changes an existing value). |
+
+### Iterating over documents and resources
+
+A file can contain more than one document, so rules iterate over `input.document` with an index (`i`). Reuse that same index when you build `documentId`.
+
+Within a document, resources of a given type form a map keyed by resource name. Rules iterate with `some name` to check every instance:
+
+```rego
+some i, name
+instance := input.document[i].resource.aws_instance[name]
+```
+
+## Testing your rule
+
+Before saving a custom rule, test it against sample infrastructure-as-code snippets in Detection Coverage. Provide a snippet that should trigger the rule and confirm it produces the finding you expect. Then provide a compliant snippet and confirm it produces no findings.
+
+## Next steps
+
+Follow the [IaC Security Custom Rule Creation Tutorial][5] to write a complete rule from scratch. Or review the [default IaC Security rules][6] for more examples of what a rule can check.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /security/code_security/iac_security/
+[2]: https://www.openpolicyagent.org/docs/latest/policy-language/
+[3]: https://app.datadoghq.com/security/code-security/detection-coverage/iac
+[4]: https://app.datadoghq.com/security/code-security/iac
+[5]: /security/code_security/iac_security/custom_rules/tutorial/
+[6]: /security/code_security/iac_security/iac_rules/

--- a/content/en/security/code_security/iac_security/custom_rules/tutorial.md
+++ b/content/en/security/code_security/iac_security/custom_rules/tutorial.md
@@ -1,0 +1,78 @@
+---
+description: Learn how to write a custom IaC Security rule from scratch.
+title: IaC Security Custom Rule Creation Tutorial
+---
+
+This tutorial shows how to write a custom rule that flags a Terraform S3 bucket that doesn't have versioning enabled.
+
+Here's the Terraform this rule detects:
+
+```hcl
+resource "aws_s3_bucket" "reports" {
+  bucket = "example-reports-bucket"
+}
+
+resource "aws_s3_bucket_versioning" "reports" {
+  bucket = aws_s3_bucket.reports.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+```
+
+## Step 1: Identify the resource to check
+
+The rule looks at `aws_s3_bucket_versioning` resources, since that's where the `status` attribute lives.
+
+```rego
+some i, name
+versioning := input.document[i].resource.aws_s3_bucket_versioning[name]
+```
+
+`i` indexes the parsed document the resource came from, and `name` is the Terraform resource name (`reports` in the example).
+
+## Step 2: Write the violation condition
+
+A bucket is non-compliant when `status` is anything other than `"Enabled"`:
+
+```rego
+versioning.versioning_configuration.status != "Enabled"
+```
+
+## Step 3: Build the result
+
+Combine the resource lookup and the condition into a single `DatadogPolicy` rule, and build a result object with the required fields:
+
+```rego
+package datadog
+
+DatadogPolicy contains result if {
+	some i, name
+	versioning := input.document[i].resource.aws_s3_bucket_versioning[name]
+	versioning.versioning_configuration.status != "Enabled"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket_versioning",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.status", [name]),
+		"remediation": "versioning_configuration { status = \"Enabled\" }",
+		"remediationType": "replacement",
+	}
+}
+```
+
+## Step 4: Test the rule
+
+In [Detection Coverage][1], add the Terraform snippet from this tutorial as a test file and confirm the rule reports a finding on the `aws_s3_bucket_versioning.reports` resource. Then change `status` to `"Enabled"` in the same snippet and confirm the rule reports no findings.
+
+## Step 5: Save and enable the rule
+
+Set a severity and category, add a description explaining the misconfiguration and how to fix it, and save the rule. After you save the rule, it runs alongside default rules on every subsequent scan of repositories where IaC Security is enabled.
+
+## Next steps
+
+For the full list of fields a rule result can set, and details on iterating over documents and resources, see [IaC Security Custom Rules][2].
+
+[1]: https://app.datadoghq.com/security/code-security/detection-coverage/iac
+[2]: /security/code_security/iac_security/custom_rules/

--- a/content/en/security/code_security/iac_security/iac_rules/_index.md
+++ b/content/en/security/code_security/iac_security/iac_rules/_index.md
@@ -8,6 +8,9 @@ further_reading:
   - link: "/security/code_security/iac_security/configuration"
     tag: "Documentation"
     text: "Configure IaC Security"
+  - link: "/security/code_security/iac_security/custom_rules/"
+    tag: "Documentation"
+    text: "IaC Security Custom Rules"
 ---
 
 {{% site-region region="gov,gov2" %}}
@@ -18,7 +21,10 @@ further_reading:
 
 <div class="alert alert-info">For Helm resolution to work correctly, each chart directory must include the charts it depends on. For details, see <a href="https://helm.sh/docs/topics/charts/#the-chart-file-structure">Chart File Structure</a> in the Helm documentation.</div>
 
+In addition to these default rules, you can write your own rules. See [IaC Security Custom Rules][2].
+
 [1]: /security/code_security/iac_security/
+[2]: /security/code_security/iac_security/custom_rules/
 
 ## Further reading
 


### PR DESCRIPTION
## Motivation

IaC Security has a custom-rule authoring feature (Detection Coverage > IaC) with no existing documentation. This adds an overview page and a step-by-step tutorial covering the Rego rule contract (`package datadog` / `DatadogPolicy contains result`) used by both default and custom IaC rules.

Fixes DOCS-XXXXX (placeholder — replace with the real ticket before merging)

## What's included

- `content/en/security/code_security/iac_security/custom_rules/_index.md`: rule contract, result fields, iteration pattern, testing guidance
- `content/en/security/code_security/iac_security/custom_rules/tutorial.md`: end-to-end tutorial (Terraform S3 versioning check)
- Nav entries in `config/_default/menus/main.en.yaml`
- Cross-links from `iac_security/_index.md` and `iac_rules/_index.md`

## AI assistance disclosure

This content was drafted with Claude Code, grounded in verified Rego syntax/examples from the `datadog-iac-scanner-default-rules` repo and cross-checked against existing docs conventions (SAST custom rules pages, CSM custom rules pages). It has not yet been reviewed against the live Detection Coverage > IaC UI for exact button/field copy — see open items below.

## Merge instructions

- [ ] Merge this PR myself once it's approved

## Open items before merging

- [ ] Replace `DOCS-XXXXX` with a real ticket number (title + Fixes line)
- [ ] Verify exact UI copy/navigation in the live Detection Coverage > IaC custom-rule editor and align wording
- [ ] Confirm whether the custom-rule editor supports importing shared libraries (`common_lib`, etc.) — guide currently avoids claiming this
- [ ] Run `yarn start` locally to preview rendering and nav placement

## Test plan

- [x] `vale` passes on all new/edited files (0 errors)
- [x] Menu YAML validated
- [ ] Local Hugo preview (not run — see open items)