### PR TITLE
MySQL DBM: recommend REFERENCES instead of SELECT for schema collection

### DIFF
--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -220,6 +220,20 @@ GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog
 
 <!-- TODO: add a custom query recipe for getting the max sql text length -->
 
+### Tables are missing from collected schemas
+
+If the Agent logs this warning:
+```
+No tables were found across any of the N databases. This may indicate insufficient privileges to view table metadata. The datadog user needs REFERENCES (or SELECT) privileges on the tables.
+```
+MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table, so the `datadog` user sees no tables at all without one. Resolve the warning by granting the `REFERENCES` privilege, which makes your table metadata visible without giving the Agent any ability to read your data:
+
+```sql
+GRANT REFERENCES ON *.* TO datadog@'%';
+```
+
+If only some tables are missing, check that the grant covers them. A grant scoped to individual columns exposes only the granted columns, and a grant scoped to one database or table covers only that database or table. See [Collecting schemas][10] for the available scopes.
+
 ### Schema or Database missing on MySQL Query Metrics & Samples
 
 The `schema` tag (also known as "database") is present on MySQL Query Metrics and Samples only when a Default Database is set on the connection that made the query. The Default Database is configured by the application by specifying the "schema" in the database connection parameters, or by executing the [USE Statement][9] on an already existing connection.
@@ -267,3 +281,4 @@ MariaDB does not produce the same JSON format as MySQL for explain plans. Certai
 [7]: /database_monitoring/data_collected/#which-queries-are-tracked
 [8]: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_digest_length
 [9]: https://dev.mysql.com/doc/refman/8.0/en/use.html
+[10]: /database_monitoring/setup_mysql/selfhosted/?tab=mysql57#collecting-schemas

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -226,7 +226,7 @@ If the Agent logs a warning starting with:
 ```
 No tables were found across any of the N databases.
 ```
-MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table, so the `datadog` user sees no tables at all without one. The rest of the warning varies by Agent version. Resolve the warning by granting the `REFERENCES` privilege, which makes your table metadata visible without giving the Agent any ability to read your data:
+MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table, so the `datadog` user sees no tables at all without one. Resolve the warning by granting the `REFERENCES` privilege, which makes your table metadata visible without giving the Agent any ability to read your data:
 
 ```sql
 GRANT REFERENCES ON *.* TO datadog@'%';

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -222,11 +222,11 @@ GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog
 
 ### Tables are missing from collected schemas
 
-If the Agent logs this warning:
+If the Agent logs a warning starting with:
 ```
-No tables were found across any of the N databases. This may indicate insufficient privileges to view table metadata. The datadog user needs REFERENCES (or SELECT) privileges on the tables.
+No tables were found across any of the N databases.
 ```
-MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table, so the `datadog` user sees no tables at all without one. Resolve the warning by granting the `REFERENCES` privilege, which makes your table metadata visible without giving the Agent any ability to read your data:
+MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table, so the `datadog` user sees no tables at all without one. The rest of the warning varies by Agent version. Resolve the warning by granting the `REFERENCES` privilege, which makes your table metadata visible without giving the Agent any ability to read your data:
 
 ```sql
 GRANT REFERENCES ON *.* TO datadog@'%';

--- a/layouts/shortcodes/dbm-mysql-agent-config-examples.en.md
+++ b/layouts/shortcodes/dbm-mysql-agent-config-examples.en.md
@@ -84,26 +84,22 @@ instances:
 ```
 **Note**: For Agent v7.68 and below, use `schemas_collection` instead of `collect_schemas`.
 
-**Note**: To collect schemas for a table, MySQL requires that the Datadog Agent has SELECT access for it. This is a [MySQL-enforced restriction](https://dev.mysql.com/doc/refman/8.4/en/information-schema-introduction.html#information-schema-privileges). Without SELECT access, the table will not appear in metadata queries.
+**Note**: To collect schemas for a table, MySQL requires that the Datadog Agent holds a privilege on that table. This is a [MySQL-enforced restriction](https://dev.mysql.com/doc/refman/8.4/en/information-schema-introduction.html#information-schema-privileges): a table that the Agent has no privilege on does not appear in metadata queries at all.
 
-The Agent does not use SELECT to access or read your table data. This permission is needed solely to retrieve schema details, due to how MySQL handles metadata visibility.
+Datadog recommends granting the `REFERENCES` privilege. It satisfies MySQL's metadata visibility requirement without granting any ability to read the contents of your tables. The Agent never reads your table data; it only needs your tables to be visible in `INFORMATION_SCHEMA`.
 
-To grant SELECT permissions to a Datadog user, use one or a combination of the following commands:
-- **All databases**:
+Use one or a combination of the following commands:
+- **All databases** (recommended, since databases and tables created later are picked up automatically):
     ```sql
-    GRANT SELECT ON *.* TO datadog@'%';
+    GRANT REFERENCES ON *.* TO datadog@'%';
     ```
 - **Per database basis**:
     ```sql
-    GRANT SELECT ON [database name].* TO datadog@'%';
+    GRANT REFERENCES ON [database name].* TO datadog@'%';
     ```
 - **Per table basis**:
     ```sql
-    GRANT SELECT ON [database name].[table name] TO datadog@'%';
-    ```
-- **Per column basis**:
-    ```sql
-    GRANT SELECT ([column name1], [column name 2]) ON [database name].[table name] TO datadog@'%';
+    GRANT REFERENCES ON [database name].[table name] TO datadog@'%';
     ```
 
 ### Working with hosts through a proxy

--- a/layouts/shortcodes/dbm-mysql-agent-config-examples.en.md
+++ b/layouts/shortcodes/dbm-mysql-agent-config-examples.en.md
@@ -102,6 +102,8 @@ Use one or a combination of the following commands:
     GRANT REFERENCES ON [database name].[table name] TO datadog@'%';
     ```
 
+**Note**: Explain plan collection relies on the `explain_statement` procedure being present in each schema you collect from, as described in the setup instructions for your hosting type. With `REFERENCES` in place of `SELECT`, the Agent can no longer run `EXPLAIN` directly as a fallback, so create the procedure in every schema you want explain plans from.
+
 ### Working with hosts through a proxy
 If the Agent must connect through a proxy such as the [Cloud SQL Auth proxy](https://cloud.google.com/sql/docs/mysql/connect-admin-proxy), all telemetry is tagged with the hostname of the proxy rather than the database instance. Use the `reported_hostname` option to set a custom override of the hostname detected by the Agent.
 ```yaml


### PR DESCRIPTION
### What does this PR do?

Changes the "Collecting schemas" section of the MySQL Database Monitoring setup pages to recommend `GRANT REFERENCES` instead of `GRANT SELECT`, drops the per-column scoping option, and adds a troubleshooting entry for the "no tables were found" warning.

Affects all five MySQL setup pages (self-hosted, RDS, Aurora, Azure, Cloud SQL), since they share the `dbm-mysql-agent-config-examples` shortcode.

### Motivation

MySQL exposes a table in `INFORMATION_SCHEMA` only to users that hold a privilege on that table. That is why this page currently asks customers to grant the Agent `SELECT` on their tables, and why it has to reassure them in prose that "the Agent does not use SELECT to access or read your table data."

The `REFERENCES` privilege satisfies the same visibility requirement and grants no ability to read data at all, so we can stop asking for read access on customer data and the reassurance becomes a property of the grant rather than a promise. Testing across MySQL 5.7 / 8.0 / 8.4 / 9.x and MariaDB 10.11 / 11.4 confirmed the Agent collects a byte-identical schema payload under `REFERENCES`, while `SELECT` on a user table returns `ERROR 1142`. The privilege is grantable on RDS/Aurora, Cloud SQL, and Azure Database for MySQL.

The per-column option is removed because a column-level grant exposes only the granted columns, so it yields an incomplete schema.

### Preview links

<!-- Filled in by the docs preview bot. -->