### PR TITLE
Move Cloud Security ownership docs under Review and Remediate

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -8382,6 +8382,16 @@ menu:
       parent: csm_review_remediate
       identifier: csm_remediate_with_ai
       weight: 103
+    - name: Ownership Agent
+      url: security/cloud_security_management/review_remediate/ownership_agent
+      parent: csm_review_remediate
+      identifier: csm_ownership_agent
+      weight: 104
+    - name: Set Up Ownership Preferences
+      url: security/cloud_security_management/review_remediate/ownership_preferences
+      parent: csm_review_remediate
+      identifier: csm_ownership_preferences
+      weight: 105
     - name: Triage and Prioritize
       url: security/cloud_security_management/triage_and_prioritize/
       parent: csm

--- a/content/en/security/cloud_security_management/guide/frontier_group/_index.md
+++ b/content/en/security/cloud_security_management/guide/frontier_group/_index.md
@@ -23,8 +23,8 @@ The frontier group is an opt-in program where you get access to the newest AI fe
 ***Status:*** *available for frontier partners*<br>
 Automated inference on who owns a particular resource and should be responsible for remediating it. See [Ownership Agent][1] for an overview of data sources, supported resource types, and the correction workflow, and [Set Up Ownership Preferences][2] to customize ownership rules with your own data.
 
-[1]: /security/cloud_security_management/guide/frontier_group/ownership_agent/
-[2]: /security/cloud_security_management/guide/frontier_group/ownership_preferences/
+[1]: /security/cloud_security_management/review_remediate/ownership_agent/
+[2]: /security/cloud_security_management/review_remediate/ownership_preferences/
 
 ### 1-click CSPM remediation
 

--- a/content/en/security/cloud_security_management/guide/frontier_group/_index.md
+++ b/content/en/security/cloud_security_management/guide/frontier_group/_index.md
@@ -20,7 +20,7 @@ The frontier group is an opt-in program where you get access to the newest AI fe
 
 ### Ownership agent
 
-***Status:*** *available for frontier partners*<br>
+***Status:*** *generally available, 6 months after it was first tested by frontier partners*<br>
 Automated inference on who owns a particular resource and should be responsible for remediating it. See [Ownership Agent][1] for an overview of data sources, supported resource types, and the correction workflow, and [Set Up Ownership Preferences][2] to customize ownership rules with your own data.
 
 [1]: /security/cloud_security_management/review_remediate/ownership_agent/

--- a/content/en/security/cloud_security_management/guide/frontier_group/_index.md
+++ b/content/en/security/cloud_security_management/guide/frontier_group/_index.md
@@ -20,7 +20,7 @@ The frontier group is an opt-in program where you get access to the newest AI fe
 
 ### Ownership agent
 
-***Status:*** *generally available, 6 months after it was first tested by frontier partners*<br>
+***Status:*** *generally available*<br>
 Automated inference on who owns a particular resource and should be responsible for remediating it. See [Ownership Agent][1] for an overview of data sources, supported resource types, and the correction workflow, and [Set Up Ownership Preferences][2] to customize ownership rules with your own data.
 
 [1]: /security/cloud_security_management/review_remediate/ownership_agent/

--- a/content/en/security/cloud_security_management/review_remediate/_index.md
+++ b/content/en/security/cloud_security_management/review_remediate/_index.md
@@ -7,5 +7,7 @@ disable_toc: true
     {{< nextlink href="/security/cloud_security_management/review_remediate/mute_issues" >}}Mute Issues in Cloud Security{{< /nextlink >}}
     {{< nextlink href="/security/cloud_security_management/review_remediate/workflows" >}}Automate Security Workflows with Workflow Automation{{< /nextlink >}}
     {{< nextlink href="/security/cloud_security_management/review_remediate/remediate_with_ai" >}}Remediate Cloud Security findings with AI{{< /nextlink >}}
+    {{< nextlink href="/security/cloud_security_management/review_remediate/ownership_agent" >}}Infer resource owners with the Ownership Agent{{< /nextlink >}}
+    {{< nextlink href="/security/cloud_security_management/review_remediate/ownership_preferences" >}}Set up ownership preferences with your own data{{< /nextlink >}}
     {{< nextlink href="/security/ticketing_integrations" >}}Create a ticket for Cloud Security Issues{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -40,15 +40,36 @@ The Ownership Agent reads multiple data sources and combines them into a ranked 
 The Ownership Agent processes the following cloud resource types:
 
 
-| Resource type                    | Cloud provider                    |
-| -------------------------------- | --------------------------------- |
-| `aws_ec2_instance`               | AWS                               |
-| `aws_s3_bucket`                  | AWS                               |
-| `azure_virtual_machine_instance` | Azure                             |
-| `gcp_compute_instance`           | GCP                               |
-| `host`                           | AWS, Azure, GCP                   |
-| `host_image`                     | AWS, Azure, GCP                   |
-| `image` (container)              | Docker, ECR, and other registries |
+| Resource type                     | Cloud provider                    |
+| --------------------------------- | --------------------------------- |
+| `aws_cloudformation_stack`        | AWS                               |
+| `aws_cloudfront_distribution`     | AWS                               |
+| `aws_cognito_user_pool`           | AWS                               |
+| `aws_dynamodb`                    | AWS                               |
+| `aws_ec2_instance`                | AWS                               |
+| `aws_ec2_settings`                | AWS                               |
+| `aws_ecr_repository`              | AWS                               |
+| `aws_ecs_cluster`                 | AWS                               |
+| `aws_ecs_service`                 | AWS                               |
+| `aws_elbv2_load_balancer`         | AWS                               |
+| `aws_iam_account`                 | AWS                               |
+| `aws_iam_policy`                  | AWS                               |
+| `aws_iam_role`                    | AWS                               |
+| `aws_iam_role_inline_policy`      | AWS                               |
+| `aws_iam_user`                    | AWS                               |
+| `aws_lambda_function`             | AWS                               |
+| `aws_rds_cluster`                 | AWS                               |
+| `aws_rds_instance`                | AWS                               |
+| `aws_s3_bucket`                   | AWS                               |
+| `aws_secretsmanager_secret`       | AWS                               |
+| `aws_security_group`              | AWS                               |
+| `aws_subnet`                      | AWS                               |
+| `aws_vpc`                         | AWS                               |
+| `azure_virtual_machine_instance`  | Azure                             |
+| `gcp_compute_instance`            | GCP                               |
+| `host`                            | AWS, Azure, GCP                   |
+| `host_image`                      | AWS, Azure, GCP                   |
+| `image` (container)               | Docker, ECR, and other registries |
 
 
 ## Review and correct ownership

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -24,7 +24,6 @@ Ownership suggestions appear in the Cloud Security side panel when you view a mi
 
 The Ownership Agent reads multiple data sources and combines them into a ranked evidence set. It evaluates data sources in priority order: stronger, more explicit signals override weaker or inferred ones.
 
-
 | Priority | Signal                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1        | **Owner tags**                 | Cloud resource tags with keys such as `owner`, `dd-team`, or `team`. An explicit ownership tag is the strongest signal.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -34,21 +33,15 @@ The Ownership Agent reads multiple data sources and combines them into a ranked 
 | 5        | **Container and host catalog** | Registry and host metadata for container images and host VMs, including image labels and host annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | 6        | **Naming patterns**            | Heuristics that infer ownership from resource names, service identifiers, or tag values that match known team naming conventions.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
-
 ## Supported resource types
 
 The Ownership Agent processes the following resource types:
 
-**AWS**: `aws_cloudformation_stack`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb`, `aws_ec2_instance`, `aws_ec2_settings`, `aws_ecr_repository`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_elbv2_load_balancer`, `aws_iam_account`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_inline_policy`, `aws_iam_user`, `aws_lambda_function`, `aws_rds_cluster`, `aws_rds_instance`, `aws_s3_bucket`, `aws_secretsmanager_secret`, `aws_security_group`, `aws_subnet`, `aws_vpc`
-
-**Azure**: `azure_virtual_machine_instance`
-
-**GCP**: `gcp_compute_instance`
-
-**AWS, Azure, GCP**: `host`, `host_image`
-
-**Container registries** (Docker, ECR, and others): `image`
-
+- **AWS**: `aws_cloudformation_stack`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb`, `aws_ec2_instance`, `aws_ec2_settings`, `aws_ecr_repository`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_elbv2_load_balancer`, `aws_iam_account`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_inline_policy`, `aws_iam_user`, `aws_lambda_function`, `aws_rds_cluster`, `aws_rds_instance`, `aws_s3_bucket`, `aws_secretsmanager_secret`, `aws_security_group`, `aws_subnet`, `aws_vpc`
+- **Azure**: `azure_virtual_machine_instance`
+- **GCP**: `gcp_compute_instance`
+- **AWS, Azure, GCP**: `host`, `host_image`
+- **Container registries** (Docker, ECR, and others): `image`
 
 ## Review and correct ownership
 
@@ -69,13 +62,11 @@ By clicking the "edit owner" pencil icon next to a suggested owner, you can upda
 
 You can provide richer feedback by clicking the "thumbs down" after hovering over the confidence score, including specifying incorrectness or incompleteness of the explanation.
 
-
 | Action          | What it does                                                                           |
 | --------------- | -------------------------------------------------------------------------------------- |
 | **Thumbs up**   | Marks the suggestion as accurate. The positive signal is recorded for future tuning.   |
 | **Thumbs down** | Marks the suggestion as inaccurate. The negative signal is recorded for future tuning. |
 | **Add details** | The correction is recorded for future tuning.                                          |
-
 
 ### Impact on evaluation
 
@@ -91,14 +82,12 @@ To adjust the confidence threshold or turn off automatic team assignment, use th
 
 You can filter findings by inferred owner in the [Misconfigurations Explorer](https://app.datadoghq.com/security/compliance) or Vulnerabilities Explorer using the following facets:
 
-
 | Facet                     | Description                                     | Example                                               |
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
 | `Ownership > Confidence`  | The numeric confidence score (0 to 1):<br>&bull; high: &ge;0.85<br>&bull; medium: &ge;0.60 and &lt;0.85<br>&bull; low: &lt;0.60 | `@_dd.ownership.inference.confidence:>=0.85`          |
 | `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
-
 
 **Example queries**
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -96,7 +96,7 @@ You can filter findings by inferred owner in the [Misconfigurations Explorer](ht
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
-| `Ownership > Confidence`  | The numeric confidence score (0 to 1):<br>&bull; high: >0.85<br>&bull; medium: 0.60-0.84<br>&bull; low: &lt;0.60 | `@_dd.ownership.inference.confidence:>0.8`            |
+| `Ownership > Confidence`  | The numeric confidence score (0 to 1):<br>&bull; high: &ge;0.85<br>&bull; medium: &ge;0.60 and &lt;0.85<br>&bull; low: &lt;0.60 | `@_dd.ownership.inference.confidence:>=0.85`          |
 | `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
 
 
@@ -111,7 +111,7 @@ To find all findings owned by a specific team:
 To find high-confidence suggestions:
 
 ```
-@_dd.ownership.inference.confidence:>0.85
+@_dd.ownership.inference.confidence:>=0.85
 ```
 
 To find findings attributed to specific users:

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -96,7 +96,10 @@ You can filter findings by inferred owner in the [Misconfigurations Explorer](ht
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
-| `Ownership > Confidence`  | The numeric confidence score (0 to 1)           | `@_dd.ownership.inference.confidence:>0.8`            |
+| `Ownership > Confidence`  | The numeric confidence score (0 to 1):          | `@_dd.ownership.inference.confidence:>0.8`            |
+|                           | - high: >0.85                                   |                                                       |
+|                           | - medium: 0.60-0.84                             |                                                       |
+|                           | - low: <0.60                                    |                                                       |
 | `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
 
 
@@ -108,7 +111,7 @@ To find all findings owned by a specific team:
 @_dd.ownership.inference.owner_handle:team-platform
 ```
 
-To find high-confidence suggestions that have not yet been reviewed:
+To find high-confidence suggestions:
 
 ```
 @_dd.ownership.inference.confidence:>0.85

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -37,23 +37,24 @@ The Ownership Agent reads multiple data sources and combines them into a ranked 
 
 ## Supported resource types
 
-The Ownership Agent processes the following cloud resource types:
+The Ownership Agent processes the following resource types:
 
+**AWS**: `aws_cloudformation_stack`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb`, `aws_ec2_instance`, `aws_ec2_settings`, `aws_ecr_repository`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_elbv2_load_balancer`, `aws_iam_account`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_inline_policy`, `aws_iam_user`, `aws_lambda_function`, `aws_rds_cluster`, `aws_rds_instance`, `aws_s3_bucket`, `aws_secretsmanager_secret`, `aws_security_group`, `aws_subnet`, `aws_vpc`
 
-| Cloud provider                    | Resource types |
-| --------------------------------- | -------------- |
-| AWS                               | `aws_cloudformation_stack`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb`, `aws_ec2_instance`, `aws_ec2_settings`, `aws_ecr_repository`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_elbv2_load_balancer`, `aws_iam_account`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_inline_policy`, `aws_iam_user`, `aws_lambda_function`, `aws_rds_cluster`, `aws_rds_instance`, `aws_s3_bucket`, `aws_secretsmanager_secret`, `aws_security_group`, `aws_subnet`, `aws_vpc` |
-| Azure                             | `azure_virtual_machine_instance` |
-| GCP                               | `gcp_compute_instance` |
-| AWS, Azure, GCP                   | `host`, `host_image` |
-| Docker, ECR, and other registries | `image` (container) |
+**Azure**: `azure_virtual_machine_instance`
+
+**GCP**: `gcp_compute_instance`
+
+**AWS, Azure, GCP**: `host`, `host_image`
+
+**Container registries** (Docker, ECR, and others): `image`
 
 
 ## Review and correct ownership
 
 ### View a suggestion
 
-When you open a finding in the [Misconfigurations Explorer](https://app.datadoghq.com/security/compliance) or Vulnerabilities Explorer,  the side panel displays the suggested owner under **Ownership**. Each suggestion includes:
+When you open a finding in the [Misconfigurations Explorer](https://app.datadoghq.com/security/compliance) or Vulnerabilities Explorer, the side panel displays the suggested owner under **Ownership**. Each suggestion includes:
 
 - The suggested owner handle and type (team, user, or service)
 - A confidence score (high, medium, or low)
@@ -66,7 +67,7 @@ By clicking the "edit owner" pencil icon next to a suggested owner, you can upda
 
 ### Feedback
 
-You can provide richer feedback by clicking the "thumbs down" after hovering over the confidence score, including specifying incorrectness of incompletness of the explanation.
+You can provide richer feedback by clicking the "thumbs down" after hovering over the confidence score, including specifying incorrectness or incompleteness of the explanation.
 
 
 | Action          | What it does                                                                           |
@@ -78,13 +79,13 @@ You can provide richer feedback by clicking the "thumbs down" after hovering ove
 
 ### Impact on evaluation
 
-Corrections and feedback are vital for tuning the agent to correctly infer ownership in future, and affect how the Ownership Agent behaves for that resource going forward.
+Corrections and feedback are vital for tuning the agent. They also affect how the Ownership Agent behaves for that resource going forward.
 
 ## Automatic team assignment
 
-By default, high-confidence ownership inferences are applied to the `team` tag on Cloud Security findings. This makes inferred owners available in platform features, through the MCP server, and in automatic notification routing.
+By default, high-confidence ownership inferences are applied to the `team` tag on Cloud Security findings. Inferred owners then become available in other Datadog features, including the [Datadog MCP server](/mcp_server/) and automatic notification routing.
 
-To adjust the confidence threshold, or to turn off automatic team assignment entirely, use the [ownership settings page](https://app.datadoghq.com/security/configuration/csm/ownership-agent).
+To adjust the confidence threshold or turn off automatic team assignment, use the [ownership settings page](https://app.datadoghq.com/security/configuration/csm/ownership-agent).
 
 ## Query ownership in the explorer
 
@@ -96,7 +97,7 @@ You can filter findings by inferred owner in the [Misconfigurations Explorer](ht
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
 | `Ownership > Confidence`  | The numeric confidence score (0 to 1)           | `@_dd.ownership.inference.confidence:>0.8`            |
-| `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag`*          |
+| `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
 
 
 **Example queries**

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -1,7 +1,9 @@
 ---
 title: Ownership Agent
+aliases:
+  - /security/cloud_security_management/guide/frontier_group/ownership_agent
 further_reading:
-- link: "/security/cloud_security_management/guide/frontier_group/ownership_preferences"
+- link: "/security/cloud_security_management/review_remediate/ownership_preferences"
   tag: "Documentation"
   text: "Set Up Ownership Preferences"
 - link: "/security/cloud_security_management/guide/frontier_group"
@@ -26,7 +28,7 @@ The Ownership Agent reads multiple data sources and combines them into a ranked 
 | Priority | Signal                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1        | **Owner tags**                 | Cloud resource tags with keys such as `owner`, `dd-team`, or `team`. An explicit ownership tag is the strongest signal.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| 2        | **Ownership preferences**      | Custom tag mappings and rules you define in a [reference table](/reference_tables). These act as organization-level overrides and are evaluated alongside direct tags. Learn more at [set up ownership preferences](/security/cloud_security_management/guide/frontier_group/ownership_preferences/). |
+| 2        | **Ownership preferences**      | Custom tag mappings and rules you define in a [reference table](/reference_tables). These act as organization-level overrides and are evaluated alongside direct tags. Learn more at [set up ownership preferences](/security/cloud_security_management/review_remediate/ownership_preferences/). |
 | 3        | **Service Catalog**            | Team ownership data from the Datadog Service Catalog, matched against the resource's service, application, or component tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 4        | **Cloud audit logs**           | The identity of the user or principal that created the resource, extracted from cloud provider audit logs (for example, AWS CloudTrail). Automation accounts and CI principals are filtered out.                                                                                                                                                                                                                                                                                                                                                                                   |
 | 5        | **Container and host catalog** | Registry and host metadata for container images and host VMs, including image labels and host annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -79,6 +81,12 @@ You can provide richer feedback by clicking the "thumbs down" after hovering ove
 ### Impact on evaluation
 
 Corrections and feedback are vital for tuning the agent to correctly infer ownership in future, and affect how the Ownership Agent behaves for that resource going forward.
+
+## Automatic team assignment
+
+By default, high-confidence ownership inferences are applied to the `team` tag on Cloud Security findings. This makes inferred owners available in platform features, through the MCP server, and in automatic notification routing.
+
+To adjust the confidence threshold, or to turn off automatic team assignment entirely, use the [ownership settings page](https://app.datadoghq.com/security/configuration/csm/ownership-agent).
 
 ## Query ownership in the explorer
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -40,36 +40,13 @@ The Ownership Agent reads multiple data sources and combines them into a ranked 
 The Ownership Agent processes the following cloud resource types:
 
 
-| Resource type                     | Cloud provider                    |
-| --------------------------------- | --------------------------------- |
-| `aws_cloudformation_stack`        | AWS                               |
-| `aws_cloudfront_distribution`     | AWS                               |
-| `aws_cognito_user_pool`           | AWS                               |
-| `aws_dynamodb`                    | AWS                               |
-| `aws_ec2_instance`                | AWS                               |
-| `aws_ec2_settings`                | AWS                               |
-| `aws_ecr_repository`              | AWS                               |
-| `aws_ecs_cluster`                 | AWS                               |
-| `aws_ecs_service`                 | AWS                               |
-| `aws_elbv2_load_balancer`         | AWS                               |
-| `aws_iam_account`                 | AWS                               |
-| `aws_iam_policy`                  | AWS                               |
-| `aws_iam_role`                    | AWS                               |
-| `aws_iam_role_inline_policy`      | AWS                               |
-| `aws_iam_user`                    | AWS                               |
-| `aws_lambda_function`             | AWS                               |
-| `aws_rds_cluster`                 | AWS                               |
-| `aws_rds_instance`                | AWS                               |
-| `aws_s3_bucket`                   | AWS                               |
-| `aws_secretsmanager_secret`       | AWS                               |
-| `aws_security_group`              | AWS                               |
-| `aws_subnet`                      | AWS                               |
-| `aws_vpc`                         | AWS                               |
-| `azure_virtual_machine_instance`  | Azure                             |
-| `gcp_compute_instance`            | GCP                               |
-| `host`                            | AWS, Azure, GCP                   |
-| `host_image`                      | AWS, Azure, GCP                   |
-| `image` (container)               | Docker, ECR, and other registries |
+| Cloud provider                    | Resource types |
+| --------------------------------- | -------------- |
+| AWS                               | `aws_cloudformation_stack`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb`, `aws_ec2_instance`, `aws_ec2_settings`, `aws_ecr_repository`, `aws_ecs_cluster`, `aws_ecs_service`, `aws_elbv2_load_balancer`, `aws_iam_account`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_inline_policy`, `aws_iam_user`, `aws_lambda_function`, `aws_rds_cluster`, `aws_rds_instance`, `aws_s3_bucket`, `aws_secretsmanager_secret`, `aws_security_group`, `aws_subnet`, `aws_vpc` |
+| Azure                             | `azure_virtual_machine_instance` |
+| GCP                               | `gcp_compute_instance` |
+| AWS, Azure, GCP                   | `host`, `host_image` |
+| Docker, ECR, and other registries | `image` (container) |
 
 
 ## Review and correct ownership

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -96,7 +96,7 @@ You can filter findings by inferred owner in the [Misconfigurations Explorer](ht
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
-| `Ownership > Confidence`  | The numeric confidence score (0 to 1):<ul><li>high: >0.85</li><li>medium: 0.60-0.84</li><li>low: &lt;0.60</li></ul> | `@_dd.ownership.inference.confidence:>0.8`            |
+| `Ownership > Confidence`  | The numeric confidence score (0 to 1):<br>&bull; high: >0.85<br>&bull; medium: 0.60-0.84<br>&bull; low: &lt;0.60 | `@_dd.ownership.inference.confidence:>0.8`            |
 | `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
 
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_agent.md
@@ -96,10 +96,7 @@ You can filter findings by inferred owner in the [Misconfigurations Explorer](ht
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `Ownership > Owner`       | The suggested or persisted owner handle         | `@_dd.ownership.inference.owner_handle:team-platform` |
 | `Ownership > Owner type`  | The type of owner: `team`, `service`, or `user` | `@_dd.ownership.inference.owner_type:team`            |
-| `Ownership > Confidence`  | The numeric confidence score (0 to 1):          | `@_dd.ownership.inference.confidence:>0.8`            |
-|                           | - high: >0.85                                   |                                                       |
-|                           | - medium: 0.60-0.84                             |                                                       |
-|                           | - low: <0.60                                    |                                                       |
+| `Ownership > Confidence`  | The numeric confidence score (0 to 1):<ul><li>high: >0.85</li><li>medium: 0.60-0.84</li><li>low: &lt;0.60</li></ul> | `@_dd.ownership.inference.confidence:>0.8`            |
 | `Ownership > Explanation` | The explanation for the inference               | `@_dd.ownership.inference.explanation:*tag*`          |
 
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
@@ -326,7 +326,7 @@ To update your reference table, upload a new CSV to the same table to fully repl
 
 Manual uploads support files up to 4 MB.
 
-### Option 2: cloud storage sync (S3, Azure Blob, GCS)
+### Option 2: Cloud storage sync (S3, Azure Blob, GCS)
 
 This approach is best for automated, recurring updates. Store your CSV in a cloud storage bucket so Datadog can periodically import it.
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
@@ -1,6 +1,11 @@
 ---
 title: Set Up Ownership Preferences
+aliases:
+  - /security/cloud_security_management/guide/frontier_group/ownership_preferences
 further_reading:
+- link: "/security/cloud_security_management/review_remediate/ownership_agent"
+  tag: "Documentation"
+  text: "Ownership Agent"
 - link: "/security/cloud_security_management/guide/frontier_group/"
   tag: "Documentation"
   text: "Cloud Security Frontier Group"

--- a/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
@@ -310,7 +310,7 @@ Datadog stores your preferences as a [reference table][1]. The table must be nam
 
 There are several ways to create and update the table:
 
-### Option 1: manual CSV upload (Datadog UI)
+### Option 1: Manual CSV upload (Datadog UI)
 
 This approach is best for getting started or making occasional updates.
 

--- a/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
+++ b/content/en/security/cloud_security_management/review_remediate/ownership_preferences.md
@@ -171,7 +171,7 @@ You can provide up to **three** prompt text entries, one for each priority level
 
 #### Tips for writing effective guidance
 
-- Be specific and actionable. "The `cost-center` tag is our most reliable ownership signal" is better than "Use tags".
+- Be specific and actionable. "The `cost-center` tag is the most reliable ownership signal" is better than "Use tags".
 - Explain your organization's conventions: team naming patterns, how to interpret specific tags, etc.
 - Call out accounts that should not be owners (also add these as exclusion rows for enforcement).
 - Use one entry per priority level to organize your guidance by importance.
@@ -300,7 +300,7 @@ The AI engine processes prompt text as organizational context. To help ensure yo
 
 #### Examples
 
-- "The cost-center tag is our most reliable ownership signal for all cloud resources."
+- "The cost-center tag is the most reliable ownership signal for all cloud resources."
 - "Team identifiers always use the team- prefix (for example, team-platform, team-data-eng)."
 - "Resources in the us-east-1/prod account are managed by team-sre."
 
@@ -310,7 +310,7 @@ Datadog stores your preferences as a [reference table][1]. The table must be nam
 
 There are several ways to create and update the table:
 
-### Option 1: Manual CSV upload (Datadog UI)
+### Option 1: manual CSV upload (Datadog UI)
 
 This approach is best for getting started or making occasional updates.
 
@@ -326,7 +326,7 @@ To update your reference table, upload a new CSV to the same table to fully repl
 
 Manual uploads support files up to 4 MB.
 
-### Option 2: Cloud storage sync (S3, Azure Blob, GCS)
+### Option 2: cloud storage sync (S3, Azure Blob, GCS)
 
 This approach is best for automated, recurring updates. Store your CSV in a cloud storage bucket so Datadog can periodically import it.
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -63,7 +63,7 @@ When ownership is known, the engine can route findings to the right team instead
 [4]: /security/cloud_security_management/setup/agent/kubernetes/#runtime-package-prioritization-preview
 [5]: https://app.datadoghq.com/security/csm
 [6]: /security/security_inbox/
-[7]: /security/cloud_security_management/guide/frontier_group/ownership_agent/
+[7]: /security/cloud_security_management/review_remediate/ownership_agent/
 [8]: /security/cloud_security_management/crown_jewels/
 [9]: /security/cloud_security_management/setup/agent/docker/#runtime-package-prioritization-preview
 [10]: /security/cloud_security_management/setup/agent/linux/#runtime-package-prioritization-preview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Moves the Ownership Agent and Set Up Ownership Preferences pages from the Frontier Group guide into the Review and Remediate section of Cloud Security.

- Moves both pages to `content/en/security/cloud_security_management/review_remediate/`.
- Adds `aliases` so the old `guide/frontier_group/...` URLs redirect to the new locations.
- Updates the left-nav menu, cross-links between the two pages, the Frontier Group index links, and a reference on the Runtime Prioritization Engine page.
- Adds an "Automatic team assignment" section to the Ownership Agent page describing the default `team` tag behavior and the ownership settings page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

No Jira ticket was provided, so the title omits a `[DOCS-XXXXX]` key. Let me know the ticket and I can update the title and description.


Made with [Cursor](https://cursor.com)