### PR TITLE
[SDTEST-3920] Document Ruby TIA impacted files and suite skipping

### DIFF
--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -60,8 +60,63 @@ Tests that interact with external systems may be incorrectly skipped:
 
 When you encounter these limitations, consider the following approaches:
 
-* **Mark tests as unskippable**: For tests that make external calls, fork processes, or depend on global shared state, [mark them as unskippable](#marking-tests-as-unskippable) to ensure they always run.
-* **Configure tracked files**: If your tests depend on non-Ruby files like fixtures, i18n files, or configuration files, add these files to your [tracked files configuration][2]. This causes all tests to run when these files change.
+* **Mark tests as unskippable**: For tests that make external calls, fork processes, or depend on global shared state, [mark them as unskippable](#marking-tests-as-unskippable) so they always run.
+* **Add custom impacted files**: If you can determine which non-Ruby files affect a test or suite, [associate those files with the test or suite](#add-custom-impacted-files). When one of the files changes, Test Impact Analysis runs the associated tests instead of running the entire test set.
+* **Configure tracked files**: If a non-Ruby file can affect many tests and you cannot associate it with specific tests or suites, add the file to your [tracked files configuration][2]. This causes all tests to run when the file changes.
+
+## Add custom impacted files
+
+Custom impacted files are supported in `datadog-ci >= 1.36.0`.
+
+Ruby code coverage cannot observe files executed outside the Ruby process. For example, a Capybara test can load JavaScript, TypeScript, or templates in a browser. If one of these files changes without a covered Ruby file changing, Test Impact Analysis might skip a test that the change affects.
+
+Register these dependencies as custom impacted files to associate them with a test or suite. This gives Test Impact Analysis more complete coverage data while preserving test-skipping savings for unrelated tests.
+
+### Add files for a test
+
+Call `Datadog::CI.active_test.add_impacted_files` from a `before` or `after` hook. Use this API for files that affect an individual test. The following RSpec example registers frontend files collected from the browser:
+
+```ruby
+RSpec.configure do |config|
+  config.after do
+    loaded_frontend_files = javascript_files_loaded_by_browser.map do |path|
+      File.expand_path(path, Dir.pwd)
+    end
+
+    Datadog::CI.active_test&.add_impacted_files(loaded_frontend_files)
+  end
+end
+```
+
+### Add files for a suite
+
+Call `Datadog::CI.active_test_suite.add_impacted_files` for files that affect every test in a suite, such as shared frontend setup:
+
+```ruby
+RSpec.configure do |config|
+  config.before(:context) do
+    Datadog::CI.active_test_suite&.add_impacted_files(
+      [
+        "app/frontend/test_setup.js",
+        "app/frontend/components/shared_layout.tsx"
+      ]
+    )
+  end
+end
+```
+
+Test Impact Analysis uses test-level skipping by default. In this mode, add suite-level files before the first test in the suite starts. For RSpec, use a `before(:context)` hook. Adding suite-level files after a test starts raises a `RuntimeError`.
+
+### File path requirements
+
+Pass an array of paths to `add_impacted_files`. Each call adds files to those already registered. Datadog removes duplicate paths when it sends the coverage data.
+
+Paths must resolve inside the Git repository and use one of these formats:
+
+* A relative path from the repository root, such as `app/frontend/components/checkout.tsx`.
+* An absolute path to a file inside the repository.
+
+Paths must not contain redundant `.` or `..` segments. If a collector returns paths relative to the process working directory, convert them to normalized absolute paths with `File.expand_path(path, Dir.pwd)`. Datadog ignores absolute paths outside the repository. Files do not need to exist when you register them.
 
 ## Rails system tests
 
@@ -75,7 +130,7 @@ You can override the Test Impact Analysis's behavior and prevent specific tests 
 
 {{< tabs >}}
 {{% tab "RSpec" %}}
-To ensure that RSpec tests within a specific block are not skipped, add the metadata key `datadog_itr_unskippable` with the value `true` to any `describe`, `context`, or `it` block. This marks all tests in that block as unskippable.
+To prevent RSpec from skipping tests in a specific block, add the metadata key `datadog_itr_unskippable` with the value `true`. Add the key to any `describe`, `context`, or `it` block. This marks all tests in that block as unskippable.
 
 ```ruby
 # mark the whole file as unskippable

--- a/content/en/tests/test_parallelization/best_practices.md
+++ b/content/en/tests/test_parallelization/best_practices.md
@@ -105,6 +105,19 @@ fi
 
 `ddtest` invalidates the cache when any test file changes. The set of test files is determined by `--tests-location` and `--tests-exclude-pattern`.
 
+### Use suite-level skipping for Ruby
+
+If Ruby test discovery remains a bottleneck after applying these optimizations, configure Test Impact Analysis to use suite-level skipping. This mode lets `ddtest plan` use test file discovery instead of discovering every individual test. It trades test-level skipping precision for lower planning overhead because Test Impact Analysis skips or runs an entire suite.
+
+Suite-level skipping requires `datadog-ci >= 1.34.0`. Set `DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE=suite` for both planning and test execution:
+
+{{< code-block lang="bash" >}}
+DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE=suite ddtest plan
+DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE=suite ddtest run
+{{< /code-block >}}
+
+If you execute tests with another command, set the same environment variable for that command. In CI workflows that plan and run tests in separate jobs, set the variable in both jobs.
+
 ## Configure pytest
 
 `ddtest` runs pytest as `python -m pytest` and appends the selected test files. It appends `--ddtrace` to `PYTEST_ADDOPTS`, preserving any existing value, so the `ddtrace` pytest plugin loads without changing your pytest config.
@@ -113,7 +126,7 @@ For test discovery, `ddtest` reads `testpaths` and `python_files` from `pytest.i
 
 During discovery, `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED` is set to `1`. Use this variable to skip expensive setup code during planning, similar to [skipping database setup during discovery](#skip-database-setup-during-discovery).
 
-## Configure Jest
+## Jest configuration
 
 `ddtest` runs Jest through the local `node_modules/.bin/jest` executable when it exists, or through `npx jest` otherwise. Use `--command` when your project runs Jest through a package manager or wrapper:
 
@@ -123,7 +136,7 @@ bin/ddtest run --platform javascript --framework jest --command "pnpm jest --run
 
 Do not include test files or a `--` separator in the command. `ddtest` appends the file list and Jest flags itself.
 
-`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. Ensure `dd-trace` is resolvable from the project where `ddtest` runs.
+`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. `dd-trace` must be resolvable from the project where `ddtest` runs.
 
 `ddtest` discovers and splits test files and suites, not individual Jest tests.
 

--- a/content/en/tests/test_parallelization/best_practices.md
+++ b/content/en/tests/test_parallelization/best_practices.md
@@ -126,7 +126,7 @@ For test discovery, `ddtest` reads `testpaths` and `python_files` from `pytest.i
 
 During discovery, `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED` is set to `1`. Use this variable to skip expensive setup code during planning, similar to [skipping database setup during discovery](#skip-database-setup-during-discovery).
 
-## Jest configuration
+## Configure Jest
 
 `ddtest` runs Jest through the local `node_modules/.bin/jest` executable when it exists, or through `npx jest` otherwise. Use `--command` when your project runs Jest through a package manager or wrapper:
 
@@ -136,7 +136,7 @@ bin/ddtest run --platform javascript --framework jest --command "pnpm jest --run
 
 Do not include test files or a `--` separator in the command. `ddtest` appends the file list and Jest flags itself.
 
-`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. `dd-trace` must be resolvable from the project where `ddtest` runs.
+`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. Ensure `dd-trace` is resolvable from the project where `ddtest` runs.
 
 `ddtest` discovers and splits test files and suites, not individual Jest tests.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Documents how Ruby users can associate custom impacted files with tests and suites so Test Impact Analysis accounts for dependencies that Ruby code coverage cannot observe.

Adds guidance for reducing Test Parallelization discovery overhead with suite-level Test Impact Analysis skipping.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Validated both changed files with Vale.