### PR TITLE
Update FIPS proxy version references to 1.1.29

### DIFF
--- a/content/en/agent/faq/fips_proxy.md
+++ b/content/en/agent/faq/fips_proxy.md
@@ -200,7 +200,7 @@ Ensure you add the `fips-proxy` sidecar container to your ECS task definition an
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.28",
+            "image": "datadog/fips-proxy:1.1.29",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update FIPS proxy version to 1.1.29 to match last release.

### Merge readiness

- [ ] Ready for merge