### PR TITLE
[DADP-156] Document transaction success telemetry metrics

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -181,6 +181,8 @@ agent diagnose show-metadata agent-telemetry
 | point.sent                                  | Total number of sent metrics                                                                                           |
 | transactions.input_count                    | Incoming transaction count                                                                                             |
 | transactions.input_bytes                    | Incoming transaction payload size in bytes                                                                             |
+| transactions.success                        | Successful transaction count                                                                                           |
+| transactions.success_bytes                  | Successful transaction payload size in bytes                                                                          |
 | transactions.requeued                       | Transaction requeue count                                                                                              |
 | transactions.retries                        | Transaction retry count                                                                                                |
 | **Database**                                |                                                                                                                        |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not done so.* -->

### What does this PR do? What is the motivation?

Fixes [DADP-156](https://datadoghq.atlassian.net/browse/DADP-156)

Adds [`transactions.success`](https://github.com/DataDog/saluki/pull/2180) and [`transactions.success_bytes`](https://github.com/DataDog/saluki/pull/2180) to the Agent Telemetry metric inventory. The Core Agent enrollment is implemented in [datadog-agent#54380](https://github.com/DataDog/datadog-agent/pull/54380).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes



[DADP-156]: https://datadoghq.atlassian.net/browse/DADP-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ