### PR TITLE
[DADP-162] Document DogStatsD client byte telemetry

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -157,6 +157,10 @@ agent diagnose show-metadata agent-telemetry
 | **Logs and metrics**                        |                                                                                                                        |
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |
 | dogstatsd.uds_packets_bytes                 | DogStatsD UDS packets bytes                                                                                            |
+| dogstatsd_client.bytes_sent                 | Total bytes sent by DogStatsD clients                                                                                  |
+| dogstatsd_client.bytes_dropped              | Total bytes dropped by DogStatsD clients                                                                               |
+| dogstatsd_client.bytes_dropped_queue        | Total bytes dropped because a DogStatsD client sender queue is full                                                    |
+| dogstatsd_client.bytes_dropped_writer       | Total bytes dropped because a DogStatsD client writer cannot send them                                                 |
 | logs.auto_multi_line_aggregator_flush       | Number of multi-line logs aggregated by the Agent                                                                       |
 | logs.auto_multi_line_default_total_lines    | Total log lines processed by the detecting aggregator for sources relying on the auto multi-line detection default           |
 | logs.auto_multi_line_default_would_combine  | Number of lines that would be combined if auto multi-line detection were enabled by default                              |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DADP-162

Documents the four DogStatsD client byte telemetry metrics that Agent Telemetry reports. See the [ASUP-79 metric specification](https://datadoghq.atlassian.net/browse/ASUP-79), related [Core Agent profile enrollment PR](https://github.com/DataDog/datadog-agent/pull/54316), and [ADP telemetry PR](https://github.com/DataDog/saluki/pull/2239).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
