### PR TITLE
Fix inaccurate issue team ownership priority claim

### DIFF
--- a/content/en/error_tracking/issue_team_ownership.md
+++ b/content/en/error_tracking/issue_team_ownership.md
@@ -12,9 +12,9 @@ further_reading:
 
 ## Overview
 
-Issue Team Ownership automates your triaging work by assigning issues to the right teams. Datadog infers team ownership from two prioritized sources and one additional, always-applied source:
+Issue Team Ownership automates your triaging work by assigning issues to the right teams. Datadog infers team ownership from the following sources, in priority order:
 
-1. [Team attribute](#team-attribute): based on the `team` attribute set on the error event at runtime. This takes priority over CODEOWNERS.
+1. [Team attribute](#team-attribute): based on the `team` attribute set on the error event at runtime.
 2. [CODEOWNERS](#codeowners-file): based on the top-level stack frame of the issue according to GitHub `CODEOWNERS`. This is used when no `team` attribute is set.
 
 In addition, [service ownership](#service-ownership) is always applied, based on the owner of the service where the issue happens. Unlike the other two sources, service ownership is dynamic and stays up to date with your service ownership configuration, even after the issue is created.

--- a/content/en/error_tracking/issue_team_ownership.md
+++ b/content/en/error_tracking/issue_team_ownership.md
@@ -12,11 +12,12 @@ further_reading:
 
 ## Overview
 
-Issue Team Ownership automates your triaging work by assigning issues to the right teams. There are three independent ways to infer team ownership, in order of priority:
+Issue Team Ownership automates your triaging work by assigning issues to the right teams. Datadog infers team ownership from two prioritized sources and one additional, always-applied source:
 
-1. [Team attribute](#team-attribute): based on the `team` attribute set on the error event at runtime.
-2. [CODEOWNERS](#codeowners-file): based on the top-level stack frame of the issue according to GitHub `CODEOWNERS`.
-3. [Service ownership](#service-ownership): based on the owner of the service where the issue happens.
+1. [Team attribute](#team-attribute): based on the `team` attribute set on the error event at runtime. This takes priority over CODEOWNERS.
+2. [CODEOWNERS](#codeowners-file): based on the top-level stack frame of the issue according to GitHub `CODEOWNERS`. This is used when no `team` attribute is set.
+
+In addition, [service ownership](#service-ownership) is always applied, based on the owner of the service where the issue happens. Unlike the other two sources, service ownership is dynamic and stays up to date with your service ownership configuration, even after the issue is created.
 
 ## Team attribute
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

**Why**
The Issue Team Ownership Overview stated that team attribute, CODEOWNERS, and service ownership were three items in a single priority list. This is inaccurate: service ownership is a separate, always-applied, dynamic mechanism, not just another item competing on priority with the other two.

**What**
Corrects the Overview: team attribute and CODEOWNERS are prioritized against each other, while service ownership is applied on top of that result and stays dynamically up to date after issue creation.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes