### PR TITLE
Edit CCM Recs to refer to providers and AI recs instead of only cloud providers

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -684,7 +684,7 @@ multifiltersearch:
 
 ## Overview
 
-[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud spending by optimizing the usage of your cloud resources. Datadog generates a set of recommendations by combining your observability data with your underlying provider billing data to identify orphaned, legacy, or over-provisioned cloud resources.
+[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud and AI spend by optimizing the usage of your cloud resources, AI agents, and LLMs. Datadog generates a set of recommendations by combining your observability data with your underlying provider billing data to identify orphaned, legacy, over-provisioned, and un-optimized cloud resources and AI usage.
 
 Recommendations are run on a daily basis and are automatically refreshed in your account as soon as the recommendations are released.
 
@@ -738,6 +738,8 @@ The following are requirements necessary to receive Cloud Cost recommendations:
 - [AWS integration and resource collection][3] (for AWS recommendations)
 - [Azure integration and resource collection][8] (for Azure recommendations)
 - [GCP integration and resource collection][10] (for GCP recommendations)
+- [OpenAI integration][17] (for OpenAI recommendations)
+- [Anthropic integration][18] (for Anthropic recommendations)
 - [Datadog Agent integration][5] (for Downsize recommendations)
 
 ## Setup
@@ -826,3 +828,5 @@ You can act on recommendations to save money and optimize costs. Cloud Cost Reco
 [14]: /bits_ai/bits_code/
 [15]: /cloud_cost_management/recommendations/cost_optimization_automation/
 [16]: /mcp_server/tools/#cost_recommendations
+[17]: /integrations/openai/
+[18]: /integrations/anthropic/

--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -684,7 +684,7 @@ multifiltersearch:
 
 ## Overview
 
-[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud and AI spend by optimizing the usage of your cloud resources, AI agents, and LLMs. Datadog generates a set of recommendations by combining your observability data with your underlying provider billing data to identify orphaned, legacy, over-provisioned, and un-optimized cloud resources and AI usage.
+[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud and AI spend by optimizing the usage of your cloud resources and AI/LLM API usage. Datadog generates a set of recommendations by combining your observability data with your underlying provider billing data to identify orphaned, legacy, or over-provisioned cloud resources, as well as unoptimized AI usage.
 
 Recommendations are run on a daily basis and are automatically refreshed in your account as soon as the recommendations are released.
 

--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -35,7 +35,7 @@ multifiltersearch:
     - name: Recommendation Category
       id: category
       filter_by: true
-    - name: Cloud Provider
+    - name: Provider
       id: cloud_provider
       filter_by: true
     - name: Resource Type
@@ -684,7 +684,7 @@ multifiltersearch:
 
 ## Overview
 
-[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud spending by optimizing the usage of your cloud resources. Datadog generates a set of recommendations by combining your observability data with your underlying cloud provider billing data to identify orphaned, legacy, or over-provisioned cloud resources.
+[Cloud Cost Recommendations][1] provides recommendations on reducing your cloud spending by optimizing the usage of your cloud resources. Datadog generates a set of recommendations by combining your observability data with your underlying provider billing data to identify orphaned, legacy, or over-provisioned cloud resources.
 
 Recommendations are run on a daily basis and are automatically refreshed in your account as soon as the recommendations are released.
 
@@ -734,7 +734,7 @@ Use the {{< ui >}}Risk{{< /ui >}} and {{< ui >}}Effort{{< /ui >}} columns to pri
 
 The following are requirements necessary to receive Cloud Cost recommendations:
 
-- Cloud provider accounts (for all desired Cloud Cost recommendations)
+- Provider accounts (for all desired Cloud Cost recommendations)
 - [AWS integration and resource collection][3] (for AWS recommendations)
 - [Azure integration and resource collection][8] (for Azure recommendations)
 - [GCP integration and resource collection][10] (for GCP recommendations)

--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -711,25 +711,6 @@ Below are the available cloud cost recommendation categories and their descripti
 | Purchase | Resources with on-demand charges and extended uptime. Purchasing a reservation or Savings Plan can reduce the amortized cost of the resource. |
 | Configure | Resources with configuration options that can be adjusted to reduce costs without changing capacity or terminating the resource. |
 
-## Risk and level of effort
-
-Each recommendation includes a **Risk** score and a **Level of Effort** score to help you prioritize which recommendations to act on first. Both scores use a scale of {{< ui >}}Low{{< /ui >}}, {{< ui >}}Medium{{< /ui >}}, and {{< ui >}}High{{< /ui >}}. They appear as the {{< ui >}}Risk{{< /ui >}} and {{< ui >}}Effort{{< /ui >}} columns in the {{< ui >}}Active Recommendations{{< /ui >}} table and in each recommendation's side panel.
-
-| Risk | Description |
-|--------|-------------|
-| {{< ui >}}Low{{< /ui >}} | Safe and easily undone: no data at stake or fully recoverable, resource trivially recreatable, isolated, no runtime impact. |
-| {{< ui >}}Medium{{< /ui >}} | Recoverable but takes effort: data or resources restorable via snapshot or re-provisioning, impact scoped to one app or workload, only brief disruption. |
-| {{< ui >}}High{{< /ui >}} | Hard to undo or high-impact if wrong: irreversible data loss, a resource that can't be recreated, wide blast radius, or possible downtime to a live workload. |
-
-
-| Level of Effort | Description |
-|--------|-------------|
-| {{< ui >}}Low{{< /ui >}} | A quick change that takes minutes. Usually a single console toggle or API call, and fully automatable. |
-| {{< ui >}}Medium{{< /ui >}} | A moderate effort that takes hours to days. Needs some scripting, testing, or coordination with one other team. |
-| {{< ui >}}High{{< /ui >}} | A major effort that takes weeks. An architectural change or multi-team coordination.|
-
-Use the {{< ui >}}Risk{{< /ui >}} and {{< ui >}}Effort{{< /ui >}} columns to prioritize recommendations that are low risk, low effort, or both. 
-
 ## Prerequisites
 
 The following are requirements necessary to receive Cloud Cost recommendations:
@@ -755,6 +736,25 @@ For each cloud account that you would like to receive recommendations for:
 1. Install the [Datadog Agent][5] (required for Downsize recommendations).
 
 **Note**: Cloud Cost Recommendations supports billing in customers' non-USD currencies.
+
+## Risk and level of effort
+
+Each recommendation includes a **Risk** score and a **Level of Effort** score to help you prioritize which recommendations to act on first. Both scores use a scale of {{< ui >}}Low{{< /ui >}}, {{< ui >}}Medium{{< /ui >}}, and {{< ui >}}High{{< /ui >}}. They appear as the {{< ui >}}Risk{{< /ui >}} and {{< ui >}}Effort{{< /ui >}} columns in the {{< ui >}}Active Recommendations{{< /ui >}} table and in each recommendation's side panel.
+
+| Risk | Description |
+|--------|-------------|
+| {{< ui >}}Low{{< /ui >}} | Safe and easily undone: no data at stake or fully recoverable, resource trivially recreatable, isolated, no runtime impact. |
+| {{< ui >}}Medium{{< /ui >}} | Recoverable but takes effort: data or resources restorable via snapshot or re-provisioning, impact scoped to one app or workload, only brief disruption. |
+| {{< ui >}}High{{< /ui >}} | Hard to undo or high-impact if wrong: irreversible data loss, a resource that can't be recreated, wide blast radius, or possible downtime to a live workload. |
+
+
+| Level of Effort | Description |
+|--------|-------------|
+| {{< ui >}}Low{{< /ui >}} | A quick change that takes minutes. Usually a single console toggle or API call, and fully automatable. |
+| {{< ui >}}Medium{{< /ui >}} | A moderate effort that takes hours to days. Needs some scripting, testing, or coordination with one other team. |
+| {{< ui >}}High{{< /ui >}} | A major effort that takes weeks. An architectural change or multi-team coordination.|
+
+Use the {{< ui >}}Risk{{< /ui >}} and {{< ui >}}Effort{{< /ui >}} columns to prioritize recommendations that are low risk, low effort, or both. 
 
 ## Recommendation statuses
 

--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -828,5 +828,5 @@ You can act on recommendations to save money and optimize costs. Cloud Cost Reco
 [14]: /bits_ai/bits_code/
 [15]: /cloud_cost_management/recommendations/cost_optimization_automation/
 [16]: /mcp_server/tools/#cost_recommendations
-[17]: /integrations/openai/
-[18]: /integrations/anthropic/
+[17]: /cloud_cost_management/setup/saas_costs/?tab=openai#configure-your-saas-accounts
+[18]: /cloud_cost_management/setup/saas_costs/?tab=anthropic#configure-your-saas-accounts


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX <!-- TODO: add Jira ticket -->

Updates the Cloud Cost Recommendations documentation (`content/en/cloud_cost_management/recommendations/_index.md`) to reflect that recommendations now cover providers beyond cloud providers (Databricks, Anthropic, OpenAI) and AI usage.

Changes:
- Renames the "Cloud Provider" phrase to "Provider":
  - `multifiltersearch` filter header `Cloud Provider` → `Provider`
  - Overview prose: "cloud provider billing data" → "provider billing data"
  - Prerequisites: "Cloud provider accounts" → "Provider accounts"
- Expands the Overview paragraph to cover cloud **and AI** spend, AI agents, and LLMs.
- Adds OpenAI and Anthropic integrations to the Prerequisites list.

The internal filter `id` (`cloud_provider`) and its data keys are unchanged, so table filtering behavior is unaffected. Product names ("Cloud Cost Recommendations") are intentionally left unchanged.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`).
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code: located the references in the CCM Recommendations docs, made the edits, and opened this PR.

### Additional notes

