### PR TITLE
Sync PR description template in CLAUDE.md with .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,19 +92,29 @@ CRITICAL: Always use format `<name>/<description>` with forward slash. Without t
 Use the Jira ticket key in square brackets: `[DOCS-XXXXX] Brief description`
 
 ### PR Description Template
+The canonical template is `.github/PULL_REQUEST_TEMPLATE.md`. Read that file when
+drafting a PR description rather than relying on the copy below, which can drift.
+
 ```
 <!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
-
 ### What does this PR do? What is the motivation?
 
 Fixes DOCS-XXXXX
 
 [Brief description of changes]
 
-### Merge instructions
+### Merge readiness
 
-Merge readiness:
 - [ ] Ready for merge
+
+## For Datadog employees:
+
+- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
+- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.
+
+### AI assistance
+
+[If AI tools were used, briefly note how. Leave blank if not applicable.]
 
 ### Additional notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,6 @@ CRITICAL: Always use format `<name>/<description>` with forward slash. Without t
 Use the Jira ticket key in square brackets: `[DOCS-XXXXX] Brief description`
 
 ### PR Description Template
-The canonical template is `.github/PULL_REQUEST_TEMPLATE.md`. Read that file when
-drafting a PR description rather than relying on the copy below, which can drift.
 
 ```
 <!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The PR description template embedded in `CLAUDE.md` had drifted from the real one in `.github/PULL_REQUEST_TEMPLATE.md`, so Claude Code drafts PR descriptions against a stale copy.

### Merge readiness

- [x] Ready for merge

### AI assistance

Used Claude Code to make this PR.

### Additional notes