### PR TITLE
[DOCS-XXXXX] Remove note about implementation in specific libraries

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -57,7 +57,6 @@ Use the following environment variables to configure formats for reading and wri
 `restart`: The SDK will always start a new trace. If the incoming distributed tracing headers represent a valid trace context, that trace context will be represented as a span link on service entry spans (as opposed to the parent span in the `continue` configuration).<br>
 `ignore`: The SDK will always start a new trace and all incoming distributed tracing headers are ignored.<br>
 **Default**: `continue` <br>
-**Note**: This is only implemented in the .NET, Node.js, Python, and Java libraries.
 
 ### Advanced configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Removes the note about implementation in specific libraries from the trace context propagation docs.

Reopens #38466 with a correctly named branch.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes