### PR TITLE
Enhance code coverage setup with data access control

### DIFF
--- a/content/en/code_coverage/setup.md
+++ b/content/en/code_coverage/setup.md
@@ -87,7 +87,7 @@ Navigate to [Roles settings][4], click {{< ui >}}Edit{{< /ui >}} on the role you
 
 For more granular control, use [Data Access Control][19] to restrict code coverage data by repository rather than across your entire organization. This prevents sensitive information in coverage reports, such as source paths and test names, from crossing team boundaries.
 
-In Datadog, go to **Organization Settings > Data Access Control**, create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.
+In Datadog, go to **Organization Settings > Data Access Control** and create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict. Grant access to the roles or teams that should see it.
 
 ## PR Gates
 

--- a/content/en/code_coverage/setup.md
+++ b/content/en/code_coverage/setup.md
@@ -85,7 +85,7 @@ If you are using [custom roles][2] rather than [Datadog-managed roles][3], be su
 
 Navigate to [Roles settings][4], click {{< ui >}}Edit{{< /ui >}} on the role you need, add the {{< ui >}}Code Coverage Read{{< /ui >}} permission to the role, and save the changes.
 
-For more granular control, use **Data Access Control** to restrict code coverage data by repository rather than across your entire organization. This prevents sensitive information in coverage reports, such as source paths and test names, from crossing team boundaries. 
+For more granular control, use [Data Access Control][19] to restrict code coverage data by repository rather than across your entire organization. This prevents sensitive information in coverage reports, such as source paths and test names, from crossing team boundaries.
 
 To set it up, go to **Organization Settings > Data Access Control**, create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, and grant access to the roles or teams that should see it.
 

--- a/content/en/code_coverage/setup.md
+++ b/content/en/code_coverage/setup.md
@@ -551,3 +551,4 @@ Datadog deduplicates overlapping files across reports, which can result in diffe
 [16]: https://reportgenerator.io/
 [17]: /tests/setup/
 [18]: /code_coverage/setup/#integrate-with-source-code-provider
+[19]: https://app.datadoghq.com/organization-settings/data-access-controls

--- a/content/en/code_coverage/setup.md
+++ b/content/en/code_coverage/setup.md
@@ -85,6 +85,10 @@ If you are using [custom roles][2] rather than [Datadog-managed roles][3], be su
 
 Navigate to [Roles settings][4], click {{< ui >}}Edit{{< /ui >}} on the role you need, add the {{< ui >}}Code Coverage Read{{< /ui >}} permission to the role, and save the changes.
 
+For more granular control, use **Data Access Control** to restrict code coverage data by repository rather than across your entire organization. This prevents sensitive information in coverage reports, such as source paths and test names, from crossing team boundaries. 
+
+To set it up, go to **Organization Settings > Data Access Control**, create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, and grant access to the roles or teams that should see it.
+
 ## PR Gates
 
 If you wish to gate on PR coverage, you can configure PR Gates rules in one of two ways:

--- a/content/en/code_coverage/setup.md
+++ b/content/en/code_coverage/setup.md
@@ -87,7 +87,7 @@ Navigate to [Roles settings][4], click {{< ui >}}Edit{{< /ui >}} on the role you
 
 For more granular control, use [Data Access Control][19] to restrict code coverage data by repository rather than across your entire organization. This prevents sensitive information in coverage reports, such as source paths and test names, from crossing team boundaries.
 
-To set it up, go to **Organization Settings > Data Access Control**, create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, and grant access to the roles or teams that should see it.
+In Datadog, go to **Organization Settings > Data Access Control**, create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.
 
 ## PR Gates
 


### PR DESCRIPTION
Added instructions for using Data Access Control to restrict code coverage data by repository.

### What does this PR do? What is the motivation?
Informs users of more granular data access controls that they can use to protect code coverage reports by repository. 
### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude to condense my thoughts into short statements. Iterated a few times to get the tone right. 

### Additional notes
As a new hire, this is my first attempt to change documentation. Happy to adjust if I missed anything or need to change.

