### PR TITLE
[DOCS-13801] Add note on use_device_id_as_hostname for ServiceNow network device tagging

### DIFF
--- a/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
+++ b/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
@@ -68,6 +68,8 @@ With device tagging, you can dynamically enrich network devices monitored by Dat
 
 **Note**: The device must exist in both Datadog's infrastructure and the ServiceNow topology for tag enrichment to occur.
 
+**Note**: Datadog recommends setting `use_device_id_as_hostname: true` under `init_config` in the Datadog Agent's [`snmp.d/conf.yaml`][6] file. This tags metrics and service checks from the SNMP check with `host:device:<DEVICE_ID>`. Dashboards, monitors, and queries can then associate each datapoint with the device that produced it.
+
 To enable ingestion of device tags:
 
 1. Configure a [Query Builder][1] query in your ServiceNow instance. Make sure it is returning the device IP address. The IP is matched against all IP addresses collected for the device in Datadog, not just the primary IP. Schedule the query to execute at your desired refresh interval (Datadog recommends every hour).
@@ -124,6 +126,7 @@ For tagging to work correctly, ensure that the following are true in your system
 [3]: https://docs.datadoghq.com/tracing/service_catalog/
 [4]: https://docs.datadoghq.com/tracing/service_catalog/adding_metadata/
 [5]: https://docs.datadoghq.com/network_monitoring/devices/
+[6]: https://docs.datadoghq.com/network_monitoring/devices/snmp_metrics/
 [7]: https://app.datadoghq.com/reference-tables
 [8]: https://docs.servicenow.com/bundle/rome-servicenow-platform/page/product/configuration-management/task/use-cmdb-query-builder.html
 [9]: https://app.datadoghq.com/event/pipelines

--- a/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
+++ b/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
@@ -66,9 +66,9 @@ Add tags to your network devices in Datadog populated with data from your Servic
 
 With device tagging, you can dynamically enrich network devices monitored by Datadog [Network Device Monitoring][5] with device metadata from your ServiceNow CMDB. This feature requires Datadog Agent 7.71+.
 
-Note that the device must exist in both Datadog's infrastructure and the ServiceNow topology for tag enrichment to occur.
-
-**Note**: Datadog recommends setting `use_device_id_as_hostname: true` under `init_config` in the Datadog Agent's [`snmp.d/conf.yaml`][6] file. This tags metrics and service checks from the SNMP check with `host:device:<DEVICE_ID>`. Dashboards, monitors, and queries can then associate each datapoint with the device that produced it.
+**Notes**:
+* The device must exist in both Datadog's infrastructure and the ServiceNow topology for tag enrichment to occur.
+* Datadog recommends setting `use_device_id_as_hostname: true` under `init_config` in the Datadog Agent's [`snmp.d/conf.yaml`][6] file. This tags metrics and service checks from the SNMP check with `host:device:<DEVICE_ID>`. Dashboards, monitors, and queries can then associate each datapoint with the device that produced it.
 
 To enable ingestion of device tags:
 

--- a/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
+++ b/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
@@ -66,7 +66,7 @@ Add tags to your network devices in Datadog populated with data from your Servic
 
 With device tagging, you can dynamically enrich network devices monitored by Datadog [Network Device Monitoring][5] with device metadata from your ServiceNow CMDB. This feature requires Datadog Agent 7.71+.
 
-**Note**: The device must exist in both Datadog's infrastructure and the ServiceNow topology for tag enrichment to occur.
+Note that the device must exist in both Datadog's infrastructure and the ServiceNow topology for tag enrichment to occur.
 
 **Note**: Datadog recommends setting `use_device_id_as_hostname: true` under `init_config` in the Datadog Agent's [`snmp.d/conf.yaml`][6] file. This tags metrics and service checks from the SNMP check with `host:device:<DEVICE_ID>`. Dashboards, monitors, and queries can then associate each datapoint with the device that produced it.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-13801

Per Support, users setting up ServiceNow CMDB network device tagging don't realize they need to set `use_device_id_as_hostname: true` in the Datadog Agent's `snmp.d/conf.yaml`, so their device tags don't associate with the metrics they expect. 

I wrote this as "Datadog recommends" rather than "you must." The ticket phrased it as a hard requirement, but our NDM docs only ever label this option `# recommended` (see [`network_monitoring/devices/snmp_metrics.md`](https://github.com/dataDog/documentation/blob/master/content/en/network_monitoring/devices/snmp_metrics.md)). **If it is actually required and device tag ingestion fails without it, let me know and I'll change it to "You must set."**

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code to review the request, verify the `host:device:<DEVICE_ID>` tag format and `use_device_id_as_hostname` placement against existing NDM docs, and draft the note. Reviewed and edited by me.

### Additional notes
