### PR TITLE
Document APM Home Watchdog/Error Tracking scope

### DIFF
--- a/content/en/tracing/recommendations/_index.md
+++ b/content/en/tracing/recommendations/_index.md
@@ -167,6 +167,8 @@ To review recommendations that need your attention:
 
 After you've reviewed the recommendation, you can use the {{< ui >}}FOR REVIEW{{< /ui >}} dropdown to change the recommendation status to {{< ui >}}REVIEWED{{< /ui >}}, {{< ui >}}IGNORED{{< /ui >}}, or {{< ui >}}RESOLVED{{< /ui >}}.
 
+**Note**: On the [APM Home page][5], the {{< ui >}}Watchdog{{< /ui >}} and {{< ui >}}Error Tracking{{< /ui >}} sections also respect the selected service filter (or your personalized services when no filter is set), matching how recommendations are scoped. When a service is selected and no alerts or issues match, the section shows an empty state with a {{< ui >}}Clear filter{{< /ui >}} button, and the Error Tracking {{< ui >}}View all{{< /ui >}} link is pre-filtered to that service.
+
 ## Supported recommendations
 
 <!-- The table below is auto-generated. Add new entries in multifiltersearch with new recommendations as they become available. -->
@@ -183,3 +185,4 @@ After you've reviewed the recommendation, you can use the {{< ui >}}FOR REVIEW{{
 [2]: /database_monitoring/recommendations/
 [3]: /bits_ai/bits_code/
 [4]: /bits_ai/bits_code/setup/
+[5]: https://app.datadoghq.com/apm/home


### PR DESCRIPTION
<!-- dd-meta {"pullId":"31e06185-c9d8-4ae3-8f2f-f24fcb84b228","source":"chat","resourceId":"e645442f-2857-4c4b-bb91-ac81f0d57c9b","workflowId":"f5b2527b-7949-4426-9359-dd32097c0005","codeChangeId":"f5b2527b-7949-4426-9359-dd32097c0005","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

The **Watchdog** and **Error Tracking** sections on the APM Home page (https://app.datadoghq.com/apm/home) now respect the currently selected service filter (or your personalized services when no explicit filter is set), matching the scoping that already applied to APM Recommendations. This PR updates the APM Recommendations page to document that behavior so users understand why those sections may show an empty state with a **Clear filter** button, and why the Error Tracking **View all** link is pre-filtered to the selected service.

Source PR that made this doc change necessary: https://github.com/DataDog/web-ui/pull/337151

### Changes

- Added a concise note to the "Using recommendations" section of `content/en/tracing/recommendations/_index.md` describing that the APM Home Watchdog and Error Tracking sections respect the selected service filter (or personalized services), including the empty-state/Clear filter behavior and the pre-filtered Error Tracking View all link.
- Added an `apm/home` link reference used by the new note.

### Testing

- Documentation-only change; no code paths affected.
- Reviewed the rendered Markdown locally to confirm the note follows existing repo conventions (`{{< ui >}}` shortcodes, `**Note**:` style, numbered link references) and that the new `[5]` reference resolves.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code (Claude Code) to locate the correct section and draft the note; content reviewed and finalized by the author.

### Additional notes

Documentation-only change.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e645442f-2857-4c4b-bb91-ac81f0d57c9b)

Comment @datadog to request changes