### PR TITLE
[SVLS-9084] Add Azure Container Apps to Agentic Onboarding Setup Page

### DIFF
--- a/content/en/agentic_onboarding/setup.md
+++ b/content/en/agentic_onboarding/setup.md
@@ -106,6 +106,7 @@ The Datadog MCP Server exposes the `onboarding` toolset to any MCP-compatible co
 | Linux Observability | Terraform, Ansible, other IaC (Pulumi, CloudFormation, Puppet, Chef), and plain-shell install |
 | Serverless Monitoring (AWS Lambda) | AWS SAM, AWS CDK, Serverless Framework, Terraform, `datadog-ci lambda instrument` |
 | Serverless Monitoring (GCP Cloud Run and Cloud Run Functions) | Terraform, `gcloud run deploy`, Cloud Run YAML, Dockerfile, Gen 2 `gcloud functions deploy` |
+| Serverless Monitoring (Azure Container Apps) | Terraform, Bicep, ARM template, `azure.yaml` (azd), `az containerapp` CLI |
 | Agent Observability | OpenAI, Anthropic, LangChain, Vercel AI SDK (auto-detected from project dependencies) |
 | OpenTelemetry | Node.js / server-side TS, Browser JS / React / Vite, Python (Django, Flask, FastAPI), Java, Go |
 | App and API Protection | Python, Node.js, Java, Go, Ruby, .NET, PHP, and proxies (Envoy, HAProxy) for Linux, Windows, Kubernetes, Docker, GCP Cloud Run, and AWS Lambda, AWS Fargate/ECS |
@@ -210,6 +211,10 @@ Send the prompt that matches the product you want to set up:
 
 {{< code-block lang="shell" >}}npx @datadog/ai-setup-cli --product serverless --serverless-compute-type=gcp-cloud-run-functions{{< /code-block >}}
 
+**Azure Container Apps**
+{{< code-block lang="text" >}}Add Datadog for Azure Container Apps to my project{{< /code-block >}}
+
+{{< code-block lang="shell" >}}npx @datadog/ai-setup-cli --product serverless --serverless-compute-type=azure-container-apps{{< /code-block >}}
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds Azure Container Apps as a supported Serverless Monitoring target on the Agentic Onboarding Setup page:
- New row in the "Supported frameworks" table listing the Terraform, Bicep, ARM template, `azure.yaml` (azd), and `az containerapp` CLI detection surfaces.
- New "Azure Container Apps" prompt and CLI command under the Serverless Monitoring tab in "Step 3: Instrument your project."

### How to test

Run `make start-no-pre-build` and check `http://localhost:1313/agentic_onboarding/setup/` — confirm the new "Serverless Monitoring (Azure Container Apps)" row in the supported frameworks table, and the new "Azure Container Apps" tab under Serverless Monitoring in Step 3.