### PR TITLE
Remove stale "Enable Monitor" instructions from Watchdog alerts doc

### DIFF
--- a/content/en/watchdog/alerts/_index.md
+++ b/content/en/watchdog/alerts/_index.md
@@ -30,8 +30,6 @@ In addition to repeating the information in the alert overview card, the {{< ui 
 * {{< ui >}}Suggested Next Steps{{< /ui >}}: Describes steps for investigation and triage of the anomalous behavior.
 * {{< ui >}}Monitors{{< /ui >}}: Lists monitors associated with your alert. Each monitor displayed has the metric of the current alert and its associated tags included in its scope.
 
-Additionally, Watchdog suggests one or more monitors you can create to notify you if the anomaly happens again. These monitors do not exist yet, so the table lists their status as `suggested`. Click {{< ui >}}Enable Monitor{{< /ui >}} to enable the suggested monitor for your organization. A series of icons pops up allowing you to open, edit, clone, mute, or delete the new monitor.
- 
 ## Watchdog Alert Explorer
 
 You can use the time range, search bar, or facets to filter your Watchdog Alerts feed.


### PR DESCRIPTION
## Summary
- The Watchdog alerts doc described clicking `Enable Monitor` to create a suggested monitor from an alert. That feature (suggested-monitors table + Enable Monitor button) was removed from the product on 2024-11-11 (web-ui commit 466f2d280861) and was never wired into Log Management alerts even before removal.
- Removes the stale paragraph so the doc no longer describes a UI element customers can't find.

Prompted by a support question: a customer couldn't locate the "Enable Monitor" button described at https://docs.datadoghq.com/watchdog/alerts/?tab=logmanagement#watchdog-alert-details

## Test plan
- [x] Reviewed diff for correctness
- [x] Docs review