### PR TITLE
[DOCS-14937] Any logging library with Node.js log collection

### DIFF
--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -26,15 +26,22 @@ further_reading:
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use the [Winston][1] logging library to log from your Node.js application.
+To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][15], or [Pino][16], to log from your Node.js application.
 
-Winston is available through [NPM][2], to get started, you want to add the dependency to your code:
+### Log to a file
+
+In your bootstrap file or in your code, declare the logger in the following way:
+
+{{< tabs >}}
+{{% tab "Winston 3.0" %}}
+
+Winston is available through [NPM][2]. Add the dependency to your code:
 
 ```text
 npm install --save winston
 ```
 
-`package.json` is updated with the corresponding dependencies:
+`package.json` is updated with the corresponding dependency:
 
 ```js
 {
@@ -48,13 +55,6 @@ npm install --save winston
   }
 }
 ```
-
-### Log to a file
-
-In your bootstrap file or in your code, declare the logger in the following way:
-
-{{< tabs >}}
-{{% tab "Winston 3.0" %}}
 
 ```js
 
@@ -76,8 +76,21 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
+Check the content of the `<FILE_NAME>.log` file to confirm that Winston is logging in JSON:
+
+```json
+{"level":"info","message":"Hello simple log!","timestamp":"2015-04-23T16:52:05.337Z"}
+{"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
+```
+
 {{% /tab %}}
 {{% tab "Winston 2.0" %}}
+
+Winston is available through [NPM][2]. Add the dependency to your code:
+
+```text
+npm install --save winston
+```
 
 ```js
 var winston = require('winston');
@@ -98,9 +111,6 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
-
 Check the content of the `<FILE_NAME>.log` file to confirm that Winston is logging in JSON:
 
 ```json
@@ -108,9 +118,72 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
 ```
 
+{{% /tab %}}
+{{% tab "Bunyan" %}}
+
+Bunyan is available through [NPM][2]. Add the dependency to your code:
+
+```text
+npm install --save bunyan
+```
+
+```js
+const bunyan = require('bunyan');
+
+const logger = bunyan.createLogger({
+  name: '<SERVICE_NAME>',
+  streams: [
+    {
+      level: 'info',
+      path: `${appRoot}/logs/<FILE_NAME>.log`,
+    },
+  ],
+});
+
+// Example logs
+logger.info('Hello simple log!');
+logger.info({ color: 'blue' }, 'Hello log with metas');
+```
+
+Bunyan logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to confirm:
+
+```json
+{"name":"<SERVICE_NAME>","hostname":"my-host","pid":1234,"level":30,"msg":"Hello simple log!","time":"2015-04-23T16:52:05.337Z","v":0}
+{"name":"<SERVICE_NAME>","hostname":"my-host","pid":1234,"level":30,"color":"blue","msg":"Hello log with metas","time":"2015-04-23T16:52:05.339Z","v":0}
+```
+
+{{% /tab %}}
+{{% tab "Pino" %}}
+
+Pino is available through [NPM][2]. Add the dependency to your code:
+
+```text
+npm install --save pino
+```
+
+```js
+const pino = require('pino');
+
+const logger = pino(pino.destination(`${appRoot}/logs/<FILE_NAME>.log`));
+
+// Example logs
+logger.info('Hello simple log!');
+logger.info({ color: 'blue' }, 'Hello log with metas');
+```
+
+Pino logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to confirm:
+
+```json
+{"level":30,"time":1429807925337,"pid":1234,"hostname":"my-host","msg":"Hello simple log!"}
+{"level":30,"time":1429807925339,"pid":1234,"hostname":"my-host","color":"blue","msg":"Hello log with metas"}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Configure your Datadog Agent
 
-Once [log collection is enabled][6], set up [custom log collection][7] to tail your log files and send new logs to Datadog.
+After [log collection is enabled][6], set up [custom log collection][7] to tail your log files and send new logs to Datadog.
 
 1. Create a `nodejs.d/` folder in the `conf.d/` [Agent configuration directory][8].
 2. Create a `conf.yaml` file in `nodejs.d/` with the following content:
@@ -137,16 +210,16 @@ If logs are in JSON format, Datadog automatically [parses the log messages][11] 
 
 ## Connect your service across logs and traces
 
-If APM is enabled for this application, connect your logs and traces by automatically adding trace IDs, span IDs,
-`env`, `service`, and `version` to your logs by [following the APM Node.js instructions][3].
+If APM is enabled for this application, connect your logs and traces by [following the APM Node.js instructions][3]. This automatically adds trace IDs, span IDs, `env`, `service`, and `version` to your logs.
 
 **Note**: If the Datadog SDK injects `service` into your logs, it overrides the value set in the Agent configuration.
 
 ## Agentless logging
 
-You can stream your logs from your application to Datadog without installing an Agent on your host. However, it is recommended that you use an Agent to forward your logs as it provides a native connection management.
+You can stream your logs from your application to Datadog without installing an Agent on your host. However, Datadog recommends you use an Agent to forward your logs as it provides a native connection management.
 
 Use the [Winston HTTP transport][4] to send your logs directly through the [Datadog Log API][5].
+
 In your bootstrap file or in your code, declare the logger in the following way:
 
 ```javascript
@@ -176,6 +249,7 @@ logger.info('Hello log with metas',{color: 'blue' });
 
 **Note:** You can also use the community-supported [Datadog Transport][13].
 
+Bunyan and Pino don't include a built-in HTTP transport. To stream logs from these libraries directly to Datadog without an Agent, use a community-supported package or logging layer that adds Datadog HTTP support.
 
 ## Troubleshooting
 
@@ -208,3 +282,5 @@ Make sure that the parameter `max_connect_retries` is not set to `1` (the defaul
 [12]: /logs/explorer/#overview
 [13]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
 [14]: /glossary/#tail
+[15]: https://github.com/trentm/node-bunyan
+[16]: https://github.com/pinojs/pino

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -35,7 +35,7 @@ In your bootstrap file or in your code, declare the logger in the following way:
 {{< tabs >}}
 {{% tab "Winston 3.0" %}}
 
-Winston is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
+Winston is available through [NPM][101]. Add the dependency to your code:
 
 ```text
 npm install --save winston
@@ -83,10 +83,11 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
 ```
 
+[101]: https://www.npmjs.com
 {{% /tab %}}
 {{% tab "Winston 2.0" %}}
 
-Winston is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
+Winston is available through [NPM][101]. Add the dependency to your code:
 
 ```text
 npm install --save winston
@@ -118,10 +119,11 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
 ```
 
+[101]: https://www.npmjs.com
 {{% /tab %}}
 {{% tab "Bunyan" %}}
 
-Bunyan is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
+Bunyan is available through [NPM][101]. Add the dependency to your code:
 
 ```text
 npm install --save bunyan
@@ -152,10 +154,11 @@ Bunyan logs in JSON by default. Check the content of the `<FILE_NAME>.log` file 
 {"name":"<SERVICE_NAME>","hostname":"my-host","pid":1234,"level":30,"color":"blue","msg":"Hello log with metas","time":"2015-04-23T16:52:05.339Z","v":0}
 ```
 
+[101]: https://www.npmjs.com
 {{% /tab %}}
 {{% tab "Pino" %}}
 
-Pino is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
+Pino is available through [NPM][101]. Add the dependency to your code:
 
 ```text
 npm install --save pino
@@ -178,6 +181,7 @@ Pino logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to
 {"level":30,"time":1429807925339,"pid":1234,"hostname":"my-host","color":"blue","msg":"Hello log with metas"}
 ```
 
+[101]: https://www.npmjs.com
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -26,22 +26,15 @@ further_reading:
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and [tail][13] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][14], or [Pino][15], to log from your Node.js application.
+To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][15], or [Pino][16], to log from your Node.js application. The examples on this page use Winston.
 
-### Log to a file
-
-In your bootstrap file or in your code, declare the logger in the following way:
-
-{{< tabs >}}
-{{% tab "Winston 3.0" %}}
-
-Winston is available through [NPM][101]. Add the dependency to your code:
+Winston is available through [NPM][2], to get started, you want to add the dependency to your code:
 
 ```text
 npm install --save winston
 ```
 
-`package.json` is updated with the corresponding dependency:
+`package.json` is updated with the corresponding dependencies:
 
 ```js
 {
@@ -55,6 +48,13 @@ npm install --save winston
   }
 }
 ```
+
+### Log to a file
+
+In your bootstrap file or in your code, declare the logger in the following way:
+
+{{< tabs >}}
+{{% tab "Winston 3.0" %}}
 
 ```js
 
@@ -76,22 +76,8 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
-Check the content of the `<FILE_NAME>.log` file to confirm that Winston is logging in JSON:
-
-```json
-{"level":"info","message":"Hello simple log!","timestamp":"2015-04-23T16:52:05.337Z"}
-{"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
-```
-
-[101]: https://www.npmjs.com
 {{% /tab %}}
 {{% tab "Winston 2.0" %}}
-
-Winston is available through [NPM][101]. Add the dependency to your code:
-
-```text
-npm install --save winston
-```
 
 ```js
 var winston = require('winston');
@@ -112,6 +98,9 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
+{{% /tab %}}
+{{< /tabs >}}
+
 Check the content of the `<FILE_NAME>.log` file to confirm that Winston is logging in JSON:
 
 ```json
@@ -119,77 +108,11 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
 ```
 
-[101]: https://www.npmjs.com
-{{% /tab %}}
-{{% tab "Bunyan" %}}
-
-Bunyan is available through [NPM][101]. Add the dependency to your code:
-
-```text
-npm install --save bunyan
-```
-
-```js
-const bunyan = require('bunyan');
-
-const logger = bunyan.createLogger({
-  name: '<SERVICE_NAME>',
-  streams: [
-    {
-      level: 'info',
-      path: `${appRoot}/logs/<FILE_NAME>.log`,
-    },
-  ],
-});
-
-// Example logs
-logger.info('Hello simple log!');
-logger.info({ color: 'blue' }, 'Hello log with metas');
-```
-
-Bunyan logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to confirm:
-
-```json
-{"name":"<SERVICE_NAME>","hostname":"my-host","pid":1234,"level":30,"msg":"Hello simple log!","time":"2015-04-23T16:52:05.337Z","v":0}
-{"name":"<SERVICE_NAME>","hostname":"my-host","pid":1234,"level":30,"color":"blue","msg":"Hello log with metas","time":"2015-04-23T16:52:05.339Z","v":0}
-```
-
-[101]: https://www.npmjs.com
-{{% /tab %}}
-{{% tab "Pino" %}}
-
-Pino is available through [NPM][101]. Add the dependency to your code:
-
-```text
-npm install --save pino
-```
-
-```js
-const pino = require('pino');
-
-const logger = pino(pino.destination(`${appRoot}/logs/<FILE_NAME>.log`));
-
-// Example logs
-logger.info('Hello simple log!');
-logger.info({ color: 'blue' }, 'Hello log with metas');
-```
-
-Pino logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to confirm:
-
-```json
-{"level":30,"time":1429807925337,"pid":1234,"hostname":"my-host","msg":"Hello simple log!"}
-{"level":30,"time":1429807925339,"pid":1234,"hostname":"my-host","color":"blue","msg":"Hello log with metas"}
-```
-
-[101]: https://www.npmjs.com
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Configure your Datadog Agent
 
-After [log collection is enabled][5], set up [custom log collection][6] to tail your log files and send new logs to Datadog.
+After [log collection is enabled][6], set up [custom log collection][7] to tail your log files and send new logs to Datadog.
 
-1. Create a `nodejs.d/` folder in the `conf.d/` [Agent configuration directory][7].
+1. Create a `nodejs.d/` folder in the `conf.d/` [Agent configuration directory][8].
 2. Create a `conf.yaml` file in `nodejs.d/` with the following content:
 
 ```yaml
@@ -207,14 +130,14 @@ logs:
     sourcecategory: sourcecode
 ```
 
-3. [Restart the Agent][8].
-4. Run the [Agent's status subcommand][9] and look for `nodejs` under the {{< ui >}}Checks{{< /ui >}} section to confirm logs are successfully submitted to Datadog.
+3. [Restart the Agent][9].
+4. Run the [Agent's status subcommand][10] and look for `nodejs` under the {{< ui >}}Checks{{< /ui >}} section to confirm logs are successfully submitted to Datadog.
 
-If logs are in JSON format, Datadog automatically [parses the log messages][10] to extract log attributes. Use the [Log Explorer][11] to view and troubleshoot your logs.
+If logs are in JSON format, Datadog automatically [parses the log messages][11] to extract log attributes. Use the [Log Explorer][12] to view and troubleshoot your logs.
 
 ## Connect your service across logs and traces
 
-If APM is enabled for this application, connect your logs and traces by [following the APM Node.js instructions][2]. This automatically adds trace IDs, span IDs, `env`, `service`, and `version` to your logs.
+If APM is enabled for this application, connect your logs and traces by [following the APM Node.js instructions][3]. This automatically adds trace IDs, span IDs, `env`, `service`, and `version` to your logs.
 
 **Note**: If the Datadog SDK injects `service` into your logs, it overrides the value set in the Agent configuration.
 
@@ -222,8 +145,7 @@ If APM is enabled for this application, connect your logs and traces by [followi
 
 You can stream your logs from your application to Datadog without installing an Agent on your host. However, Datadog recommends you use an Agent to forward your logs as it provides a native connection management.
 
-Use the [Winston HTTP transport][3] to send your logs directly through the [Datadog Log API][4].
-
+Use the [Winston HTTP transport][4] to send your logs directly through the [Datadog Log API][5].
 In your bootstrap file or in your code, declare the logger in the following way:
 
 ```javascript
@@ -251,9 +173,8 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
-**Note:** You can also use the community-supported [Datadog Transport][12].
+**Note:** You can also use the community-supported [Datadog Transport][13].
 
-Bunyan and Pino don't include a built-in HTTP transport. To stream logs from these libraries directly to Datadog without an Agent, use a community-supported package or logging layer that adds Datadog HTTP support.
 
 ## Troubleshooting
 
@@ -273,17 +194,18 @@ Make sure that the parameter `max_connect_retries` is not set to `1` (the defaul
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/winstonjs/winston
-[2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
-[3]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport
-[4]: /api/v1/logs/#send-logs
-[5]: /agent/logs/?tab=tailfiles#activate-log-collection
-[6]: /agent/logs/?tab=tailfiles#custom-log-collection
-[7]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-configuration-directory
-[8]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent
-[9]: /agent/configuration/agent-commands/?tab=agentv6v7#agent-status-and-information
-[10]: /logs/log_configuration/parsing/?tab=matchers
-[11]: /logs/explorer/#overview
-[12]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
-[13]: /glossary/#tail
-[14]: https://github.com/trentm/node-bunyan
-[15]: https://github.com/pinojs/pino
+[2]: https://www.npmjs.com
+[3]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
+[4]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport
+[5]: /api/v1/logs/#send-logs
+[6]: /agent/logs/?tab=tailfiles#activate-log-collection
+[7]: /agent/logs/?tab=tailfiles#custom-log-collection
+[8]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-configuration-directory
+[9]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent
+[10]: /agent/configuration/agent-commands/?tab=agentv6v7#agent-status-and-information
+[11]: /logs/log_configuration/parsing/?tab=matchers
+[12]: /logs/explorer/#overview
+[13]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
+[14]: /glossary/#tail
+[15]: https://github.com/trentm/node-bunyan
+[16]: https://github.com/pinojs/pino

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -26,7 +26,7 @@ further_reading:
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][15], or [Pino][16], to log from your Node.js application.
+To send your logs to Datadog, log to a file and [tail][13] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][14], or [Pino][15], to log from your Node.js application.
 
 ### Log to a file
 
@@ -35,7 +35,7 @@ In your bootstrap file or in your code, declare the logger in the following way:
 {{< tabs >}}
 {{% tab "Winston 3.0" %}}
 
-Winston is available through [NPM][2]. Add the dependency to your code:
+Winston is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
 
 ```text
 npm install --save winston
@@ -86,7 +86,7 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {{% /tab %}}
 {{% tab "Winston 2.0" %}}
 
-Winston is available through [NPM][2]. Add the dependency to your code:
+Winston is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
 
 ```text
 npm install --save winston
@@ -121,7 +121,7 @@ Check the content of the `<FILE_NAME>.log` file to confirm that Winston is loggi
 {{% /tab %}}
 {{% tab "Bunyan" %}}
 
-Bunyan is available through [NPM][2]. Add the dependency to your code:
+Bunyan is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
 
 ```text
 npm install --save bunyan
@@ -155,7 +155,7 @@ Bunyan logs in JSON by default. Check the content of the `<FILE_NAME>.log` file 
 {{% /tab %}}
 {{% tab "Pino" %}}
 
-Pino is available through [NPM][2]. Add the dependency to your code:
+Pino is available through [NPM](https://www.npmjs.com). Add the dependency to your code:
 
 ```text
 npm install --save pino
@@ -183,9 +183,9 @@ Pino logs in JSON by default. Check the content of the `<FILE_NAME>.log` file to
 
 ## Configure your Datadog Agent
 
-After [log collection is enabled][6], set up [custom log collection][7] to tail your log files and send new logs to Datadog.
+After [log collection is enabled][5], set up [custom log collection][6] to tail your log files and send new logs to Datadog.
 
-1. Create a `nodejs.d/` folder in the `conf.d/` [Agent configuration directory][8].
+1. Create a `nodejs.d/` folder in the `conf.d/` [Agent configuration directory][7].
 2. Create a `conf.yaml` file in `nodejs.d/` with the following content:
 
 ```yaml
@@ -203,14 +203,14 @@ logs:
     sourcecategory: sourcecode
 ```
 
-3. [Restart the Agent][9].
-4. Run the [Agent's status subcommand][10] and look for `nodejs` under the {{< ui >}}Checks{{< /ui >}} section to confirm logs are successfully submitted to Datadog.
+3. [Restart the Agent][8].
+4. Run the [Agent's status subcommand][9] and look for `nodejs` under the {{< ui >}}Checks{{< /ui >}} section to confirm logs are successfully submitted to Datadog.
 
-If logs are in JSON format, Datadog automatically [parses the log messages][11] to extract log attributes. Use the [Log Explorer][12] to view and troubleshoot your logs.
+If logs are in JSON format, Datadog automatically [parses the log messages][10] to extract log attributes. Use the [Log Explorer][11] to view and troubleshoot your logs.
 
 ## Connect your service across logs and traces
 
-If APM is enabled for this application, connect your logs and traces by [following the APM Node.js instructions][3]. This automatically adds trace IDs, span IDs, `env`, `service`, and `version` to your logs.
+If APM is enabled for this application, connect your logs and traces by [following the APM Node.js instructions][2]. This automatically adds trace IDs, span IDs, `env`, `service`, and `version` to your logs.
 
 **Note**: If the Datadog SDK injects `service` into your logs, it overrides the value set in the Agent configuration.
 
@@ -218,7 +218,7 @@ If APM is enabled for this application, connect your logs and traces by [followi
 
 You can stream your logs from your application to Datadog without installing an Agent on your host. However, Datadog recommends you use an Agent to forward your logs as it provides a native connection management.
 
-Use the [Winston HTTP transport][4] to send your logs directly through the [Datadog Log API][5].
+Use the [Winston HTTP transport][3] to send your logs directly through the [Datadog Log API][4].
 
 In your bootstrap file or in your code, declare the logger in the following way:
 
@@ -247,7 +247,7 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
-**Note:** You can also use the community-supported [Datadog Transport][13].
+**Note:** You can also use the community-supported [Datadog Transport][12].
 
 Bunyan and Pino don't include a built-in HTTP transport. To stream logs from these libraries directly to Datadog without an Agent, use a community-supported package or logging layer that adds Datadog HTTP support.
 
@@ -269,18 +269,17 @@ Make sure that the parameter `max_connect_retries` is not set to `1` (the defaul
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/winstonjs/winston
-[2]: https://www.npmjs.com
-[3]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
-[4]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport
-[5]: /api/v1/logs/#send-logs
-[6]: /agent/logs/?tab=tailfiles#activate-log-collection
-[7]: /agent/logs/?tab=tailfiles#custom-log-collection
-[8]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-configuration-directory
-[9]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent
-[10]: /agent/configuration/agent-commands/?tab=agentv6v7#agent-status-and-information
-[11]: /logs/log_configuration/parsing/?tab=matchers
-[12]: /logs/explorer/#overview
-[13]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
-[14]: /glossary/#tail
-[15]: https://github.com/trentm/node-bunyan
-[16]: https://github.com/pinojs/pino
+[2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
+[3]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport
+[4]: /api/v1/logs/#send-logs
+[5]: /agent/logs/?tab=tailfiles#activate-log-collection
+[6]: /agent/logs/?tab=tailfiles#custom-log-collection
+[7]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-configuration-directory
+[8]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent
+[9]: /agent/configuration/agent-commands/?tab=agentv6v7#agent-status-and-information
+[10]: /logs/log_configuration/parsing/?tab=matchers
+[11]: /logs/explorer/#overview
+[12]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
+[13]: /glossary/#tail
+[14]: https://github.com/trentm/node-bunyan
+[15]: https://github.com/pinojs/pino

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -208,4 +208,4 @@ Make sure that the parameter `max_connect_retries` is not set to `1` (the defaul
 [13]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
 [14]: /glossary/#tail
 [15]: https://github.com/trentm/node-bunyan
-[16]: https://github.com/pinojs/pino
+[16]: https://getpino.io/

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -26,9 +26,9 @@ further_reading:
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use a Node.js logging library, such as [Winston][1], [Bunyan][15], or [Pino][16], to log from your Node.js application. The examples on this page use Winston.
+To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use a logging library, such as [Winston][1], [Bunyan][15], or [Pino][16], to log from your Node.js application. The examples on this page use Winston.
 
-Winston is available through [NPM][2], to get started, you want to add the dependency to your code:
+Winston is available through [NPM][2]. To get started, add the dependency to your code:
 
 ```text
 npm install --save winston


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Addresses DOCS-14937

Log collection does not strictly require the Winston logging library, so this changes the wording slightly to ensure users know Winston is just an example. We list other example logging libraries [elsewhere](https://docs.datadoghq.com/tracing/trace_collection/compatibility/nodejs/#logger-compatibility).

### Merge readiness

- [X] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to scope the change and draft the wording.

### Additional notes


