### PR TITLE
Document EvalMetric status/error fields

### DIFF
--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -650,14 +650,6 @@ To create dashboard widgets from feedback, create the widget as you would for an
 
 For feedback events, provide exactly one of `span_id`, `trace_id`, `session_id`, or `feedback_join_key`. If you provide `eval_scope`, it must match the target field: `span_id` maps to `"span"`, `trace_id` maps to `"trace"`, `session_id` maps to `"session"`, and `feedback_join_key` maps to `"external"`.
 
-#### EvalMetricError
-
-| Field   | Type   | Description                                                |
-|---------|--------|------------------------------------------------------------|
-| type    | string | The error or exception type (for example, `"ValueError"`). |
-| message | string | A human-readable description of the error.                 |
-| stack   | string | The stack trace, if available.                             |
-
 #### Submitter
 
 | Field | Type | Description |
@@ -693,6 +685,14 @@ For feedback events, provide exactly one of `span_id`, `trace_id`, `session_id`,
 |------------|-----------------|--------------|
 | type [*required*]      | string | Identifier for the request. Set to `evaluation_metric`. |
 | attributes [*required*] | [[Attributes](#attributes)] | The body of the request. |
+
+#### EvalMetricError
+
+| Field   | Type   | Description                                                |
+|---------|--------|------------------------------------------------------------|
+| type    | string | The error or exception type (for example, `"ValueError"`). |
+| message | string | A human-readable description of the error.                 |
+| stack   | string | The stack trace, if available.                             |
 
 ## Further Reading
 

--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -637,16 +637,26 @@ To create dashboard widgets from feedback, create the widget as you would for an
 | ml_app [*required*]                                                | string              | The name of your LLM application. See [Application naming guidelines](#application-naming-guidelines). |
 | metric_type [*required*]                                           | string              | The value type: `"categorical"`, `"score"`, `"boolean"`, `"json"`, or `"text"`. The `"text"` type is supported only for feedback events. |
 | label [*required*]                                                 | string              | The unique name or label for the provided evaluation or feedback.                                      |
-| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category value.                                                              |
-| score_value [*required if the metric_type is "score"*]             | number              | A score value.                                                                                         |
-| boolean_value [*required if the metric_type is "boolean"*]         | boolean             | A boolean value.                                                                                       |
-| json_value [*required if the metric_type is "json"*]               | Dict[key (string), value] | A JSON object value.                                                                              |
+| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category value. Not required when `status` is `"WARN"` or `"ERROR"`. |
+| score_value [*required if the metric_type is "score"*]             | number              | A score value. Not required when `status` is `"WARN"` or `"ERROR"`. |
+| boolean_value [*required if the metric_type is "boolean"*]         | boolean             | A boolean value. Not required when `status` is `"WARN"` or `"ERROR"`. |
+| json_value [*required if the metric_type is "json"*]               | Dict[key (string), value] | A JSON object value. Not required when `status` is `"WARN"` or `"ERROR"`. |
 | text_value [*required if the metric_type is "text"*]               | string              | A text value. This is supported only for feedback events and is useful for free-text feedback.          |
+| status                                                             | string              | The evaluator run outcome. Accepted values are `"OK"`, `"WARN"`, and `"ERROR"`. When `"WARN"` or `"ERROR"`, the evaluator was skipped or failed, and no typed value field (`categorical_value`, `score_value`, and so on) is required. |
+| error                                                              | [EvalMetricError](#evalmetricerror) | Structured error details. Required when `status` is `"WARN"` or `"ERROR"`. |
 | assessment                                                         | string              | An assessment of this evaluation. Accepted values are `pass` and `fail`.                               |
 | reasoning                                                          | string              | A text explanation of the evaluation result.                                                           |
 | tags                                                               | [[Tag](#tag)]       | A list of tags to apply to this particular evaluation metric.                                          |
 
 For feedback events, provide exactly one of `span_id`, `trace_id`, `session_id`, or `feedback_join_key`. If you provide `eval_scope`, it must match the target field: `span_id` maps to `"span"`, `trace_id` maps to `"trace"`, `session_id` maps to `"session"`, and `feedback_join_key` maps to `"external"`.
+
+#### EvalMetricError
+
+| Field   | Type   | Description                                                |
+|---------|--------|------------------------------------------------------------|
+| type    | string | The error or exception type (for example, `"ValueError"`). |
+| message | string | A human-readable description of the error.                 |
+| stack   | string | The stack trace, if available.                             |
 
 #### Submitter
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5aa1f01f-a567-4316-9479-a02b75177eb9","source":"chat","resourceId":"9c65ef5c-fe5f-4f48-8aaa-2d06737fd9f4","workflowId":"b80d64d6-d934-4b33-8682-2e7d97c0164d","codeChangeId":"b80d64d6-d934-4b33-8682-2e7d97c0164d","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

The LLM Observability Evaluations API now supports reporting an evaluator run outcome on `EvalMetric`, so that a metric can be submitted even when the evaluator was skipped or failed without a typed value. This updates the Evaluations API reference (`content/en/llm_observability/instrumentation/api.md`) to document the new fields.

This documents the API changes introduced in the source PR: https://github.com/ddoghq/dd-source/pull/37855

**Changes**

- Add a `status` field (string, optional) to the **EvalMetric** table — accepted values `"OK"`, `"WARN"`, and `"ERROR"`. When `"WARN"` or `"ERROR"`, the evaluator was skipped or failed and no typed value field is required.
- Add an `error` field (optional) to the **EvalMetric** table, typed as `EvalMetricError` and required when `status` is `"WARN"` or `"ERROR"`.
- Note in the `categorical_value`, `score_value`, `boolean_value`, and `json_value` descriptions that they are not required when `status` is `"WARN"` or `"ERROR"`.
- Add a new **EvalMetricError** reference sub-section (`type`, `message`, `stack`) alongside the other API-standards tables.

**Testing**

- Reviewed the rendered `git diff`; the change is scoped to the single reference file with no unrelated edits.
- Verified the Markdown tables are well-formed and column-aligned with the surrounding tables.
- Confirmed the `EvalMetricError` cross-reference (`#evalmetricerror`) resolves to the new `#### EvalMetricError` heading, consistent with the file's existing anchor convention (for example `#evalmetric`, `#submitter`).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): applied the requested EvalMetric table edits and added the EvalMetricError section; wording and formatting reviewed against the surrounding reference tables.

### Additional notes

Reference-only documentation change; no code or build configuration is affected.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9c65ef5c-fe5f-4f48-8aaa-2d06737fd9f4)

Comment @datadog to request changes