### PR TITLE
[reorg fix] [TEST] New page with nav link, no base conflict (auto-fixable)

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -51,6 +51,10 @@ menu:
       pre: hex-ringed
       parent: essentials_heading
       weight: 10000
+    - name: Example Auto Fix
+      identifier: example_auto_fix_heading
+      url: /getting_started/example_auto_fix/
+      weight: 500000
     - name: Agent
       identifier: getting_started_agent
       url: getting_started/agent/

--- a/hugo/content/en/getting_started/example_auto_fix/_index.md
+++ b/hugo/content/en/getting_started/example_auto_fix/_index.md
@@ -1,0 +1,5 @@
+---
+title: Example Auto Fix
+---
+
+Placeholder page for exercising the astro reorg tooling.


### PR DESCRIPTION
🤖 Auto-generated fix for #38802.

@jhgilbert — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38802. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38802 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38802) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

Test PR for exercising the astro reorg tooling. Adds a new page and a nav menu entry linking to it. The base branch does not touch that menu line, so the auto-fix should replay both changes cleanly.

Do not merge.