### PR TITLE
[MCPSS-49] Note that the cases toolset is not enabled by default

### DIFF
--- a/content/en/mcp_server/tools.md
+++ b/content/en/mcp_server/tools.md
@@ -411,6 +411,8 @@ Translates a natural-language description into an Audit Trail query string. If y
 
 Tools for [Case Management][38], including creating, searching, and updating cases; managing projects; and linking Jira issues.
 
+<div class="alert alert-info">The <code>cases</code> toolset is not enabled by default. See <a href="/mcp_server/setup">Set Up the Datadog MCP Server</a> for instructions on enabling toolsets.</div>
+
 ### `search_datadog_cases`
 *Toolset: **cases***\
 *Permissions Required: `Cases Read`*\


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes MCPSS-49

Adds a note to the Case Management toolset section of the MCP Server tools page clarifying that the `cases` toolset is not enabled by default, and links to the setup page for instructions on enabling toolsets.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes