### PR TITLE
Clarify auto multi-line before/after example in Overview

### DIFF
--- a/content/en/agent/logs/auto_multiline_detection.md
+++ b/content/en/agent/logs/auto_multiline_detection.md
@@ -17,21 +17,26 @@ algolia:
 ## Overview
 
 Automatic multi-line detection allows the Agent to detect and aggregate common multi-line logs automatically.
-For example, the Agent receives the following lines separately:
+
+For example, an application writes the following five lines. Without Auto multi-line detection, the Agent sends each line as its own log, splitting the exception away from the message that introduced it:
+
+```text
+2024-08-13 17:15:17 INFO Starting request handler             -> log 1
+Exception in thread "main" java.lang.NullPointerException     -> log 2
+    at com.example.MyClass.doSomething(MyClass.java:42)       -> log 3
+    at com.example.MyClass.main(MyClass.java:20)              -> log 4
+2024-08-13 17:15:18 INFO Request handler stopped              -> log 5
 ```
-2024-08-13 17:15:17 INFO Starting request handler
-Exception in thread "main" java.lang.NullPointerException
-    at com.example.MyClass.doSomething(MyClass.java:42)
-    at com.example.MyClass.main(MyClass.java:20)
-2024-08-13 17:15:18 INFO Request handler stopped
-```
-With Auto multi-line detection enabled, the stack trace is aggregated into a single log:
-```
-2024-08-13 17:15:17 INFO Starting request handler
-Exception in thread "main" java.lang.NullPointerException
-    at com.example.MyClass.doSomething(MyClass.java:42)
-    at com.example.MyClass.main(MyClass.java:20)
-2024-08-13 17:15:18 INFO Request handler stopped
+
+With Auto multi-line detection enabled, only lines that begin with a datetime start a new log. The exception and its stack trace are aggregated into the log that precedes them, so the same five lines are sent as two logs:
+
+```text
++- 2024-08-13 17:15:17 INFO Starting request handler
+|  Exception in thread "main" java.lang.NullPointerException
+|      at com.example.MyClass.doSomething(MyClass.java:42)     -> log 1
++-     at com.example.MyClass.main(MyClass.java:20)
+
++- 2024-08-13 17:15:18 INFO Request handler stopped            -> log 2
 ```
 
 ## Getting started


### PR DESCRIPTION
Follow-up to #37889, addressing @Brian-Floersch's review feedback.

### What does this PR do? What is the motivation?

Two fixes to the example in the Overview:

- The "before" and "after" blocks were identical, so the rendered page didn't actually show what aggregation does. The lines are now annotated to show the log count changing from 5 to 2.
- The text said the stack trace is aggregated into "a single log." It's two — the trailing `INFO` line begins with a datetime, so it starts its own log.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to revise the example and draft this description.

### Additional notes

Opened as a new PR since #37889 is already merged. Happy to swap the annotated text blocks for a Logs Explorer screenshot if that reads better.