### PR TITLE
[CCT-1717] Add Cursor, Bedrock, Vertex AI, and Gemini to custom anomaly detection provider list

### DIFF
--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -36,7 +36,7 @@ To distinguish between true anomalies and expected fluctuations, Datadog's algor
 
 ## Customize anomaly detection
 
-By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, and Oracle Cloud.
+By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, Oracle Cloud, Cursor, Amazon Bedrock, Vertex AI, and Gemini.
 
 To customize anomaly detection:
 

--- a/content/en/cloud_cost_management/cost_changes/anomalies.md
+++ b/content/en/cloud_cost_management/cost_changes/anomalies.md
@@ -36,7 +36,7 @@ To distinguish between true anomalies and expected fluctuations, Datadog's algor
 
 ## Customize anomaly detection
 
-By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, Oracle Cloud, Cursor, Amazon Bedrock, Vertex AI, and Gemini.
+By default, Datadog automatically detects cost anomalies for each cloud provider. If you have the `cloud_cost_management_write` permission, you can customize how Datadog detects anomalies per provider to better match your organization's cost structure. Custom anomaly detection is available for AWS, Azure, Google Cloud, Datadog, Oracle Cloud, Anthropic, OpenAI, Cursor, Amazon Bedrock, Vertex AI, and Gemini.
 
 To customize anomaly detection:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

[CCT-1717](https://datadoghq.atlassian.net/browse/CCT-1717)

Cursor, Amazon Bedrock, Vertex AI, and Gemini are now supported for custom anomaly detection configuration, but the **Customize anomaly detection** section of the Cost Anomalies doc doesn't list them yet.

### Before
<img width="764" height="540" alt="Screenshot 2026-08-04 at 3 53 50 PM" src="https://github.com/user-attachments/assets/000c672b-e20e-48fa-9aa1-ecd6aecb74f8" />

### After
<img width="835" height="473" alt="Screenshot 2026-08-04 at 4 01 38 PM" src="https://github.com/user-attachments/assets/8f72d559-4d28-400b-ad02-384726ba2f4d" />




[CCT-1717]: https://datadoghq.atlassian.net/browse/CCT-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ