### PR TITLE
Document automatic dataset curation for Patterns

### DIFF
--- a/content/en/llm_observability/monitoring/patterns.md
+++ b/content/en/llm_observability/monitoring/patterns.md
@@ -65,6 +65,7 @@ Each topic shows its interaction volume and share of total traffic. Interactions
    - **On demand** (default): Run the Pattern manually.
    - **Daily**, **Weekdays**, or **Weekly**: Run automatically at a time (and, for weekly, a day) you choose.
    - **Custom**: Run automatically every 1 to 7 days.
+1. (Optional) Under **Dataset coverage**, select one or more offline evaluation datasets to measure production traffic coverage against. To automatically fill coverage gaps, enable the **Automatic dataset curation** toggle. When enabled, Datadog creates a managed project (`Patterns-coverage`) and a per-pattern dataset (`{pattern-name}-pattern-curated`) to receive suggested interactions after each run. The toggle is **on** by default for new Patterns.
 1. Click **Create and Run Pattern**, or **Create Pattern** to create it without running it.
 
 ## Explore your Patterns
@@ -130,6 +131,10 @@ Use traffic percentage to identify your most common use cases. The parent-child 
 ### Find evaluation coverage gaps
 
 Compare your topic distribution against what your golden datasets actually cover. Look at topics that represent high production volume but have no corresponding evaluation cases: this is where your test coverage has gaps, and where model regressions are least likely to be caught before they reach users.
+
+### Automatically curate evaluation datasets
+
+When automatic dataset curation is enabled, each Patterns run adds suggested interactions for under-covered topics directly into a managed dataset (`{pattern-name}-pattern-curated` inside the `Patterns-coverage` project). After a run completes, open a topic's detail view and click **Access dataset** to review the curated records and use them as evaluation test cases.
 
 ### Diagnose failure patterns
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"83b3a3c6-98a4-429c-8bbc-50cba552641e","source":"chat","resourceId":"f9b4e0cd-a74c-413d-ae6a-493cc0e3cd75","workflowId":"f0b8629c-80bd-44be-946b-59757141e2fb","codeChangeId":"f0b8629c-80bd-44be-946b-59757141e2fb","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the new **Automatic dataset curation** toggle in the Patterns configuration form. The prior flow of manually selecting a curated project and dataset has been removed in favor of a single toggle that provisions a managed project (`Patterns-coverage`) and a per-pattern dataset (`{pattern-name}-pattern-curated`) automatically. Updating the docs keeps the Patterns setup and evaluation guidance aligned with the new UI.

Source PRs:

- https://github.com/ddoghq/dd-source/pull/29600
- https://github.com/DataDog/web-ui/pull/331192

### What changed?

- Added an optional **Dataset coverage** / **Automatic dataset curation** step to the "Set up a Pattern" instructions in `content/en/llm_observability/monitoring/patterns.md`.
- Added an "Automatically curate evaluation datasets" subsection under "Use topics to improve your application" describing the managed dataset and the **Access dataset** action.

### How was this tested?

- Reviewed the rendered Markdown structure to confirm the new numbered step and subsection fit the existing heading hierarchy.
- Checked the added prose against the Datadog Vale style substitutions (no banned terms such as "ensure", "once", "simply", or "via", and no temporal words).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Datadog AI agent); prose manually reviewed for style compliance.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f9b4e0cd-a74c-413d-ae6a-493cc0e3cd75)

Comment @datadog to request changes