### PR TITLE
Document LLMObs span metadata redaction

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -2727,7 +2727,7 @@ def call_openai():
 
 ### Example: redacting span metadata
 
-The `metadata` field exposes the span's top-level metadata dictionary. You can mutate, add, or remove keys. Internal Datadog fields are never exposed and cannot be modified.
+The `metadata` field exposes the span's top-level metadata dictionary. You can mutate, add, or remove keys.
 
 {{< code-block lang="python" >}}
 from ddtrace.llmobs import LLMObs

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -2727,14 +2727,16 @@ def call_openai():
 
 ### Example: redacting span metadata
 
-The `metadata` field exposes the span's top-level metadata dictionary. You can mutate, add, or remove keys.
+Integrations and manual annotations can record sensitive values in a span's metadata, such as tool configuration or request parameters. A span processor can remove or redact those values before the span is emitted.
+
+Internal Datadog fields, such as cost data, are not exposed through `metadata` and cannot be modified by a processor.
 
 {{< code-block lang="python" >}}
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs import LLMObsSpan
 
 def redact_metadata_processor(span: LLMObsSpan) -> LLMObsSpan:
-    # Remove or redact sensitive keys recorded in span metadata
+    # Drop the tool config recorded by auto-instrumentation
     span.metadata.pop("tool_config", None)
     return span
 

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -2671,7 +2671,7 @@ public class MyJavaClass {
 
 ## Span processing
 
-To modify input and output data on spans, you can configure a processor function. The processor function has access to span tags to enable conditional input/output modification. Processor functions can either return the modified span to emit it, or return `None`/`null` to prevent the span from being emitted entirely. This is useful for filtering out spans that contain sensitive data or meet certain criteria.
+To modify input and output data on spans, you can configure a processor function. The processor function has access to span tags to enable conditional input, output, and metadata modification. Processor functions can either return the modified span to emit it, or return `None`/`null` to prevent the span from being emitted entirely. This is useful for filtering out spans that contain sensitive data or meet certain criteria.
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -2723,6 +2723,22 @@ def call_openai():
     with LLMObs.annotation_context(tags={"no_input": "true"}):
         # make call to openai
         ...
+{{< /code-block >}}
+
+### Example: redacting span metadata
+
+The `metadata` field exposes the span's top-level metadata dictionary. You can mutate, add, or remove keys. Internal Datadog fields are never exposed and cannot be modified.
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs import LLMObsSpan
+
+def redact_metadata_processor(span: LLMObsSpan) -> LLMObsSpan:
+    # Remove or redact sensitive keys recorded in span metadata
+    span.metadata.pop("tool_config", None)
+    return span
+
+LLMObs.register_processor(redact_metadata_processor)
 {{< /code-block >}}
 
 ### Example: preventing spans from being emitted


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2439b604-c7ca-4583-b785-c1794bc2aaeb","source":"chat","resourceId":"345ec7fb-4f0b-4086-990a-551d25a9f862","workflowId":"5a93b4ee-ce27-4842-a388-dda14dd8e0ac","codeChangeId":"5a93b4ee-ce27-4842-a388-dda14dd8e0ac","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents Python LLM Observability span processor metadata support added in https://github.com/DataDog/dd-trace-py/pull/18648.

Changes:
- Updates the Span processing description to mention conditional metadata modification.
- Adds a Python example showing how to remove a sensitive key from span metadata.

### Testing

- Reviewed the generated diff for content and placement.
- Ran `git diff --check -- content/en/llm_observability/instrumentation/sdk.md`.
- Attempted `vale content/en/llm_observability/instrumentation/sdk.md`, but Vale is not installed in this environment.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to update the documentation.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/345ec7fb-4f0b-4086-990a-551d25a9f862)

Comment @datadog to request changes