### PR TITLE
Correct cases MCP toolset status: Preview, not GA

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -697,7 +697,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 
 These toolsets are in Preview and are not included in the `all` alias; request them explicitly by name. Access requirements vary by toolset, as noted below. Where a Product Preview form is listed, sign up through it or contact [Datadog support][47] to request access.
 - `apm`: ([Sign up][45]) Tools for in-depth [APM][34] trace analysis, span search, Watchdog insights, and performance investigation
-- `cases`: (No access request required) Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues
+- `cases`: Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues. No sign-up or access request required.
 - `code-exec`: ([Sign up][60]) A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 - `remote-actions`: ([Sign up][62]) Tools for on-host diagnostics, including reading files, listing directories, and running safe read-only shell commands directly on instrumented hosts through the Agent
 

--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -672,7 +672,6 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `core`: The default toolset for logs, metrics, traces, dashboards, monitors, incidents, hosts, services, events, and notebooks
 - `alerting`: Tools for validating and creating monitors, searching monitor groups, retrieving monitor templates, analyzing monitor coverage, and searching SLOs
 - `audit-trail`: Tools for [Audit Trail][70], including searching and retrieving Audit Trail events and forming Audit Trail search queries
-- `cases`: Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues
 - `cost`: Tools for [Cloud Cost Management][63], including listing cost-saving recommendations ranked by estimated potential daily savings
 - `dashboards`: Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation
 - `data-observability`: Tools for [Data Observability][69], including data catalog search, lineage analysis, data quality monitoring, and cost and performance recommendations for data warehouses and Spark jobs
@@ -696,8 +695,9 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 
 ### Preview toolsets
 
-These toolsets are in Preview. Sign up for a toolset by completing the Product Preview form or contact [Datadog support][47] to request access.
+These toolsets are in Preview and are not included in the `all` alias; request them explicitly by name. Access requirements vary by toolset, as noted below. Where a Product Preview form is listed, sign up through it or contact [Datadog support][47] to request access.
 - `apm`: ([Sign up][45]) Tools for in-depth [APM][34] trace analysis, span search, Watchdog insights, and performance investigation
+- `cases`: (No access request required) Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues
 - `code-exec`: ([Sign up][60]) A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 - `remote-actions`: ([Sign up][62]) Tools for on-host diagnostics, including reading files, listing directories, and running safe read-only shell commands directly on instrumented hosts through the Agent
 

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -411,7 +411,7 @@ Translates a natural-language description into an Audit Trail query string. If y
 
 Tools for [Case Management][38], including creating, searching, and updating cases; managing projects; and linking Jira issues.
 
-<div class="alert alert-info">The <code>cases</code> toolset is in Preview and is not included in <code>toolsets=all</code>. Request it explicitly with <code>toolsets=cases</code>. No sign-up or access request is required.</div>
+<div class="alert alert-info">The <code>cases</code> toolset is not enabled by default. See <a href="/mcp_server/setup">Set Up the Datadog MCP Server</a> for instructions on enabling toolsets.</div>
 
 ### `search_datadog_cases`
 *Toolset: **cases***\

--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -411,6 +411,8 @@ Translates a natural-language description into an Audit Trail query string. If y
 
 Tools for [Case Management][38], including creating, searching, and updating cases; managing projects; and linking Jira issues.
 
+<div class="alert alert-info">The <code>cases</code> toolset is in Preview and is not included in <code>toolsets=all</code>. Request it explicitly with <code>toolsets=cases</code>. No sign-up or access request is required.</div>
+
 ### `search_datadog_cases`
 *Toolset: **cases***\
 *Permissions Required: `Cases Read`*\


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Corrects the documented status of the `cases` MCP Server toolset. It was listed under **Available toolsets**, a section introduced with "These toolsets are generally available", which implied `cases` is generally available and included in the `toolsets=all` alias. Neither is true: the toolset is not part of `all` and has to be requested explicitly with `toolsets=cases`. A reader following the current docs would enable `toolsets=all`, expect the case tools, and not get them.

Changes, all in `content/en`:

- `mcp_server/setup.md`: moved the `cases` bullet from the generally-available list into the **Preview toolsets** list.
- `mcp_server/setup.md`: reworded the Preview section intro. It previously told every reader to complete a Product Preview form or contact support, which is only true for the toolsets that carry a sign-up link. It now says Preview toolsets are excluded from `all` and must be requested by name, and that access requirements vary per toolset.
- `mcp_server/tools.md`: added a Preview callout under the `## Cases` heading, matching the existing convention for `apm`, `code-exec`, and `remote-actions`.

One nuance worth a reviewer's eye: unlike the other Preview toolsets, `cases` has no sign-up or access request associated with it — it is available to organizations that have Case Management, which is the default. So the entry is annotated "(No access request required)" and the callout says no sign-up is needed. The only actual restriction is its exclusion from `all`. Happy to reword if the docs team would rather keep the Preview section uniform in tone.

### Merge readiness

- [ ] Ready for merge

<!-- Left unchecked: opened as a draft. Since this removes a generally-available claim rather than adding one, it would be good to have the MCP Server owners confirm the intended status of `cases` before merge. -->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the incorrect claim, cross-check it against the MCP Server's toolset configuration, and draft the wording. Reviewed manually.

### Additional notes

Only `content/en` was touched. The `es`/`fr`/`ja`/`ko` copies of these pages carry the same error but are handled by the translation pipeline.
