### PR TITLE
DJM: fix EMR OpenLineage default and add Spark on Kubernetes OpenLineage setup

### DIFF
--- a/content/en/data_observability/jobs_monitoring/emr.md
+++ b/content/en/data_observability/jobs_monitoring/emr.md
@@ -133,7 +133,7 @@ When you create a new EMR cluster in the [Amazon EMR console][4], add a bootstra
 | DD_ENV                   | Set the `env` environment tag on metrics, traces, and logs from this cluster.   |         |
 | DD_EMR_LOGS_ENABLED      | Send Spark driver and worker logs to Datadog.                                                                                                                  | false   |
 | DD_LOGS_CONFIG_PROCESSING_RULES | Filter the logs collected with processing rules. See [Advanced Log Collection][16] for more details. |         |
-| DD_OPENLINEAGE_ENABLED   | Collect Spark lineage data with OpenLineage to see upstream and downstream tables of your jobs and visualize entire Spark pipelines. Set to `false` to disable. | true    |
+| DD_OPENLINEAGE_ENABLED   | Collect Spark lineage data with OpenLineage to see upstream and downstream tables of your jobs and visualize entire Spark pipelines. Set to `true` to enable; the setup snippet above sets it. | false   |
 
 [15]: /getting_started/tagging/
 [16]: /agent/logs/advanced_log_collection/?tab=environmentvariable#global-processing-rules

--- a/content/en/data_observability/jobs_monitoring/emr.md
+++ b/content/en/data_observability/jobs_monitoring/emr.md
@@ -133,7 +133,7 @@ When you create a new EMR cluster in the [Amazon EMR console][4], add a bootstra
 | DD_ENV                   | Set the `env` environment tag on metrics, traces, and logs from this cluster.   |         |
 | DD_EMR_LOGS_ENABLED      | Send Spark driver and worker logs to Datadog.                                                                                                                  | false   |
 | DD_LOGS_CONFIG_PROCESSING_RULES | Filter the logs collected with processing rules. See [Advanced Log Collection][16] for more details. |         |
-| DD_OPENLINEAGE_ENABLED   | Collect Spark lineage data with OpenLineage to see upstream and downstream tables of your jobs and visualize entire Spark pipelines. Set to `true` to enable; the setup snippet above sets it. | false   |
+| DD_OPENLINEAGE_ENABLED   | Collect Spark lineage data with OpenLineage to see upstream and downstream tables of your jobs and visualize entire Spark pipelines. Set to `true` to enable. | false   |
 
 [15]: /getting_started/tagging/
 [16]: /agent/logs/advanced_log_collection/?tab=environmentvariable#global-processing-rules

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -273,7 +273,7 @@ Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLinea
 
 2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` on the Spark driver.
 
-   If using [Single Step Instrumentation](#enable-single-step-instrumentation), add it to the `ddTraceConfigs` of the `spark-driver` target:
+   If using [Single Step Instrumentation](#enable-single-step-instrumentation), add it to the `ddTraceConfigs` section of the `spark-driver` target:
 
    ```yaml
    ddTraceConfigs:

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -271,7 +271,9 @@ Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLinea
 
    You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
 
-2. **Enable OpenLineage collection.** Add `DD_DATA_JOBS_OPENLINEAGE_ENABLED` to the `ddTraceConfigs` of the `spark-driver` target from [Enable Single Step Instrumentation](#enable-single-step-instrumentation). Lineage collection runs on the Spark driver, so the `spark-executor` target does not need this setting:
+2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` for your Spark driver. Lineage collection runs on the driver, so the executor does not need this setting.
+
+   You can set the variable through any mechanism that adds environment variables to the driver. One way is the `ddTraceConfigs` of the `spark-driver` target from [Enable Single Step Instrumentation](#enable-single-step-instrumentation):
 
    ```yaml
    ddTraceConfigs:

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -146,7 +146,7 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
 {{% /tab %}}
 {{< /tabs >}}
 
-### Collect Spark lineage with OpenLineage
+### (Optional) Collect Spark Data Lineage with OpenLineage
 
 Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLineage][8], so you can see the upstream and downstream tables of your jobs and visualize entire Spark pipelines. Setup has two steps: install the OpenLineage Spark provider, then enable the feature in the Java tracer.
 

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -18,7 +18,8 @@ further_reading:
 Follow these steps to enable Data Observability: Jobs Monitoring for Spark on Kubernetes.
 
 1. [Install the Datadog Agent](#install-the-datadog-agent-on-your-kubernetes-cluster) on your Kubernetes cluster.
-2. [Enable Single Step Instrumentation](#enable-single-step-instrumentation).
+2. (Optional) [Collect Spark lineage with OpenLineage](#collect-spark-lineage-with-openlineage).
+3. [Enable Single Step Instrumentation](#enable-single-step-instrumentation).
 
 ### Install the Datadog Agent on your Kubernetes cluster
 
@@ -145,6 +146,30 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
 {{% /tab %}}
 {{< /tabs >}}
 
+### Collect Spark lineage with OpenLineage
+
+Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLineage][8], so you can see the upstream and downstream tables of your jobs and visualize entire Spark pipelines. Setup has two steps: install the OpenLineage Spark provider, then enable the feature in the Java tracer.
+
+<div class="alert alert-info">OpenLineage lineage collection requires <a href="https://github.com/DataDog/dd-trace-java/releases" target="_blank">Java tracer</a> version 1.48.0 or later.</div>
+
+1. **Install the OpenLineage Spark provider.** Make the `openlineage-spark` JAR available on the classpath of your Spark driver and executors, following the [OpenLineage Spark installation guide][9]. Use OpenLineage version `1.29.0` or later, which is the first version that supports the run-tag facets that Data Observability: Jobs Monitoring relies on.
+
+   You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
+
+2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` on the Spark driver.
+
+   If using [Single Step Instrumentation](#enable-single-step-instrumentation), add it to the `ddTraceConfigs` section of the `spark-driver` target:
+
+   ```yaml
+   ddTraceConfigs:
+     - name: DD_DATA_JOBS_ENABLED
+       value: "true"
+     - name: DD_DATA_JOBS_OPENLINEAGE_ENABLED
+       value: "true"
+   ```
+
+   Reapply your configuration and restart the targeted pods.
+
 ### Enable Single Step Instrumentation
 
 Single Step Instrumentation (SSI) injects the Java tracer into your Spark driver and executor pods at startup. It works regardless of whether your Spark driver runs in **cluster mode** (as a dedicated Kubernetes pod) or **client mode** (as a process inside your submitter pod; for example, an Airflow scheduler or worker).
@@ -260,30 +285,6 @@ To attach service, environment, and version tags to your job traces, pass the fo
 spark.driver.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.version=<VERSION>
 spark.executor.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.version=<VERSION>
 ```
-
-### Collect Spark lineage with OpenLineage
-
-Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLineage][8], so you can see the upstream and downstream tables of your jobs and visualize entire Spark pipelines. Setup has two steps: install the OpenLineage Spark provider, then enable the feature in the Java tracer.
-
-<div class="alert alert-info">OpenLineage lineage collection requires <a href="https://github.com/DataDog/dd-trace-java/releases" target="_blank">Java tracer</a> version 1.48.0 or later.</div>
-
-1. **Install the OpenLineage Spark provider.** Make the `openlineage-spark` JAR available on the classpath of your Spark driver and executors, following the [OpenLineage Spark installation guide][9]. Use OpenLineage version `1.29.0` or later, which is the first version that supports the run-tag facets that Data Observability: Jobs Monitoring relies on.
-
-   You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
-
-2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` on the Spark driver.
-
-   If using [Single Step Instrumentation](#enable-single-step-instrumentation), add it to the `ddTraceConfigs` section of the `spark-driver` target:
-
-   ```yaml
-   ddTraceConfigs:
-     - name: DD_DATA_JOBS_ENABLED
-       value: "true"
-     - name: DD_DATA_JOBS_OPENLINEAGE_ENABLED
-       value: "true"
-   ```
-
-   Reapply your configuration and restart the targeted pods.
 
 ### Tag spans at runtime
 

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -18,7 +18,7 @@ further_reading:
 Follow these steps to enable Data Observability: Jobs Monitoring for Spark on Kubernetes.
 
 1. [Install the Datadog Agent](#install-the-datadog-agent-on-your-kubernetes-cluster) on your Kubernetes cluster.
-2. (Optional) [Collect Spark lineage with OpenLineage](#collect-spark-lineage-with-openlineage).
+2. (Optional) [Collect Spark Data Lineage with OpenLineage](#optional-collect-spark-data-lineage-with-openlineage).
 3. [Enable Single Step Instrumentation](#enable-single-step-instrumentation).
 
 ### Install the Datadog Agent on your Kubernetes cluster

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -261,6 +261,26 @@ spark.driver.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.versio
 spark.executor.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.version=<VERSION>
 ```
 
+### Collect Spark lineage with OpenLineage
+
+Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLineage][8], so you can see the upstream and downstream tables of your jobs and visualize entire Spark pipelines. Setup has two steps: install the OpenLineage Spark provider, then enable the feature in the Java tracer.
+
+1. **Install the OpenLineage Spark provider.** Make the `openlineage-spark` JAR available on the classpath of your Spark driver and executors, following the [OpenLineage Spark installation guide][9]. Use OpenLineage version `1.29.0` or later, which is the first version that supports the run-tag facets that Data Observability: Jobs Monitoring relies on.
+
+   You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
+
+2. **Enable OpenLineage collection.** Add `DD_DATA_JOBS_OPENLINEAGE_ENABLED` to the `ddTraceConfigs` of the `spark-driver` and `spark-executor` targets from [Enable Single Step Instrumentation](#enable-single-step-instrumentation):
+
+   ```yaml
+   ddTraceConfigs:
+     - name: DD_DATA_JOBS_ENABLED
+       value: "true"
+     - name: DD_DATA_JOBS_OPENLINEAGE_ENABLED
+       value: "true"
+   ```
+
+   Reapply your configuration and restart the targeted pods.
+
 ### Tag spans at runtime
 
 {{% djm-runtime-tagging %}}
@@ -275,3 +295,5 @@ spark.executor.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.vers
 [4]: https://helm.sh
 [5]: https://app.datadoghq.com/data-jobs/
 [6]: /data_jobs
+[8]: https://openlineage.io/
+[9]: https://openlineage.io/docs/integrations/spark/installation

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -273,7 +273,7 @@ Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLinea
 
 2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` on the Spark driver.
 
-   You can set the variable through any mechanism that adds environment variables to the driver. One way is the `ddTraceConfigs` of the `spark-driver` target from [Enable Single Step Instrumentation](#enable-single-step-instrumentation):
+   If using [Single Step Instrumentation](#enable-single-step-instrumentation), add it to the `ddTraceConfigs` of the `spark-driver` target:
 
    ```yaml
    ddTraceConfigs:

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -265,6 +265,8 @@ spark.executor.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.vers
 
 Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLineage][8], so you can see the upstream and downstream tables of your jobs and visualize entire Spark pipelines. Setup has two steps: install the OpenLineage Spark provider, then enable the feature in the Java tracer.
 
+<div class="alert alert-info">OpenLineage lineage collection requires <a href="https://github.com/DataDog/dd-trace-java/releases" target="_blank">Java tracer</a> version 1.48.0 or later.</div>
+
 1. **Install the OpenLineage Spark provider.** Make the `openlineage-spark` JAR available on the classpath of your Spark driver and executors, following the [OpenLineage Spark installation guide][9]. Use OpenLineage version `1.29.0` or later, which is the first version that supports the run-tag facets that Data Observability: Jobs Monitoring relies on.
 
    You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -271,7 +271,7 @@ Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLinea
 
    You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
 
-2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` for your Spark driver. Lineage collection runs on the driver, so the executor does not need this setting.
+2. **Enable OpenLineage collection.** Set the `DD_DATA_JOBS_OPENLINEAGE_ENABLED` environment variable to `true` on the Spark driver.
 
    You can set the variable through any mechanism that adds environment variables to the driver. One way is the `ddTraceConfigs` of the `spark-driver` target from [Enable Single Step Instrumentation](#enable-single-step-instrumentation):
 

--- a/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -269,7 +269,7 @@ Data Observability: Jobs Monitoring can collect Spark lineage through [OpenLinea
 
    You do not need to set `spark.extraListeners` or configure any `spark.openlineage.transport.*` options. When the feature is enabled and the JAR is present, the Datadog Java tracer registers the OpenLineage listener and routes lineage events through the local Datadog Agent.
 
-2. **Enable OpenLineage collection.** Add `DD_DATA_JOBS_OPENLINEAGE_ENABLED` to the `ddTraceConfigs` of the `spark-driver` and `spark-executor` targets from [Enable Single Step Instrumentation](#enable-single-step-instrumentation):
+2. **Enable OpenLineage collection.** Add `DD_DATA_JOBS_OPENLINEAGE_ENABLED` to the `ddTraceConfigs` of the `spark-driver` target from [Enable Single Step Instrumentation](#enable-single-step-instrumentation). Lineage collection runs on the Spark driver, so the `spark-executor` target does not need this setting:
 
    ```yaml
    ddTraceConfigs:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Two related Data Observability: Jobs Monitoring (DJM) documentation changes:

- **EMR:** Correct the documented default of `DD_OPENLINEAGE_ENABLED` from `true` to `false`. The installer only enables OpenLineage when the variable is explicitly set to `true`; when it is unset, OpenLineage is not enabled. The quickstart snippet on the page continues to set it to `true`.
- **Spark on Kubernetes:** Add a "Collect Spark lineage with OpenLineage" section documenting the two-step setup — install the `openlineage-spark` provider JAR (OpenLineage `1.29.0`+, the first version with the required run-tag facets), then enable `DD_DATA_JOBS_OPENLINEAGE_ENABLED` in the Single Step Instrumentation `ddTraceConfigs`. The Java tracer registers the listener and routes lineage through the local Agent, so users do not configure `spark.extraListeners` or `spark.openlineage.transport.*` themselves.

### Merge instructions

Merge readiness:
- [ ] Ready for merge
