### PR TITLE
Add Evaluation Context concept doc for Feature Flags

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6443,46 +6443,51 @@ menu:
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_variants
       weight: 302
+    - name: Evaluation Context
+      url: feature_flags/concepts/evaluation_context
+      parent: feature_flags_concepts
+      identifier: feature_flags_concepts_evaluation_context
+      weight: 303
     - name: Targeting Rules and Filters
       url: feature_flags/concepts/targeting_rules
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_targeting_rules
-      weight: 303
+      weight: 304
     - name: Saved Filters
       url: feature_flags/concepts/saved_filters
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_saved_filters
-      weight: 304
+      weight: 305
     - name: Traffic Splitting and Randomization
       url: feature_flags/concepts/traffic_splitting
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_traffic_splitting
-      weight: 305
+      weight: 306
     - name: Distribution Channels
       url: feature_flags/concepts/distribution_channels
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_distribution_channels
-      weight: 306
+      weight: 307
     - name: Configuration Sources
       url: feature_flags/concepts/configuration_sources
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_configuration_sources
-      weight: 307
+      weight: 308
     - name: Flag History
       url: feature_flags/concepts/flag_history
       parent: feature_flags_concepts
       identifier: feature_flags_history
-      weight: 308
+      weight: 309
     - name: Feature Flag Graphs
       url: feature_flags/concepts/flag_graphs
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_flag_graphs
-      weight: 309
+      weight: 310
     - name: Stale Flags
       url: feature_flags/concepts/stale_flags
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_stale_flags
-      weight: 310
+      weight: 311
     - name: Permissions and Access Control
       url: feature_flags/concepts/permissions
       parent: feature_flags_concepts

--- a/content/en/feature_flags/concepts/_index.md
+++ b/content/en/feature_flags/concepts/_index.md
@@ -8,6 +8,7 @@ Learn how Datadog Feature Flags work and how to configure flags, environments, t
 {{< whatsnext desc=" " >}}
     {{< nextlink href="/feature_flags/concepts/environments" >}}Environments{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/variants_and_flag_types" >}}Variants and Flag Types{{< /nextlink >}}
+    {{< nextlink href="/feature_flags/concepts/evaluation_context" >}}Evaluation Context{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/targeting_rules" >}}Targeting Rules and Filters{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/saved_filters" >}}Saved Filters{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/traffic_splitting" >}}Traffic Splitting and Randomization{{< /nextlink >}}

--- a/content/en/feature_flags/concepts/evaluation_context.md
+++ b/content/en/feature_flags/concepts/evaluation_context.md
@@ -1,0 +1,104 @@
+---
+title: Evaluation Context
+description: Learn how Datadog Feature Flags uses evaluation context and the targeting key to evaluate flags for a subject.
+further_reading:
+- link: "/feature_flags/concepts/targeting_rules"
+  tag: "Documentation"
+  text: "Targeting Rules and Filters"
+- link: "/feature_flags/concepts/traffic_splitting"
+  tag: "Documentation"
+  text: "Traffic Splitting and Randomization"
+- link: "/feature_flags/client/"
+  tag: "Documentation"
+  text: "Client-Side SDKs"
+- link: "/feature_flags/server/"
+  tag: "Documentation"
+  text: "Server-Side SDKs"
+---
+
+## Overview
+
+An **evaluation context** is the set of attributes an SDK passes to Datadog when it evaluates a flag. Datadog Feature Flags uses [OpenFeature][1]'s evaluation context: a flat map of attributes describing the subject being evaluated, such as a user, session, or device. [Targeting rules][2] and [percentage rollouts][3] read these attributes to decide which variant a subject receives.
+
+Without an evaluation context, the SDK can still evaluate Boolean on/off flags. It cannot match targeting rules that filter on subject attributes, or produce a consistent rollout assignment for that subject.
+
+## The targeting key
+
+The `targetingKey` is the primary identifier in an evaluation context. It's typically a user ID, session ID, or device ID. Datadog uses the `targetingKey` for [deterministic randomization][3], so the same subject consistently receives the same variant for a flag.
+
+Use a stable, consistent identifier for the same subject across sessions. For logged-out or anonymous subjects, use a persistent identifier, such as a UUID stored in local storage or `SharedPreferences`, instead of omitting the `targetingKey` or regenerating it each session.
+
+## Context attributes
+
+Beyond the `targetingKey`, an evaluation context can include any number of additional attributes, such as `user_role`, `country`, or `tier`. Reference these attributes in targeting rule [filters][2] to control who sees each variant.
+
+<div class="alert alert-warning">Datadog Feature Flags requires evaluation context attributes to be flat primitive values: strings, numbers, and Booleans. Nested objects and arrays are not supported and can cause exposure data to be dropped.</div>
+
+### Example evaluation context
+
+{{< programming-lang-wrapper langs="javascript,python,go" >}}
+
+{{< programming-lang lang="javascript" >}}
+
+```javascript
+const evaluationContext = {
+  targetingKey: 'user-123',
+  user_id: 'user-123',
+  user_role: 'admin',
+  country: 'US',
+  tier: 'premium',
+};
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="python" >}}
+
+```python
+from openfeature.evaluation_context import EvaluationContext
+
+eval_ctx = EvaluationContext(
+    targeting_key="user-123",
+    attributes={
+        "user_id": "user-123",
+        "user_role": "admin",
+        "country": "US",
+        "tier": "premium",
+    },
+)
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="go" >}}
+
+```go
+evalCtx := openfeature.NewEvaluationContext(
+    "user-123",
+    map[string]interface{}{
+        "user_id":   "user-123",
+        "user_role": "admin",
+        "country":   "US",
+        "tier":      "premium",
+    },
+)
+```
+
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}
+
+## Client-side vs. server-side context
+
+Client and server SDKs set the evaluation context differently:
+
+- **Client-side SDKs** hold a single global evaluation context for the SDK instance. Set it once during initialization, then call `OpenFeature.setContext()` to update it when subject attributes change, such as after a user logs in. All subsequent flag evaluations use the updated context.
+- **Server-side SDKs** don't hold a global context. Build an evaluation context for each incoming request, based on the current user or session, and pass it explicitly to every flag evaluation call for that request. Reuse the same context object across evaluations within a request, and only rebuild it if subject attributes change.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://openfeature.dev/docs/reference/concepts/evaluation-context
+[2]: /feature_flags/concepts/targeting_rules/
+[3]: /feature_flags/concepts/traffic_splitting/

--- a/content/en/feature_flags/concepts/targeting_rules.md
+++ b/content/en/feature_flags/concepts/targeting_rules.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/feature_flags/concepts/traffic_splitting"
   tag: "Documentation"
   text: "Traffic Splitting and Randomization"
+- link: "/feature_flags/concepts/evaluation_context"
+  tag: "Documentation"
+  text: "Evaluation Context"
 - link: "/feature_flags/concepts/environments"
   tag: "Documentation"
   text: "Environments"
@@ -57,80 +60,14 @@ SDKs do not evaluate targeting rules when the flag is <b>disabled</b> or <b>over
 
 ## Filters and evaluation context
 
-Filters use attributes from your SDK's **evaluation context**. Define attributes when you set the evaluation context before evaluating flags. Attributes must be flat primitive values (strings, numbers, Booleans). Nested objects and arrays are not supported.
+Filters use attributes from your SDK's [evaluation context][4]. Define attributes when you set the evaluation context before evaluating flags. Attributes must be flat primitive values (strings, numbers, Booleans). Nested objects and arrays are not supported.
 
-### Example evaluation contexts and filters
-
-With the following evaluation context, you can build filters with different operators, such as equality, **is one of**, **is not**, or numeric comparisons:
-
-**Evaluation context:**
-
-{{< programming-lang-wrapper langs="javascript,python,go" >}}
-
-{{< programming-lang lang="javascript" >}}
-
-```javascript
-await OpenFeature.setContext({
-  targetingKey: 'user-123',
-  user_id: 'user-123',
-  user_role: 'admin',
-  email: 'user@example.com',
-  country: 'US',
-  tier: 'premium',
-  account_age_days: 120,
-});
-```
-
-{{< /programming-lang >}}
-
-{{< programming-lang lang="python" >}}
-
-```python
-from openfeature.evaluation_context import EvaluationContext
-
-eval_ctx = EvaluationContext(
-    targeting_key="user-123",
-    attributes={
-        "user_id": "user-123",
-        "user_role": "admin",
-        "email": "user@example.com",
-        "country": "US",
-        "tier": "premium",
-        "account_age_days": 120,
-    },
-)
-```
-
-{{< /programming-lang >}}
-
-{{< programming-lang lang="go" >}}
-
-```go
-evalCtx := openfeature.NewEvaluationContext(
-    "user-123",
-    map[string]interface{}{
-        "user_id":          "user-123",
-        "user_role":        "admin",
-        "email":            "user@example.com",
-        "country":          "US",
-        "tier":             "premium",
-        "account_age_days": 120,
-    },
-)
-```
-
-{{< /programming-lang >}}
-
-{{< /programming-lang-wrapper >}}
-
-#### Example filters
+Given an evaluation context with `country`, `tier`, `user_role`, and `account_age_days` attributes, you can build filters with different operators, such as equality, **is one of**, **is not**, or numeric comparisons:
 
 - `country` **is one of** `US`, `CA`
 - `tier` **equals** `premium`
 - `user_role` **is not** `guest`
 - `account_age_days` **greater than** `90`
-
-**Note**: Other SDKs follow the same pattern. See your platform's [client](/feature_flags/client/) or [server](/feature_flags/server/) SDK documentation for evaluation context setup.
 
 ## Rule hierarchy
 
@@ -145,3 +82,4 @@ Targeting rules are evaluated **in order** from top to bottom:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /feature_flags/concepts/saved_filters/
+[4]: /feature_flags/concepts/evaluation_context/

--- a/content/en/feature_flags/concepts/traffic_splitting.md
+++ b/content/en/feature_flags/concepts/traffic_splitting.md
@@ -5,11 +5,14 @@ further_reading:
 - link: "/feature_flags/concepts/targeting_rules"
   tag: "Documentation"
   text: "Targeting Rules and Filters"
+- link: "/feature_flags/concepts/evaluation_context"
+  tag: "Documentation"
+  text: "Evaluation Context"
 ---
 
 ## Overview
 
-When you define a targeting rule, you can serve a variant to a percentage of subjects that match your targeting filter. Datadog uses **deterministic randomization** based on the `targetingKey` in your evaluation context so the same subject consistently receives the same variant for a given flag.
+When you define a targeting rule, you can serve a variant to a percentage of subjects that match your targeting filter. Datadog uses **deterministic randomization** based on the `targetingKey` in your [evaluation context][1] so the same subject consistently receives the same variant for a given flag.
 
 ## Percentage rollouts
 
@@ -29,45 +32,10 @@ Randomization is **deterministic**: a subject with the same `targetingKey` alway
 
 For multi-variant rules, the SDK applies the same bucketing logic to distribute subjects across variants according to the percentages defined on the rule.
 
-### Example evaluation context
-
-{{< programming-lang-wrapper langs="javascript,python,go" >}}
-
-{{< programming-lang lang="javascript" >}}
-
-```javascript
-await OpenFeature.setContext({
-  targetingKey: 'user-123',
-  user_id: 'user-123',
-});
-```
-
-{{< /programming-lang >}}
-
-{{< programming-lang lang="python" >}}
-
-```python
-eval_ctx = EvaluationContext(
-    targeting_key="user-123",
-    attributes={"user_id": "user-123"},
-)
-```
-
-{{< /programming-lang >}}
-
-{{< programming-lang lang="go" >}}
-
-```go
-evalCtx := openfeature.NewEvaluationContext(
-    "user-123",
-    map[string]interface{}{"user_id": "user-123"},
-)
-```
-
-{{< /programming-lang >}}
-
-{{< /programming-lang-wrapper >}}
+See [Evaluation Context][1] for how to set the `targetingKey` in your SDK.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /feature_flags/concepts/evaluation_context/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a new Concepts page for Feature Flags explaining evaluation context and the targeting key: what they are, how the `targetingKey` drives deterministic randomization, the flat-attribute constraint, and how client-side SDKs (global context) differ from server-side SDKs (per-request context). Also adds a nextlink entry to the Feature Flags Concepts index page, and trims the duplicated evaluation-context explanations in Targeting Rules and Traffic Splitting to link to this new canonical page instead.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code based on existing Feature Flags product documentation; reviewed and lint-checked (Vale) before submission.

### Additional notes