### PR TITLE
[FFL-2960] Document Contributor access level for feature flag permissions

### DIFF
--- a/content/en/feature_flags/concepts/permissions.md
+++ b/content/en/feature_flags/concepts/permissions.md
@@ -39,10 +39,10 @@ Grant one of the following access levels to individual users, service accounts, 
 | Access level | Description |
 |--------------|-------------|
 | **Viewer** | View the flag. |
-| **Contributor** | View the flag and [submit change suggestions][2] for review. Can't approve or reject suggestions, or manage permissions on the flag. |
+| **Contributor** | View the flag and [submit change suggestions][2] for review. Cannot approve or reject suggestions, or manage permissions on the flag. |
 | **Editor** | View the flag, submit change suggestions for review, and [approve or reject][3] suggested changes. Can also manage permissions on the flag. |
 
-Users without any granular access can still view the flag if they have read permissions at the organization level.
+Users without granular access can still view the flag if they have read permissions at the organization level.
 
 ## Further reading
 

--- a/content/en/feature_flags/concepts/permissions.md
+++ b/content/en/feature_flags/concepts/permissions.md
@@ -30,21 +30,23 @@ Assign these permissions through [Datadog roles][1].
 
 ## Granular access on individual flags
 
-Restrict edit access on a specific flag by selecting **Settings > Permissions** on the flag details page:
+Restrict access on a specific flag by selecting **Settings > Permissions** on the flag details page:
 
 {{< img src="feature_flags/concepts/flag-grace-modal-2.png" alt="Permissions settings panel on a feature flag showing granular access controls for users, service accounts, roles, and teams." style="width:65%;" >}}
 
-You can limit edit access to:
+Grant one of the following access levels to individual users, service accounts, roles, or teams:
 
-- Individual users
-- Service accounts
-- Roles
-- Teams
+| Access level | Description |
+|--------------|-------------|
+| **Viewer** | View the flag. |
+| **Contributor** | View the flag and [submit change suggestions][2] for review. Can't approve or reject suggestions, or manage permissions on the flag. |
+| **Editor** | View the flag, submit change suggestions, and [approve or reject][2] suggested changes. Can also manage permissions on the flag. |
 
-Users without edit access can still view the flag if they have read permissions at the organization level.
+Users without any granular access can still view the flag if they have read permissions at the organization level.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/rbac/
+[2]: /feature_flags/concepts/approvals/#approve-reject-or-apply

--- a/content/en/feature_flags/concepts/permissions.md
+++ b/content/en/feature_flags/concepts/permissions.md
@@ -40,7 +40,7 @@ Grant one of the following access levels to individual users, service accounts, 
 |--------------|-------------|
 | **Viewer** | View the flag. |
 | **Contributor** | View the flag and [submit change suggestions][2] for review. Can't approve or reject suggestions, or manage permissions on the flag. |
-| **Editor** | View the flag, submit change suggestions, and [approve or reject][2] suggested changes. Can also manage permissions on the flag. |
+| **Editor** | View the flag, submit change suggestions for review, and [approve or reject][2] suggested changes. Can also manage permissions on the flag. |
 
 Users without any granular access can still view the flag if they have read permissions at the organization level.
 

--- a/content/en/feature_flags/concepts/permissions.md
+++ b/content/en/feature_flags/concepts/permissions.md
@@ -40,7 +40,7 @@ Grant one of the following access levels to individual users, service accounts, 
 |--------------|-------------|
 | **Viewer** | View the flag. |
 | **Contributor** | View the flag and [submit change suggestions][2] for review. Can't approve or reject suggestions, or manage permissions on the flag. |
-| **Editor** | View the flag, submit change suggestions for review, and [approve or reject][2] suggested changes. Can also manage permissions on the flag. |
+| **Editor** | View the flag, submit change suggestions for review, and [approve or reject][3] suggested changes. Can also manage permissions on the flag. |
 
 Users without any granular access can still view the flag if they have read permissions at the organization level.
 
@@ -49,4 +49,5 @@ Users without any granular access can still view the flag if they have read perm
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/rbac/
-[2]: /feature_flags/concepts/approvals/#approve-reject-or-apply
+[2]: /feature_flags/concepts/approvals/#submit-changes-for-review
+[3]: /feature_flags/concepts/approvals/#approve-reject-or-apply


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes FFL-2960

Adds a **Contributor** access level to the granular per-flag permissions table in [Permissions and Access Control for Feature Flags](/feature_flags/concepts/permissions). Contributors can view a flag and submit change suggestions, but can't approve or reject suggestions or manage permissions on the flag — distinct from the existing Viewer (read-only) and Editor (full edit + approve/reject + manage permissions) levels.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code, based on the Contributor GRACE role implementation in dd-source.

### Additional notes