### PR TITLE
Fix misleading Docker volume path guidance for private locations

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -178,7 +178,7 @@ Launch your private location on:
 {{< tabs >}}
 {{% tab "Docker" %}}
 
-Run this command to boot your private location worker by mounting your configuration file to the container. Ensure that your `<MY_WORKER_CONFIG_FILE_NAME>.json` file is in `/etc/docker`, not the root home folder:
+Run this command to boot your private location worker by mounting your configuration file to the container. The `$PWD` in the command below refers to the directory you run the command from, so replace it with the path to wherever your `<MY_WORKER_CONFIG_FILE_NAME>.json` file is stored. The path before the colon (the location on your host machine) can be any directory; only the path after the colon (`/etc/datadog/synthetics-check-runner.json`) must match exactly, since that is where the worker expects to find its configuration inside the container:
 
 ```shell
 docker run -d --restart unless-stopped -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker:latest


### PR DESCRIPTION
## Summary
- Fixes DOCS-14963: the Docker tab instructions for Synthetic private locations said the worker config file must be placed in `/etc/docker`, but the example command mounts from `$PWD` — these two statements contradicted each other.
- Clarifies that the host-side path (before the colon in the `-v` flag) can be any directory; only the container-side path (`/etc/datadog/synthetics-check-runner.json`) needs to match exactly, since that's what the worker looks for inside the container.

## Test plan
- [ ] Docs preview renders the "Docker" tab correctly under **Synthetic Monitoring > Settings > Private Locations**
- [ ] Verify the corrected wording matches the actual `-v` bind-mount semantics used by the `docker run` command

Jira: https://datadoghq.atlassian.net/browse/DOCS-14963