### PR TITLE
Remove stray <br> tags after card-grid shortcodes

### DIFF
--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -246,7 +246,6 @@ Or check out the libraries directly:
   {{< image-card href="https://github.com/DataDog/datadog-api-client-typescript" src="integrations_logos/typescript.png" alt="Typescript" >}}
   {{< image-card href="https://github.com/DataDog/datadog-api-client-rust" src="integrations_logos/rust.png" alt="Rust" >}}
 {{< /card-grid >}}
-</br>
 Trying to get started with the application instead? Check out Datadog's general [Getting Started docs][7].
 
 ## Further reading

--- a/content/en/cloud_cost_management/setup/saas_costs.md
+++ b/content/en/cloud_cost_management/setup/saas_costs.md
@@ -46,8 +46,6 @@ SaaS and AI Costs allow you to send cost data **directly from your providers** b
   {{< image-card href="/cloud_cost_management/setup/saas_costs/?tab=twilio#configure-your-saas-accounts" src="integrations_logos/twilio_small.svg" alt="twilio" >}}
 {{< /card-grid >}}
 
-</br>
-
 If your provider is not supported, use [Custom Costs][1] to upload any cost data source to Datadog and understand the total cost of your services. Only SaaS costs in USD are supported at this time.
 
 ## Setup

--- a/content/en/cloud_cost_management/tags/tag_explorer.md
+++ b/content/en/cloud_cost_management/tags/tag_explorer.md
@@ -41,8 +41,6 @@ See the respective documentation for your cloud provider:
   {{< image-card href="/cloud_cost_management/setup/google_cloud/" src="integrations_logos/google-cloud-platform_avatar.svg" alt="google cloud" >}}
 {{< /card-grid >}}
 
-<br>
-
 ## Search and manage tags
 
 Navigate to [{{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Tag Explorer{{< /ui >}}][2] to search for tags related to your cloud provider bills, custom costs, Datadog costs, SaaS cost integrations, and tag pipelines.

--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -93,8 +93,6 @@ Datadog integrates with a variety of CI providers to collect metrics that track 
   {{< image-card href="/continuous_integration/pipelines/custom/" src="integrations_logos/docs_other_ci_providers.png" alt="other ci providers" >}}
 {{< /card-grid >}}
 
-</br>
-
 You can use the `datadog-ci` CLI to [trace commands][8] and add [custom tags and measures][9], which allows you to add user-defined text and numerical tags in your pipeline traces.
 
 ## Ready to start?

--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -41,7 +41,6 @@ Select your CI provider to set up CI Visibility in Datadog:
   {{< image-card href="/continuous_integration/pipelines/teamcity/" src="integrations_logos/teamcity_small.svg" alt="teamcity" >}}
   {{< image-card href="/continuous_integration/pipelines/custom/" src="integrations_logos/docs_other_ci_providers.png" alt="other ci providers" >}}
 {{< /card-grid >}}
-<br />
 
 {{< whatsnext desc="For customization options, see the following sections:" >}}
     {{< nextlink href="continuous_integration/pipelines/custom_commands" >}}Custom Commands{{< /nextlink >}}

--- a/content/en/continuous_testing/_index.md
+++ b/content/en/continuous_testing/_index.md
@@ -70,8 +70,6 @@ Fast-track your application development by testing and troubleshooting in one pl
   {{< image-card href="/continuous_testing/cicd_integrations/bitrise_run/" src="integrations_logos/bitrise_run.png" alt="bitrise run-tests step" >}}
 {{< /card-grid >}}
 
-</br>
-
 You can use the [Datadog Terraform provider][10] to control test creation and state management. Leverage your Synthetic tests as [integration and end-to-end tests][11] for your staging, pre-prod, and canary deployments, or run them directly in your [CI pipelines][11].
 
 ## Accelerate troubleshooting

--- a/content/en/data_observability/jobs_monitoring/_index.md
+++ b/content/en/data_observability/jobs_monitoring/_index.md
@@ -41,8 +41,6 @@ Data Observability: Jobs Monitoring supports multiple job technologies. To get s
   {{< image-card href="/data_observability/jobs_monitoring/azure_data_factory/" src="integrations_logos/azure_data_factory.png" alt="Azure Data Factory" >}}
 {{< /card-grid >}}
 
-<br/>
-
 Data Observability: Jobs Monitoring also supports Apache Spark jobs on the following platforms:
 
 {{< card-grid >}}
@@ -50,8 +48,6 @@ Data Observability: Jobs Monitoring also supports Apache Spark jobs on the follo
   {{< image-card href="/data_observability/jobs_monitoring/emr" src="integrations_logos/amazon_emr.png" alt="Amazon EMR" >}}
   {{< image-card href="/data_observability/jobs_monitoring/dataproc/" src="integrations_logos/google_cloud_dataproc.png" alt="GCP Dataproc" >}}
 {{< /card-grid >}}
-
-<br/>
 
 ## Explore Data Observability: Jobs Monitoring
 

--- a/content/en/data_streams/_index.md
+++ b/content/en/data_streams/_index.md
@@ -91,8 +91,6 @@ Data Streams Monitoring supports OpenTelemetry. If you have set up Datadog APM t
   {{< image-card href="/data_streams/setup/technologies/bullmq/" src="integrations_logos/bullmq2.png" alt="BullMQ" >}}
 {{< /card-grid >}}
 
-<br/>
-
 ## Explore Data Streams Monitoring
 
 ### Visualize the architecture of your streaming data pipelines

--- a/content/en/database_monitoring/setup_mysql/_index.md
+++ b/content/en/database_monitoring/setup_mysql/_index.md
@@ -26,5 +26,3 @@ For setup instructions, select your hosting type:
   {{< image-card href="/database_monitoring/setup_mysql/gcsql" src="integrations_logos/google_cloudsql.png" alt="Google Cloud SQL" >}}
   {{< image-card href="/database_monitoring/setup_mysql/azure" src="integrations_logos/azure_db_for_mysql.png" alt="MySQL" >}}
 {{< /card-grid >}}
-
-<br>

--- a/content/en/database_monitoring/setup_postgres/supabase/_index.md
+++ b/content/en/database_monitoring/setup_postgres/supabase/_index.md
@@ -12,5 +12,3 @@ Select your setup method to get started:
   {{< image-card href="/database_monitoring/setup_postgres/supabase/cloud" src="integrations_logos/supabase.png" alt="Supabase Cloud" title="Supabase Cloud (Recommended)" subtitle="Set up Database Monitoring through the Supabase Cloud integration tile. No Agent installation required." >}}
   {{< image-card href="/database_monitoring/setup_postgres/supabase/agent" src="integrations_logos/supabase.png" alt="Supabase Self-Hosted" title="Supabase Self-Hosted" subtitle="Set up Database Monitoring with the Datadog Agent for self-hosted Supabase deployments." >}}
 {{< /card-grid >}}
-
-<br>

--- a/content/en/database_monitoring/setup_sql_server/_index.md
+++ b/content/en/database_monitoring/setup_sql_server/_index.md
@@ -25,6 +25,4 @@ For setup instructions, select your hosting type:
   {{< image-card href="/database_monitoring/setup_sql_server/gcsql" src="integrations_logos/google_cloudsql.png" alt="Google Cloud SQL" >}}
 {{< /card-grid >}}
 
-<br>
-
 [1]: /database_monitoring/setup_sql_server/troubleshooting/#known-limitations

--- a/content/en/error_tracking/backend/capturing_handled_errors/_index.md
+++ b/content/en/error_tracking/backend/capturing_handled_errors/_index.md
@@ -43,7 +43,6 @@ Set up your application to capture handled errors using one of the following off
   {{< image-card href="/error_tracking/backend/capturing_handled_errors/python" src="integrations_logos/python.png" alt="Python" >}}
   {{< image-card href="/error_tracking/backend/capturing_handled_errors/ruby" src="integrations_logos/ruby.png" alt="Ruby" >}}
 {{< /card-grid >}}
-<br />
 
 ## Further reading
 

--- a/content/en/getting_started/continuous_testing/_index.md
+++ b/content/en/getting_started/continuous_testing/_index.md
@@ -80,8 +80,6 @@ To integrate with a CI provider or a collaboration tool like [Slack][28] or [Jir
   {{< image-card href="/continuous_testing/cicd_integrations/bitrise_run/" src="integrations_logos/bitrise_run.png" alt="bitrise run-tests step" >}}
 {{< /card-grid >}}
 
-</br>
-
 ## Run your Continuous Testing tests
 
 To improve your development workflow, you can use `datadog-ci` in your CLI as a CI environment to configure your test. 

--- a/content/en/getting_started/test_impact_analysis/_index.md
+++ b/content/en/getting_started/test_impact_analysis/_index.md
@@ -48,8 +48,6 @@ To set up Test Impact Analysis, see the following documentation for your program
   {{< image-card href="/tests/test_impact_analysis/setup/go/" src="integrations_logos/golang-avatar.png" alt="go" >}}
 {{< /card-grid >}}
 
-</br>
-
 ## Enable Test Impact Analysis
 
 To enable Test Impact Analysis:

--- a/content/en/getting_started/test_optimization/_index.md
+++ b/content/en/getting_started/test_optimization/_index.md
@@ -52,8 +52,6 @@ To start instrumenting and running tests, see the documentation for one of the f
   {{< image-card href="/tests/setup/junit_xml/" src="integrations_logos/junit_xml.png" alt="upload junit tests to datadog" >}}
 {{< /card-grid >}}
 
-</br>
-
 Test Optimization is compatible with any CI provider and is not limited to those supported by CI Visibility. For more information about supported features, see [Test Optimization][3].
 
 ## Use CI test data

--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -129,8 +129,6 @@ Select an application type to start collecting RUM data:
   {{< image-card href="/real_user_monitoring/application_monitoring/kotlin_multiplatform/setup" src="integrations_logos/kotlin-multiplatform_large.svg" alt="Kotlin Multiplatform" >}}
 {{< /card-grid >}}
 
-</br>
-
 ### Capabilities and platform support
 
 **Note**: The Datadog Flutter SDK is not supported for MacOS, Windows, or Linux.

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/_index.md
@@ -36,7 +36,6 @@ Select a platform to start collecting RUM data on your application:
   {{< image-card href="/real_user_monitoring/application_monitoring/browser/setup/server/apache" src="integrations_logos/apache_large.svg" alt="apache" >}}
   {{< image-card href="/real_user_monitoring/application_monitoring/browser/setup/server/ibm" src="integrations_logos/ibm_http_large.svg" alt="ibm" >}}
 {{< /card-grid >}}
-<br>
 
 {{% rum-browser-auto-instrumentation-limitations %}}
 

--- a/content/en/real_user_monitoring/feature_flag_tracking/setup.md
+++ b/content/en/real_user_monitoring/feature_flag_tracking/setup.md
@@ -141,8 +141,6 @@ You can start collecting feature flag data with [custom feature flag management 
   {{< image-card href="/real_user_monitoring/feature_flag_tracking/setup/?tab=npm#statsig-integration" src="integrations_logos/statsig_large.svg" alt="statsig" >}}
 {{< /card-grid >}}
 
-</br>
-
 ### Amplitude integration
 
 Before you initialize this feature flag integration, make sure you've [set up RUM monitoring](#set-up-rum-monitoring).

--- a/content/en/tests/_index.md
+++ b/content/en/tests/_index.md
@@ -76,8 +76,6 @@ Select an option to configure Test Optimization in Datadog:
   {{< image-card href="/tests/setup/junit_xml/" src="integrations_logos/junit_xml.png" alt="upload junit tests to datadog" >}}
 {{< /card-grid >}}
 
-</br>
-
 If you use Bazel to run Go, Java, or Python tests, use the Datadog [Bazel rules for Test Optimization][10].
 
 In addition to tests, Test Optimization provides visibility over the whole testing phase of your project.

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -18,8 +18,6 @@ For information about configuration options for [Test Optimization][1], choose y
   {{< image-card href="/tests/setup/junit_xml/" src="integrations_logos/junit_xml.png" alt="upload junit tests to datadog" >}}
 {{< /card-grid >}}
 
-<br>
-
 If you use Bazel to run Go, Java, or Python tests, use the Datadog [Bazel rules for Test Optimization][2].
 
 If you run your tests in an environment with network restrictions,

--- a/content/en/tests/test_impact_analysis/setup/_index.md
+++ b/content/en/tests/test_impact_analysis/setup/_index.md
@@ -18,6 +18,4 @@ For information about configuration options for [Test Impact Analysis][1], choos
   {{< image-card href="/tests/test_impact_analysis/setup/go/" src="integrations_logos/golang-avatar.png" alt="go" >}}
 {{< /card-grid >}}
 
-<br>
-
 [1]: /tests/test_impact_analysis/

--- a/content/en/tracing/trace_collection/custom_instrumentation/client-side/_index.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/client-side/_index.md
@@ -19,7 +19,6 @@ Select your platform to get started:
   {{< image-card href="/tracing/trace_collection/custom_instrumentation/client-side/android/" src="integrations_logos/android_large.svg" alt="Android" >}}
   {{< image-card href="/tracing/trace_collection/custom_instrumentation/client-side/ios/" src="integrations_logos/ios_large.svg" alt="iOS" >}}
 {{< /card-grid >}}
-<br>
 
 ## Further reading
 

--- a/content/en/tracing/trace_collection/dd_libraries/_index.md
+++ b/content/en/tracing/trace_collection/dd_libraries/_index.md
@@ -32,8 +32,6 @@ For containerized environments, follow the links below to enable trace collectio
   {{< image-card href="/integrations/ecs_fargate/#trace-collection" src="integrations_logos/ecs_fargate.png" alt="ECS Fargate" >}}
 {{< /card-grid >}}
 
-</br>
-
 3. The trace client attempts to send traces to the Unix domain socket `/var/run/datadog/apm.socket` by default. If the socket does not exist, traces are sent to `http://localhost:8126`.
 
    If a different socket, host, or port is required, use the `DD_TRACE_AGENT_URL` environment variable. For example:
@@ -80,8 +78,6 @@ Set up your application to send [traces][2] using one of the following official 
   {{< image-card href="/tracing/trace_collection/dd_libraries/android" src="integrations_logos/android.png" alt="Android" >}}
   {{< image-card href="/tracing/trace_collection/dd_libraries/ios" src="integrations_logos/ios_large.svg" alt="iOS" >}}
 {{< /card-grid >}}
-
-<br>
 
 To instrument an application written in a language that does not have official library support, see the list of [community SDKs][1].
 

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -20,8 +20,6 @@ You can set up tracing to include collecting trace information about proxies.
   {{< image-card href="azure_apim/" src="integrations_logos/azure_api_management.png" alt="Azure API Management" >}}
 {{< /card-grid >}}
 
-<br>
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/trace_collection/single-step-apm/_index.md
+++ b/content/en/tracing/trace_collection/single-step-apm/_index.md
@@ -60,8 +60,6 @@ Click on one of the following tiles to learn how to set up SSI for your deployme
   {{< image-card href="windows/" src="integrations_logos/windows.png" alt="windows" >}}
 {{< /card-grid >}}
 
-<br>
-
 ## Troubleshooting
 
 If you encounter problems enabling APM with SSI, see the [SSI troubleshooting guide][15].


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The card-grid shortcode already provides bottom margin, making the extra manual `<br>` line breaks after it redundant. I suspect these might also have some negative impact on the plaintext build in some situations.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
