### PR TITLE
Fix link reference for free text search

### DIFF
--- a/content/en/observability_pipelines/guide/upgrade_your_filter_queries_to_the_new_search_syntax.md
+++ b/content/en/observability_pipelines/guide/upgrade_your_filter_queries_to_the_new_search_syntax.md
@@ -78,7 +78,7 @@ The following examples show matched logs, along with the legacy syntax and new s
 `{"message": "hEllo world"}`
 : **Legacy syntax**: `HELLO OR hello OR Hello`
 : **New syntax**: `hello`
-: **Difference**: With the new syntax, [free text search][4] is case insensitive.
+: **Difference**: With the new syntax, [free text search][6] is case insensitive.
 
 `{"user": "name"}`
 : **Legacy syntax**: `@user:(name OR Name OR nAme)`
@@ -129,3 +129,4 @@ See [Reserved attributes][3] for more information.
 [3]: /logs/log_configuration/attributes_naming_convention/#reserved-attributes
 [4]: /observability_pipelines/search_syntax/logs/#attribute-search
 [5]: /observability_pipelines/live_capture/
+[6]: /observability_pipelines/search_syntax/logs/#free-text-search


### PR DESCRIPTION
Updated link reference for free text search in new syntax section.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
