### PR TITLE
Add Feature Flags and Experiments concept doc

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6458,31 +6458,36 @@ menu:
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_traffic_splitting
       weight: 305
+    - name: Experiments
+      url: feature_flags/concepts/experiments
+      parent: feature_flags_concepts
+      identifier: feature_flags_concepts_experiments
+      weight: 306
     - name: Distribution Channels
       url: feature_flags/concepts/distribution_channels
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_distribution_channels
-      weight: 306
+      weight: 307
     - name: Configuration Sources
       url: feature_flags/concepts/configuration_sources
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_configuration_sources
-      weight: 307
+      weight: 308
     - name: Flag History
       url: feature_flags/concepts/flag_history
       parent: feature_flags_concepts
       identifier: feature_flags_history
-      weight: 308
+      weight: 309
     - name: Feature Flag Graphs
       url: feature_flags/concepts/flag_graphs
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_flag_graphs
-      weight: 309
+      weight: 310
     - name: Stale Flags
       url: feature_flags/concepts/stale_flags
       parent: feature_flags_concepts
       identifier: feature_flags_concepts_stale_flags
-      weight: 310
+      weight: 311
     - name: Permissions and Access Control
       url: feature_flags/concepts/permissions
       parent: feature_flags_concepts

--- a/content/en/feature_flags/concepts/_index.md
+++ b/content/en/feature_flags/concepts/_index.md
@@ -11,6 +11,7 @@ Learn how Datadog Feature Flags work and how to configure flags, environments, t
     {{< nextlink href="/feature_flags/concepts/targeting_rules" >}}Targeting Rules and Filters{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/saved_filters" >}}Saved Filters{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/traffic_splitting" >}}Traffic Splitting and Randomization{{< /nextlink >}}
+    {{< nextlink href="/feature_flags/concepts/experiments" >}}Feature Flags and Experiments{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/distribution_channels" >}}Distribution Channels{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/configuration_sources" >}}Server SDK Configuration Sources{{< /nextlink >}}
     {{< nextlink href="/feature_flags/concepts/flag_history" >}}Flag History{{< /nextlink >}}

--- a/content/en/feature_flags/concepts/experiments.md
+++ b/content/en/feature_flags/concepts/experiments.md
@@ -21,24 +21,24 @@ further_reading:
 
 ## Overview
 
-Datadog Feature Flags is the default way to randomize a [Datadog Experiment][1]. When you link a flag to an experiment, Datadog adds an **Experiment** targeting rule to the flag. Evaluations of that rule assign subjects to a variant and record an exposure event that Datadog uses to analyze the experiment.
+Datadog Feature Flags is the default way to randomize a [Datadog Experiment][1]. When you link a flag to an experiment, Datadog adds an Experiment targeting rule to the flag. Evaluations of that rule assign subjects to a variant and record an exposure event that Datadog uses to analyze the experiment.
 
 ## Link a flag to an experiment
 
 Link a flag to an experiment from either side of the workflow:
 
-- From [Product Analytics > Experiments][1], create an experiment and [add an existing feature flag][2] to it.
-- From a flag's detail page, click **Create New Experiment** in the **Targeting Rules & Rollouts** section to create an experiment pre-filled with that flag.
+- From [{{< ui >}}Product Analytics > Experiments{{< /ui >}}][1], create an experiment and [add an existing feature flag][2] to it.
+- From a flag's detail page, click {{< ui >}}Create New Experiment{{< /ui >}} in the {{< ui >}}Targeting Rules & Rollouts{{< /ui >}} section to create an experiment pre-filled with that flag.
 
 ## Experiment targeting rules
 
-An **Experiment** targeting rule works like any other [targeting rule][3]: it can include a filter, and it uses the same [deterministic randomization][4] to assign subjects to a variant. Randomization is based on the `targetingKey` in your [evaluation context][5], so the same subject consistently receives the same variant for the life of the experiment.
+An experiment targeting rule works like any other [targeting rule][3]: it can include a filter, and it uses the same [deterministic randomization][4] to assign subjects to a variant. Randomization is based on the `targetingKey` in your [evaluation context][5], so the same subject consistently receives the same variant for the life of the experiment.
 
 If multiple experiments share the same flag, Datadog evaluates their targeting rules in order, top to bottom. Reorder the rules before you launch an experiment to control which one takes priority for a given subject.
 
 ## Exposures
 
-Each time the SDK evaluates a flag's **Experiment** targeting rule for a subject, Datadog records an **exposure**: the subject, the variant served, and a timestamp. Datadog joins exposures to metric events to calculate the lift between variants. Those metric events can come from Product Analytics, Real User Monitoring, or your data warehouse.
+Each time the SDK evaluates a flag's experiment targeting rule for a subject, Datadog records an _exposure_: the subject, the variant served, and a timestamp. Datadog joins exposures to metric events to calculate the lift between variants. Those metric events can come from Product Analytics, Real User Monitoring, or your data warehouse.
 
 Datadog joins exposures and metrics by subject identifier. The `targetingKey` your SDK sets in the [evaluation context][5] must match the [subject type attribute][6] configured for the experiment, such as `@usr.id`, or Datadog can't associate metric events with the correct exposure.
 

--- a/content/en/feature_flags/concepts/experiments.md
+++ b/content/en/feature_flags/concepts/experiments.md
@@ -4,19 +4,19 @@ description: Learn how a feature flag's targeting rules randomize a Datadog Expe
 further_reading:
 - link: "/experiments/"
   tag: "Documentation"
-  text: "Experiments"
-- link: "/feature_flags/concepts/targeting_rules"
-  tag: "Documentation"
-  text: "Targeting Rules and Filters"
-- link: "/feature_flags/concepts/evaluation_context"
-  tag: "Documentation"
-  text: "Evaluation Context"
+  text: "Learn about Datadog Experiments"
 - link: "/experiments/plan_and_launch_experiments"
   tag: "Documentation"
   text: "Plan and Launch Experiments"
 - link: "/experiments/concepts/subject_types"
   tag: "Documentation"
-  text: "Subject Types"
+  text: "Subject Types in Experiments"
+- link: "/feature_flags/concepts/targeting_rules"
+  tag: "Documentation"
+  text: "Feature Flags Targeting Rules and Filters"
+- link: "/feature_flags/concepts/evaluation_context"
+  tag: "Documentation"
+  text: "Feature Flags Evaluation Context"
 ---
 
 ## Overview

--- a/content/en/feature_flags/concepts/experiments.md
+++ b/content/en/feature_flags/concepts/experiments.md
@@ -1,0 +1,59 @@
+---
+title: Feature Flags and Experiments
+description: Learn how a feature flag's targeting rules randomize a Datadog Experiment and record exposures for analysis.
+further_reading:
+- link: "/experiments/"
+  tag: "Documentation"
+  text: "Experiments"
+- link: "/feature_flags/concepts/targeting_rules"
+  tag: "Documentation"
+  text: "Targeting Rules and Filters"
+- link: "/feature_flags/concepts/evaluation_context"
+  tag: "Documentation"
+  text: "Evaluation Context"
+- link: "/experiments/plan_and_launch_experiments"
+  tag: "Documentation"
+  text: "Plan and Launch Experiments"
+- link: "/experiments/concepts/subject_types"
+  tag: "Documentation"
+  text: "Subject Types"
+---
+
+## Overview
+
+Datadog Feature Flags is the default way to randomize a [Datadog Experiment][1]. When you link a flag to an experiment, Datadog adds an **Experiment** targeting rule to the flag. Evaluations of that rule assign subjects to a variant and record an exposure event that Datadog uses to analyze the experiment.
+
+## Link a flag to an experiment
+
+Link a flag to an experiment from either side of the workflow:
+
+- From [Product Analytics > Experiments][1], create an experiment and [add an existing feature flag][2] to it.
+- From a flag's detail page, click **Create New Experiment** in the **Targeting Rules & Rollouts** section to create an experiment pre-filled with that flag.
+
+## Experiment targeting rules
+
+An **Experiment** targeting rule works like any other [targeting rule][3]: it can include a filter, and it uses the same [deterministic randomization][4] to assign subjects to a variant. Randomization is based on the `targetingKey` in your [evaluation context][5], so the same subject consistently receives the same variant for the life of the experiment.
+
+If multiple experiments share the same flag, Datadog evaluates their targeting rules in order, top to bottom. Reorder the rules before you launch an experiment to control which one takes priority for a given subject.
+
+## Exposures
+
+Each time the SDK evaluates a flag's **Experiment** targeting rule for a subject, Datadog records an **exposure**: the subject, the variant served, and a timestamp. Datadog joins exposures to metric events to calculate the lift between variants. Those metric events can come from Product Analytics, Real User Monitoring, or your data warehouse.
+
+Datadog joins exposures and metrics by subject identifier. The `targetingKey` your SDK sets in the [evaluation context][5] must match the [subject type attribute][6] configured for the experiment, such as `@usr.id`, or Datadog can't associate metric events with the correct exposure.
+
+## Bring your own randomization
+
+If you randomize subjects with a system other than Datadog Feature Flags, this flag-to-experiment integration doesn't apply. Datadog can still analyze the experiment: define an [Exposure SQL Model][7] that reads exposure records from your data warehouse instead.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /experiments/
+[2]: /experiments/plan_and_launch_experiments/#add-a-feature-flag
+[3]: /feature_flags/concepts/targeting_rules/
+[4]: /feature_flags/concepts/traffic_splitting/
+[5]: /feature_flags/concepts/evaluation_context/
+[6]: /experiments/concepts/subject_types/
+[7]: /experiments/concepts/exposure_sql/

--- a/content/en/feature_flags/concepts/targeting_rules.md
+++ b/content/en/feature_flags/concepts/targeting_rules.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/feature_flags/concepts/traffic_splitting"
   tag: "Documentation"
   text: "Traffic Splitting and Randomization"
+- link: "/feature_flags/concepts/experiments"
+  tag: "Documentation"
+  text: "Feature Flags and Experiments"
 - link: "/feature_flags/concepts/environments"
   tag: "Documentation"
   text: "Environments"
@@ -28,7 +31,7 @@ Datadog supports different targeting rule types depending on your rollout strate
 |------|-------------|
 | **Feature gate** | Roll out immediately to a percentage of subjects matching your filter (randomized or not) |
 | **Progressive rollout** | Randomized rollout over a schedule with multiple steps |
-| **Experiment** | Randomized allocation associated with an experiment |
+| **Experiment** | Randomized allocation associated with an [experiment][2] |
 
 ## Configure targeting rules
 
@@ -145,3 +148,4 @@ Targeting rules are evaluated **in order** from top to bottom:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /feature_flags/concepts/saved_filters/
+[2]: /feature_flags/concepts/experiments/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a new Concepts page for Feature Flags explaining how a flag becomes an Experiment's randomization mechanism: linking a flag to an experiment, how the Experiment targeting rule type assigns variants, how exposures are recorded and joined to metrics by subject identifier, and how warehouse-based (bring-your-own) randomization differs. Also adds a nextlink entry to the Feature Flags Concepts index page, and links the existing "Experiment" targeting rule type row in Targeting Rules and Filters to this new page.

This page links to `/feature_flags/concepts/evaluation_context/`, which is being added in a separate, parallel PR (#38689).

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code based on existing Feature Flags and Experiments product documentation; reviewed and lint-checked (Vale) before submission.

### Additional notes