### PR TITLE
Update note on default monitors for private locations

### DIFF
--- a/content/en/synthetics/platform/private_locations/monitoring.md
+++ b/content/en/synthetics/platform/private_locations/monitoring.md
@@ -44,7 +44,7 @@ By default, no handle is set in these monitors. To be alerted in case one of you
 
 Monitors in the {{< ui >}}Monitors{{< /ui >}} tab either have a group that corresponds to your private location ID or are tagged with `location_id:<ID_OF_THE_PL>`.
 
-> **Note:** Default monitors are created **only once**, when the first private location is created. Deleting a private location and creating a new one does **not** recreate the default monitors.
+> **Note:** Default monitors are created **only once**, when the first private location is created. Deleting a private location and creating a new one does **not** affect the existence of those default monitors. They will continue existing when no PL exists and will start reporting when a new PL is created.
 
 ## Monitor your private locations with the Datadog Agent
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarified the behavior of default monitors when a private location is deleted and recreated.

https://datadoghq.atlassian.net/browse/DOCS-14964
Doc
https://docs.datadoghq.com/synthetics/platform/private_locations/monitoring/


### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
