### PR TITLE
[DOCS-15183] Add glossary entries for personal and service access tokens

### DIFF
--- a/content/en/getting_started/access_for_enterprises/credential_management.md
+++ b/content/en/getting_started/access_for_enterprises/credential_management.md
@@ -37,7 +37,7 @@ This section covers the five types of programmatic credentials in Datadog, best 
 | :---- | :---- | :---- | :---- |
 | **API Key** | Submitting data to Datadog (metrics, logs, traces, events). Used by Agents, integrations, and data submission pipelines. | Org-wide. Any data submitted with an API key is associated with the org. | Long-lived. No built-in expiration. |
 | **Personal Access Token (PAT)** | Short-lived token for individual user API access. Tied to the user's identity and permissions. | Scoped to the creating user's permissions. | Short-lived. Configurable expiration. |
-| **Service Account Token (SAT)** | Short-lived (optional) token for service-to-service API access. Tied to a service account's identity and permissions. | Scoped to the service account's permissions. | Short-lived (optional). Configurable expiration. |
+| **Service Access Token (SAT)** | Short-lived (optional) token for service-to-service API access. Tied to a service account's identity and permissions. | Scoped to the service account's permissions. | Short-lived (optional). Configurable expiration. |
 | **Application Key** | Accessing Datadog's API to read data, manage resources, and perform administrative actions. | Scoped to the permissions of the user or service account that created it. Can be further restricted with [scopes][1]. | Long-lived. No built-in expiration. |
 | **RUM Client Token** | Used to match data from the end user's browser to a specific RUM application. | Scoped to a specific RUM application. | Long-lived. No built-in expiration. |
 

--- a/content/en/glossary/terms/personal_access_token.md
+++ b/content/en/glossary/terms/personal_access_token.md
@@ -1,0 +1,11 @@
+---
+id: personal_access_token
+title: personal access token (PAT)
+synonyms:
+  - PAT
+related_terms:
+  - api_key
+  - application_key
+  - service_access_token
+---
+A personal access token (PAT) authenticates Datadog API calls on behalf of an individual user. Unlike an application key, a PAT does not need to be paired with an API key. PATs are scoped by default and require a time-to-live (TTL), so they expire and are automatically revoked. For more information, see the <a href="/account_management/personal-access-tokens/">Personal Access Tokens documentation</a>.

--- a/content/en/glossary/terms/service_access_token.md
+++ b/content/en/glossary/terms/service_access_token.md
@@ -1,0 +1,13 @@
+---
+id: service_access_token
+title: service access token (SAT)
+synonyms:
+  - SAT
+  - service account token
+related_terms:
+  - api_key
+  - application_key
+  - personal_access_token
+  - service_account
+---
+A service access token (SAT) authenticates Datadog API calls on behalf of a service account rather than an individual user. Because a SAT is not tied to a person, it remains valid when team members join or leave the organization. Like a personal access token, a SAT does not need to be paired with an API key and is scoped by default. Its time-to-live (TTL) is optional, so a SAT can be long-lived. For more information, see the <a href="/account_management/service-access-tokens/">Service Access Tokens documentation</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15183

Adds glossary entries for the two programmatic credential types that were missing from the glossary:

- `content/en/glossary/terms/personal_access_token.md`
- `content/en/glossary/terms/service_access_token.md`

The [Credential Management](https://docs.datadoghq.com/getting_started/access_for_enterprises/credential_management/#types-of-programmatic-credentials) page lists five programmatic credential types. DOCS-10869 added glossary entries for three of them (API key, application key, client token); these are the remaining two.

Both entries follow the format of the existing credential terms (short definition, no `core_product`, link to the dedicated reference page).

**Drive-by fix:** the Credential Management table called SATs "Service Account Token." The product name is **Service Access Token** (see the [Service Access Tokens](https://docs.datadoghq.com/account_management/service-access-tokens/) page). Corrected to match. "Service account token" is kept as a glossary synonym so the term is still findable.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code was used to check the existing glossary term conventions, verify the PAT/SAT terminology against the published reference pages, and draft the definitions. All content was reviewed.

### Additional notes

