### PR TITLE
[OPA-6142] Document destination buffer reconfiguration

### DIFF
--- a/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
+++ b/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
@@ -63,6 +63,23 @@ This table compares the differences between the memory and disk buffer.
 | Data loss due to an unexpected restart or crash          | All buffered data is lost | All buffered data is retained        |
 | Data loss on graceful shutdown                           | All buffered data is lost | None, all data in the pipeline is flushed to disk before exit  |
 
+### Changing or removing destination buffers
+
+When you update a running pipeline, the Worker handles existing buffered events based on the destination's previous and new buffer configurations. In this table, the same destination means a destination with the same component ID.
+
+| Before | After | Handling of existing buffered events | Data loss or inactive buffer risk |
+| ------- | ----- | ------------------------------------ | --------------------------------- |
+| Destination with a memory or disk buffer | Same destination with an unchanged buffer configuration | The buffer is transferred to the updated destination. The updated destination processes the backlog using its new configuration. | No expected data loss or inactive buffer. If the destination endpoint changed, buffered events are sent to the new endpoint. |
+| Destination with a memory buffer | Same destination with a different memory buffer configuration | The previous destination drains its memory buffer in the background while the updated destination starts with a new buffer. | Events remaining in the previous memory buffer are lost if the Worker stops before the background drain completes. |
+| Destination with a memory buffer | Same destination with a disk buffer | The previous destination drains its memory buffer in the background while the updated destination starts with a new disk buffer. | Events remaining in the previous memory buffer are lost if the Worker stops before the background drain completes. |
+| Destination with a disk buffer | Same destination with a different disk buffer configuration | The updated disk buffer opens the same buffer directory and resumes processing the persisted backlog. | No expected data loss or inactive buffer. |
+| Destination with a disk buffer | Same destination with a memory buffer | The updated destination starts with a new memory buffer. The previous disk backlog remains on disk and is not processed. | The disk buffer becomes inactive. Restore a disk buffer on the same destination to resume processing its persisted events. Treat the events as lost if the disk buffer is not restored. |
+| Destination with a memory buffer | Destination removed | The removed destination drains its memory buffer in the background. | Events remaining in memory are lost if the Worker stops before the background drain completes. |
+| Destination with a disk buffer | Destination removed | The removed destination drains its disk buffer in the background. | A Worker restart before the drain completes leaves the remaining disk buffer inactive. Re-add a disk buffer with the same component ID to resume processing it. |
+| Inactive disk buffer from a removed or changed destination | Disk-buffered destination re-added with the same component ID | The destination opens the existing disk buffer and resumes processing its persisted events. | This recovers the inactive disk backlog. |
+
+Background draining continues only while the same Worker process is running. A pipeline update can complete before a background drain finishes. If the previous destination uses a resource required by the updated pipeline, the update waits for the previous destination to stop.
+
 ### Using buffers with multiple destinations
 
 After your events are sent through your processors, the events go through a fanout to all of your pipeline's destinations. If backpressure propagates to the fanout from any destination, **all** destinations are blocked. No additional events are sent by any destination until the blocked destination resumes sending events successfully.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes OPA-6142

Documents how existing destination-buffer events are handled when a pipeline update changes or removes a destination or its buffer configuration. The new table separates the before and after states and identifies data-loss, restart, and inactive disk-buffer risks.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you’ve already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used AI assistance to trace the existing buffer reload behavior and draft and review the table.

### Additional notes

Vale reports no errors and no new warnings. The existing page has two pre-existing warnings and six pre-existing sentence-length suggestions.