### PR TITLE
Add Vertex AI and Gemini to Cost Anomalies provider list

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -14,7 +14,7 @@ further_reading:
 
 ## Overview
 
-Datadog Cloud Cost Management (CCM) continuously monitors your environment to detect and prioritize unexpected cost changes, enabling you to share, investigate, and resolve anomalies. Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, OpenAI, Cursor, and Amazon Bedrock and do not require any additional setup after CCM is set up.
+Datadog Cloud Cost Management (CCM) continuously monitors your environment to detect and prioritize unexpected cost changes, enabling you to share, investigate, and resolve anomalies. Cost anomalies are available for AWS, Azure, Google Cloud, Oracle Cloud, Datadog, Anthropic, OpenAI, Cursor, Amazon Bedrock, Vertex AI, and Gemini and do not require any additional setup after CCM is set up.
 
 {{< img src="cloud_cost/anomalies/anomalies-overview.png" alt="List of cost anomalies showing service names, usage types, and cost impacts" style="width:80;" >}}
 


### PR DESCRIPTION
## Summary
- Adds Vertex AI and Gemini to the list of providers supported by Cost Anomalies, following the same pattern as #38453 (Cursor, Amazon Bedrock).

## Test plan
- [ ] Docs build preview renders correctly