### PR TITLE
Document data access principal limit

### DIFF
--- a/content/en/account_management/rbac/data_access.md
+++ b/content/en/account_management/rbac/data_access.md
@@ -51,6 +51,8 @@ Select data to be included in this Dataset
 Grant access
 : Select one or more teams or roles that may access the content bound in the Restricted Dataset. Any users who are not members of these groups are blocked from accessing this data.
 
+**Note:** A maximum of 50 principals (roles or teams) can be tied to a given Restricted Dataset.
+
 You may create a maximum of 10 key:value pairs per Restricted Dataset. Consider defining an additional Restricted Dataset if you need additional pairs.
 
 After completing all the fields to define the dataset, click {{< ui >}}Create Restricted Dataset{{< /ui >}} to apply it to your organization.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b2610b52-f4bb-46aa-91de-dba2aafa1634","source":"chat","resourceId":"26d4526c-d2b1-4b1e-bb0d-4e90c4aa5f9b","workflowId":"5a3f92e7-ff77-4d3a-9c2e-027b706610f2","codeChangeId":"5a3f92e7-ff77-4d3a-9c2e-027b706610f2","sourceType":"chat"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds documentation for the Data Access Control limit on principals tied to a Restricted Dataset, so users know a dataset can include up to 50 roles or teams.

Changes:
- Added a note to content/en/account_management/rbac/data_access.md stating that a Restricted Dataset can be tied to a maximum of 50 principals.

### Testing/Validation

- Ran `git diff --check`.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to make this documentation edit.

### Additional notes

None.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/26d4526c-d2b1-4b1e-bb0d-4e90c4aa5f9b)

Comment @datadog to request changes