### PR TITLE
Runtime Package Prioritization: remove unnecessary caveats (follow-up to #38728)

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -67,7 +67,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][5]. To query the signals yourself, see [Filter findings by runtime signals][6].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][5]. To query these signals directly, see [Filter findings by runtime signals][6].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -206,8 +206,8 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later** for the most complete signal coverage.
-- Linux only (eBPF dependency)
-- Applies to operating system packages in container image vulnerability findings
+- Linux only (eBPF dependency).
+- Applies to operating system packages in container image vulnerability findings.
 
 **Note**: Use Datadog Agent **7.79.0 or later**. Earlier Agent versions enable this feature through [Workload Protection][8] and can affect its usage. From 7.79.0, runtime package prioritization runs independently and does not affect its usage.
 

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -202,10 +202,10 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][9]. To query the signals yourself, see [Filter findings by runtime signals][10].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][9]. To query these signals directly, see [Filter findings by runtime signals][10].
 
 **Requirements**:
-- Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later**: earlier versions can miss runtime signals on some kubelet-managed images.
+- Datadog Agent **7.79.0 or later**
 - Linux only (eBPF dependency)
 - Applies to operating system packages in container image vulnerability findings
 

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -205,7 +205,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 *Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][9]. To query these signals directly, see [Filter findings by runtime signals][10].
 
 **Requirements**:
-- Datadog Agent **7.79.0 or later**
+- Datadog Agent **7.79.0 or later**. On Kubernetes, use **7.81.0 or later** for the most complete signal coverage.
 - Linux only (eBPF dependency)
 - Applies to operating system packages in container image vulnerability findings
 

--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -97,7 +97,7 @@ When enabled, the Agent uses eBPF to observe file access on your workloads and a
 | Accessed by root process | The package was accessed by a process running as root (UID 0). |
 | SUID binary present | The package contains a binary with the SUID bit set, which can enable privilege escalation. |
 
-*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][8]. To query the signals yourself, see [Filter findings by runtime signals][9].
+*Package is running* feeds the **Reachability** dimension of the [Runtime Prioritization Engine][8]. To query these signals directly, see [Filter findings by runtime signals][9].
 
 **Requirements**:
 - Datadog Agent **7.79.0 or later**

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -57,7 +57,7 @@ When [Runtime Package Prioritization][4] is enabled, Datadog adds the runtime si
 | Accessed by root process | `@package.is_running_as_root:true` |
 | SUID binary present | `@package.has_suid:true` |
 
-Datadog adds a tag when it observes the signal. Use the tags to prioritize what to fix first, rather than to rule findings out.
+Datadog adds a tag when it observes the signal. An absent tag means the signal was not observed, not that the package is unused, so use the tags to prioritize what to fix first rather than to rule findings out.
 
 Use the tags in the [Vulnerability Explorer][11], combined with any other criteria. For example, high and critical vulnerabilities that are running and have a fix available:
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -57,7 +57,7 @@ When [Runtime Package Prioritization][4] is enabled, Datadog adds the runtime si
 | Accessed by root process | `@package.is_running_as_root:true` |
 | SUID binary present | `@package.has_suid:true` |
 
-Datadog adds a tag when it observes the signal. An absent tag means the signal was not observed, not that the package is unused, so use the tags to prioritize what to fix first rather than to rule findings out.
+Datadog adds a tag when it observes a signal. An absent tag means Datadog did not observe the signal; it does not mean the package is unused. Use the tags to prioritize what to fix first, not to rule findings out.
 
 Use the tags in the [Vulnerability Explorer][11], combined with any other criteria. For example, high and critical vulnerabilities that are running and have a fix available:
 

--- a/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
+++ b/content/en/security/cloud_security_management/triage_and_prioritize/runtime_prioritization_engine.md
@@ -57,7 +57,7 @@ When [Runtime Package Prioritization][4] is enabled, Datadog adds the runtime si
 | Accessed by root process | `@package.is_running_as_root:true` |
 | SUID binary present | `@package.has_suid:true` |
 
-Datadog sets a tag only for signals it observed; the absence of a tag does not mean a package is unused.
+Datadog adds a tag when it observes the signal. Use the tags to prioritize what to fix first, rather than to rule findings out.
 
 Use the tags in the [Vulnerability Explorer][11], combined with any other criteria. For example, high and critical vulnerabilities that are running and have a fix available:
 
@@ -65,7 +65,7 @@ Use the tags in the [Vulnerability Explorer][11], combined with any other criter
 @risk.is_package_running:true @severity:(high OR critical) @remediation.is_available:true
 ```
 
-Signals persist for the lifetime of an image version: after a package is observed running in an image, findings for that image keep the signal. Because container images are immutable, this means "has been observed running in this image" rather than "is running right now". When the image is no longer deployed, its findings age out and close.
+Signals persist for the lifetime of an image version: after a package is observed running, findings for that image keep the signal. Because container images are immutable, the signal reflects what has run in that image. When the image is no longer deployed, its findings age out and close.
 
 ## Get started
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Follow-up to #38728 — wording only, no new content.

These docs are customer-facing, and a few lines described internal limitations rather than telling customers what they need to do:

- **Kubernetes Agent version**: keeps the actionable recommendation (use `7.81.0 or later` for the most complete signal coverage) but drops the description of the underlying defect.
- **Tag coverage**: reframed as prioritization guidance ("use the tags to prioritize what to fix first") instead of a caveat about missing tags.
- **Signal persistence**: states the behavior without editorializing on what the label means.

[K9VULN-17099](https://datadoghq.atlassian.net/browse/K9VULN-17099)

### Merge readiness

- [x] Ready for merge

### AI assistance

Wording changes drafted with Claude Code (Claude Opus 5).


[K9VULN-17099]: https://datadoghq.atlassian.net/browse/K9VULN-17099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ