### PR TITLE
[CCR-3653] Document notification rules and update automation coverage

### DIFF
--- a/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
+++ b/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
@@ -1,5 +1,5 @@
 ---
-title: Cost Optimization Automation
+title: Cost Optimization Automations
 description: Set up automations that continuously act on Cloud Cost Recommendations to clean up unused or wasteful cloud resources on a recurring schedule.
 further_reading:
 - link: "/cloud_cost_management/"
@@ -21,7 +21,7 @@ Cost Optimization Automation lets you continuously act on [Cloud Cost Recommenda
 Each automation targets a single recommendation type and includes the following:
 
 - A schedule (weekly, biweekly, every 30 days, or every 90 days)
-- A scope (AWS account, region, tags, and a maximum number of resources per run)
+- A scope (account, region, tags, and a maximum number of resources per run)
 - Safeguards specific to the recommendation type (for example, a pre-deletion snapshot)
 - An optional human approval step routed through Slack or Microsoft Teams
 
@@ -29,26 +29,40 @@ Recommendations acted on by an automation move to {{< ui >}}Completed{{< /ui >}}
 
 Cost Optimization Automation is different from the 1-click Workflow Automation actions described in [Recommendation action-taking][2]. 1-click actions execute a single change on demand from the recommendation side panel. Automations execute on a recurring schedule and act on every matching resource in scope.
 
+Automations are also different from [notification rules](#set-up-a-notification-rule), which send a recurring Slack summary of matching recommendations but don't take any action.
+
 **Note**: Cost Optimization Automation uses Datadog Workflows and incurs additional costs. For detailed pricing information, see the [Workflow Automation pricing page][3].
 
 ## Supported recommendation types
 
-Cost Optimization Automation supports the following AWS recommendation types:
+Cost Optimization Automation supports the following recommendation types:
 
-| Recommendation type | Built-in safeguards |
-|---------------------|---------------------|
-| Delete unattached EBS volume | An EBS snapshot is taken before each volume is deleted. |
-| Transition S3 Standard objects to Amazon S3 Intelligent-Tiering | Reversible. The lifecycle configuration can be removed at any time. |
-| Delete unused RDS instance | A final RDS snapshot is taken before each instance is deleted. |
-| Delete extra on-demand backups (DynamoDB) | The two most recent backups are preserved on every run. |
-| Set CloudWatch logs retention policy | Reversible. The retention period can be adjusted or removed at any time. |
-| Delete old EBS snapshots | Snapshots referenced by an AMI are skipped. |
+| Provider | Recommendation type | Built-in safeguards |
+|----------|---------------------|---------------------|
+| AWS | Delete unattached EBS volume | Optional: takes an EBS snapshot before each volume is deleted. |
+| AWS | Migrate EBS volume from gp2 to gp3 | Reversible, in-place migration with no data loss. |
+| AWS | Delete unused EBS snapshots | Snapshots referenced by an AMI are skipped. |
+| AWS | Delete extra on-demand backups (DynamoDB) | The two most recent backups are preserved on every run. |
+| AWS | Migrate DynamoDB table to Infrequent Access table class | Reversible. The table class can be changed back at any time. |
+| AWS | Delete unused DynamoDB table | A backup is taken before each table is deleted. |
+| AWS | Set CloudWatch logs retention policy | Reversible. The retention period can be adjusted or removed at any time. |
+| AWS | Delete unused RDS instance | A final RDS snapshot is taken before each instance is deleted. |
+| AWS | Delete unused NAT gateway | None. Deletion is irreversible. |
+| AWS | Transition S3 Standard objects to Amazon S3 Intelligent-Tiering | Existing lifecycle rules are preserved rather than overwritten. |
+| AWS | Terminate unused EC2 instance | Optional: creates an AMI before each instance is terminated. |
+| AWS | Delete unused Redshift cluster | A final snapshot is taken before each cluster is deleted. |
+| GCP | Delete unattached Compute Engine disk | Optional: takes a snapshot before each disk is deleted. |
+| GCP | Enable Autoclass on a Cloud Storage bucket | Reversible. Autoclass can be disabled at any time. |
+| Azure | Delete unattached managed disk | Optional: takes a snapshot before each disk is deleted. |
+| Azure | Delete unused SQL database | None. Deletion is irreversible. |
+
+Safeguards marked "Optional" are enabled by default and can be turned off in the automation form. All other listed safeguards are always applied and can't be disabled.
 
 ## Prerequisites
 
-- An AWS account configured with [Cloud Cost Recommendations][4] and actively generating recommendations.
+- An AWS, GCP, or Azure account configured with [Cloud Cost Recommendations][4] and actively generating recommendations.
 - The **Cloud Cost Management - Cloud Cost Management Write** permission to create or edit an automation.
-- A [Workflow Automation connection][5] to each AWS account you want an automation to act on. Datadog uses this connection to assume an IAM role with the write permissions needed for the recommended action. Datadog grants only the permissions required for the selected recommendation type.
+- A connection to each account you want an automation to act on, set up from {{< ui >}}Manage Connections{{< /ui >}} on the {{< ui >}}Automations{{< /ui >}} page. Datadog uses this connection to assume a role with the write permissions needed for the recommended action, and grants only the permissions required for the selected recommendation type. To act across multiple accounts with one automation, create a [connection group][7].
 - (Optional) A Slack or Microsoft Teams connection if you want approval messages routed to a channel.
 
 ## Set up an automation
@@ -56,9 +70,10 @@ Cost Optimization Automation supports the following AWS recommendation types:
 To set up an automation on a recurring schedule for a recommendation type:
 
 1. Navigate to [{{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Optimize{{< /ui >}} > {{< ui >}}Automations{{< /ui >}}][6].
+1. Select the {{< ui >}}Remediation{{< /ui >}} tab.
 1. On the left side of the page, select the recommendation type.
 1. Click **Create New Automation**.
-1. In the {{< ui >}}AWS Connection{{< /ui >}} dropdown menu, select or create a [connection][5]. To act across multiple accounts with one automation, select or create a [connection group][7].
+1. In the {{< ui >}}Connection{{< /ui >}} dropdown menu, select a connection or connection group configured in [{{< ui >}}Manage Connections{{< /ui >}}][5].
 1. In the {{< ui >}}Define scope{{< /ui >}} section:
     1. Enter tags to restrict the automation to resources matching those tags, such as `env`, `service`, and `team`.
     1. Enter the maximum resources per run to cap how many resources the automation acts on during a single execution. The automation prioritizes resources by highest potential savings.
@@ -73,9 +88,36 @@ Each recommendation type has built-in safeguards. For example, the **Delete Unat
 
 If {{< ui >}}Require approval before execution{{< /ui >}} is enabled in the [automation setup](#set-up-an-automation), Datadog posts in the designated channel a summary of the resources targeted on each run. The automation only runs after a user approves the request in the channel.
 
+## Set up a notification rule
+
+A notification rule sends a recurring Slack summary of Cloud Cost Recommendations matching a scope you define, without taking any action on your resources. Use a notification rule when you want visibility into new savings opportunities without configuring Datadog to make changes automatically.
+
+**Prerequisite**: A Slack connection. See [Slack integration][8].
+
+To set up a notification rule:
+
+1. Navigate to [{{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Optimize{{< /ui >}} > {{< ui >}}Automations{{< /ui >}}][6].
+1. Select the {{< ui >}}Notification{{< /ui >}} tab.
+1. Click **Set New Notification**.
+1. In the {{< ui >}}Define scope{{< /ui >}} section, enter tags to restrict the notification to resources matching those tags. Leave this blank to include all resources.
+1. In the {{< ui >}}Set schedule{{< /ui >}} section, select the notification frequency, execution day, execution time, and timezone.
+1. In the destination section, select a Slack workspace connection and channel. Optionally, select teammates to @-mention in the message.
+1. Enter a name for the notification rule.
+1. Use the {{< ui >}}Notification enabled{{< /ui >}} toggle to control whether the rule is active.
+1. (Optional) Click {{< ui >}}Test Notification{{< /ui >}} to send a sample message to the selected Slack channel before saving.
+1. Click **Save**.
+
+### Manage notification rules
+
+The {{< ui >}}Notification{{< /ui >}} tab lists every notification rule in your organization. From this page you can:
+
+- Toggle a rule on or off without deleting it
+- Edit a rule's scope, schedule, destination, or name
+- Delete a rule
+
 ## Manage automations
 
-The {{< ui >}}Automations{{< /ui >}} page lists every automation in your organization, grouped by recommendation type. From this page you can:
+The {{< ui >}}Remediation{{< /ui >}} tab lists every automation (labeled as a **policy** in this view) in your organization, grouped by recommendation type. Use the {{< ui >}}Provider{{< /ui >}}, {{< ui >}}Resource Type{{< /ui >}}, and {{< ui >}}Recommendation Type{{< /ui >}} filters at the top of the page to narrow the list. From this page you can:
 
 - Pause or resume an automation
 - Edit an automation's scope, schedule, or safeguards
@@ -114,3 +156,4 @@ If you set a recommendation to {{< ui >}}Dismissed{{< /ui >}}, automations skip 
 [5]: /actions/connections/
 [6]: https://app.datadoghq.com/cost/optimize/automations
 [7]: /actions/connections/#connection-groups
+[8]: /integrations/slack/

--- a/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
+++ b/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
@@ -88,33 +88,6 @@ Each recommendation type has built-in safeguards. For example, the **Delete Unat
 
 If {{< ui >}}Require approval before execution{{< /ui >}} is enabled in the [automation setup](#set-up-an-automation), Datadog posts in the designated channel a summary of the resources targeted on each run. The automation only runs after a user approves the request in the channel.
 
-## Set up a notification rule
-
-A notification rule sends a recurring Slack summary of Cloud Cost Recommendations matching a scope you define, without taking any action on your resources. Use a notification rule when you want visibility into new savings opportunities without configuring Datadog to make changes automatically.
-
-**Prerequisite**: A Slack connection. See [Slack integration][8].
-
-To set up a notification rule:
-
-1. Navigate to [{{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Optimize{{< /ui >}} > {{< ui >}}Automations{{< /ui >}}][6].
-1. Select the {{< ui >}}Notification{{< /ui >}} tab.
-1. Click **Set New Notification**.
-1. In the {{< ui >}}Define scope{{< /ui >}} section, enter tags to restrict the notification to resources matching those tags. Leave this blank to include all resources.
-1. In the {{< ui >}}Set schedule{{< /ui >}} section, select the notification frequency, execution day, execution time, and timezone.
-1. In the destination section, select a Slack workspace connection and channel. Optionally, select teammates to @-mention in the message.
-1. Enter a name for the notification rule.
-1. Use the {{< ui >}}Notification enabled{{< /ui >}} toggle to control whether the rule is active.
-1. (Optional) Click {{< ui >}}Test Notification{{< /ui >}} to send a sample message to the selected Slack channel before saving.
-1. Click **Save**.
-
-### Manage notification rules
-
-The {{< ui >}}Notification{{< /ui >}} tab lists every notification rule in your organization. From this page you can:
-
-- Toggle a rule on or off without deleting it
-- Edit a rule's scope, schedule, destination, or name
-- Delete a rule
-
 ## Manage automations
 
 The {{< ui >}}Remediation{{< /ui >}} tab lists every automation (labeled as a **policy** in this view) in your organization, grouped by recommendation type. Use the {{< ui >}}Provider{{< /ui >}}, {{< ui >}}Resource Type{{< /ui >}}, and {{< ui >}}Recommendation Type{{< /ui >}} filters at the top of the page to narrow the list. From this page you can:
@@ -144,6 +117,33 @@ Datadog records a new version of an automation each time it's created, edited, e
 When an automation successfully acts on a resource, the corresponding recommendation moves to {{< ui >}}Completed{{< /ui >}} and is labeled as completed by automation. Its savings count toward the realized savings totals on the [Cloud Cost Recommendations][1] page.
 
 If you set a recommendation to {{< ui >}}Dismissed{{< /ui >}}, automations skip it on future runs until the dismissal expires.
+
+## Set up a notification rule
+
+A notification rule sends a recurring Slack summary of Cloud Cost Recommendations matching a scope you define, without taking any action on your resources. Use a notification rule when you want visibility into new savings opportunities without configuring Datadog to make changes automatically.
+
+**Prerequisite**: A Slack connection. See [Slack integration][8].
+
+To set up a notification rule:
+
+1. Navigate to [{{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Optimize{{< /ui >}} > {{< ui >}}Automations{{< /ui >}}][6].
+1. Select the {{< ui >}}Notification{{< /ui >}} tab.
+1. Click **Set New Notification**.
+1. In the {{< ui >}}Define scope{{< /ui >}} section, enter tags to restrict the notification to resources matching those tags. Leave this blank to include all resources.
+1. In the {{< ui >}}Set schedule{{< /ui >}} section, select the notification frequency, execution day, execution time, and timezone.
+1. In the destination section, select a Slack workspace connection and channel. Optionally, select teammates to @-mention in the message.
+1. Enter a name for the notification rule.
+1. Use the {{< ui >}}Notification enabled{{< /ui >}} toggle to control whether the rule is active.
+1. (Optional) Click {{< ui >}}Test Notification{{< /ui >}} to send a sample message to the selected Slack channel before saving.
+1. Click **Save**.
+
+## Manage notification rules
+
+The {{< ui >}}Notification{{< /ui >}} tab lists every notification rule in your organization. From this page you can:
+
+- Toggle a rule on or off without deleting it
+- Edit a rule's scope, schedule, destination, or name
+- Delete a rule
 
 ## Further reading
 

--- a/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
+++ b/content/en/cloud_cost_management/recommendations/cost_optimization_automation.md
@@ -80,7 +80,7 @@ To set up an automation on a recurring schedule for a recommendation type:
 1. In the {{< ui >}}Set schedule{{< /ui >}} section, select the automation frequency and execution time.
 1. (Optional) Enable the {{< ui >}}Require approval before execution{{< /ui >}} toggle to require human review before execution. If enabled, select {{< ui >}}Slack{{< /ui >}} or {{< ui >}}Microsoft Teams{{< /ui >}}, and fill out the channel notification fields. See [Safeguards](#safeguards).
 1. Enter a name for the automation.
-1. Click {{< ui >}}Save Policy{{< /ui >}}.
+1. Click {{< ui >}}Save Automation{{< /ui >}}.
 
 ### Safeguards
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Cost Optimization Automations page to reflect the new Notification/Remediation tab split:

- Adds a "Set up a notification rule" section covering scope, schedule, Slack destination, and test message for the new Notification tab.
- Expands "Supported recommendation types" from 6 AWS-only entries to the current 16 types across AWS, GCP, and Azure.
- Updates the connection prerequisite/setup steps to reflect centralized connection management via Manage Connections.
- Documents the new Provider / Resource Type / Recommendation Type filters on the Remediation list.
- Renames the page title to plural "Cost Optimization Automations" to match the live UI.

Opened as a draft since the Notification feature (Milestone 1) is still in progress — see the "What's left" table below.

### What's left

| Area | Status | Notes |
|---|---|---|
| Notification rule creation (Save) | Not yet functional | No create/persist endpoint wired up in the UI yet |
| Notification rules list view | Not yet functional | List, enable/disable toggle, and delete are UI stubs |
| Test Notification | Working | Sends a live sample message to the configured Slack channel |
| Notification rule editing | Unknown / not verified | Depends on list view and save landing first |
| Automation form "Save Automation" button label | Verified in code | Confirmed against `CostAutomationConfigurationForm.tsx` |
| Notification form "Save" button label | Verified in code | Confirmed against `NotificationForm.tsx` |
| Remediation-side content in this PR | Verified against current prod UI | Recommendation types, connections, and filters cross-checked against the live app |

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Drafted with Claude Code: researched current UI/behavior against the `web-ui` repo (merged and draft PRs, and component source) to identify documentation drift and draft the new Notification content.

### Additional notes

Do not merge until Notification rule creation and the rules list view are functional in production — several steps in the "Set up a notification rule" section describe UI that isn't wired to a backend yet.