### PR TITLE
[DOCS-15274] Document Bits Code support for SDS log findings

### DIFF
--- a/content/en/bits_ai/bits_code/_index.md
+++ b/content/en/bits_ai/bits_code/_index.md
@@ -75,7 +75,7 @@ Bits Code can suggest code improvements within several Datadog products, includi
 | [Test Optimization][4]    | Provides code fixes for [flaky tests][24] and verifies that tests remain stable  |
 | [Continuous Profiler][3]  | Provides code changes for [Automated Analysis][10] insights   |
 | [Containers][12]          | Provides code changes for [Kubernetes Remediations][13]  |
-| [Sensitive Data Scanner][36] | Generates code fixes for log statements causing sensitive data leaks |
+| [Sensitive Data Scanner][36] | Generates code fixes for logs causing sensitive data leaks |
 
 ## Key capabilities 
 

--- a/content/en/bits_ai/bits_code/_index.md
+++ b/content/en/bits_ai/bits_code/_index.md
@@ -75,6 +75,7 @@ Bits Code can suggest code improvements within several Datadog products, includi
 | [Test Optimization][4]    | Provides code fixes for [flaky tests][24] and verifies that tests remain stable  |
 | [Continuous Profiler][3]  | Provides code changes for [Automated Analysis][10] insights   |
 | [Containers][12]          | Provides code changes for [Kubernetes Remediations][13]  |
+| [Sensitive Data Scanner][36] | Generates code fixes for log statements causing sensitive data leaks |
 
 ## Key capabilities 
 
@@ -149,6 +150,7 @@ Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is
 [29]: https://app.datadoghq.com/code/automations
 [34]: /security/cloud_security_management/
 [35]: /security/cloud_security_management/review_remediate/remediate_with_ai/
+[36]: /security/sensitive_data_scanner/
 [30]: https://docs.github.com/en/enterprise-cloud@latest/admin/overview/about-github-enterprise-cloud
 [31]: https://docs.github.com/en/enterprise-cloud@latest/admin/overview/about-github-enterprise-cloud#about-data-residency
 [32]: https://docs.gitlab.com/subscriptions/gitlab_dedicated/

--- a/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -12,6 +12,9 @@ further_reading:
     - link: "sensitive_data_scanner/setup/cloud_storage/"
       tag: "Documentation"
       text: "Set up Sensitive Data Scanner for Cloud Storage"
+    - link: "bits_ai/bits_code/"
+      tag: "Documentation"
+      text: "Bits Code"
     - link: "https://www.datadoghq.com/blog/scaling-sensitive-data-scanner/"
       tag: "Blog"
       text: "Discover, triage, and remediate sensitive data issues at scale with Sensitive Data Scanner"
@@ -56,8 +59,10 @@ To investigate a log finding:
 Additionally, you can:
 - Use {{< ui >}}Apply Targeted Obfuscation{{< /ui >}} to obfuscate future sensitive data matches in new logs for this finding, or extend obfuscation to the entire service. If redaction is already enabled, use this section to verify how matching logs are obfuscated.
 - Use {{< ui >}}Tune Detection Logic{{< /ui >}} to edit the scanning rule's keywords or apply suppressions for false positives or risk-accepted data.
+- Use {{< ui >}}Generate Code Fix{{< /ui >}} to launch a [Bits Code][2] session that identifies the log statement causing the leak and proposes a fix. Review the fix and create a pull request directly from the session. The source repository must already be onboarded to Bits Code.
 
 [1]: /help
+[2]: /bits_ai/bits_code/
 
 {{% /tab %}}
 {{% tab "APM, RUM, and Events" %}}

--- a/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -12,9 +12,6 @@ further_reading:
     - link: "sensitive_data_scanner/setup/cloud_storage/"
       tag: "Documentation"
       text: "Set up Sensitive Data Scanner for Cloud Storage"
-    - link: "bits_ai/bits_code/"
-      tag: "Documentation"
-      text: "Bits Code"
     - link: "https://www.datadoghq.com/blog/scaling-sensitive-data-scanner/"
       tag: "Blog"
       text: "Discover, triage, and remediate sensitive data issues at scale with Sensitive Data Scanner"
@@ -59,7 +56,7 @@ To investigate a log finding:
 Additionally, you can:
 - Use {{< ui >}}Apply Targeted Obfuscation{{< /ui >}} to obfuscate future sensitive data matches in new logs for this finding, or extend obfuscation to the entire service. If redaction is already enabled, use this section to verify how matching logs are obfuscated.
 - Use {{< ui >}}Tune Detection Logic{{< /ui >}} to edit the scanning rule's keywords or apply suppressions for false positives or risk-accepted data.
-- Use {{< ui >}}Generate Code Fix{{< /ui >}} to launch a [Bits Code][2] session that identifies the log statement causing the leak and proposes a fix. Review the fix and create a pull request directly from the session. The source repository must already be onboarded to Bits Code.
+- Use {{< ui >}}Generate Code Fix{{< /ui >}} to launch a [Bits Code][2] session that identifies the log pattern causing the leak and proposes a fix. Review the fix and create a pull request directly from the session. The source repository must already be onboarded to Bits Code.
 
 [1]: /help
 [2]: /bits_ai/bits_code/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15274

Bits Code now supports generating code-level fixes directly from Sensitive Data Scanner log findings. This PR documents that capability:

- Adds Sensitive Data Scanner to the "Supported Datadog products" table on the Bits Code overview page.
- Adds a "Generate Code Fix" bullet to the Logs tab of the Investigate Sensitive Data Findings guide, alongside the existing Apply Targeted Obfuscation and Tune Detection Logic bullets, and cross-links to the Bits Code page.

Scope is intentionally limited to what is shipped today: logs findings only, manual repository selection, and the repository must already be onboarded to Bits Code.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Opened as a draft pending PM review.