### PR TITLE
[AWSINTS] chore(docs): mention dedicated delivery stream for cloudwatch metrics

### DIFF
--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -164,9 +164,9 @@ To resolve any issues encountered while setting up Metric Streams or the associa
 
 ### Delivery stream contains data from other sources
 
-The delivery stream connected to Datadog must only receive data from your CloudWatch Metric Stream. If any other source of data, such as a CloudWatch log group subscription filter, interacts with the delivery stream, Datadog can't decode the mixed payload data.
+The delivery stream connected to Datadog must receive data only from your CloudWatch Metric Stream. If another source, such as a CloudWatch log group subscription filter, writes to the delivery stream, Datadog can't decode the mixed payload.
 
-To fix this, use a dedicated delivery stream for your CloudWatch Metric Stream, and remove any log subscription filters that target it.
+To fix this, use a dedicated delivery stream for your CloudWatch Metric Stream and remove any log group subscription filters that target it.
 
 ## Further Reading
  {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -162,6 +162,12 @@ Once the resources are deleted, wait for five minutes for Datadog to recognize t
 
 To resolve any issues encountered while setting up Metric Streams or the associated resources, see [AWS Troubleshooting][6].
 
+### Delivery stream contains data from other sources
+
+The delivery stream connected to Datadog must only receive data from your CloudWatch Metric Stream. If any other source of data, such as a CloudWatch log group subscription filter, interacts with the delivery stream, Datadog can't decode the mixed payload data.
+
+To fix this, use a dedicated delivery stream for your CloudWatch Metric Stream, and remove any log subscription filters that target it.
+
 ## Further Reading
  {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
Adds a callout in the AWS Metric Streams documentation about mixed data being streamed to Datadog. We're working on adding a visual aid to customer to diagnose these issues and fix them but would like to have some wording in the public docs to reference