### PR TITLE
[DOCS-15222] Fix Java DD_SITE example

### DIFF
--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -122,7 +122,7 @@ Configure the API key, Datadog site, and environment in the application process:
 
 {{< code-block lang="bash" >}}
 export DD_API_KEY=<YOUR_API_KEY>
-export DD_SITE={{< region-param key="dd_site" code="true" >}}
+export DD_SITE=<YOUR_DATADOG_SITE>
 export DD_ENV=<YOUR_ENVIRONMENT>
 export DD_SERVICE=<YOUR_SERVICE_NAME>
 export DD_VERSION=<YOUR_APP_VERSION>


### PR DESCRIPTION
## Motivation

The Java Feature Flags setup renders shortcode markup as the DD_SITE value. This makes the command incorrect for users.

## Changes and Decisions

The example uses YOUR_DATADOG_SITE as a clear replacement value. This keeps the fix limited to the Java setup page.