### PR TITLE
[DOCS-15165] Add view.memory_average/view.memory_max to Android Data Collected docs

### DIFF
--- a/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/data_collected/android.mdoc.md
@@ -150,6 +150,8 @@ RUM action, error, resource, and long task events contain information about the 
 | `view.is_active`      |    Boolean   | Indicates whether the view corresponding to this event is considered active.            |
 | `view.loading_time` | number (ns) | Time it took for the view to load, set by the `addViewLoadingTime(override:)` call. |
 | `view.long_task.count`        | number      | Count of all long tasks collected for this view.                                |
+| `view.memory_average` | number (bytes) | Average amount of resident memory (native and JVM/ART heap) used while this view was foregrounded. |
+| `view.memory_max` | number (bytes) | Peak amount of resident memory (native and JVM/ART heap) used while this view was foregrounded. |
 | `view.name` | string | Customizable name of the view corresponding to the event. |
 | `view.network_settled_time` | number (ns) | Time it took for a view to be fully loaded with all relevant network calls initiated at the start of the view. |
 | `view.resource.count`         | number      | Count of all resources collected for this view.                                 |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-15165

Adds public definitions for two existing Android RUM View attributes that previously had no documentation:

- `view.memory_average` — average resident memory used while the view was foregrounded
- `view.memory_max` — peak resident memory used while the view was foregrounded

Both rows are added to the View attributes table on the [Android Data Collected](https://docs.datadoghq.com/real_user_monitoring/application_monitoring/android/data_collected/#view-attributes) page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes