### PR TITLE
[DADP-158] Document Agent performance CPU metric

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -239,6 +239,7 @@ agent diagnose show-metadata agent-telemetry
 | agent_performance.containers_terminated     | Number of container terminations for the Cluster Agent and Cluster Checks Runner pods, tagged by reason                |
 | agent_performance.memory_usage              | Total container runtime memory usage, in bytes, for the Cluster Agent and Cluster Checks Runner pods                   |
 | agent_performance.memory_limit              | Total container runtime memory limits, in bytes, for the Cluster Agent and Cluster Checks Runner pods                  |
+| agent_performance.cpu_usage                 | Total container runtime CPU usage, in CPU cores, for the Cluster Agent and Cluster Checks Runner pods                  |
 | **eBPF**                                    |                                                                                                                        |
 | ebpf.core_load_success                      | Number of successful loads of an eBPF CO-RE program                                                                    |
 | ebpf.core_load_error                        | Number of errors loading an eBPF CO-RE program                                                                         |


### PR DESCRIPTION
Adds documentation for a new COAT metric `agent_performance.cpu_usage` following the same patterns for the existing `agent_performance.` metrics. Implementation PR: https://github.com/DataDog/datadog-agent/pull/54144

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DADP-158

Adds `agent_performance.cpu_usage` to the Agent Telemetry metric reference.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

