### PR TITLE
Bits Code: link permission name to permission docs

### DIFF
--- a/content/en/bits_ai/bits_code/automations.md
+++ b/content/en/bits_ai/bits_code/automations.md
@@ -23,7 +23,7 @@ With Bits Code automations, you can:
 
 ## Prerequisites
 To set up a Bits Code automation, each of the following must be true:
-- You have the `Bits Code Write` (`bits_dev_write`) permission in Datadog.
+- You have the [`Bits Code Write` (`bits_dev_write`) permission][6] in Datadog.
 - You have completed the Bits Code [setup][2].
 - If you plan to have your automations [output Slack notifications](#slack-message-output), you have set up the [Slack integration][4].
 
@@ -109,3 +109,4 @@ You can pause or resume any automation, but you can only edit or delete automati
 [3]: https://app.datadoghq.com/code/automations
 [4]: /integrations/slack/
 [5]: /internal_developer_portal/catalog/
+[6]: /account_management/rbac/permissions/#bits-ai

--- a/content/en/bits_ai/bits_code/setup.md
+++ b/content/en/bits_ai/bits_code/setup.md
@@ -11,7 +11,7 @@ disable_toc: false
 
 ## Prerequisites
 
-To set up Bits Code, you need the `Bits Code Write` (`bits_dev_write`) permission. This permission is included in managed Datadog roles such as the Datadog Standard Role.
+To set up Bits Code, you need the [`Bits Code Write` (`bits_dev_write`) permission][1]. This permission is included in managed Datadog roles such as the Datadog Standard Role.
 
 If your organization uses custom roles, an admin must add this permission manually. For details, see [Access Control][1].
 

--- a/content/en/security/cloud_security_management/review_remediate/remediate_with_ai.md
+++ b/content/en/security/cloud_security_management/review_remediate/remediate_with_ai.md
@@ -32,7 +32,7 @@ A misconfiguration finding tells you what is wrong with a cloud resource. **Reme
 
 Copying a fix prompt for your own coding agent requires no setup. To have Bits Code generate the fix, you need:
 
-- The [**Bits Code Write** (`bits_dev_write`) permission][8] in Datadog.
+- The [`Bits Code Write` (`bits_dev_write`) permission][8] in Datadog.
 - Bits Code [set up][5] for your source control provider.
 
 Bits Code resolves fixes most reliably when Datadog knows where the affected resource is defined in your code. See [Code Locations][6] for how that mapping is established.

--- a/content/en/security/cloud_security_management/review_remediate/remediate_with_ai.md
+++ b/content/en/security/cloud_security_management/review_remediate/remediate_with_ai.md
@@ -32,7 +32,7 @@ A misconfiguration finding tells you what is wrong with a cloud resource. **Reme
 
 Copying a fix prompt for your own coding agent requires no setup. To have Bits Code generate the fix, you need:
 
-- The **Bits Code Write** (`bits_dev_write`) permission in Datadog.
+- The [**Bits Code Write** (`bits_dev_write`) permission][8] in Datadog.
 - Bits Code [set up][5] for your source control provider.
 
 Bits Code resolves fixes most reliably when Datadog knows where the affected resource is defined in your code. See [Code Locations][6] for how that mapping is established.
@@ -68,3 +68,4 @@ Bits Code usage is billed through [AI Credits][7].
 [5]: /bits_ai/bits_code/setup/
 [6]: /security/cloud_security_management/code_locations/
 [7]: /account_management/billing/ai_credits/
+[8]: /account_management/rbac/permissions/#bits-ai


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1dc298a6-c57d-4ccc-b285-0e7758b80f65","source":"chat","resourceId":"10a7b89e-a982-47c3-a2d1-bc24972e5f84","workflowId":"9aa4e660-9dc8-414c-9c16-a3b50b47ba25","codeChangeId":"9aa4e660-9dc8-414c-9c16-a3b50b47ba25","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

links instances of the required Bits Code permission to the permission docs where it's explained in further depth/put into context amongst other Bits AI permissions

also standardizes the Remediate with AI permission text so `Bits Code Write` uses inline code formatting consistently

### Merge readiness
- [x] Ready for merge

### AI assistance

Used Bits Code to update Markdown links and verify the diff.

### Additional notes
n/a

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/10a7b89e-a982-47c3-a2d1-bc24972e5f84)

Comment @datadog to request changes