### PR TITLE
Document AI Guard message redaction in the Python SDK

### DIFF
--- a/content/en/security/ai_guard/setup/sdk.md
+++ b/content/en/security/ai_guard/setup/sdk.md
@@ -88,6 +88,7 @@ The method returns an `Evaluation` object containing:
 - `reason`: natural language summary of the decision.
 - `tags`: list of attack category tags detected (for example, `["indirect-prompt-injection", "destructive-tool-call"]`).
 - `sds`: list of Sensitive Data Scanner findings.
+- `messages`: the evaluated conversation, with sensitive values redacted when redaction is enabled for the service. See [Example: Redact sensitive data](#python-example-redact-sensitive-data).
 
 ### Example: Evaluate a user prompt with content parts {#python-example-evaluate-user-prompt-content-parts}
 
@@ -134,7 +135,57 @@ result = client.evaluate(
 )
 ```
 
+### Example: Redact sensitive data {#python-example-redact-sensitive-data}
+
+<!-- TODO: v4.14.0 is tentative. Confirm the release that includes redaction once https://github.com/DataDog/dd-trace-py/pull/19360 is merged. -->
+<div class="alert alert-info">
+Message redaction requires dd-trace-py v4.14.0 or later.
+</div>
+
+When [sensitive data detection][2] is enabled for your service, AI Guard can also redact the sensitive values it finds. Redaction rules and placeholders are configured in Datadog, per service: go to {{< ui >}}Security{{< /ui >}} > {{< ui >}}Sensitive Data Scanner{{< /ui >}} > {{< ui >}}Configuration{{< /ui >}} > [{{< ui >}}AI Guard{{< /ui >}}][3]. The SDK never chooses a placeholder itself; it applies what the service returns.
+
+To use redaction, send the conversation to `evaluate` as usual, then pass the `messages` field of the result to your LLM provider instead of the list you started with:
+
+```py
+messages = [
+    Message(role="system", content="You are an AI Assistant"),
+    Message(role="user", content="My SSN is 123-45-6789, is that a valid one?"),
+]
+
+result = client.evaluate(messages=messages)
+
+# Sensitive values are replaced with the placeholder configured for your service:
+# [{"role": "system", "content": "You are an AI Assistant"},
+#  {"role": "user", "content": "My SSN is <REDACTED>, is that a valid one?"}]
+# llm_client is your LLM provider client, for example openai.OpenAI()
+response = llm_client.chat.completions.create(
+    model="gpt-4o",
+    messages=result["messages"],
+)
+```
+
+The SDK never modifies the list you passed in. When there is nothing to redact, `result["messages"]` is that same list, so you can always forward it without checking whether redaction happened.
+
+When blocking is enabled and the evaluation blocks the conversation, no `Evaluation` is returned. The redacted conversation is available on the exception instead, which lets you log or store it without leaking the original values:
+
+```py
+from ddtrace.appsec.ai_guard import AIGuardAbortError
+
+try:
+    result = client.evaluate(messages=messages, options=Options(block=True))
+    messages = result["messages"]
+except AIGuardAbortError as e:
+    # e.messages holds the redacted conversation
+    logger.warning("AI Guard blocked the request: %s", e.reason)
+```
+
+The messages AI Guard reports to Datadog are redacted as well, so the original values do not appear in traces or in the AI Guard UI.
+
+To turn the transformation off without changing your code, set `DD_AI_GUARD_REDACTION_ENABLED=false`. Evaluations still run and sensitive data findings are still reported, but no message is modified.
+
 [1]: https://github.com/DataDog/dd-trace-py/releases/tag/v3.18.0
+[2]: /security/ai_guard/setup/#sensitive-data-scanning
+[3]: https://app.datadoghq.com/sensitive-data-scanner/configuration/ai-guard
 {{% /tab %}}
 {{% tab "Javascript" %}}
 The JavaScript SDK ([dd-trace-js v5.69.0][1] or later) offers a simplified interface for interacting with the REST API directly from JavaScript applications.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents AI Guard sensitive data redaction in the Python tab of the [AI Guard SDK setup page](/security/ai_guard/setup/sdk/). Redaction is a new capability: when redaction rules are configured for a service in Sensitive Data Scanner, the AI Guard service returns the redacted conversation and the SDK applies it, so customers need to know to forward `result["messages"]` to their LLM provider instead of the list they built.

Changes, all scoped to the Python tab:

- Adds the `messages` field to the documented `Evaluation` return values.
- New **Example: Redact sensitive data** section covering: where rules and placeholders are configured (per service, in Sensitive Data Scanner > AI Guard), forwarding `result["messages"]` to the provider, the copy-on-write guarantee (the caller's list is never mutated, and the same list comes back when nothing was redacted), the redacted conversation on `AIGuardAbortError.messages` when the evaluation blocks, that reported messages are redacted too, and the `DD_AI_GUARD_REDACTION_ENABLED=false` kill-switch.

Related:

- Tracer implementation: DataDog/dd-trace-py#19360
- JIRA: https://datadoghq.atlassian.net/browse/APPSEC-69387

### Merge readiness

- [ ] Ready for merge

**Blocked on the tracer release.** The version note says dd-trace-py **v4.14.0**, which is tentative — DataDog/dd-trace-py#19360 is still open. There is an inline `<!-- TODO -->` next to it; the version must be confirmed (and the TODO removed) once that PR merges and ships. Please hold this PR until then.

### AI assistance

Drafted with Claude Code from the redaction RFC and the tracer implementation, then reviewed manually.

### Additional notes

The examples use the existing `from ddtrace.appsec.ai_guard import ...` import path for consistency with the rest of the page, though the module in recent tracer versions is `ddtrace.aiguard`. Worth a separate pass over this page if the old path is deprecated.