### PR TITLE
Workload Protection reorg content review 1

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -8570,6 +8570,11 @@ menu:
       parent: security_platform_heading
       identifier: workload_protection
       weight: 70000
+    - name: How it works
+      url: security/workload_protection/how_it_works
+      parent: workload_protection
+      identifier: workload_protection_how_it_works
+      weight: 89
     - name: Setup
       url: security/workload_protection/setup
       parent: workload_protection

--- a/content/en/security/workload_protection/_index.md
+++ b/content/en/security/workload_protection/_index.md
@@ -87,13 +87,9 @@ Workload Protection evaluates runtime activity in two places. Agent rules decide
 
 {{< img src="security/workload_protection/architecture.png" alt="Workload Protection architecture overview" width="100%">}}
 
-For the full model, including how activity is collected on each platform and how response actions run, see [How Workload Protection works][6].
+For the full model, see [How Workload Protection works][6].
 
 ## Next steps
-
-### How it works
-
-Read [How Workload Protection works][6] for the complete model. It covers how the Agent collects activity on each platform, how the detection pipeline evaluates it, and how response actions run.
 
 ### Setup
 

--- a/content/en/security/workload_protection/_index.md
+++ b/content/en/security/workload_protection/_index.md
@@ -77,7 +77,7 @@ Many organizations use Workload Protection across a range of security and operat
 
 - **Runtime Security Posture:** Workload Protection improves your security posture by identifying unsafe runtime practices and sensitive configuration drifts, helping you catch weaknesses before they can be exploited.
 
-- **Infrastructure Monitoring:** Acting as a Swiss army knife for runtime observability, Workload Protection enables teams to track any kind of runtime behavior, whether security-related or not. From debugging custom workloads to monitoring system-level processes and remote user sessions, Workload Protection offers deep, real-time visibility into how your environments operate.
+- **Infrastructure Monitoring:** Workload Protection tracks any kind of runtime behavior, whether security-related or not. From debugging custom workloads to monitoring system-level processes and remote user sessions, it offers real-time visibility into how your environments operate.
 
 {{< img src="security/workload_protection/k8s_remote_access.png" alt="Breakdown of Kubernetes remote user sessions" width="100%">}}
 

--- a/content/en/security/workload_protection/_index.md
+++ b/content/en/security/workload_protection/_index.md
@@ -47,17 +47,31 @@ cascade:
 
 Datadog Workload Protection provides real-time visibility and defense for your infrastructure by continuously monitoring file, network, and process activity across your environments. It detects threats as they occur, helping you identify, investigate, and stop malicious behaviors before they impact your workloads.
 
-### Actionable, prioritized and contextualized threat detection in real-time
+## Key capabilities
+
+### Threat detection
 
 Workload Protection relies on event correlation to surface contextualized and prioritized alerts. As part of the Datadog Security platform, Workload Protection correlates runtime threat detection with findings from misconfiguration scans, vulnerability assessments, and code security. This deep integration enables you to link runtime attacks with preexisting weaknesses, providing the complete context you need to investigate and remediate security incidents. Because Workload Protection is built on the Datadog platform, it also connects with your infrastructure telemetry, including metrics, traces, and logs, so you can understand the scope and impact of threats across your systems. Investigations are enriched with full context, so you can reconstruct the entire attack story from detection to resolution.
 
-### Response and hardening capabilities
+### Out-of-the-box detections
+
+Workload Protection comes out of the box (OOTB) with a comprehensive set of security rules and visibility tools. It includes over 350 agent rules and 200 detection rules, carefully designed to cover most of the MITRE ATT&CK tactics and techniques used by attackers today. This extensive coverage allows teams to detect and mitigate threats across various stages of exploitation, even if they lack the time or specialized expertise to craft detection rules themselves. To complement these detections, the platform provides in-app coverage maps that help users visualize what's deployed, where it's active, and what's protected, for complete and transparent visibility across the entire infrastructure.
+
+### Custom detection logic
+
+For advanced detection and response capabilities, Workload Protection supports custom rule writing, correlation, and automated actions. It supports over 40 event types on Linux and Windows, spanning process, file system, kernel, and network activities. Security teams can define in-agent state machines, enabling contextualized detection logic that triggers alerts only on meaningful and complex indicators of compromise (IOCs).
+
+### Response and hardening
 
 You can also take action directly in Datadog to block malicious behaviors, trigger workflows, or integrate with your existing response pipelines. Whether your goal is to enforce compliance, strengthen your runtime security posture, or address workload hardening use cases, Workload Protection can take action on your behalf to keep your environments secure and resilient.
 
-### Beyond threat detection: expanded use cases
+### Rule and fleet management
 
-Workload Protection is not limited to runtime threat detection. Many organizations use it across a range of security and operational use cases:
+Managing and scaling protection across large environments is simplified with powerful agent fleet and rule management capabilities. Using {{< tooltip glossary="Remote Configuration" case="title" >}}, teams can push agent rules directly from the UI and receive automatic threat definition updates from Datadog to stay current with evolving attack techniques. The platform also offers flexible configuration and customization options through the UI, CLI, or Terraform, allowing security teams to tailor their detection strategy and deployment workflows to their specific operational needs.
+
+## Use cases
+
+Many organizations use Workload Protection across a range of security and operational use cases:
 
 - **Compliance Validation:** Workload Protection helps you validate compliance with regulatory frameworks such as PCI, FedRAMP, and SOC 2 by continuously monitoring runtime activity for policy violations, risky configurations, and unauthorized changes.
 
@@ -67,15 +81,7 @@ Workload Protection is not limited to runtime threat detection. Many organizatio
 
 {{< img src="security/workload_protection/k8s_remote_access.png" alt="Breakdown of Kubernetes remote user sessions" width="100%">}}
 
-### Detection rules, automation, and fleet management
-
-Workload Protection comes out of the box (OOTB) with a comprehensive set of security rules and visibility tools. It includes over 350 agent rules and 200 detection rules, carefully designed to cover most of the MITRE ATT&CK tactics and techniques used by attackers today. This extensive coverage allows teams to detect and mitigate threats across various stages of exploitation, even if they lack the time or specialized expertise to craft detection rules themselves. To complement these detections, the platform provides in-app coverage maps that help users visualize what's deployed, where it's active, and what's protected, for complete and transparent visibility across the entire infrastructure.
-
-For advanced detection and response capabilities, Workload Protection supports custom rule writing, correlation, and automated actions. It supports over 40 event types on Linux and Windows, spanning process, file system, kernel, and network activities. Security teams can define in-agent state machines, enabling contextualized detection logic that triggers alerts only on meaningful and complex indicators of compromise (IOCs).
-
-Managing and scaling protection across large environments is simplified with powerful agent fleet and rule management capabilities. Using {{< tooltip glossary="Remote Configuration" case="title" >}}, teams can push agent rules directly from the UI and receive automatic threat definition updates from Datadog to stay current with evolving attack techniques. The platform also offers flexible configuration and customization options through the UI, CLI, or Terraform, allowing security teams to tailor their detection strategy and deployment workflows to their specific operational needs.
-
-## High level architecture overview
+## How it works
 
 Workload Protection is built on top of the Datadog Agent, which continuously collects real-time runtime telemetry from your workloads. Agent rules determine which security-relevant events are streamed to Datadog for centralized analysis. After they are ingested, these events are processed by backend detection and finding rules, which analyze the data to generate detailed, prioritized Signals or Findings.
 
@@ -87,7 +93,7 @@ Using Remote Configuration, you can manage agent rule deployments and trigger re
 
 ### Setup
 
-Begin with the [Setup][1] guide, which introduces the high-level architecture of Workload Protection. It covers supported environments, how to deploy the Agent, and how to experiment with Workload Protection's features using the playground scripts.
+Begin with the [Setup][1] guide. It covers supported environments, how to deploy the Agent, and how to experiment with Workload Protection's features using the playground scripts.
 
 ### Detect and monitor
 

--- a/content/en/security/workload_protection/_index.md
+++ b/content/en/security/workload_protection/_index.md
@@ -83,13 +83,17 @@ Many organizations use Workload Protection across a range of security and operat
 
 ## How it works
 
-Workload Protection is built on top of the Datadog Agent, which continuously collects real-time runtime telemetry from your workloads. Agent rules determine which security-relevant events are streamed to Datadog for centralized analysis. After they are ingested, these events are processed by backend detection and finding rules, which analyze the data to generate detailed, prioritized Signals or Findings.
-
-Using Remote Configuration, you can manage agent rule deployments and trigger response actions directly in Datadog. In addition, Workload Protection integrates with the Datadog Terraform provider, allowing you to define, version, and maintain your rules as code outside the app.
+Workload Protection evaluates runtime activity in two places. Agent rules decide which system activity the Datadog Agent sends to Datadog. Matching activity becomes an agent event. In Datadog, detection rules turn agent events into signals, and finding rules turn them into findings.
 
 {{< img src="security/workload_protection/architecture.png" alt="Workload Protection architecture overview" width="100%">}}
 
+For the full model, including how activity is collected on each platform and how response actions run, see [How Workload Protection works][6].
+
 ## Next steps
+
+### How it works
+
+Read [How Workload Protection works][6] for the complete model. It covers how the Agent collects activity on each platform, how the detection pipeline evaluates it, and how response actions run.
 
 ### Setup
 
@@ -122,3 +126,4 @@ Use [Coverage][5] to get a unified, real-time view of Workload Protection postur
 [3]: /security/workload_protection/investigate_and_triage
 [4]: /security/workload_protection/respond_and_report
 [5]: /security/workload_protection/inventory
+[6]: /security/workload_protection/how_it_works

--- a/content/en/security/workload_protection/detect_and_monitor/_index.md
+++ b/content/en/security/workload_protection/detect_and_monitor/_index.md
@@ -10,33 +10,13 @@ disable_toc: false
 
 ## Overview
 
-Workload Protection processes multiple feeds to detect threats, evaluate your runtime security posture, and provide granular audit capabilities in your environment. This documentation describes each feed, their purpose, how they interact with each other and how to configure them to implement your own logic.
+Workload Protection evaluates your workload activity against several kinds of rules. Together they detect threats, assess your runtime security posture, and provide granular audit capabilities. Agent rules select which activity reaches Datadog. Detection rules and finding rules analyze that activity. Threat intelligence and Content Packs extend what those rules cover.
 
-## High level architecture
-
-Workload Protection is built on top of the Datadog Agent, which continuously collects runtime telemetry from your workloads. Depending on your environment, this telemetry is collected using eBPF, ptrace, or a Windows driver. Agent rules determine which security-relevant events are streamed to Datadog for centralized analysis. After they are ingested, these events are processed by backend detection and finding rules, which analyze the data to generate detailed and prioritized Signals or Findings.
-
-{{< img src="security/workload_protection/detect_and_monitor/threat_detection_pipeline_2.png" alt="Workload Protection detection architecture overview" width="100%">}}
-
-Workload Protection uses the following pipeline to protect your workloads:
-
-1. The [Agent rules][1] evaluate system activity on the Agent host.
-2. When activity matches an Agent rule expression, the Agent generates an [Agent Event][2] and passes it to the Datadog backend.
-3. The Datadog backend evaluates the agent events to see if they match any threat [Detection rules][11] or [Finding rules][12].
-4. If a detection rule matches, a signal is generated and displayed in [Signals][5].
-5. If a finding rule matches, a finding is generated and displayed in [Findings][6].
-6. If the value of one of the attributes of an agent event matches a [threat intelligence indicator][7], a signal is generated and displayed in [Signals][5].
-7. Any [Notification Rules][8] that match the severity, detection rule type, tags, and attributes of the generated signal are triggered.
-
-### Saving resources by design
-
-Workload Protection detection rules are complex, correlating several datapoints across time and processes. This complexity would result in considerable compute resource demands on the Agent host if all rules were evaluated there.
-
-Datadog solves this problem by keeping the Agent lightweight with efficient rules that filter out all non security relevant activity from your workloads, and processes the rest using the threat detection and finding rules on the Datadog backend. You can learn more about this process in the dedicated [Agent rules][1] page.
+For how these rules fit together in the detection pipeline, see [How Workload Protection works][19].
 
 ## Agent rules
 
-[Agent rules][1] define which system activity is sent to the Datadog backend for further analysis. The section covers:
+[Agent rules][1] define which system activity is sent to the Datadog backend for further analysis:
 - [SecL guide][15] for writing custom agent rules with the SecL expression language
 - [Policy management][9] for deploying custom and default agent rules
 - [Variables and actions][16] for stateful detections and additional telemetry collection
@@ -44,7 +24,7 @@ Datadog solves this problem by keeping the Agent lightweight with efficient rule
 
 ## Detection and finding rules
 
-[Detection and finding rules][3] describe the backend logic used to analyze [Agent events][2] and generate [signals][5] or [findings][6]. The section covers:
+[Detection and finding rules][3] describe the backend logic used to analyze [Agent events][2] and generate [signals][5] or [findings][6]:
 - [Detection rules][11] for threat detection and incident response
 - [Finding rules][12] for runtime posture and hardening
 - [Linux backend syntax][13] and [Windows backend syntax][14] for the full set of queryable event fields
@@ -65,11 +45,9 @@ Workload Protection provides targeted, Datadog-crafted [Content Packs][10] built
 [1]: /security/workload_protection/detect_and_monitor/agent_rules
 [2]: /security/workload_protection/investigate_and_triage/agent_events
 [3]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules
-[4]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules/finding_rules
 [5]: /security/workload_protection/investigate_and_triage/security_signals
 [6]: /security/workload_protection/investigate_and_triage/security_findings
 [7]: /security/workload_protection/detect_and_monitor/threat_intelligence
-[8]: /security/notifications/rules
 [9]: /security/workload_protection/detect_and_monitor/agent_rules/policy_management
 [10]: /security/workload_protection/detect_and_monitor/content_packs
 [11]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules/detection_rules
@@ -80,3 +58,4 @@ Workload Protection provides targeted, Datadog-crafted [Content Packs][10] built
 [16]: /security/workload_protection/detect_and_monitor/agent_rules/variables_and_actions
 [17]: /security/workload_protection/linux_expressions
 [18]: /security/workload_protection/windows_expressions
+[19]: /security/workload_protection/how_it_works

--- a/content/en/security/workload_protection/detect_and_monitor/_index.md
+++ b/content/en/security/workload_protection/detect_and_monitor/_index.md
@@ -10,7 +10,7 @@ disable_toc: false
 
 ## Overview
 
-Workload Protection evaluates your workload activity against several kinds of rules. Together they detect threats, assess your runtime security posture, and provide granular audit capabilities. Agent rules select which activity reaches Datadog. Detection rules and finding rules analyze that activity. Threat intelligence and Content Packs extend what those rules cover.
+Workload Protection evaluates your workload activity against several kinds of rules. Together they detect threats, assess your runtime security posture, and provide granular audit capabilities. Agent rules select which activity reaches Datadog. Detection rules and finding rules analyze that activity. Threat intelligence enriches it with reputation context, and Content Packs bundle optional rules for specific software stacks and threat vectors.
 
 For how these rules fit together in the detection pipeline, see [How Workload Protection works][19].
 

--- a/content/en/security/workload_protection/how_it_works.md
+++ b/content/en/security/workload_protection/how_it_works.md
@@ -22,7 +22,7 @@ Workload Protection detects threats and evaluates runtime security posture by co
 The Datadog Agent collects runtime activity from your workloads. The collection mechanism depends on the platform:
 
 - **Linux**: the eBPF Agent, which offers the broadest feature support.
-- **AWS Fargate**: the eBPF-less Agent. Fargate does not provide eBPF access, so this Agent uses ptrace instead. It covers File Integrity Monitoring and process execution monitoring.
+- **AWS Fargate**: the eBPF-less Agent. Fargate does not provide eBPF access, so this Agent uses ptrace instead. It covers the major Workload Protection features, including File Integrity Monitoring and process execution monitoring.
 - **Windows**: a Windows driver.
 
 For the distributions, versions, and cloud environments each one supports, see [Setting up Workload Protection][9].
@@ -58,9 +58,14 @@ Both depend on enforcement being enabled in the Agent. See [Respond and Report][
 
 ## Managing rules and policies
 
-Agent rules are grouped into [policies][11]. Datadog delivers policies to your Agents using {{< tooltip glossary="Remote Configuration" case="title" >}}, so you can change which rules are active without redeploying the Agent. Datadog ships updates to its own threat definitions through the same channel.
+Agent rules are organized in [policies][11]. A policy is a set of rules that you deploy together and scope to specific infrastructure using tags.
 
-You can manage rules and policies from the Datadog UI, the CLI, or the Datadog Terraform provider. The Terraform provider lets you define and version your rules as code outside the app.
+You deploy a policy in one of two ways:
+
+- **{{< tooltip glossary="Remote Configuration" case="title" >}}**: Datadog delivers the policy to the Agents that its tags target, so you can change which rules are active without touching the host. Datadog ships updates to its own managed policies through the same channel.
+- **Manual deployment**: you install the policy file on each Agent yourself, then reload the runtime policies or restart the Agent.
+
+You can manage rules and policies in the Datadog UI, in Agent configuration files, or with the Datadog Terraform provider. The Terraform provider lets you define and version your rules as code outside the app.
 
 ## Further reading
 

--- a/content/en/security/workload_protection/how_it_works.md
+++ b/content/en/security/workload_protection/how_it_works.md
@@ -1,0 +1,79 @@
+---
+title: How Workload Protection works
+disable_toc: false
+further_reading:
+- link: "/security/workload_protection/setup"
+  tag: "Documentation"
+  text: "Setting up Workload Protection"
+- link: "/security/workload_protection/detect_and_monitor/agent_rules"
+  tag: "Documentation"
+  text: "Agent rules"
+- link: "/security/workload_protection/detect_and_monitor/detection_and_finding_rules"
+  tag: "Documentation"
+  text: "Detection and finding rules"
+---
+
+Workload Protection detects threats and evaluates runtime security posture by collecting activity from your workloads. It evaluates that activity in two places: on the Datadog Agent, and in Datadog.
+
+[Agent rules][1] decide which system activity the Agent sends to Datadog. Matching activity becomes an [agent event][2]. In Datadog, [detection rules][3] turn agent events into [signals][5], and [finding rules][4] turn them into [findings][6]. [Notification rules][7] route signals to your team. [Response actions][10], which run in the Agent, stop the activity.
+
+## Collecting runtime activity
+
+The Datadog Agent collects runtime activity from your workloads. The collection mechanism depends on the platform:
+
+- **Linux**: the eBPF Agent, which offers the broadest feature support.
+- **AWS Fargate**: the eBPF-less Agent. Fargate does not provide eBPF access, so this Agent uses ptrace instead. It covers File Integrity Monitoring and process execution monitoring.
+- **Windows**: a Windows driver.
+
+For the distributions, versions, and cloud environments each one supports, see [Setting up Workload Protection][9].
+
+## Evaluating activity
+
+{{< img src="security/workload_protection/detect_and_monitor/threat_detection_pipeline_2.png" alt="Workload Protection detection architecture overview" width="100%">}}
+
+Workload Protection uses the following pipeline to protect your workloads:
+
+1. The [Agent rules][1] evaluate system activity on the Agent host.
+2. When activity matches an Agent rule expression, the Agent generates an [Agent Event][2] and passes it to the Datadog backend.
+3. The Datadog backend evaluates the agent events to see if they match any threat [Detection rules][3] or [Finding rules][4].
+4. If a detection rule matches, a signal is generated and displayed in [Signals][5].
+5. If a finding rule matches, a finding is generated and displayed in [Findings][6].
+6. If the value of one of the attributes of an agent event matches a [threat intelligence indicator][8], a signal is generated and displayed in [Signals][5].
+7. Any [Notification Rules][7] that match the severity, detection rule type, tags, and attributes of the generated signal are triggered.
+
+### Why evaluation is split between the Agent and Datadog
+
+Workload Protection detection rules are complex, correlating several datapoints across time and processes. Evaluating all of them on the Agent host would place considerable demand on that host's compute resources.
+
+Datadog keeps the Agent lightweight instead. The Agent runs efficient rules that filter out activity that is not security relevant, and Datadog evaluates the rest with detection and finding rules. For more detail on this division, see [Agent rules][1].
+
+## Responding to threats
+
+Response actions run in the Agent. The Agent can terminate a process or container, or block network traffic using an eBPF-based filter. You can trigger these actions two ways:
+
+- **Automated response** attaches an action to an Agent rule, so the Agent acts as soon as the rule matches.
+- **Response** lets you act manually from a signal after it is generated.
+
+Both depend on enforcement being enabled in the Agent. See [Respond and Report][10].
+
+## Managing rules and policies
+
+Agent rules are grouped into [policies][11]. Datadog delivers policies to your Agents using {{< tooltip glossary="Remote Configuration" case="title" >}}, so you can change which rules are active without redeploying the Agent. Datadog ships updates to its own threat definitions through the same channel.
+
+You can manage rules and policies from the Datadog UI, the CLI, or the Datadog Terraform provider. The Terraform provider lets you define and version your rules as code outside the app.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /security/workload_protection/detect_and_monitor/agent_rules
+[2]: /security/workload_protection/investigate_and_triage/agent_events
+[3]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules/detection_rules
+[4]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules/finding_rules
+[5]: /security/workload_protection/investigate_and_triage/security_signals
+[6]: /security/workload_protection/investigate_and_triage/security_findings
+[7]: /security/notifications/rules
+[8]: /security/workload_protection/detect_and_monitor/threat_intelligence
+[9]: /security/workload_protection/setup
+[10]: /security/workload_protection/respond_and_report
+[11]: /security/workload_protection/detect_and_monitor/agent_rules/policy_management

--- a/content/en/security/workload_protection/inventory/_index.md
+++ b/content/en/security/workload_protection/inventory/_index.md
@@ -14,7 +14,9 @@ further_reading:
     text: "Review your Workload Protection coverage with the Coverage map"
 ---
 
-Workload Protection [Coverage][1] provides a real-time view of security coverage across your hosts, ECS Fargate, and EKS Fargate workloads. Use Coverage to assess protection posture, identify gaps, and take action on unprotected or misconfigured workloads.
+Workload Protection [Coverage][1] provides a real-time view of security coverage across your hosts, ECS Fargate, and EKS Fargate workloads. Use Coverage to assess protection posture, identify gaps, and act on unprotected or misconfigured workloads.
+
+Coverage reflects which Agents are reporting and which policies reached them. For how policies are delivered, see [How Workload Protection works][5].
 
 {{< img src="security/workload_protection/coverage/coverage_map.png" alt="Use the Coverage page to get real-time visibility into Workload Protection status across all your resources and see which policies are applied" width="100%">}}
 
@@ -156,3 +158,4 @@ As an example of how to use Coverage to triage and respond to coverage issues, h
 [2]: /security/detection_rules/#mitre-attck-map
 [3]: /security/workload_protection/setup/
 [4]: /security/workload_protection/detect_and_monitor/detection_and_finding_rules/detection_rules
+[5]: /security/workload_protection/how_it_works

--- a/content/en/security/workload_protection/inventory/_index.md
+++ b/content/en/security/workload_protection/inventory/_index.md
@@ -16,7 +16,7 @@ further_reading:
 
 Workload Protection [Coverage][1] provides a real-time view of security coverage across your hosts, ECS Fargate, and EKS Fargate workloads. Use Coverage to assess protection posture, identify gaps, and act on unprotected or misconfigured workloads.
 
-Coverage reflects which Agents are reporting and which policies reached them. For how policies are delivered, see [How Workload Protection works][5].
+Coverage reflects whether the policies and agent rules on each resource loaded successfully. For how policies reach your Agents, see [How Workload Protection works][5].
 
 {{< img src="security/workload_protection/coverage/coverage_map.png" alt="Use the Coverage page to get real-time visibility into Workload Protection status across all your resources and see which policies are applied" width="100%">}}
 

--- a/content/en/security/workload_protection/investigate_and_triage/_index.md
+++ b/content/en/security/workload_protection/investigate_and_triage/_index.md
@@ -3,7 +3,9 @@ title: Investigate and Triage
 disable_toc: false
 ---
 
-Use the explorers and in-app views in Workload Protection to investigate runtime activity, triage threats, and review security posture findings.
+As Workload Protection evaluates runtime activity, it produces agent events, signals, and findings. Use the explorers and in-app views to investigate that activity, triage threats, and review security posture findings.
+
+For how each one is produced, see [How Workload Protection works][4].
 
 ## Agent events
 
@@ -25,3 +27,4 @@ Use the explorers and in-app views in Workload Protection to investigate runtime
 [1]: /security/workload_protection/investigate_and_triage/agent_events
 [2]: /security/workload_protection/investigate_and_triage/security_signals
 [3]: /security/workload_protection/investigate_and_triage/security_findings
+[4]: /security/workload_protection/how_it_works

--- a/content/en/security/workload_protection/respond_and_report/_index.md
+++ b/content/en/security/workload_protection/respond_and_report/_index.md
@@ -24,7 +24,7 @@ further_reading:
   text: "Detect Host and Container Compromises with Workload Protection"
 ---
 
-Workload Protection can act on the threats it detects. The Datadog Agent terminates processes and containers or blocks network traffic, either automatically when an Agent rule matches or manually when you respond to a signal. Both paths require enforcement to be enabled in the Agent.
+Workload Protection can act on the threats it detects. The Datadog Agent terminates processes and containers or blocks network traffic, either automatically when an Agent rule matches or manually when you respond to a signal. Both paths depend on enforcement in the Agent, which is enabled by default.
 
 For where response sits in the detection pipeline, see [How Workload Protection works][7].
 

--- a/content/en/security/workload_protection/respond_and_report/_index.md
+++ b/content/en/security/workload_protection/respond_and_report/_index.md
@@ -24,7 +24,9 @@ further_reading:
   text: "Detect Host and Container Compromises with Workload Protection"
 ---
 
-After Workload Protection surfaces runtime risk through Agent events, signals, and findings, **Respond and Report** is where you configure enforcement, drive response, and measure outcomes.
+Workload Protection can act on the threats it detects. The Datadog Agent terminates processes and containers or blocks network traffic, either automatically when an Agent rule matches or manually when you respond to a signal. Both paths require enforcement to be enabled in the Agent.
+
+For where response sits in the detection pipeline, see [How Workload Protection works][7].
 
 ## Enable enforcement
 
@@ -152,4 +154,4 @@ When a response action runs, the Agent reports a **status** for each action. The
 [4]: /security/workload_protection/setup/advanced_configuration
 [5]: /account_management/rbac/permissions
 [6]: /security/workload_protection/investigate_and_triage/security_signals
-[7]: /security/workload_protection/setup/kubernetes
+[7]: /security/workload_protection/how_it_works

--- a/content/en/security/workload_protection/setup/_index.md
+++ b/content/en/security/workload_protection/setup/_index.md
@@ -9,7 +9,11 @@ disable_toc: false
 
 {{< partial name="security-platform/WP-billing-note.html" >}}
 
-This page guides you through the process of enabling Workload Protection in your environment. Start by activating Workload Protection in Datadog, then deploy the Datadog Agent to begin collecting runtime telemetry. After setup is complete, you can explore Workload Protection's capabilities using the playground scripts. Optionally, you can also request access to enforcement capabilities to take automated response actions directly with the Datadog platform.
+Workload Protection collects runtime activity through the Datadog Agent. Setting it up means enabling the product in Datadog, then deploying the Agent to the workloads you want to protect.
+
+After the Agent is running, you can try Workload Protection safely using the playground scripts. Enforcement, which lets the Agent act on the threats it detects, requires separate access.
+
+For what happens to the activity the Agent collects, see [How Workload Protection works][6].
 
 ## 1) Enable Workload Protection in Datadog
 
@@ -113,3 +117,4 @@ The [advanced Agent configuration page][5] describes how to configure and tune t
 [3]: https://github.com/DataDog/datadog-security-playground
 [4]: /security/workload_protection/respond_and_report/#automated-response
 [5]: /security/workload_protection/setup/advanced_configuration
+[6]: /security/workload_protection/how_it_works


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

First of several content review PRs on the Workload Protection docs, split up to keep each one small. This one covers the overview page, the five section landing pages, and one new page.

| What changed | Why |
|---|---|
| Added a new page, **How Workload Protection works**, and put it in the left nav above Setup | The explanation of how the product works was spread across eight spots on five pages, so there was nowhere to send a reader who just wants the model. The new page holds the collection mechanisms per platform, the detection pipeline, why evaluation splits between the Agent and Datadog, how response actions run, and how policies reach Agents. |
| Deleted the architecture explanation from the overview page and from Detect and Monitor | Both carried a near-identical paragraph, and the two copies had already drifted apart in wording. That content moved to the new page. The overview keeps a short version naming the pieces in order, plus the diagram. Detect and Monitor links out. |
| Reorganized the overview page under new headings | Moves existing headings only, no rewriting. The four capability sections moved under a new **Key capabilities** heading. The rule management section split into three at its existing paragraph breaks. "Beyond threat detection: expanded use cases" became **Use cases**. "High level architecture overview" became **How it works**. |
| Rewrote the opening paragraph on Setup, Detect and Monitor, Investigate and Triage, Respond and Report, and Coverage | Each page opened differently, and several described the documentation instead of the product: "This page guides you through the process of...", "This documentation describes each feed...", "**Respond and Report** is where you...". Each now says what the subject is in product terms and links once to How Workload Protection works. |
| Removed the "Swiss army knife" metaphor from the Infrastructure Monitoring use case | Reads as marketing and doesn't tell the reader anything. |
| Small cleanups | Removed two unused link definitions, one of which pointed at a page it never linked. Changed "take action on" to "act on" in Coverage to clear a Vale warning. |

No content was deleted outright except the duplicated architecture paragraphs. Everything else moved.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.