### PR TITLE
Document status/error fields for external evals

### DIFF
--- a/content/en/llm_observability/evaluations/external_evaluations.md
+++ b/content/en/llm_observability/evaluations/external_evaluations.md
@@ -78,6 +78,26 @@ def llm_call():
     )
 {{< /code-block >}}
 
+### Reporting a failed or skipped evaluation
+
+When an evaluator fails or is skipped, pass `status` and `error` to `LLMObs.submit_evaluation()` instead of a typed value:
+
+- `status`: one of `"OK"`, `"WARN"`, or `"ERROR"`. `"OK"` is the default for a successful evaluation that carries a value. `"WARN"` means the evaluator was skipped, and `"ERROR"` means it failed.
+- `error`: a dict with the fields `type`, `message`, and optionally `stack`. It is required when `status` is `"WARN"` or `"ERROR"`.
+
+When `status` is `"WARN"` or `"ERROR"`, you do not need to provide a typed value such as `score_value` or `categorical_value`. The status and error appear in the **Evaluations** tab on the span.
+
+{{< code-block lang="python" >}}
+LLMObs.submit_evaluation(
+    span=span_context,
+    ml_app="chatbot",
+    label="harmfulness",
+    metric_type="score",
+    status="ERROR",
+    error={"type": "ValueError", "message": "Evaluator crashed"},
+)
+{{< /code-block >}}
+
 
 ## Submitting external evaluations with the API
 
@@ -110,6 +130,34 @@ To submit evaluations for <a href="/llm_observability/instrumentation/otel_instr
           "tags": ["source:otel"],
           "assessment": "pass",
           "reasoning": "it makes sense"
+        }
+      ]
+    }
+  }
+}
+{{< /code-block >}}
+
+For a failed or skipped evaluation, include the `status` and `error` fields instead of a typed value. `status` is one of `"OK"`, `"WARN"`, or `"ERROR"`, and `error` is an object with `type`, `message`, and optionally `stack`. The status and error appear in the **Evaluations** tab on the span.
+
+{{< code-block lang="json" >}}
+{
+  "data": {
+    "type": "evaluation_metric",
+    "id": "456f4567-e89b-12d3-a456-426655440000",
+    "attributes": {
+      "metrics": [
+        {
+          "id": "cdfc4fc7-e2f6-4149-9c35-edc4bbf7b525",
+          "join_on": { "span": { "trace_id": "123", "span_id": "456" } },
+          "ml_app": "weather-bot",
+          "timestamp_ms": 1765990800016,
+          "metric_type": "score",
+          "label": "Accuracy",
+          "status": "ERROR",
+          "error": {
+            "type": "ValueError",
+            "message": "Evaluator crashed before producing a score"
+          }
         }
       ]
     }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"76119c78-c293-4b58-8b63-d8096d89584f","source":"chat","resourceId":"f2a7bcba-60d5-49d2-abda-96e2e8e92c46","workflowId":"3420b838-311d-4110-9fd7-db60ac69e965","codeChangeId":"3420b838-311d-4110-9fd7-db60ac69e965","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The External Evaluations page documented `LLMObs.submit_evaluation()` and the evaluations API JSON format, but did not mention the newly accepted `status` and `error` fields that let a caller report a failed or skipped evaluator run.

This PR documents those fields so customers know what to submit and what they'll see in the Evaluations tab on the span.

Source PR: https://github.com/ddoghq/dd-source/pull/37855

**Changes** (in `content/en/llm_observability/evaluations/external_evaluations.md`):
- Added a "Reporting a failed or skipped evaluation" subsection to the SDK section explaining the `status` (`OK`/`WARN`/`ERROR`) and `error` (`type`/`message`/optional `stack`) fields, with a Python example.
- Added a second JSON example to the API section showing the `status` and `error` fields for a failed evaluation, plus a short explanatory paragraph.

**Testing**: Verified the markdown structure, shortcode fences (`code-block`), and JSON/Python code samples render as valid, consistent additions alongside the existing examples.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Datadog AI agent) based on a specified documentation gap; content reviewed and finalized in-session.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f2a7bcba-60d5-49d2-abda-96e2e8e92c46)

Comment @datadog to request changes