### PR TITLE
Update setGlobalContextProperty and addAttribute keys to 'team' inste…

### DIFF
--- a/content/en/real_user_monitoring/guide/tracking-rum-usage-with-usage-attribution-tags.md
+++ b/content/en/real_user_monitoring/guide/tracking-rum-usage-with-usage-attribution-tags.md
@@ -35,17 +35,17 @@ Categories for usage are determined by tags. Before setting up your RUM usage at
 To set tags for **browser sessions**, set the RUM global context at the start of the session (right after calling `datadogRum.init`) using the [`setGlobalContextProperty`][3] method. For example, here's how you could tag sessions so they can be tracked for the marketing department: 
 
 ```javascript
-datadogRum.setGlobalContextProperty('department', 'marketing');
+datadogRum.setGlobalContextProperty('team', 'marketing');
 ```
 
 To set tags for **mobile sessions**, use the [`addAttribute`][5] method. Here's an example:
 
 ```
 //Android
-GlobalRumMonitor.get().addAttribute("department", "marketing")
+GlobalRumMonitor.get().addAttribute("team", "marketing")
 
 //iOS
-RumMonitor.shared().addAttribute(forKey: "department", value: "marketing")
+RumMonitor.shared().addAttribute(forKey: "team", value: "marketing")
 ```
 
 **Note**: A few tags are included by default (`service`, `env`, `version`, `application.id`, and `application.name`). For anything else, set the global context using the method above.


### PR DESCRIPTION
Update setGlobalContextProperty and addAttribute keys to 'team' instead of 'department'

example for setGlobalContextProperty used 'department' as the key, but screenshot shows 'team'. Update setGlobalContext and addAttribute code example to use 'team' as the key.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ X] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
