### PR TITLE
[CCM][CCV-4671] Restore Azure VM commitments mention in Commitment Programs docs

### DIFF
--- a/content/en/cloud_cost_management/planning/commitment_programs.md
+++ b/content/en/cloud_cost_management/planning/commitment_programs.md
@@ -7,7 +7,7 @@ further_reading:
   text: "Learn about Cloud Cost Management"
 ---
 
-<div class="alert alert-info">CCM Commitment Programs supports Amazon EC2 and RDS Reserved Instances, Amazon EC2 Savings Plans, and Amazon ElastiCache Reserved Nodes.</div>
+<div class="alert alert-info">CCM Commitment Programs supports Reserved Instances and Savings Plans, for EC2, RDS, and ElastiCache on AWS, and Virtual Machines on Azure.</div>
 
 ## Overview
 

--- a/content/en/cloud_cost_management/planning/commitment_programs.md
+++ b/content/en/cloud_cost_management/planning/commitment_programs.md
@@ -74,7 +74,8 @@ The table lists your active commitments. Columns vary depending on the product a
 
 | Column | Description |
 |---|---|
-| Savings Plan ARN or Reservation ARN | Unique identifier for the commitment. |
+| Savings Plan ARN, Reservation ARN, or Commitment ID | Unique identifier for the commitment (Commitment ID for Azure). |
+| Benefit Name | Name of the Azure savings plan or reservation benefit. |
 | Payment Model | Payment option (for example, No Upfront, Partial Upfront, All Upfront). |
 | Term | Duration of the commitment (for example, 1 Year, 3 Years). |
 | Type | The commitment type (for example, `ComputeSavingsPlans`). |


### PR DESCRIPTION
## Summary
- The Commitment Programs docs page's supported-services note dropped its Azure VM Reserved Instances/Savings Plans mention during a broader page rewrite (#35741), reverting back to AWS-only wording that PR #35437 had already fixed. This restores the original combined AWS + Azure wording.
- The Commitments Inventory table description was AWS-only (`Savings Plan ARN or Reservation ARN`), which doesn't match the Azure UI. Verified against a live screenshot of the Azure Virtual Machines Commitments view: Azure's table uses `Commitment ID` and `Benefit Name` columns instead of an ARN. Added both to the table.
- Azure VM commitment support has been live in the product since Feb 2026 (CCM epic CCV-4206), so the public docs have been out of sync since.

## Test plan
- [x] Preview the page locally/via Netlify build to confirm the alert and table render correctly
- [x] Docs team sign-off on wording