### PR TITLE
Add Data Access Control information to Test Optimization Setup

### DIFF
--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -29,7 +29,8 @@ If you run your tests in a container, see the [Tests in Containers][5] guide for
 
 To have a supported Test Optimization library upload code coverage reports automatically, see [Upload reports automatically with Test Optimization][6].
 
-#### Data Access Control
+## Data Access Control
+
 You can restrict Test Optimization data on the repository level to the appropriate teams and roles in Datadog. This will ensure that sensitive information, like test names or source paths, does not cross team boundaries.
 
 To use Data Access Control, go to [Organization Settings > Data Access Control][7], create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -33,7 +33,7 @@ To have a supported Test Optimization library upload code coverage reports autom
 
 You can restrict Test Optimization data at the repository level to the appropriate teams and roles in Datadog. This helps prevent sensitive information, such as test names or source paths, from crossing team boundaries.
 
-To use Data Access Control, go to [Organization Settings > Data Access Control][7], create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.
+To use Data Access Control, go to [Organization Settings > Data Access Control][7] and create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict. Grant access to the roles or teams that should see it.
 
 [1]: /continuous_integration/tests
 [2]: /tests/setup/bazel/

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -29,9 +29,15 @@ If you run your tests in a container, see the [Tests in Containers][5] guide for
 
 To have a supported Test Optimization library upload code coverage reports automatically, see [Upload reports automatically with Test Optimization][6].
 
+#### Data Access Control
+You can restrict Test Optimization data on the repository level to the appropriate teams and roles in Datadog. This will ensure that sensitive information, like test names or source paths, does not cross team boundaries.
+
+To use Data Access Control, go to [Organization Settings > Data Access Control][7], create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.
+
 [1]: /continuous_integration/tests
 [2]: /tests/setup/bazel/
 [3]: /agent/configuration/network/
 [4]: /tests/network/
 [5]: /tests/containers/
 [6]: /code_coverage/setup/#upload-reports-automatically-with-test-optimization
+[7]: https://app.datadoghq.com/organization-settings/data-access-controls

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -31,7 +31,7 @@ To have a supported Test Optimization library upload code coverage reports autom
 
 ## Data Access Control
 
-You can restrict Test Optimization data on the repository level to the appropriate teams and roles in Datadog. This will ensure that sensitive information, like test names or source paths, does not cross team boundaries.
+You can restrict Test Optimization data at the repository level to the appropriate teams and roles in Datadog. This helps prevent sensitive information, such as test names or source paths, from crossing team boundaries.
 
 To use Data Access Control, go to [Organization Settings > Data Access Control][7], create a Restricted Dataset scoped to Software Delivery and the repository you want to restrict, then grant access to the roles or teams that should see it.
 


### PR DESCRIPTION
Added section on Data Access Control for Test Optimization.

### What does this PR do? What is the motivation?

This PR adds a note about the Data Access Control feature for Test Optimization, that allows users to restrict visibility by roles or teams on the repository level. 

### Merge readiness

- [ ] Ready for merge


### AI assistance

### Additional notes
Please let me know if anything needs to be adjusted. As a new hire, I value any feedback provided. 

