### PR TITLE
[FFL-2915] Document MCP server SDK setup use case for Feature Flags

### DIFF
--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -29,6 +29,14 @@ The MCP Server includes tools to help you manage feature flags in your codebase.
   The code implementation tools, such as <code>check_datadog_flag_implementation</code>, target React applications. Other tools, such as <code>list_datadog_feature_flags</code> and <code>update_datadog_feature_flag_environment</code>, are framework-agnostic.
 </div>
 
+### Set up Feature Flags in your app
+
+The Feature Flags MCP server can install the SDK and add the required code snippets to your application automatically. After [connecting to the MCP server][2], prompt your AI agent:
+
+- Help me set up Datadog Feature Flags in my app.
+
+The MCP server reviews your codebase, selects the appropriate SDK for your language and framework, and installs the required dependencies and initialization code.
+
 ### Create feature flags
 
 Use the `create_datadog_feature_flag` tool to create feature flags. You do not need to specify the tool name in the prompt. Including it can provide more consistent results.

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -33,7 +33,9 @@ The MCP Server includes tools to help you manage feature flags in your codebase.
 
 The Feature Flags MCP Server can install the SDK and add the required code snippets to your application automatically. After [connecting to the MCP Server][2], prompt your AI agent:
 
-- Help me set up Datadog Feature Flags in my app.
+```text
+Help me set up Datadog Feature Flags in my app.
+```
 
 The MCP Server reviews your codebase, selects the appropriate SDK for your language and framework, and installs the required dependencies and initialization code.
 

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -29,7 +29,7 @@ The MCP Server includes tools to help you manage feature flags in your codebase.
   The code implementation tools, such as <code>check_datadog_flag_implementation</code>, target React applications. Other tools, such as <code>list_datadog_feature_flags</code> and <code>update_datadog_feature_flag_environment</code>, are framework-agnostic.
 </div>
 
-### Set up Feature Flags in your app
+### Set up feature flags in your app
 
 The Feature Flags MCP server can install the SDK and add the required code snippets to your application automatically. After [connecting to the MCP server][2], prompt your AI agent:
 

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -31,7 +31,7 @@ The MCP Server includes tools to help you manage feature flags in your codebase.
 
 ### Set up feature flags in your app
 
-The Feature Flags MCP server can install the SDK and add the required code snippets to your application automatically. After [connecting to the MCP server][2], prompt your AI agent:
+The Feature Flags MCP Server can install the SDK and add the required code snippets to your application automatically. After [connecting to the MCP Server][2], prompt your AI agent:
 
 - Help me set up Datadog Feature Flags in my app.
 

--- a/content/en/feature_flags/feature_flag_mcp_server.md
+++ b/content/en/feature_flags/feature_flag_mcp_server.md
@@ -35,7 +35,7 @@ The Feature Flags MCP Server can install the SDK and add the required code snipp
 
 - Help me set up Datadog Feature Flags in my app.
 
-The MCP server reviews your codebase, selects the appropriate SDK for your language and framework, and installs the required dependencies and initialization code.
+The MCP Server reviews your codebase, selects the appropriate SDK for your language and framework, and installs the required dependencies and initialization code.
 
 ### Create feature flags
 

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -81,7 +81,6 @@ Your organization likely already has pre-configured environments for Development
 <div class="alert alert-info">
 You can set up Feature Flags automatically with the <a href="/feature_flags/feature_flag_mcp_server/">Feature Flags MCP Server</a>. After connecting, prompt your AI agent: "Help me set up Datadog Feature Flags in my app." The MCP Server reviews your codebase and installs the required SDK and code snippets for your language and framework.
 </div>
-</div>
 
 ### Step 1: Import and initialize the SDK
 

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -78,6 +78,10 @@ Your organization likely already has pre-configured environments for Development
 
 ## Create your first feature flag
 
+<div class="alert alert-info">
+You can set up Feature Flags automatically with the <a href="/feature_flags/feature_flag_mcp_server/">Feature Flags MCP server</a>. After connecting, prompt your AI agent: "Help me set up Datadog Feature Flags in my app." The MCP server reviews your codebase and installs the required SDK and code snippets for your language and framework.
+</div>
+
 ### Step 1: Import and initialize the SDK
 
 Choose the SDK that matches where the flag is evaluated and initialize the Datadog Feature Flags provider.

--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -79,7 +79,8 @@ Your organization likely already has pre-configured environments for Development
 ## Create your first feature flag
 
 <div class="alert alert-info">
-You can set up Feature Flags automatically with the <a href="/feature_flags/feature_flag_mcp_server/">Feature Flags MCP server</a>. After connecting, prompt your AI agent: "Help me set up Datadog Feature Flags in my app." The MCP server reviews your codebase and installs the required SDK and code snippets for your language and framework.
+You can set up Feature Flags automatically with the <a href="/feature_flags/feature_flag_mcp_server/">Feature Flags MCP Server</a>. After connecting, prompt your AI agent: "Help me set up Datadog Feature Flags in my app." The MCP Server reviews your codebase and installs the required SDK and code snippets for your language and framework.
+</div>
 </div>
 
 ### Step 1: Import and initialize the SDK


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds documentation for the new Feature Flags MCP server use case that lets users set up the SDK in their app automatically. After connecting to the MCP server, users prompt their AI agent: "Help me set up Datadog Feature Flags in my app."

Changes:
- `feature_flag_mcp_server.md`: Added a "Set up Feature Flags in your app" use case section as the first entry in the use cases list.
- `getting_started/feature_flags/_index.md`: Added an info callout before Step 1 pointing to the MCP server as an automatic alternative to manual SDK setup.

### Merge readiness
- [ ] Ready for merge

## For Datadog employees:
- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft and place content.

### Additional notes
