### PR TITLE
Clarify RUM header propagator dependency

### DIFF
--- a/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
+++ b/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
@@ -654,6 +654,8 @@ The default injection style is `tracecontext`, `Datadog`.
 ## How RUM resources are linked to traces
 
 Datadog uses the distributed tracing protocol and sets up the HTTP headers below. By default, both trace context and Datadog-specific headers are used.
+
+The headers documented below are only added when their corresponding propagator type is active. By default, RUM includes the `datadog` propagator alongside trace context; see [OpenTelemetry support](#opentelemetry-support) above to view or change which propagators are enabled.
 {{< tabs >}} {{% tab "Datadog" %}}
 `x-datadog-trace-id`
 : Generated from the Real User Monitoring SDK. Allows Datadog to link the trace with the RUM resource.

--- a/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
+++ b/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
@@ -653,9 +653,9 @@ The default injection style is `tracecontext`, `Datadog`.
 
 ## How RUM resources are linked to traces
 
-Datadog uses the distributed tracing protocol and sets up the HTTP headers below. By default, both trace context and Datadog-specific headers are used.
+Datadog uses the distributed tracing protocol and sets up the following HTTP headers. By default, both trace context and Datadog-specific headers are used.
 
-The headers documented below are only added when their corresponding propagator type is active. By default, RUM includes the `datadog` propagator alongside trace context; see [OpenTelemetry support](#opentelemetry-support) above to view or change which propagators are enabled.
+These headers are added only when their corresponding propagator type is active. By default, RUM includes the `datadog` propagator alongside trace context. See [OpenTelemetry support](#opentelemetry-support) to view or change which propagators are enabled.
 {{< tabs >}} {{% tab "Datadog" %}}
 `x-datadog-trace-id`
 : Generated from the Real User Monitoring SDK. Allows Datadog to link the trace with the RUM resource.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a clarifying sentence to the "How RUM resources are linked to traces" section, explicitly noting that the documented headers are only sent when their corresponding propagator type is active, and pointing back to the "OpenTelemetry support" section where propagator types are configured.

https://datadoghq.atlassian.net/browse/DOCS-14955

Doc
https://docs.datadoghq.com/tracing/other_telemetry/rum/?tab=datadog#how-rum-resources-are-linked-to-traces

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code based on user feedback about the docs page.

### Additional notes