### PR TITLE
[DOCS-15244] Clarify Korean and Japanese chat support hours

### DIFF
--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -78,9 +78,9 @@ If additional investigation is required, the ticket is routed to experts in the 
 
 ## Language support
 
-Japanese language support is available Monday to Friday from 9am to 5pm Japan Standard Time (JST), excluding local public holidays and December 29 to January 3. Chat support in Japanese is available from 10am to 4pm JST on business days.
+Japanese language support is available Monday to Friday from 09:00 to 17:00 Japan Standard Time (JST), excluding local public holidays and December 29 to January 3. Chat support in Japanese is available from 10:00 to 16:00 JST on business days.
 
-Korean language support is available Monday to Friday from 09:00 to 17:00 Korea Standard Time (KST), excluding local public holidays. Chat support in Korean is available on weekdays from 10:00 to 11:30 and from 13:00 to 16:00.
+Korean language support is available Monday to Friday from 09:00 to 17:00 Korea Standard Time (KST), excluding local public holidays. Chat support in Korean is available from 10:00 to 11:30 and from 13:00 to 16:00 KST on business days.
 
 When support in your preferred language is not available, you can continue working with Datadog Support in English.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15244

Standardizes the Japanese and Korean chat support hours paragraphs to use the same 24-hour time format and wording ("on business days"), addressing follow-up feedback that the previous Korean phrasing was unclear.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft and apply the wording/format edits.

### Additional notes