### PR TITLE
[SDTEST-3942] Add ddtest CI adoption guide

### DIFF
--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -241,7 +241,7 @@ Files under `.testoptimization/runner/cache/`, `.testoptimization/tests-discover
 
 ## Use a plan with another test runner
 
-Use a `ddtest` plan when you want `ddtest` to select runnable test files, but another runner should execute them.
+Use a `ddtest` plan when you want `ddtest` to select runnable test files, but another runner executes them.
 
 See [Plan artifacts](#plan-artifacts) for the `test-files.txt` and per-runner `tests-split/runner-N` files that another runner can consume.
 

--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -243,10 +243,7 @@ Files under `.testoptimization/runner/cache/`, `.testoptimization/tests-discover
 
 Use a `ddtest` plan when you want `ddtest` to select runnable test files, but another runner should execute them.
 
-| File | Use |
-| ---- | --- |
-| `.testoptimization/runner/test-files.txt` | All runnable test files after Test Impact Analysis skips are applied. |
-| `.testoptimization/runner/tests-split/runner-N` | Files assigned to CI node or worker `N`. |
+See [Plan artifacts](#plan-artifacts) for the `test-files.txt` and per-runner `tests-split/runner-N` files that another runner can consume.
 
 For example, use `.testoptimization/runner/test-files.txt` with Knapsack Pro:
 

--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -239,6 +239,30 @@ Most integrations should treat `.testoptimization/` as a generated artifact. The
 
 Files under `.testoptimization/runner/cache/`, `.testoptimization/tests-discovery/`, and `.testoptimization/cache/http/*.json` are implementation details. Use them only for troubleshooting.
 
+## Use plan artifacts with another test runner
+
+Use `ddtest` plan files when you want `ddtest` to select runnable test files, but another runner should execute them.
+
+| File | Use |
+| ---- | --- |
+| `.testoptimization/runner/test-files.txt` | All runnable test files after Test Impact Analysis skips are applied. |
+| `.testoptimization/runner/tests-split/runner-N` | Files assigned to CI node or worker `N`. |
+
+For example, use `.testoptimization/runner/test-files.txt` with Knapsack Pro:
+
+{{< code-block lang="bash" >}}
+KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.testoptimization/runner/test-files.txt bundle exec rake knapsack_pro:queue:rspec
+{{< /code-block >}}
+
+For pytest, enable the `ddtrace` plugin with `PYTEST_ADDOPTS` and pass the file list to `python -m pytest`:
+
+{{< code-block lang="bash" >}}
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:+$PYTEST_ADDOPTS }--ddtrace"
+if [ -s .testoptimization/runner/test-files.txt ]; then
+  xargs python -m pytest < .testoptimization/runner/test-files.txt
+fi
+{{< /code-block >}}
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tests/test_parallelization/configuration.md
+++ b/content/en/tests/test_parallelization/configuration.md
@@ -239,9 +239,9 @@ Most integrations should treat `.testoptimization/` as a generated artifact. The
 
 Files under `.testoptimization/runner/cache/`, `.testoptimization/tests-discovery/`, and `.testoptimization/cache/http/*.json` are implementation details. Use them only for troubleshooting.
 
-## Use plan artifacts with another test runner
+## Use a plan with another test runner
 
-Use `ddtest` plan files when you want `ddtest` to select runnable test files, but another runner should execute them.
+Use a `ddtest` plan when you want `ddtest` to select runnable test files, but another runner should execute them.
 
 | File | Use |
 | ---- | --- |

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -154,7 +154,7 @@ The CI examples on this page show how to pass the generated plan and selected ru
 
 After replacing the test command, confirm that the expected tests complete and that the test session appears in Datadog. Compare the test stage duration and CI resource consumption with your previous workflow.
 
-Local workers primarily reduce test stage duration. When you distribute tests across CI nodes, using the selected runner count can also avoid unnecessary CI nodes after Test Impact Analysis removes unaffected tests.
+If all workers run on one CI node, parallel execution shortens the test stage without changing the number of CI nodes. If each worker runs on a separate CI node, use the runner count in `parallel-runners.txt` to size the CI matrix. Because Test Impact Analysis removes unaffected tests before `ddtest` selects the runner count, smaller changes can result in fewer CI nodes being started.
 
 Use `--max-parallelism` to limit CI capacity. The planner accounts for the setup cost of each additional runner through `--ci-job-overhead`. For details about these settings, see [Configuration][4].
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -648,5 +648,5 @@ Keep the `ddtest` download, plan, cache, and continuation steps from the CircleC
 [3]: https://github.com/DataDog/ddtest/releases/latest
 [4]: /tests/test_parallelization/configuration/
 [5]: /tests/test_parallelization/configuration/#plan-artifacts
-[6]: https://app.datadoghq.com/ci/test-runs
+[6]: /tests/explorer/
 [7]: /continuous_integration/explorer/

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -133,7 +133,7 @@ bin/ddtest run \
 
 #### Run workers on one CI node
 
-On a single CI node, the selected parallelism is the number of local worker processes that `ddtest` starts. The command does not require additional options.
+On a single CI node, `ddtest plan` is optional. Run `ddtest run` directly, or run `ddtest plan` and `ddtest run` back-to-back in the same job if you want to inspect the plan first. The selected parallelism is the number of local worker processes that `ddtest` starts. The command does not require additional options.
 
 #### Distribute tests across CI nodes
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -112,11 +112,14 @@ wc -l .testoptimization/runner/test-files.txt
 
 # Preview the first 20 test files to verify test discovery.
 sed -n '1,20p' .testoptimization/runner/test-files.txt
+
+# Optional: List the per-runner split files to see how ddtest distributed the tests.
+find .testoptimization/runner/tests-split -maxdepth 1 -type f -print
 {{< /code-block >}}
 
 Alternatively, download the `.testoptimization/` directory as a CI artifact and open the files in your editor.
 
-Confirm that `test-files.txt` contains a list of files to run. Optionally, inspect `.testoptimization/runner/tests-split/` to see how `ddtest` distributed the files across runners. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
+Confirm that `test-files.txt` contains a list of files to run. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
 
 ### 3. Replace the existing test command
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -73,38 +73,44 @@ chmod +x bin/ddtest
 {{% /tab %}}
 {{< /tabs >}}
 
+These examples download the latest Linux AMD64 binary. For another operating system or architecture, select the corresponding asset from [GitHub Releases][3].
+
 ## Adopt ddtest in CI
 
-Adopt Test Parallelization in two stages. First, add planning without changing how tests run. Then, replace the existing test command with `ddtest` to use the selected parallelism.
+Adopt Test Parallelization in four steps. First, add planning without changing how tests run. After validating the plan, replace the existing test command with `ddtest`, choose an execution mode, and measure the resulting CI savings.
 
-### 1. Validate test planning
+### 1. Add test planning
 
-After setting up dependencies and Test Optimization, add `ddtest plan` before your existing test step. Set the minimum to `1` and the maximum to the largest number of CI nodes or local workers you want `ddtest` to consider:
+After setting up dependencies and Test Optimization, add `ddtest plan` before your existing test step. Keep the existing test command in place during this step.
+
+Set the minimum to `1` and the maximum to the largest number of CI nodes or local workers that `ddtest` should consider:
 
 {{< code-block lang="bash" >}}
 bin/ddtest plan \
   --platform <PLATFORM> \
   --framework <FRAMEWORK> \
   --min-parallelism 1 \
-  --max-parallelism 8 \
-  --strict-discovery
+  --max-parallelism 8
 {{< /code-block >}}
 
-For example, use `ruby` and `rspec`, `python` and `pytest`, or `javascript` and `jest` for `<PLATFORM>` and `<FRAMEWORK>`.
+For example, use `ruby` with `rspec`, `ruby` with `minitest`, `python` with `pytest`, or `javascript` with `jest`. For all supported values and defaults, see [Configuration][4].
 
-Planning discovers tests, retrieves test duration and Test Impact Analysis data, selects a parallelism level, and writes the test splits to `.testoptimization/`. It does not execute tests, so keep your existing test command unchanged while you validate the plan.
+Planning discovers tests, retrieves test duration and Test Impact Analysis data, and chooses a parallelism level. It does not execute tests. The generated `.testoptimization/` directory contains the test files and splits selected for execution.
+
+### 2. Inspect the plan
 
 Inspect the proposed runner count and test files in the CI logs:
 
 {{< code-block lang="bash" >}}
 cat .testoptimization/runner/parallel-runners.txt
+wc -l .testoptimization/runner/test-files.txt
 sed -n '1,20p' .testoptimization/runner/test-files.txt
-ls .testoptimization/runner/tests-split/
+find .testoptimization/runner/tests-split -maxdepth 1 -type f -print
 {{< /code-block >}}
 
 Confirm that `test-files.txt` contains the files your existing command should run and that the number of split files matches `parallel-runners.txt`. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
 
-### 2. Replace the existing test command
+### 3. Replace the existing test command
 
 After the plan contains the expected tests, replace the existing test command with:
 
@@ -114,9 +120,15 @@ bin/ddtest run \
   --framework <FRAMEWORK>
 {{< /code-block >}}
 
-`ddtest run` reuses the plan generated earlier in the job. On a single CI node, the selected parallelism is the number of local worker processes that `ddtest` starts.
+`ddtest run` reuses the plan generated earlier in the workflow. Choose how to run the selected splits based on your CI architecture.
 
-To distribute tests across multiple CI nodes, run `ddtest plan` once in a planning job. Share the complete `.testoptimization/` directory with the test jobs, and expose the selected runner count to your CI matrix. On each node, run:
+#### Run workers on one CI node
+
+On a single CI node, the selected parallelism is the number of local worker processes that `ddtest` starts. The command does not require additional options.
+
+#### Distribute tests across CI nodes
+
+Run `ddtest plan` once in a planning job. Share the complete `.testoptimization/` directory with the test jobs, and use the selected parallelism to define the size of your CI matrix. On each node, run:
 
 {{< code-block lang="bash" >}}
 bin/ddtest run \
@@ -125,102 +137,19 @@ bin/ddtest run \
   --ci-node <CI_NODE_INDEX>
 {{< /code-block >}}
 
-The CI examples on this page show how to pass the generated plan and selected runner count between jobs.
-
-### 3. Tune for CI savings
-
-Compare the test stage duration before and after the change. Use `--max-parallelism` to limit CI capacity. The planner accounts for the setup cost of each additional runner; adjust `--ci-job-overhead` if your jobs have significantly more or less setup time than the default. Increase the overhead to favor fewer CI nodes, or decrease it to favor shorter wall time. Enable [Test Impact Analysis][2] to exclude unaffected tests before `ddtest` creates the splits.
-
-Add `.testoptimization/` to `.gitignore`. Generate a fresh plan for each CI workflow run, and share it only between jobs for the same source revision and execution environment. Run planning and tests from the same working directory. For details about the generated files, see [Plan artifacts][5].
-
-## Run on a single CI node
-
-If you run your tests on a single CI node, run `ddtest run`:
-
-{{< tabs >}}
-{{% tab "Ruby" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest run --platform ruby --framework rspec
-{{< /code-block >}}
-
-{{% /tab %}}
-{{% tab "Python" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest run --platform python --framework pytest
-{{< /code-block >}}
-
-{{% /tab %}}
-{{% tab "JavaScript" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest run --platform javascript --framework jest
-{{< /code-block >}}
-
-{{% /tab %}}
-{{< /tabs >}}
-
-By default, `ddtest` can start one worker for each physical CPU core available on the node.
-
-## Run across multiple CI nodes
-
-For multiple CI nodes, run `ddtest plan` once, share the `.testoptimization/` directory with every CI node, and pass each node its zero-indexed CI node number:
-
-{{< tabs >}}
-{{% tab "Ruby" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest plan \
-  --platform ruby \
-  --framework rspec \
-  --min-parallelism 1 \
-  --max-parallelism 8
-
-bin/ddtest run \
-  --platform ruby \
-  --framework rspec \
-  --ci-node <CI_NODE_INDEX>
-{{< /code-block >}}
-
-{{% /tab %}}
-{{% tab "Python" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest plan \
-  --platform python \
-  --framework pytest \
-  --min-parallelism 1 \
-  --max-parallelism 8
-
-bin/ddtest run \
-  --platform python \
-  --framework pytest \
-  --ci-node <CI_NODE_INDEX>
-{{< /code-block >}}
-
-{{% /tab %}}
-{{% tab "JavaScript" %}}
-
-{{< code-block lang="bash" >}}
-bin/ddtest plan \
-  --platform javascript \
-  --framework jest \
-  --min-parallelism 1 \
-  --max-parallelism 8
-
-bin/ddtest run \
-  --platform javascript \
-  --framework jest \
-  --ci-node <CI_NODE_INDEX>
-{{< /code-block >}}
-
-{{% /tab %}}
-{{< /tabs >}}
-
 In CI-node mode, `ddtest` uses one local worker by default. To start multiple workers in each CI node, set `--ci-node-workers` to a positive integer or `ncpu`.
 
-For a list of available environment variables, defaults, and examples, see [Configuration][4].
+The CI examples on this page show how to pass the generated plan and selected runner count between jobs.
+
+### 4. Measure CI savings
+
+After replacing the test command, confirm that the expected tests complete and that the test session appears in Datadog. Compare the test stage duration and CI resource consumption with your previous workflow.
+
+Local workers primarily reduce test stage duration. When you distribute tests across CI nodes, using the selected runner count can also avoid unnecessary CI nodes after Test Impact Analysis removes unaffected tests.
+
+Use `--max-parallelism` to limit CI capacity. The planner accounts for the setup cost of each additional runner through `--ci-job-overhead`. For details about these settings, see [Configuration][4].
+
+Add `.testoptimization/` to `.gitignore`. Generate a fresh plan for each CI workflow run, and share it only between jobs for the same source revision and execution environment. Run planning and tests from the same working directory. For details about the generated files, see [Plan artifacts][5].
 
 ## CI examples
 
@@ -701,32 +630,6 @@ Keep the `ddtest` download, plan, cache, and continuation steps from the CircleC
 `ddtest` prepends `NODE_OPTIONS=-r dd-trace/ci/init` for Jest worker processes, so the project dependencies installed before `ddtest plan` must include `dd-trace`.
 
 {{< /collapse-content >}}
-
-## Use third-party test runners
-
-Use `ddtest` plan files when you want `ddtest` to choose which files should run, but another runner should execute them.
-
-To learn about the full contents of the plan directory, see [Plan artifacts][5].
-
-| File | Use |
-| ---- | --- |
-| `.testoptimization/runner/test-files.txt` | All runnable test files after Test Impact Analysis skips are applied. |
-| `.testoptimization/runner/tests-split/runner-N` | Files assigned to CI node or worker `N`. |
-
-For example, use `.testoptimization/runner/test-files.txt` with Knapsack Pro:
-
-{{< code-block lang="bash" >}}
-KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.testoptimization/runner/test-files.txt bundle exec rake knapsack_pro:queue:rspec
-{{< /code-block >}}
-
-For pytest, enable the `ddtrace` plugin with `PYTEST_ADDOPTS` and pass the file list to `python -m pytest`:
-
-{{< code-block lang="bash" >}}
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:+$PYTEST_ADDOPTS }--ddtrace"
-if [ -s .testoptimization/runner/test-files.txt ]; then
-  xargs python -m pytest < .testoptimization/runner/test-files.txt
-fi
-{{< /code-block >}}
 
 ## Further reading
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -73,60 +73,65 @@ chmod +x bin/ddtest
 {{% /tab %}}
 {{< /tabs >}}
 
-## Validate the setup
+## Adopt ddtest in CI
 
-Validate test discovery and execution with one worker before distributing tests across workers or CI nodes:
+Adopt Test Parallelization in two stages. First, add planning without changing how tests run. Then, replace the existing test command with `ddtest` to use the selected parallelism.
 
-1. Run the test suite with its existing command. Record the exit status and expected test results.
-2. Run the test suite with Test Optimization enabled. Confirm that the test session appears in Datadog before adding `ddtest`.
-3. From the directory where the test command runs, remove any previous plan and generate a one-worker plan:
+### 1. Validate test planning
 
-   {{< code-block lang="bash" >}}
-   rm -rf .testoptimization
-   bin/ddtest plan \
-     --platform <PLATFORM> \
-     --framework <FRAMEWORK> \
-     --min-parallelism 1 \
-     --max-parallelism 1 \
-     --strict-discovery
-   {{< /code-block >}}
-
-   For example, use `ruby` and `rspec`, `python` and `pytest`, or `javascript` and `jest` for `<PLATFORM>` and `<FRAMEWORK>`.
-4. Inspect the generated plan:
-
-   {{< code-block lang="bash" >}}
-   cat .testoptimization/runner/parallel-runners.txt
-   sed -n '1,20p' .testoptimization/runner/test-files.txt
-   {{< /code-block >}}
-
-   Confirm that `parallel-runners.txt` contains `1` and that `test-files.txt` contains the expected runnable test files. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
-5. Run the one-worker plan:
-
-   {{< code-block lang="bash" >}}
-   bin/ddtest run \
-     --platform <PLATFORM> \
-     --framework <FRAMEWORK>
-   {{< /code-block >}}
-
-   Compare the exit status and results with the existing test command. Account for expected Test Impact Analysis skips, and confirm that the test session appears in Datadog.
-6. After the one-worker run succeeds, remove the validation plan or generate a fresh plan with the intended parallelism settings before distributing tests.
-
-## Manage plan artifacts
-
-Add the generated plan directory to `.gitignore`:
-
-{{< code-block lang="text" >}}
-.testoptimization/
-{{< /code-block >}}
-
-`ddtest run` uses an existing plan when `.testoptimization/runner/parallel-runners.txt` is present. Generate a fresh plan after changing the source revision, dependencies, platform, framework, test location, or working directory. To remove files from a previous plan before generating another plan, run:
+After setting up dependencies and Test Optimization, add `ddtest plan` before your existing test step. Set the minimum to `1` and the maximum to the largest number of CI nodes or local workers you want `ddtest` to consider:
 
 {{< code-block lang="bash" >}}
-rm -rf .testoptimization
-bin/ddtest plan --platform <PLATFORM> --framework <FRAMEWORK>
+bin/ddtest plan \
+  --platform <PLATFORM> \
+  --framework <FRAMEWORK> \
+  --min-parallelism 1 \
+  --max-parallelism 8 \
+  --strict-discovery
 {{< /code-block >}}
 
-In CI, generate one plan for each workflow run. Share the complete `.testoptimization/` directory only with test jobs for the same source revision. Run the plan and test jobs from the same working directory, with the same platform, framework, runtime, and dependencies. For details about the generated files, see [Plan artifacts][5].
+For example, use `ruby` and `rspec`, `python` and `pytest`, or `javascript` and `jest` for `<PLATFORM>` and `<FRAMEWORK>`.
+
+Planning discovers tests, retrieves test duration and Test Impact Analysis data, selects a parallelism level, and writes the test splits to `.testoptimization/`. It does not execute tests, so keep your existing test command unchanged while you validate the plan.
+
+Inspect the proposed runner count and test files in the CI logs:
+
+{{< code-block lang="bash" >}}
+cat .testoptimization/runner/parallel-runners.txt
+sed -n '1,20p' .testoptimization/runner/test-files.txt
+ls .testoptimization/runner/tests-split/
+{{< /code-block >}}
+
+Confirm that `test-files.txt` contains the files your existing command should run and that the number of split files matches `parallel-runners.txt`. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
+
+### 2. Replace the existing test command
+
+After the plan contains the expected tests, replace the existing test command with:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run \
+  --platform <PLATFORM> \
+  --framework <FRAMEWORK>
+{{< /code-block >}}
+
+`ddtest run` reuses the plan generated earlier in the job. On a single CI node, the selected parallelism is the number of local worker processes that `ddtest` starts.
+
+To distribute tests across multiple CI nodes, run `ddtest plan` once in a planning job. Share the complete `.testoptimization/` directory with the test jobs, and expose the selected runner count to your CI matrix. On each node, run:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run \
+  --platform <PLATFORM> \
+  --framework <FRAMEWORK> \
+  --ci-node <CI_NODE_INDEX>
+{{< /code-block >}}
+
+The CI examples on this page show how to pass the generated plan and selected runner count between jobs.
+
+### 3. Tune for CI savings
+
+Compare the test stage duration before and after the change. Use `--max-parallelism` to limit CI capacity. The planner accounts for the setup cost of each additional runner; adjust `--ci-job-overhead` if your jobs have significantly more or less setup time than the default. Increase the overhead to favor fewer CI nodes, or decrease it to favor shorter wall time. Enable [Test Impact Analysis][2] to exclude unaffected tests before `ddtest` creates the splits.
+
+Add `.testoptimization/` to `.gitignore`. Generate a fresh plan for each CI workflow run, and share it only between jobs for the same source revision and execution environment. Run planning and tests from the same working directory. For details about the generated files, see [Plan artifacts][5].
 
 ## Run on a single CI node
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -83,7 +83,7 @@ Adopt Test Parallelization in four steps. First, add planning without changing h
 
 After setting up dependencies and Test Optimization, add `ddtest plan` before your existing test step. Keep the existing test command in place during this step.
 
-Set the minimum to `1` and the maximum to the largest number of CI nodes or local workers that `ddtest` should consider:
+Choose the minimum and maximum parallelism for your CI environment. For example, the following values allow `ddtest` to choose between 1 and 8 CI nodes or local workers:
 
 {{< code-block lang="bash" >}}
 bin/ddtest plan \
@@ -93,7 +93,7 @@ bin/ddtest plan \
   --max-parallelism 8
 {{< /code-block >}}
 
-For example, use `ruby` with `rspec`, `ruby` with `minitest`, `python` with `pytest`, or `javascript` with `jest`. For all supported values and defaults, see [Configuration][4].
+`--platform` identifies the language platform, and `--framework` identifies the test framework. Supported combinations include `ruby` with `rspec` or `minitest`, `python` with `pytest`, and `javascript` with `jest`. For all supported values and defaults, see [Configuration][4].
 
 Planning discovers tests, retrieves test duration and Test Impact Analysis data, and chooses a parallelism level. It does not execute tests. The generated `.testoptimization/` directory contains the test files and splits selected for execution.
 

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -79,6 +79,8 @@ These examples download the latest Linux AMD64 binary. For another operating sys
 
 Adopt Test Parallelization in four steps. First, add planning without changing how tests run. After validating the plan, replace the existing test command with `ddtest`, choose an execution mode, and measure the resulting CI savings.
 
+Make these changes on a feature branch. Commit and push each CI configuration change, then review the resulting CI run before continuing.
+
 ### 1. Add test planning
 
 After setting up dependencies and Test Optimization, add `ddtest plan` before your existing test step. Keep the existing test command in place during this step.
@@ -110,14 +112,11 @@ wc -l .testoptimization/runner/test-files.txt
 
 # Preview the first 20 test files to verify test discovery.
 sed -n '1,20p' .testoptimization/runner/test-files.txt
-
-# List the per-runner split files to verify that work was distributed.
-find .testoptimization/runner/tests-split -maxdepth 1 -type f -print
 {{< /code-block >}}
 
 Alternatively, download the `.testoptimization/` directory as a CI artifact and open the files in your editor.
 
-Confirm that `test-files.txt` contains the files your existing command should run and that the number of split files matches `parallel-runners.txt`. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
+Confirm that `test-files.txt` contains a list of files to run. Optionally, inspect `.testoptimization/runner/tests-split/` to see how `ddtest` distributed the files across runners. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
 
 ### 3. Replace the existing test command
 
@@ -152,7 +151,7 @@ The CI examples on this page show how to pass the generated plan and selected ru
 
 ### 4. Measure CI savings
 
-After replacing the test command, confirm that the expected tests complete and that the test session appears in Datadog. Compare the test stage duration and CI resource consumption with your previous workflow.
+After replacing the test command, confirm in the [Test Optimization Explorer][6] that the expected tests completed. Use the [CI Visibility Explorer][7] to compare test job durations and the number of test jobs between pipeline runs. If CI Visibility is not enabled, use the equivalent job metrics in your CI provider.
 
 If all workers run on one CI node, parallel execution shortens the test stage without changing the number of CI nodes. If each worker runs on a separate CI node, use the runner count in `parallel-runners.txt` to size the CI matrix. Because Test Impact Analysis removes unaffected tests before `ddtest` selects the runner count, smaller changes can result in fewer CI nodes being started.
 
@@ -649,3 +648,5 @@ Keep the `ddtest` download, plan, cache, and continuation steps from the CircleC
 [3]: https://github.com/DataDog/ddtest/releases/latest
 [4]: /tests/test_parallelization/configuration/
 [5]: /tests/test_parallelization/configuration/#plan-artifacts
+[6]: https://app.datadoghq.com/ci/test-runs
+[7]: /continuous_integration/explorer/

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -73,6 +73,61 @@ chmod +x bin/ddtest
 {{% /tab %}}
 {{< /tabs >}}
 
+## Validate the setup
+
+Validate test discovery and execution with one worker before distributing tests across workers or CI nodes:
+
+1. Run the test suite with its existing command. Record the exit status and expected test results.
+2. Run the test suite with Test Optimization enabled. Confirm that the test session appears in Datadog before adding `ddtest`.
+3. From the directory where the test command runs, remove any previous plan and generate a one-worker plan:
+
+   {{< code-block lang="bash" >}}
+   rm -rf .testoptimization
+   bin/ddtest plan \
+     --platform <PLATFORM> \
+     --framework <FRAMEWORK> \
+     --min-parallelism 1 \
+     --max-parallelism 1 \
+     --strict-discovery
+   {{< /code-block >}}
+
+   For example, use `ruby` and `rspec`, `python` and `pytest`, or `javascript` and `jest` for `<PLATFORM>` and `<FRAMEWORK>`.
+4. Inspect the generated plan:
+
+   {{< code-block lang="bash" >}}
+   cat .testoptimization/runner/parallel-runners.txt
+   sed -n '1,20p' .testoptimization/runner/test-files.txt
+   {{< /code-block >}}
+
+   Confirm that `parallel-runners.txt` contains `1` and that `test-files.txt` contains the expected runnable test files. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
+5. Run the one-worker plan:
+
+   {{< code-block lang="bash" >}}
+   bin/ddtest run \
+     --platform <PLATFORM> \
+     --framework <FRAMEWORK>
+   {{< /code-block >}}
+
+   Compare the exit status and results with the existing test command. Account for expected Test Impact Analysis skips, and confirm that the test session appears in Datadog.
+6. After the one-worker run succeeds, remove the validation plan or generate a fresh plan with the intended parallelism settings before distributing tests.
+
+## Manage plan artifacts
+
+Add the generated plan directory to `.gitignore`:
+
+{{< code-block lang="text" >}}
+.testoptimization/
+{{< /code-block >}}
+
+`ddtest run` uses an existing plan when `.testoptimization/runner/parallel-runners.txt` is present. Generate a fresh plan after changing the source revision, dependencies, platform, framework, test location, or working directory. To remove files from a previous plan before generating another plan, run:
+
+{{< code-block lang="bash" >}}
+rm -rf .testoptimization
+bin/ddtest plan --platform <PLATFORM> --framework <FRAMEWORK>
+{{< /code-block >}}
+
+In CI, generate one plan for each workflow run. Share the complete `.testoptimization/` directory only with test jobs for the same source revision. Run the plan and test jobs from the same working directory, with the same platform, framework, runtime, and dependencies. For details about the generated files, see [Plan artifacts][5].
+
 ## Run on a single CI node
 
 If you run your tests on a single CI node, run `ddtest run`:

--- a/content/en/tests/test_parallelization/setup.md
+++ b/content/en/tests/test_parallelization/setup.md
@@ -99,14 +99,23 @@ Planning discovers tests, retrieves test duration and Test Impact Analysis data,
 
 ### 2. Inspect the plan
 
-Inspect the proposed runner count and test files in the CI logs:
+The following commands are one way to inspect the proposed runner count and test files in the CI logs:
 
 {{< code-block lang="bash" >}}
+# Show the number of runners selected by ddtest.
 cat .testoptimization/runner/parallel-runners.txt
+
+# Count the test files selected for execution.
 wc -l .testoptimization/runner/test-files.txt
+
+# Preview the first 20 test files to verify test discovery.
 sed -n '1,20p' .testoptimization/runner/test-files.txt
+
+# List the per-runner split files to verify that work was distributed.
 find .testoptimization/runner/tests-split -maxdepth 1 -type f -print
 {{< /code-block >}}
+
+Alternatively, download the `.testoptimization/` directory as a CI artifact and open the files in your editor.
 
 Confirm that `test-files.txt` contains the files your existing command should run and that the number of split files matches `parallel-runners.txt`. If Test Impact Analysis is enabled, files whose tests are all skipped are absent from the plan.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes SDTEST-3942

Reworks the Test Parallelization setup guide into a linear CI adoption flow:

1. Add `ddtest plan` while keeping the existing test command.
2. Inspect the proposed runner count and test-file splits.
3. Replace the existing command with `ddtest run`.
4. Choose single-node or multi-node execution and measure the result.

The update removes duplicate single-node and multi-node command sections while preserving the existing GitHub Actions and CircleCI examples. It also moves alternative-runner plan artifact examples to the Configuration page, where they fit with the other advanced options.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Codex to cross-check ddtest behavior, rework the documentation, and run validation.
