### PR TITLE
[DOCS-15235] Fix missing comma in JetBrains AI Assistant MCP config JSON

### DIFF
--- a/content/en/mcp_server/setup.md
+++ b/content/en/mcp_server/setup.md
@@ -360,7 +360,7 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
     <pre><code>{
       "mcpServers": {
         "datadog": {
-          "url": "{{< region-param key="mcp_server_endpoint" >}}"
+          "url": "{{< region-param key="mcp_server_endpoint" >}}",
           "headers": {
             "DD_API_KEY": "&lt;YOUR_API_KEY&gt;",
             "DD_APPLICATION_KEY": "&lt;YOUR_APP_KEY&gt;"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15235

Adds a missing comma after the `"url"` value in the JetBrains AI Assistant MCP server configuration JSON example on the MCP Server setup page, correcting invalid JSON syntax.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`).
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the error and apply the fix. (Yes, I used AI to add a single comma, but it was part of testing a skill for generating/updating docs.)

### Additional notes
