### PR TITLE
[DOCS-9151] Document custom certificate authorities for the private action runner

### DIFF
--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -635,7 +635,7 @@ As an alternative to the agent-based installation, you can run the private actio
 
    You can safely ignore the error `DATADOG TRACER DIAGNOSTIC - Agent Error: connect ECONNREFUSED`.
 
-[101]: https://docs.docker.com/compose/compose-application-model/
+[101]: https://docs.docker.com/compose/intro/compose-application-model/
 {{% /tab %}}
 
 {{% tab "Kubernetes" %}}
@@ -724,7 +724,7 @@ export DD_APP_KEY="<YOUR_APP_KEY>"
 DD_API_KEY=$DD_API_KEY DD_APP_KEY=$DD_APP_KEY docker compose up -d
 ```
 
-[101]: https://docs.docker.com/compose/compose-application-model/
+[101]: https://docs.docker.com/compose/intro/compose-application-model/
 {{% /tab %}}
 
 {{% tab "Kubernetes" %}}
@@ -764,14 +764,17 @@ See [Connect a runner](#connect-a-runner) for more information on pairing your r
 
 ### Custom CA certificates
 
-If your organization uses a custom certificate authority (CA) to issue certificates for internal services, such as HTTP endpoints or Jenkins, you can configure your private action runner to trust that CA.
+If your organization uses a custom certificate authority (CA) to issue certificates for internal services, such as HTTP endpoints or Jenkins, you can configure a standalone private action runner to trust that CA.
 
 {{< tabs >}}
 {{% tab "Docker" %}}
 
 Add the `SSL_CERT_DIR` environment variable and mount your certificate to the `docker run` command, replacing `<PATH_TO_YOUR_CA_CERTIFICATE>` with the path to your CA certificate file:
 
-  ...
+```bash
+docker run -d \
+  -e SSL_CERT_DIR=/etc/dd-action-runner/config/ca-certificates \
+  -v <PATH_TO_YOUR_CA_CERTIFICATE>:/etc/dd-action-runner/config/ca-certificates/ca.crt \
 ```
 
 {{% /tab %}}
@@ -780,6 +783,12 @@ Add the `SSL_CERT_DIR` environment variable and mount your certificate to the `d
 
 Add the `SSL_CERT_DIR` environment variable and mount your certificate in your `docker-compose.yaml` file, replacing `<PATH_TO_YOUR_CA_CERTIFICATE>` with the path to your CA certificate file:
 
+```yaml
+runner:
+  environment:
+    SSL_CERT_DIR: /etc/dd-action-runner/config/ca-certificates
+  volumes:
+    - "<PATH_TO_YOUR_CA_CERTIFICATE>:/etc/dd-action-runner/config/ca-certificates/ca.crt"
 ```
 
 {{% /tab %}}

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -769,12 +769,8 @@ If your organization uses a custom certificate authority (CA) to issue certifica
 {{< tabs >}}
 {{% tab "Docker" %}}
 
-Add the `SSL_CERT_DIR` environment variable and mount your certificate to the `docker run` command, replacing `PATH_TO_YOUR_CA_CERTIFICATE` with the path to your CA certificate file:
+Add the `SSL_CERT_DIR` environment variable and mount your certificate to the `docker run` command, replacing `<PATH_TO_YOUR_CA_CERTIFICATE>` with the path to your CA certificate file:
 
-```bash
-docker run -d \
-  -e SSL_CERT_DIR=/etc/dd-action-runner/config/ca-certificates \
-  -v PATH_TO_YOUR_CA_CERTIFICATE:/etc/dd-action-runner/config/ca-certificates/ca.crt \
   ...
 ```
 
@@ -782,14 +778,8 @@ docker run -d \
 
 {{% tab "Docker Compose" %}}
 
-Add the `SSL_CERT_DIR` environment variable and mount your certificate in your `docker-compose.yaml` file, replacing `PATH_TO_YOUR_CA_CERTIFICATE` with the path to your CA certificate file:
+Add the `SSL_CERT_DIR` environment variable and mount your certificate in your `docker-compose.yaml` file, replacing `<PATH_TO_YOUR_CA_CERTIFICATE>` with the path to your CA certificate file:
 
-```yaml
-runner:
-  environment:
-    SSL_CERT_DIR: /etc/dd-action-runner/config/ca-certificates
-  volumes:
-    - "PATH_TO_YOUR_CA_CERTIFICATE:/etc/dd-action-runner/config/ca-certificates/ca.crt"
 ```
 
 {{% /tab %}}

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -762,6 +762,63 @@ When you see the {{< ui >}}Ready to use{{< /ui >}} status, you can create a new 
 
 See [Connect a runner](#connect-a-runner) for more information on pairing your runner with a connection.
 
+### Custom CA certificates
+
+If your organization uses a custom certificate authority (CA) to issue certificates for internal services, such as HTTP endpoints or Jenkins, you can configure a standalone private action runner to trust that CA. Provide the runner with the `SSL_CERT_DIR` environment variable and mount your CA certificate into the container at that path.
+
+{{< tabs >}}
+{{% tab "Docker" %}}
+
+Add the `SSL_CERT_DIR` environment variable and mount your certificate to the `docker run` command, replacing `PATH_TO_YOUR_CA_CERTIFICATE` with the path to your CA certificate file:
+
+```bash
+docker run -d \
+  -e SSL_CERT_DIR=/etc/dd-action-runner/config/ca-certificates \
+  -v PATH_TO_YOUR_CA_CERTIFICATE:/etc/dd-action-runner/config/ca-certificates/ca.crt \
+  ...
+```
+
+{{% /tab %}}
+
+{{% tab "Docker Compose" %}}
+
+Add the `SSL_CERT_DIR` environment variable and mount your certificate in your `docker-compose.yaml` file, replacing `PATH_TO_YOUR_CA_CERTIFICATE` with the path to your CA certificate file:
+
+```yaml
+runner:
+  environment:
+    SSL_CERT_DIR: /etc/dd-action-runner/config/ca-certificates
+  volumes:
+    - "PATH_TO_YOUR_CA_CERTIFICATE:/etc/dd-action-runner/config/ca-certificates/ca.crt"
+```
+
+{{% /tab %}}
+
+{{% tab "Kubernetes" %}}
+
+1. Create a ConfigMap containing your CA certificate:
+
+   ```bash
+   kubectl create configmap my-ca-cert --from-file=ca.crt=./my-custom-ca.pem
+   ```
+
+1. In your Helm `values.yaml` file, reference the ConfigMap:
+
+   ```yaml
+   runner:
+     customCaCert:
+       configMapName: my-ca-cert
+   ```
+
+1. Apply the updated values:
+
+   ```bash
+   helm upgrade --install datadog-par datadog/private-action-runner -f values.yaml
+   ```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Manage access
 
 Use [role-based access control (RBAC)][17] to control access to your private action runner. To see the list of permissions that apply to private action runner, see [Datadog Role Permissions][18].

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -764,7 +764,7 @@ See [Connect a runner](#connect-a-runner) for more information on pairing your r
 
 ### Custom CA certificates
 
-If your organization uses a custom certificate authority (CA) to issue certificates for internal services, such as HTTP endpoints or Jenkins, you can configure a standalone private action runner to trust that CA. Provide the runner with the `SSL_CERT_DIR` environment variable and mount your CA certificate into the container at that path.
+If your organization uses a custom certificate authority (CA) to issue certificates for internal services, such as HTTP endpoints or Jenkins, you can configure your private action runner to trust that CA.
 
 {{< tabs >}}
 {{% tab "Docker" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [DOCS-9151](https://datadoghq.atlassian.net/browse/DOCS-9151)

- Adds a "Custom CA certificates" section to the private action runner setup docs, covering how to configure a standalone runner to trust an internal certificate authority.
- Docker and Docker Compose instructions use the `SSL_CERT_DIR` environment variable with a mounted certificate.
- Kubernetes instructions use the private action runner Helm chart's native `customCaCert.configMapName` option.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-9151]: https://datadoghq.atlassian.net/browse/DOCS-9151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ