### PR TITLE
Clarify Bits Code sessions are org-wide

### DIFF
--- a/content/en/bits_ai/bits_code/_index.md
+++ b/content/en/bits_ai/bits_code/_index.md
@@ -39,10 +39,16 @@ After [completing setup][6], do one of the following to start a Bits Code sessio
 
 A session can also be created when another Bits AI agent (like [Bits Chat][16] or [Bits Investigation][17]) hands off a coding task to Bits Code.
 
-### View and manage sessions
-On **[Sessions][7]**, view your past sessions in the **My Sessions** panel. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR or MR.
+### Session visibility
 
-Click a session to view its details and continue working with Bits Code. To remove a session from your **My Sessions** list, click <i class="icon-archive-wui"></i> (**Archive for everyone**) or <i class="icon-eye-slashed-wui"></i> (**Unwatch session**).
+Bits Code sessions are shared across your Datadog organization by default. Anyone in your organization can open a session to review its analysis, actions, and code changes, or continue working with Bits Code in it. This makes it easy to share context and pick up a teammate's in-progress work—for example, when they're out of office.
+
+### View and manage sessions
+On **[Sessions][7]**, the **My Sessions** panel shows the sessions you're involved in. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR or MR. **My Sessions** is a personalized view, not a privacy boundary: other members of your organization can still access these sessions.
+
+Click a session to view its details and continue working with Bits Code. To remove a session from your **My Sessions** list, click one of the following:
+- <i class="icon-eye-slashed-wui"></i> **Unwatch session**: removes the session from your own **My Sessions** list only. Other users are not affected.
+- <i class="icon-archive-wui"></i> **Archive for everyone**: archives the session for all users in your organization.
 
 ## Supported source code providers
 Bits Code supports the following source code providers:

--- a/content/en/bits_ai/bits_code/_index.md
+++ b/content/en/bits_ai/bits_code/_index.md
@@ -41,14 +41,14 @@ A session can also be created when another Bits AI agent (like [Bits Chat][16] o
 
 ### Session visibility
 
-Bits Code sessions are shared across your Datadog organization by default. Anyone in your organization can open a session to review its analysis, actions, and code changes, or continue working with Bits Code in it. This makes it easy to share context and pick up a teammate's in-progress work—for example, when they're out of office.
+Bits Code sessions are shared across your Datadog organization by default. Anyone in your organization can open a session to review its analysis, actions, and code changes—or continue working with Bits Code in it. This makes it easy to share context and pick up a teammate's in-progress work.
 
 ### View and manage sessions
-On **[Sessions][7]**, the **My Sessions** panel shows the sessions you're involved in. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR or MR. **My Sessions** is a personalized view, not a privacy boundary: other members of your organization can still access these sessions.
+On **[Sessions][7]**, the **My Sessions** panel shows the sessions you're involved in. A session appears here if you initiated it or interacted with it in some way, like participating in the conversation or creating an associated PR or MR. **My Sessions** is a personalized view, not a privacy boundary—that is, other members of your organization can still access these sessions.
 
 Click a session to view its details and continue working with Bits Code. To remove a session from your **My Sessions** list, click one of the following:
-- <i class="icon-eye-slashed-wui"></i> **Unwatch session**: removes the session from your own **My Sessions** list only. Other users are not affected.
-- <i class="icon-archive-wui"></i> **Archive for everyone**: archives the session for all users in your organization.
+- <i class="icon-eye-slashed-wui"></i> (**Unwatch session**): removes the session from your own **My Sessions** list only. Other users are not affected.
+- <i class="icon-archive-wui"></i> (**Archive for everyone**): archives the session for all users in your organization.
 
 ## Supported source code providers
 Bits Code supports the following source code providers:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3ab00876-30b1-4f8a-96e4-cc2b79d2d8e5","source":"chat","resourceId":"d4538cc3-a581-44f6-bc4d-de23e5d7af3e","workflowId":"51f9119b-3250-42ba-9869-c97ee759c38c","codeChangeId":"51f9119b-3250-42ba-9869-c97ee759c38c","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

**Motivation (WHY):** Users repeatedly assume Bits Code sessions are private to the person who started them. This is recurring implicit feedback (a Datadog team asked how to share sessions across users/within a team for context sharing and picking up a teammate's work when they're out of office—which is already possible, since sessions are org-wide by default). The existing docs never state this; the only hint is the **Archive for everyone** button label, which is easy to miss.

**Changes (WHAT):** In `content/en/bits_ai/bits_code/_index.md`:
- Add a new **Session visibility** subsection stating that Bits Code sessions are shared across your Datadog organization by default, and that anyone in the org can open a session to review it or continue the work.
- Clarify in **View and manage sessions** that **My Sessions** is a personalized view of the sessions you're involved in, not a privacy boundary.
- Split the **Unwatch session** and **Archive for everyone** controls into a list so their personal vs. org-wide scope is explicit.

**Testing/Validation (HOW verified):** Documentation-only change. Verified the edited Markdown/HTML (`<i>` icon shortcodes, list formatting) renders correctly, confirmed no existing internal links pointed to the changed lines, and reviewed the surrounding section for consistency in tone and terminology.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): located the relevant docs, proposed the wording, and edited the file. Reviewed by a human before merge.

### Additional notes

The org-wide-by-default behavior is consistent with the pre-existing **Archive for everyone** action. If the product also exposes a distinct "all sessions" / org-wide browsing view in the UI, a reviewer may want to add a pointer to it in the new **Session visibility** subsection.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d4538cc3-a581-44f6-bc4d-de23e5d7af3e)

Comment @datadog to request changes