### PR TITLE
[mongo] Document DBM sample and explain-plan exclusions

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
@@ -11,9 +11,9 @@ Database Monitoring for MongoDB captures slow operations from either MongoDB slo
 
 Database Monitoring for MongoDB gathers operation samples using the `currentOp` command. This command provides information about operations that are currently being executed on the MongoDB instance. Additionally, Database Monitoring collects explain plans for the read operation samples using the `explain` command, offering detailed insights into the query execution plans.
 
-Operations against the `admin` database and `hello`/heartbeat commands are not collected as samples.
+Operations against the `admin` database and `hello` and heartbeat commands are not collected as samples.
 
-Explain plans are not generated for operations against system databases (`admin`, `config`, `local`), write operations (insert/update/delete/getMore), and other unexplainable operations.
+Explain plans are not generated for operations against system databases (`admin`, `config`, `local`), write operations (insert/update/delete/getMore), and other unexplainable operations, such as `listIndexes` and `dbStats`.
 
 ### Replication state changes
 

--- a/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
@@ -11,6 +11,10 @@ Database Monitoring for MongoDB captures slow operations from either MongoDB slo
 
 Database Monitoring for MongoDB gathers operation samples using the `currentOp` command. This command provides information about operations that are currently being executed on the MongoDB instance. Additionally, Database Monitoring collects explain plans for the read operation samples using the `explain` command, offering detailed insights into the query execution plans.
 
+Operations against the `admin` database and `hello`/heartbeat commands are not collected as samples.
+
+Explain plans are not generated for operations against system databases (`admin`, `config`, `local`), write operations (insert/update/delete/getMore), and other unexplainable operations.
+
 ### Replication state changes
 
 Database Monitoring for MongoDB generates an event each time there is a change in the replication state within the MongoDB instance. This ensures that any changes in replication are promptly detected and reported.


### PR DESCRIPTION
## Summary
- Documents that MongoDB DBM operation samples exclude the `admin` database and `hello`/heartbeat commands.
- Documents that explain plans are additionally skipped for system databases (`admin`, `config`, `local`), write operations, and other unexplainable operation types.

Both exclusions exist in `integrations-core` (mongo integration, `dbm/operation_samples.py`, `dbm/query_metrics.py`, `dbm/utils.py`) but were previously undocumented anywhere customer-facing. Raised while investigating SDBM-2845.

## Test plan
- [ ] Docs site preview renders the new paragraphs correctly under both `setup_mongodb/selfhosted` and `setup_mongodb/mongodbatlas` (shared shortcode).