### PR TITLE
Document evaluation health tab

### DIFF
--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -516,6 +516,15 @@ Results are available across Agent Observability in near-real-time for published
 
 {{< img src="llm_observability/evaluations/custom_llm_judge_3-2.png" alt="The Evaluations tab of a trace, displaying custom evaluation results alongside managed evaluations." style="width:100%;" >}}
 
+### Health tab and Evaluation Traces table
+
+When evaluation tracing is enabled, the evaluation detail page includes a {{< ui >}}Health{{< /ui >}} tab for inspecting judge run volume, usage, cost, and failures.
+
+- Summary cards show {{< ui >}}Spans Evaluated{{< /ui >}}, {{< ui >}}Token Usage{{< /ui >}}, {{< ui >}}Cost{{< /ui >}}, and {{< ui >}}Errors{{< /ui >}}. The {{< ui >}}Evaluation Traces{{< /ui >}} table below uses the same columns for every selected card: Evaluated at, Evaluated Span (or Evaluated Session for session-scoped evaluations), Result, Duration, Input Tokens, Output Tokens, Total Tokens, and Cost. To show Content, Reasoning, and Model, open the {{< ui >}}Columns{{< /ui >}} manager in the table toolbar.
+- Select a summary card to sort the table by that card's primary metric. For example, {{< ui >}}Token Usage{{< /ui >}} sorts by total tokens, {{< ui >}}Cost{{< /ui >}} sorts by cost, and {{< ui >}}Errors{{< /ui >}} filters {{< ui >}}Run status{{< /ui >}} to errors only. The columns stay the same when you switch cards.
+- Above the table, use {{< ui >}}Run status{{< /ui >}} (All, OK, Error) to filter by whether the judge run succeeded or failed, and {{< ui >}}Judge result{{< /ui >}} (All, Pass, Fail) to filter by the judge's pass/fail assessment. A {{< ui >}}Reset filters{{< /ui >}} button appears after any filter changes from its default. {{< ui >}}Judge result{{< /ui >}} is disabled unless assessment criteria are configured for the evaluation.
+- The evaluated subject name in the {{< ui >}}Evaluated Span{{< /ui >}} or {{< ui >}}Evaluated Session{{< /ui >}} column is a link. Select it to open that span or session in the trace-detail side panel and navigate from a judge trace back to the subject it evaluated.
+
 Each evaluation result includes:
 
 - The evaluated value (for example `True`, `9`, or `Neutral`)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bf7b8915-922e-49db-9668-1230716e9953","source":"chat","resourceId":"fdcd727b-7774-4ac5-baa7-f3ec36e1ecd0","workflowId":"25b5e60d-c4cc-4f7c-af3c-f0653c0d6e4c","codeChangeId":"25b5e60d-c4cc-4f7c-af3c-f0653c0d6e4c","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

Motivation/Summary:
- Documents the Health tab and Evaluation Traces table for custom LLM-as-a-judge evaluations.
- Source PR: https://github.com/DataDog/web-ui/pull/331502

Changes:
- Added a Health tab subsection to content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md.
- Described the summary cards, Evaluation Traces table columns, card-driven sorting, filters, and evaluated subject links.

Testing/Validation:
- Reviewed the Markdown source for placement and content.
- Ran `git diff --check`.
- Attempted `vale content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md`, but Vale is not installed in this sandbox.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code for the documentation update.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/fdcd727b-7774-4ac5-baa7-f3ec36e1ecd0)

Comment @datadog to request changes