### PR TITLE
[SCRS-2230] Configure source IP forwarding for GCP Service Extensions

### DIFF
--- a/content/en/security/application_security/setup/gcp/service-extensions.md
+++ b/content/en/security/application_security/setup/gcp/service-extensions.md
@@ -144,10 +144,23 @@ The App and API Protection Service Extension deployment requires several compone
     touch main.tf variables.tf
     ```
 
-2. Add the following code to your `main.tf` file. This file defines all the infrastructure components needed for the App and API Protection Service Extension, including network rules, VM instances, and load balancer configuration:
+2. Add the following code to your `main.tf` file. This file defines the `google-beta` provider, network rules, VM instances, and load balancer configuration. Configure `forward_attributes = ["source.ip"]` on the traffic extension to provide the client address observed by the load balancer for App and API Protection client-IP attribution:
 
    ```hcl
    # main.tf
+
+   terraform {
+     required_providers {
+       google-beta = {
+         source  = "hashicorp/google-beta"
+         version = "~> 6.0"
+       }
+     }
+   }
+
+   provider "google-beta" {
+     region = var.region
+   }
 
    #----------------------------------------------------------
    # Network Configuration
@@ -337,16 +350,20 @@ The App and API Protection Service Extension deployment requires several compone
    # GCP Service Extension
    #----------------------------------------------------------
 
-   # GCP Service Extension configuration for traffic interception
-   resource "google_network_services_lb_traffic_extension" "default" {
-     name        = "${var.project_prefix}-service-extension"
-     description = "Datadog App and API Protection Service Extension"
-     location    = "global"
+    # GCP Service Extension configuration for traffic interception
+    resource "google_beta_network_services_lb_traffic_extension" "default" {
+      name        = "${var.project_prefix}-service-extension"
+      description = "Datadog App and API Protection Service Extension"
+      location    = "global"
 
-     load_balancing_scheme = "EXTERNAL_MANAGED"
-     forwarding_rules      = [var.load_balancer_forwarding_rule]
+      load_balancing_scheme = "EXTERNAL_MANAGED"
+      forwarding_rules      = [var.load_balancer_forwarding_rule]
 
-     extension_chains {
+      # Forward source.ip to provide the client address observed by the load balancer
+      # for App & API Protection client-IP attribution.
+      forward_attributes = ["source.ip"]
+
+      extension_chains {
        name = "${var.project_prefix}-service-extension-chain"
 
        match_condition {

--- a/content/en/security/application_security/setup/gcp/service-extensions.md
+++ b/content/en/security/application_security/setup/gcp/service-extensions.md
@@ -153,7 +153,7 @@ The App and API Protection Service Extension deployment requires several compone
      required_providers {
        google-beta = {
          source  = "hashicorp/google-beta"
-         version = "~> 6.0"
+         version = ">= 7.39.0"
        }
      }
    }
@@ -351,7 +351,8 @@ The App and API Protection Service Extension deployment requires several compone
    #----------------------------------------------------------
 
     # GCP Service Extension configuration for traffic interception
-    resource "google_beta_network_services_lb_traffic_extension" "default" {
+    resource "google_network_services_lb_traffic_extension" "default" {
+      provider    = google-beta
       name        = "${var.project_prefix}-service-extension"
       description = "Datadog App and API Protection Service Extension"
       location    = "global"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes SCRS-2230

Updates the GCP Service Extensions Terraform deployment guide to configure `forward_attributes = ["source.ip"]` on `google_network_services_lb_traffic_extension` with `provider = google-beta` and update the required providers configuration to use `google-beta`. This ensures the service extension receives the client IP address observed by the load balancer for App and API Protection client-IP attribution.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
