### PR TITLE
[DOCS-9459] Document GCP log tag enrichment behavior

### DIFF
--- a/content/en/logs/guide/google-cloud-log-forwarding.md
+++ b/content/en/logs/guide/google-cloud-log-forwarding.md
@@ -260,6 +260,10 @@ New logging events delivered to the Cloud Pub/Sub topic appear in the [Datadog L
 
 **Note**: You can use the [Google Cloud Pricing Calculator][9] to calculate potential costs.
 
+## Tags
+
+Logs forwarded through the Datadog Dataflow template are enriched with resource tags collected by the Google Cloud integration, so you can correlate your Google Cloud logs with your Google Cloud metrics using the same tags. Tag enrichment support varies by resource type.
+
 ## Monitor the Cloud Pub/Sub log forwarding
 
 The [Google Cloud Pub/Sub integration][10] provides helpful metrics to monitor the status of the log forwarding:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-9459

Adds a "Tags" section to the Google Cloud log forwarding guide, documenting that logs forwarded through the Datadog Dataflow template are enriched with resource tags so they can be correlated with Google Cloud metrics using the same tags.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Open question for reviewer: tag enrichment support is resource-type-dependent, and specific unsupported resource types were intentionally left out of this doc since my source for that detail may be outdated. Please confirm whether known gaps should be called out explicitly, or if the resource-type-dependent framing is sufficient as written.