### PR TITLE
Add error in troubleshooting page

### DIFF
--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -30,6 +30,7 @@ Use this table to find troubleshooting steps for common errors.
 | `401 Unauthorized`                           | [API and Browser Tests → Unauthorized](#api-and-browser-tests) |
 | `Element not found`                            | [Test execution → Element selection issues](#element-detection-warning-in-browser-test-steps) |
 | `Unsupported browser version`                  | [Private Locations → Browser compatibility](?tab=common#requirements-for-browser-tests-running-on-private-location) |
+| `Failed to load resource: ERR_INVALID_ARGUMENT`| [Private Locations → Chrome 149 issue](?tab=common#chrome-149-issue-on-private-locations) |
 
 
 ## API tests
@@ -251,6 +252,12 @@ Additionally, `ping` requires elevated privileges to create the raw socket. The 
 
 {{< img src="synthetics/timeout.png" alt="API test on private location timing out" style="width:70%;" >}}
 
+### Chrome 149 issue on private locations
+
+Chromium version 149 introduced stricter validation for request headers, which can cause sub‑resource requests to fail with `net::ERR_INVALID_ARGUMENT`. Earlier Chrome versions were more permissive.
+
+**Solution:** Upgrade your private location to [version 1.69.1 or later][18] to resolve this issue.
+
 [101]: /synthetics/private_locations/dimensioning
 [102]: https://docs.docker.com/config/containers/resource_constraints/
 [103]: /synthetics/private_locations/dimensioning#define-your-total-hardware-requirements
@@ -387,3 +394,4 @@ Additionally, Private Location versions `>v1.27` depend the `clone3` system call
 [14]: /synthetics/guide/step-duration
 [16]: /synthetics/network_path_tests/#agent-configuration
 [17]: /network_monitoring/network_path/setup/?tab=linux#increase-the-number-of-workers
+[18]: https://hub.docker.com/r/datadog/synthetics-private-location-worker

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -30,7 +30,7 @@ Use this table to find troubleshooting steps for common errors.
 | `401 Unauthorized`                           | [API and Browser Tests → Unauthorized](#api-and-browser-tests) |
 | `Element not found`                            | [Test execution → Element selection issues](#element-detection-warning-in-browser-test-steps) |
 | `Unsupported browser version`                  | [Private Locations → Browser compatibility](?tab=common#requirements-for-browser-tests-running-on-private-location) |
-| `Failed to load resource: ERR_INVALID_ARGUMENT`| [Private Locations → Chrome 149 issue](?tab=common#chrome-149-issue-on-private-locations) |
+| `Failed to load resource: ERR_INVALID_ARGUMENT` | [Private Locations → Chrome 149 issue](?tab=common#chrome-149-issue-on-private-locations) |
 
 
 ## API tests
@@ -254,15 +254,16 @@ Additionally, `ping` requires elevated privileges to create the raw socket. The 
 
 ### Chrome 149 issue on private locations
 
-Chromium version 149 introduced stricter validation for request headers, which can cause sub‑resource requests to fail with `net::ERR_INVALID_ARGUMENT`. Earlier Chrome versions were more permissive.
+Chrome version 149 introduced stricter validation for request headers, which can cause subresource requests to fail with `net::ERR_INVALID_ARGUMENT`. Earlier Chrome versions were more permissive.
 
-**Solution:** Upgrade your private location to [version 1.69.1 or later][18] to resolve this issue.
+**Solution**: Upgrade your private location to [version 1.69.1 or later][106] to resolve this issue.
 
 [101]: /synthetics/private_locations/dimensioning
 [102]: https://docs.docker.com/config/containers/resource_constraints/
 [103]: /synthetics/private_locations/dimensioning#define-your-total-hardware-requirements
 [104]: /help/
 [105]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+[106]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
 
 {{% /tab %}}
 {{% tab "Docker" %}}
@@ -394,4 +395,3 @@ Additionally, Private Location versions `>v1.27` depend the `clone3` system call
 [14]: /synthetics/guide/step-duration
 [16]: /synthetics/network_path_tests/#agent-configuration
 [17]: /network_monitoring/network_path/setup/?tab=linux#increase-the-number-of-workers
-[18]: https://hub.docker.com/r/datadog/synthetics-private-location-worker


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

- Adds a new troubleshooting entry for the `Failed to load resource: ERR_INVALID_ARGUMENT` error caused by Chrome 149's stricter header validation on Private Locations
- Documents the fix: upgrade Private Location to v1.69.1 or later

https://datadoghq.atlassian.net/browse/DOCS-15009
Doc
https://docs.datadoghq.com/synthetics/troubleshooting/


### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
