### PR TITLE
[MCPS-591] Update MCP UK1 endpoint URL

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -842,7 +842,7 @@ export default {
     ap1: 'https://mcp.ap1.datadoghq.com/v1/mcp',
     ap2: 'https://mcp.ap2.datadoghq.com/v1/mcp',
     gov2: 'The MCP Server endpoint for US2-FED is not supported.',
-    uk1: 'https://mcp.uk1.datadoghq.com/api/unstable/mcp-server/mcp',
+    uk1: 'https://mcp.uk1.datadoghq.com/v1/mcp',
     gov: 'The MCP Server endpoint for GOV is not supported.'
   },
   cursor_mcp_install_deeplink: {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes MCPS-591

Updates the MCP Server endpoint URL for UK1 from `https://mcp.uk1.datadoghq.com/api/unstable/mcp-server/mcp` to `https://mcp.uk1.datadoghq.com/v1/mcp`.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to update the endpoint URL and open this PR.

### Additional notes