### PR TITLE
Add Confluent Platform RBAC guidance to Kafka ACL setup

### DIFF
--- a/content/en/data_streams/kafka/setup.md
+++ b/content/en/data_streams/kafka/setup.md
@@ -13,6 +13,11 @@ Datadog Agent version 7.78 or later is required.
 
 ### ACL permissions
 
+The Datadog Agent needs read-only, describe-level access to your cluster's topics, consumer groups, and cluster metadata. How you grant this depends on whether your cluster authorizes with native Kafka ACLs or with Confluent Platform's role-based access control (RBAC).
+
+{{< tabs >}}
+{{% tab "ACLs" %}}
+
 If your Kafka cluster uses ACLs, the Datadog Agent user requires the following minimum permissions:
 
 | Resource Name | Resource Type | Operation        |
@@ -22,6 +27,44 @@ If your Kafka cluster uses ACLs, the Datadog Agent user requires the following m
 | `*`           | `TOPIC`       | `Describe`       |
 | `*`           | `TOPIC`       | `DescribeConfigs` |
 | `*`           | `GROUP`       | `Describe`       |
+
+{{% /tab %}}
+{{% tab "Confluent Platform roles" %}}
+
+If your Confluent Platform cluster uses RBAC instead of native ACLs, grant the Datadog Agent's principal the following role bindings:
+
+| Role            | Resource scope                          |
+|-----------------|------------------------------------------|
+| `Operator`      | `Cluster` (the Kafka cluster)            |
+| `DeveloperRead` | `Topic` (the topics you want to monitor) |
+| `DeveloperRead` | `Group` (the consumer groups you want to monitor) |
+
+`Operator` on the `Cluster` resource covers cluster-level `Describe`/`DescribeConfigs`. `DeveloperRead` covers `Describe` on the scoped topics and consumer groups; it also grants `Read`, which is broader than what the Agent uses but is the narrowest predefined role available for this access.
+
+Create these role bindings with the Confluent CLI, for example:
+
+```shell
+confluent iam rbac role-binding create \
+  --principal User:<datadog-agent-principal> \
+  --role Operator \
+  --resource Cluster:kafka-cluster \
+  --kafka-cluster <cluster-id>
+
+confluent iam rbac role-binding create \
+  --principal User:<datadog-agent-principal> \
+  --role DeveloperRead \
+  --resource Topic:<topic-name> \
+  --kafka-cluster <cluster-id>
+
+confluent iam rbac role-binding create \
+  --principal User:<datadog-agent-principal> \
+  --role DeveloperRead \
+  --resource Group:<consumer-group-name> \
+  --kafka-cluster <cluster-id>
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Setup
 
@@ -37,7 +80,9 @@ This section applies only if you want to view Kafka message payloads in the {{< 
 
 ### Additional ACL permission
 
-In addition to the ACL permissions listed in [Prerequisites](#acl-permissions), the Datadog Agent user requires:
+If your cluster uses Confluent Platform RBAC, no additional role binding is needed: the `DeveloperRead` role from [Prerequisites](#acl-permissions) already includes `Read` on the scoped topics.
+
+If your cluster uses native ACLs, in addition to the permissions listed in [Prerequisites](#acl-permissions), the Datadog Agent user requires:
 
 | Resource Name | Resource Type | Operation |
 |---------------|---------------|-----------|

--- a/content/en/data_streams/kafka/setup.md
+++ b/content/en/data_streams/kafka/setup.md
@@ -13,8 +13,6 @@ Datadog Agent version 7.78 or later is required.
 
 ### ACL permissions
 
-The Datadog Agent needs read-only, describe-level access to your cluster's topics, consumer groups, and cluster metadata. How you grant this depends on whether your cluster authorizes with native Kafka ACLs or with Confluent Platform's role-based access control (RBAC).
-
 {{< tabs >}}
 {{% tab "ACLs" %}}
 
@@ -33,35 +31,11 @@ If your Kafka cluster uses ACLs, the Datadog Agent user requires the following m
 
 If your Confluent Platform cluster uses RBAC instead of native ACLs, grant the Datadog Agent's principal the following role bindings:
 
-| Role            | Resource scope                          |
-|-----------------|------------------------------------------|
-| `Operator`      | `Cluster` (the Kafka cluster)            |
-| `DeveloperRead` | `Topic` (the topics you want to monitor) |
-| `DeveloperRead` | `Group` (the consumer groups you want to monitor) |
-
-`Operator` on the `Cluster` resource covers cluster-level `Describe`/`DescribeConfigs`. `DeveloperRead` covers `Describe` on the scoped topics and consumer groups; it also grants `Read`, which is broader than what the Agent uses but is the narrowest predefined role available for this access.
-
-Create these role bindings with the Confluent CLI, for example:
-
-```shell
-confluent iam rbac role-binding create \
-  --principal User:<datadog-agent-principal> \
-  --role Operator \
-  --resource Cluster:kafka-cluster \
-  --kafka-cluster <cluster-id>
-
-confluent iam rbac role-binding create \
-  --principal User:<datadog-agent-principal> \
-  --role DeveloperRead \
-  --resource Topic:<topic-name> \
-  --kafka-cluster <cluster-id>
-
-confluent iam rbac role-binding create \
-  --principal User:<datadog-agent-principal> \
-  --role DeveloperRead \
-  --resource Group:<consumer-group-name> \
-  --kafka-cluster <cluster-id>
-```
+| Role            | Resource scope       |
+|-----------------|----------------------|
+| `Operator`      | `Cluster` (the Kafka cluster) |
+| `DeveloperRead` | All topics           |
+| `DeveloperRead` | All consumer groups  |
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Splits the "ACL permissions" section of the Kafka Monitoring setup page into two tabs — **ACLs** and **Confluent Platform roles** — so self-hosted Confluent Platform customers using RBAC (instead of native Kafka ACLs) have explicit guidance on which role bindings (`Operator` on the cluster, `DeveloperRead` on topics/groups) to grant the Datadog Agent principal, including example `confluent iam rbac role-binding create` commands. Also clarifies that the message-inspection "Additional ACL permission" section doesn't require an extra RBAC binding, since `DeveloperRead` already includes `Read`.

Prompted by a support case where a Confluent Platform RBAC customer asked whether ACL requirements differ under RBAC.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code based on Slack thread discussion and a read of the `kafka_consumer` integration's admin-client calls in `integrations-core`; not yet reviewed by a Confluent RBAC subject-matter expert.

### Additional notes

The exact RBAC role-to-operation mapping (`Operator` + `DeveloperRead`) is based on Confluent's documented predefined roles and the Kafka Agent's `describe_cluster`/`describe_consumer_groups`/`list_consumer_group_offsets` calls, but has not been validated against a live Confluent RBAC cluster. Please have someone with hands-on Confluent RBAC experience confirm before merging.