### PR TITLE
Remove inaccurate export references in lineage docs

### DIFF
--- a/content/en/data_observability/lineage.md
+++ b/content/en/data_observability/lineage.md
@@ -132,7 +132,7 @@ Before changing or dropping a column, table, or model, use lineage to see what d
 1. Anchor on the asset you plan to change.
 2. Set downstream depth to `∞` and upstream depth to `0`.
 3. Filter to the asset types you care about—for example, leave dashboards and reports visible to identify affected BI consumers.
-4. Switch to {{< ui >}}List{{< /ui >}} view to view the full list of affected assets.
+4. Switch to {{< ui >}}List{{< /ui >}} view to see the full list of affected assets.
 
 {{< img src="data_observability/lineage/impact-analysis-list-view.png" alt="The List view showing every downstream asset that depends on a given Snowflake table, with type and source columns" style="width:100%;" >}}
 

--- a/content/en/data_observability/lineage.md
+++ b/content/en/data_observability/lineage.md
@@ -81,7 +81,7 @@ The {{< ui >}}Lineage Controls{{< /ui >}} panel on the left configures the shape
 
 ### Map, List, and Find
 
-Toggle between {{< ui >}}Map{{< /ui >}} (the default graph view) and {{< ui >}}List{{< /ui >}} (a flat, sortable list of every asset in the current slice). Use {{< ui >}}List{{< /ui >}} to export, copy, or scan a large lineage; use {{< ui >}}Map{{< /ui >}} to understand structure visually.
+Toggle between {{< ui >}}Map{{< /ui >}} (the default graph view) and {{< ui >}}List{{< /ui >}} (a flat, sortable list of every asset in the current slice). Use {{< ui >}}List{{< /ui >}} to scan a large lineage; use {{< ui >}}Map{{< /ui >}} to understand structure visually.
 
 The magnifying-glass icon next to the toggle fits the graph to the viewport.
 
@@ -132,7 +132,7 @@ Before changing or dropping a column, table, or model, use lineage to see what d
 1. Anchor on the asset you plan to change.
 2. Set downstream depth to `∞` and upstream depth to `0`.
 3. Filter to the asset types you care about—for example, leave dashboards and reports visible to identify affected BI consumers.
-4. Switch to {{< ui >}}List{{< /ui >}} view to export the full list of affected assets or share it with the owning teams.
+4. Switch to {{< ui >}}List{{< /ui >}} view to view the full list of affected assets.
 
 {{< img src="data_observability/lineage/impact-analysis-list-view.png" alt="The List view showing every downstream asset that depends on a given Snowflake table, with type and source columns" style="width:100%;" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The lineage List view does not support exporting data! This PR removes the incorrect "export" wording from the lineage docs and rephrases the affected sentences.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes