### PR TITLE
[CHORE] Add AI Credit Limits page to billing navigation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -10604,6 +10604,11 @@ menu:
       url: account_management/billing/ai_credits/
       parent: account_management_billing
       weight: 1521
+    - name: AI Credit Limits
+      identifier: account_management_billing_ai_credit_limits
+      url: account_management/billing/ai_credit_limits/
+      parent: account_management_billing
+      weight: 1522
     - name: Multi-org Accounts
       identifier: account_management_multi_org_accounts
       url: account_management/multi_organization/

--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -115,6 +115,7 @@ If you pay by check, ACH, or wire, invoices are emailed to the billing email add
     {{< nextlink href="account_management/billing/vsphere/" >}}vSphere integration{{< /nextlink >}}
     {{< nextlink href="account_management/billing/usage_attribution/" >}}Usage attribution{{< /nextlink >}}
     {{< nextlink href="account_management/billing/ai_credits/" >}}AI Credits{{< /nextlink >}}
+    {{< nextlink href="account_management/billing/ai_credit_limits/" >}}AI Credit Limits{{< /nextlink >}}
 {{< /whatsnext >}}
 
 

--- a/content/en/account_management/billing/ai_credits.md
+++ b/content/en/account_management/billing/ai_credits.md
@@ -58,7 +58,7 @@ If your usage exceeds your monthly Commit, additional credits are billed automat
 
 ## Admin controls
 
-All AI Credit management lives in [**Plan & Usage > AI Credits**][6]. From there, admins can:
+Usage tracking and product access are managed in [**Plan & Usage > AI Credits**][6]. From there, admins can:
 
 - **View usage**: See the current month's credit consumption, broken down by AI product.
 - **Enable or disable AI products powered by AI Credits**: A single org-level toggle controls all AI products powered by AI Credits. When disabled, users can still see product surfaces and view past results, but new requests are blocked.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Follow-up to #38668, which added the AI Credit Limits page but did not register it in the navigation.

- Adds `AI Credit Limits` to the Billing section of the left nav (`main.en.yaml`, weight 1522, after `AI Credits`).
- Adds a `nextlink` for the page to the Billing landing page, which lists every other page in the section.
- Corrects the scope of the `Admin controls` intro on the AI Credits page. It said "All AI Credit management lives in **Plan & Usage > AI Credits**," which is no longer accurate now that limits are configured in **Bits AI > AI Credits Management**.

No content changes to the AI Credit Limits page itself.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

One item on the AI Credit Limits page is intentionally out of scope here and will be handled separately: the override precedence rules still disagree about whether a per-user override replaces the default per-user limit or whether the higher of the two applies. That needs product confirmation before the wording can be corrected.

### AI assistance

Used Claude to make the changes and the PR 
