### PR TITLE
Specify Managed Archive storage period options

### DIFF
--- a/content/en/real_user_monitoring/managed_archive.md
+++ b/content/en/real_user_monitoring/managed_archive.md
@@ -20,7 +20,7 @@ Datadog's [RUM without Limits][1] provides an accurate, long-term overview of ap
 
 RUM Managed Archive acts as a **safety net**, enabling teams to:
 
-- **Store everything**: Store all sessions for several months automatically
+- **Store everything**: Store all sessions automatically for 1, 3, or 6 months
 - **Recover on demand**: Bring back specific sessions for full investigation
 - **Investigate in depth**: Explore recovered sessions like regularly retained sessions
 

--- a/content/en/real_user_monitoring/managed_archive.md
+++ b/content/en/real_user_monitoring/managed_archive.md
@@ -72,7 +72,7 @@ To enable session storage for an application:
 1. In Datadog, navigate to {{< ui >}}Digital Experience{{< /ui >}} > {{< ui >}}Real User Monitoring{{< /ui >}} > {{< ui >}}Manage Applications{{< /ui >}}.
 2. Select your application.
 3. Go to {{< ui >}}Routing{{< /ui >}} > {{< ui >}}Managed Archive{{< /ui >}}.
-4. Toggle {{< ui >}}Enable Managed Archive{{< /ui >}} on and select the storage period: 1, 3, or 6 months.
+4. Toggle {{< ui >}}Enable Managed Archive{{< /ui >}} on and select the storage period.
 
 {{< img src="real_user_monitoring/managed_archive/managed_archive_setup.png" alt="The Managed Archive configuration panel showing the Store sessions toggle" style="width:70%;" >}}
 

--- a/content/en/real_user_monitoring/managed_archive.md
+++ b/content/en/real_user_monitoring/managed_archive.md
@@ -72,7 +72,7 @@ To enable session storage for an application:
 1. In Datadog, navigate to {{< ui >}}Digital Experience{{< /ui >}} > {{< ui >}}Real User Monitoring{{< /ui >}} > {{< ui >}}Manage Applications{{< /ui >}}.
 2. Select your application.
 3. Go to {{< ui >}}Routing{{< /ui >}} > {{< ui >}}Managed Archive{{< /ui >}}.
-4. Toggle {{< ui >}}Enable Managed Archive{{< /ui >}} on and select the storage period.
+4. Toggle {{< ui >}}Enable Managed Archive{{< /ui >}} on and select the storage period: 1, 3, or 6 months.
 
 {{< img src="real_user_monitoring/managed_archive/managed_archive_setup.png" alt="The Managed Archive configuration panel showing the Store sessions toggle" style="width:70%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Replaces the vague "several months" in the Managed Archive Overview with the storage period options users can choose from: 1, 3, or 6 months.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes