### PR TITLE
Update custom_charts.md w/ Vega -> Vega-Lite

### DIFF
--- a/content/en/actions/app_builder/components/custom_charts.md
+++ b/content/en/actions/app_builder/components/custom_charts.md
@@ -50,7 +50,7 @@ The following example shows how to create a histogram chart illustrating Datadog
 
 1. Click {{< ui >}}+ All Components{{< /ui >}} and select {{< ui >}}Custom Chart{{< /ui >}} to add a component called `customChart0`.
 1. Click {{< ui >}}Show Chart Examples{{< /ui >}}.
-1. Select {{< ui >}}Simple Histogram{{< /ui >}} and click {{< ui >}}Confirm{{< /ui >}}.<br>The following value populates in the Vega Specification:
+1. Select {{< ui >}}Simple Histogram{{< /ui >}} and click {{< ui >}}Confirm{{< /ui >}}.<br>The following value populates in the Vega-Lite Specification:
 
    {{< code-block lang="json" disable_copy="true" collapsible="true" >}}${{
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
@@ -75,7 +75,7 @@ The following example shows how to create a histogram chart illustrating Datadog
 
 ### Replace example values with your data
 
-Replace the auto-populated Vega Specification with the following to change the data source and the value being graphed on the x-axis:
+Replace the auto-populated Vega-Lite Specification with the following to change the data source and the value being graphed on the x-axis:
 
 {{< highlight json "hl_lines=4 12" >}}${{
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",


### PR DESCRIPTION
### Motivation

Reduce user confusion about Vega vs Vega-Lite by relabeling the example specs for app-builder custom charts

Redo of https://github.com/DataDog/documentation/pull/26653 which was closed for inactivity . Clarify language around preferring Vega-Lite to Vega in this integration. The diff is the same as before , it's a sequel to https://github.com/DataDog/documentation/pull/26421

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
