### PR TITLE
Runtime Package Prioritization: clarify value and document runtime signal filtering

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -72,7 +72,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 **Requirements**:
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
-- Applies to container image vulnerability findings, for operating system packages
+- Applies to operating system packages in container image vulnerability findings
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][4] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 

--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -57,21 +57,22 @@ docker run -d --name dd-agent \
 
 ## Runtime Package Prioritization (Preview)
 
-Runtime package prioritization enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
 
-Each vulnerability finding is enriched with the following signals:
+When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
 
-| Signal | Description |
-|--------|-------------|
-| Package is running | The package files are actively being accessed by running processes. |
-| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| Signal | What it tells you |
+|--------|-------------------|
+| Package is running | The package's files were observed being accessed by a running process. |
+| Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][5]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][6].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
+- Applies to container image vulnerability findings, for operating system packages
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][4] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 
@@ -93,3 +94,5 @@ docker run -d --name dd-agent \
 [2]: /security/threats
 [3]: /security/cloud_security_management/setup#supported-deployment-types-and-features
 [4]: /security/workload_protection/
+[5]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
+[6]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/#filter-findings-by-runtime-signals

--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -57,9 +57,9 @@ docker run -d --name dd-agent \
 
 ## Runtime Package Prioritization (Preview)
 
-Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
+Runtime package prioritization identifies which packages in a container image are used at runtime, so you can prioritize vulnerabilities in code that runs over vulnerabilities in packages that are installed but never executed.
 
-When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
+When enabled, the Agent uses eBPF to observe file access on your workloads and adds these signals to vulnerability findings for that image:
 
 | Signal | What it tells you |
 |--------|-------------------|
@@ -67,7 +67,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and r
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][5]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][6].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][5]. To query the signals yourself, see [Filter findings by runtime signals][6].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -192,21 +192,22 @@ The `languages` analyzer covers the following package ecosystems:
 
 ## Runtime Package Prioritization (Preview)
 
-Runtime package prioritization enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
 
-Each vulnerability finding is enriched with the following signals:
+When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
 
-| Signal | Description |
-|--------|-------------|
-| Package is running | The package files are actively being accessed by running processes. |
-| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| Signal | What it tells you |
+|--------|-------------------|
+| Package is running | The package's files were observed being accessed by a running process. |
+| Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][9]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][10].
 
 **Requirements**:
-- Datadog Agent **7.79.0 or later**
+- Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later**: earlier versions can miss the *Package is running* signal on some kubelet-managed images.
 - Linux only (eBPF dependency)
+- Applies to container image vulnerability findings, for operating system packages
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 
@@ -283,3 +284,5 @@ Restart the Agent.
 [6]: https://app.datadoghq.com/account/settings/agent/latest
 [7]: https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable
 [8]: /security/workload_protection/
+[9]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
+[10]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/#filter-findings-by-runtime-signals

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -192,9 +192,9 @@ The `languages` analyzer covers the following package ecosystems:
 
 ## Runtime Package Prioritization (Preview)
 
-Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
+Runtime package prioritization identifies which packages in a container image are used at runtime, so you can prioritize vulnerabilities in code that runs over vulnerabilities in packages that are installed but never executed.
 
-When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
+When enabled, the Agent uses eBPF to observe file access on your workloads and adds these signals to vulnerability findings for that image:
 
 | Signal | What it tells you |
 |--------|-------------------|
@@ -202,10 +202,10 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and r
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][9]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][10].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][9]. To query the signals yourself, see [Filter findings by runtime signals][10].
 
 **Requirements**:
-- Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later**: earlier versions can miss the *Package is running* signal on some kubelet-managed images.
+- Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later**: earlier versions can miss runtime signals on some kubelet-managed images.
 - Linux only (eBPF dependency)
 - Applies to container image vulnerability findings, for operating system packages
 

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -207,7 +207,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 **Requirements**:
 - Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later**: earlier versions can miss runtime signals on some kubelet-managed images.
 - Linux only (eBPF dependency)
-- Applies to container image vulnerability findings, for operating system packages
+- Applies to operating system packages in container image vulnerability findings
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -102,7 +102,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 **Requirements**:
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
-- Applies to container image vulnerability findings, for operating system packages
+- Applies to operating system packages in container image vulnerability findings
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][7] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -87,9 +87,9 @@ The `languages` analyzer covers the following package ecosystems:
 
 ## Runtime Package Prioritization (Preview)
 
-Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
+Runtime package prioritization identifies which packages in a container image are used at runtime, so you can prioritize vulnerabilities in code that runs over vulnerabilities in packages that are installed but never executed.
 
-When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
+When enabled, the Agent uses eBPF to observe file access on your workloads and adds these signals to vulnerability findings for that image:
 
 | Signal | What it tells you |
 |--------|-------------------|
@@ -97,7 +97,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and r
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][8]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][9].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][8]. To query the signals yourself, see [Filter findings by runtime signals][9].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -87,21 +87,22 @@ The `languages` analyzer covers the following package ecosystems:
 
 ## Runtime Package Prioritization (Preview)
 
-Runtime package prioritization enriches each vulnerability finding with real-time signals from the running environment. When enabled, the Agent uses eBPF to monitor file access at runtime and records how packages are actually used by running processes.
+Most vulnerabilities Datadog detects are in packages that ship inside an image but never execute. Runtime package prioritization identifies the ones that actually run, so you can remediate those first.
 
-Each vulnerability finding is enriched with the following signals:
+When enabled, the Agent uses eBPF to observe file access on your workloads and records how each package in the image is used at runtime. Datadog adds these signals to every vulnerability finding for that image:
 
-| Signal | Description |
-|--------|-------------|
-| Package is running | The package files are actively being accessed by running processes. |
-| Accessed by root process | The package is being accessed by a process running as root (UID 0). |
+| Signal | What it tells you |
+|--------|-------------------|
+| Package is running | The package's files were observed being accessed by a running process. |
+| Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-These signals power vulnerability prioritization in Cloud Security, surfacing findings where vulnerable code is confirmed running in production.
+Together, these answer whether a vulnerability is reachable and how much damage it could do. They feed the **Reachability** dimension of the [Runtime Prioritization Engine][8]. Once enabled, you can filter and group findings by them — see [Filter findings by runtime signals][9].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
+- Applies to container image vulnerability findings, for operating system packages
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][7] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 
@@ -143,3 +144,5 @@ sudo chgrp dd-agent /etc/datadog-agent/security-agent.yaml
 [5]: /getting_started/agent/#installation
 [6]: /agent/?tab=Linux
 [7]: /security/workload_protection/
+[8]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
+[9]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/#filter-findings-by-runtime-signals

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -49,7 +49,7 @@ When ownership is known, the engine can route findings to the right team instead
 
 ## Filter findings by runtime signals
 
-When [Runtime Package Prioritization][4] is enabled, every vulnerability finding for the affected image carries its runtime signals as tags, so you can search, filter, and group by them:
+When [Runtime Package Prioritization][4] is enabled, Datadog adds the runtime signals it observes to your vulnerability findings as tags, so you can search, filter, and group by them:
 
 | Signal | Tag |
 |---|---|
@@ -57,20 +57,15 @@ When [Runtime Package Prioritization][4] is enabled, every vulnerability finding
 | Accessed by root process | `@package.is_running_as_root:true` |
 | SUID binary present | `@package.has_suid:true` |
 
-Use these as a filter or facet in:
+A tag is set only for signals Datadog observed, so the absence of a tag is not evidence that a package is unused.
 
-- **[Vulnerability Explorer][11]** to focus remediation on vulnerabilities in code that actually runs.
-- **[Security Inbox][6]** to review the prioritized findings that carry runtime evidence.
-- **Notifications** to alert only when a vulnerable package is observed running.
-- **Findings Automation** to build remediation rules around runtime-confirmed risk.
-
-You can combine them with any other criteria. For example, to find the work most worth doing first — high or critical vulnerabilities, running in your environment, with a fix available:
+Use the tags in the [Vulnerability Explorer][11], combined with any other criteria. For example, high and critical vulnerabilities that are running and have a fix available:
 
 ```
 @risk.is_package_running:true @severity:(high OR critical) @remediation.is_available:true
 ```
 
-Signals persist for the lifetime of an image version: once a package is observed running in a given image, findings for that image keep the signal. Because container images are immutable, this reflects "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
+Signals persist for the lifetime of an image version: once a package is observed running in an image, findings for that image keep the signal. Because container images are immutable, this means "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
 
 ## Get started
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -47,6 +47,31 @@ Crown Jewels update continuously as your environment changes. You can also add y
 
 When ownership is known, the engine can route findings to the right team instead of leaving security teams to manually chase remediation owners.
 
+## Filter findings by runtime signals
+
+When [Runtime Package Prioritization][4] is enabled, every vulnerability finding for the affected image carries its runtime signals as tags, so you can search, filter, and group by them:
+
+| Signal | Tag |
+|---|---|
+| Package is running | `@risk.is_package_running:true` |
+| Accessed by root process | `@package.is_running_as_root:true` |
+| SUID binary present | `@package.has_suid:true` |
+
+Use these as a filter or facet in:
+
+- **[Vulnerability Explorer][11]** to focus remediation on vulnerabilities in code that actually runs.
+- **[Security Inbox][6]** to review the prioritized findings that carry runtime evidence.
+- **Notifications** to alert only when a vulnerable package is observed running.
+- **Findings Automation** to build remediation rules around runtime-confirmed risk.
+
+You can combine them with any other criteria. For example, to find the work most worth doing first — high or critical vulnerabilities, running in your environment, with a fix available:
+
+```
+@risk.is_package_running:true @severity:(high OR critical) @remediation.is_available:true
+```
+
+Signals persist for the lifetime of an image version: once a package is observed running in a given image, findings for that image keep the signal. Because container images are immutable, this reflects "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
+
 ## Get started
 
 1. Deploy the Datadog Agent version 7.79 or later with Cloud Security enabled. See [Setting Up Cloud Security][3].
@@ -67,3 +92,4 @@ When ownership is known, the engine can route findings to the right team instead
 [8]: /security/cloud_security_management/crown_jewels/
 [9]: /security/cloud_security_management/setup/agent/docker/#runtime-package-prioritization-preview
 [10]: /security/cloud_security_management/setup/agent/linux/#runtime-package-prioritization-preview
+[11]: https://app.datadoghq.com/security/csm/vm

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -57,7 +57,7 @@ When [Runtime Package Prioritization][4] is enabled, Datadog adds the runtime si
 | Accessed by root process | `@package.is_running_as_root:true` |
 | SUID binary present | `@package.has_suid:true` |
 
-A tag is set only for signals Datadog observed, so the absence of a tag is not evidence that a package is unused.
+Datadog sets a tag only for signals it observed; the absence of a tag does not mean a package is unused.
 
 Use the tags in the [Vulnerability Explorer][11], combined with any other criteria. For example, high and critical vulnerabilities that are running and have a fix available:
 
@@ -65,7 +65,7 @@ Use the tags in the [Vulnerability Explorer][11], combined with any other criter
 @risk.is_package_running:true @severity:(high OR critical) @remediation.is_available:true
 ```
 
-Signals persist for the lifetime of an image version: once a package is observed running in an image, findings for that image keep the signal. Because container images are immutable, this means "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
+Signals persist for the lifetime of an image version: after a package is observed running in an image, findings for that image keep the signal. Because container images are immutable, this means "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
 
 ## Get started
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Customers who enable Runtime Package Prioritization (Preview) have no documented way to *use* the signals — the tags aren't published anywhere. This PR closes that gap and sharpens the feature intro.

- Adds **Filter findings by runtime signals** to the [Runtime Prioritization Engine][1] page, documenting the tags (`@risk.is_package_running`, `@package.is_running_as_root`, `@package.has_suid`), following the [Crown Jewels][2] pattern.
- Rewrites the feature intro on the Kubernetes, Docker, and Linux setup pages to lead with what it's for rather than the eBPF mechanism.
- **Enablement steps and config are unchanged.**

[K9VULN-17099](https://datadoghq.atlassian.net/browse/K9VULN-17099)

### Merge readiness

- [ ] Ready for merge

Three items below would benefit from a Cloud Security docs/PM look first.

### AI assistance

Drafted with Claude Code (Claude Opus 5). All factual claims verified against source before pushing — tag names and behavior against `infra-sbom-reducer`, the OS-package/eBPF scope against `datadog-agent`. An earlier draft claimed "most vulnerabilities are in packages that never execute"; removed, as we have no measurement supporting it.

### Additional notes

1. **Scope line** — added "Applies to container image vulnerability findings, for operating system packages". Verified accurate, but it's a limitation the docs didn't previously state. Strike if that's not the Preview message.
2. **Sticky semantics** — signals now read as "has been observed running in this image" rather than "is running right now", pre-empting "why is it still true?". Behavior is intentional (immutable images).
3. **Kubernetes 7.81** — earlier Agents can miss runtime signals on some kubelet-managed images (fixed in 7.81.0 GA by [datadog-agent#52294][3]).

Filtering guidance is scoped to the Vulnerability Explorer. If these tags also work in Notifications or Findings Automation (as `@risk.is_crown_jewel` does), happy to add — I couldn't verify that.

[1]: /security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine/
[2]: /security/cloud_security_management/crown_jewels/#use-the-list-to-filter-findings
[3]: https://github.com/DataDog/datadog-agent/pull/52294


[K9VULN-17099]: https://datadoghq.atlassian.net/browse/K9VULN-17099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ