### PR TITLE
Document Session ID for Agent Observability Annotation Contexts

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1904,7 +1904,8 @@ To annotate session ID on auto-instrumented spans, provide the `session_id` tag:
 {{< code-block lang="javascript" >}}
 const { llmobs } = require('dd-trace');
 
-function runChat(userQuestion, sessionId) {
+async function runChat(userQuestion, sessionId) {
+    return llmobs.annotationContext({
     const completion = await llmobs.annotationContext({
       tags: {
         session_id: sessionId

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1838,6 +1838,11 @@ def rag_workflow(user_question):
 
 To annotate session ID on auto-instrumented spans, provide the `session_id` tag:
 
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import workflow
+
+@workflow
 def run_chat(user_question, session_id):
     with LLMObs.annotation_context(
         tags = {
@@ -1911,6 +1916,8 @@ function runChat(userQuestion, sessionId) {
 }
 
 {{< /code-block >}}
+
+{{% /tab %}}
 
 {{< /tabs >}}
 

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1912,7 +1912,6 @@ function runChat(userQuestion, sessionId) {
 
 {{< /code-block >}}
 
-{{% /tab %}}
 {{< /tabs >}}
 
 ## Prompt tracking

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1836,6 +1836,19 @@ def rag_workflow(user_question):
 
 {{< /code-block >}}
 
+To annotate session ID on auto-instrumented spans, provide the `session_id` tag:
+
+def run_chat(user_question, session_id):
+    with LLMObs.annotation_context(
+        tags = {
+            "session_id": session_id
+        },
+    ):
+        completion = openai_client.chat.completions.create(...)
+    return completion.choices[0].message.content
+
+{{< /code-block >}}
+
 {{% /tab %}}
 
 {{% tab "Node.js" %}}
@@ -1874,7 +1887,25 @@ function ragWorkflow(userQuestion) {
       },
       name: "augmented_generation"
     }, async () => {
-      const completion = await openai_client.chat.completions.create(...);
+      const completion = await openaiClient.chat.completions.create(...);
+      return completion.choices[0].message.content;
+    });
+}
+
+{{< /code-block >}}
+
+To annotate session ID on auto-instrumented spans, provide the `session_id` tag:
+
+{{< code-block lang="javascript" >}}
+const { llmobs } = require('dd-trace');
+
+function runChat(userQuestion, sessionId) {
+    const completion = await llmobs.annotationContext({
+      tags: {
+        session_id: sessionId
+      }
+    }, async () => {
+      const completion = await openaiClient.chat.completions.create(...);
       return completion.choices[0].message.content;
     });
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds examples in Agent Observability SDK documentation for tagging `session_id` for auto-instrumented spans via annotation contexts.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
