### PR TITLE
[DOCS-15327] Make App and API Protection naming consistent

### DIFF
--- a/content/en/getting_started/security/application_security.md
+++ b/content/en/getting_started/security/application_security.md
@@ -19,7 +19,7 @@ further_reading:
   text: "Security research, reports, tips, and videos from Datadog"
 - link: "https://learn.datadoghq.com/courses/app-protection-block-attacks"
   tag: "Learning Center"
-  text: "Block Application Attacks with Application & API Protection"
+  text: "Block Application Attacks with App and API Protection"
 site_support_id: application_security_override
 
 ---

--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -36,7 +36,7 @@ further_reading:
   text: "Mitigate account takeovers with Datadog App and API Protection"
 - link: "https://learn.datadoghq.com/courses/app-protection-block-attacks"
   tag: "Learning Center"
-  text: "Block Application Attacks with Application & API Protection"
+  text: "Block Application Attacks with App and API Protection"
 algolia:
   tags: ["asm", "App and API Protection"]
 site_support_id: application_security_override
@@ -60,7 +60,7 @@ AI Guard is in Preview. Get real-time security guardrails for your AI apps and a
 
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 
-**App & API Protection (AAP)** provides unified visibility and security for your applications and APIs, helping you detect, investigate, and prevent threats across modern workloads.
+**App and API Protection (AAP)** provides unified visibility and security for your applications and APIs, helping you detect, investigate, and prevent threats across modern workloads.
 
 Whether you're defending public-facing APIs, internal services, or user-facing applications, AAP equips your teams with realtime OOTB threat detection, posture assessment, and in-app protections.
 
@@ -97,11 +97,11 @@ If you're curious how App and API Protection is structured and how it uses traci
 
 Powered by provided [out-of-the-box rules][4], AAP detects threats without manual configuration. If you already have Datadog [APM][1] configured on a physical or virtual host, [setup][16] only requires setting one environment variable to get started.
 
-To start configuring your environment to detect and protect threats with AAP, follow the enabling documentation for each product. Once AAP is configured, you can begin investigating and remediating security signals in the [Security Signals Explorer][6].
+To start configuring your environment to detect and protect threats with AAP, follow the enabling documentation for each product. Once AAP is configured, you can begin investigating and remediating security signals in the [{{< ui >}}Security Signals Explorer{{< /ui >}}][6].
 
 ## Investigate and remediate security signals
 
-In the [Security Signals Explorer][6], click on any security signal to see what happened and the suggested steps to mitigate the attack. In the same panel, view traces with their correlated attack flow and request information to gain further context.
+In the [{{< ui >}}Security Signals Explorer{{< /ui >}}][6], click on any security signal to see what happened and the suggested steps to mitigate the attack. In the same panel, view traces with their correlated attack flow and request information to gain further context.
 
 ## Exploit Prevention vs. In-App WAF
 

--- a/content/en/security/application_security/api_posture/api_findings.md
+++ b/content/en/security/application_security/api_posture/api_findings.md
@@ -13,11 +13,11 @@ The [API Findings][1] explorer provides a central triage view of the API risks d
 
 **API Findings** columns:
 
-- **Severity:** Each issue is ranked by risk.
-- **Endpoints:** Shows how many endpoints are affected and their services.
-- **Status and Ticketing:** `Open` or `In Progress` tracks remediation progress and workflow integration.
+- {{< ui >}}Severity{{< /ui >}}: Each issue is ranked by risk.
+- {{< ui >}}Endpoints{{< /ui >}}: Shows how many endpoints are affected and their services.
+- {{< ui >}}Status and Ticketing{{< /ui >}}: `Open` or `In Progress` tracks remediation progress and workflow integration.
 
-Use the **Service** facet to see each service's endpoints to identify ownership and prioritize by business impact.
+Use the {{< ui >}}Service{{< /ui >}} facet to see each service's endpoints to identify ownership and prioritize by business impact.
 
 ## Common operations
 
@@ -40,12 +40,12 @@ Click a finding to view its details and perform a workflow such as Validate > In
 
 Datadog API Posture uses [Bits Code][3] to generate code fixes for vulnerabilities.
 
-1. In Datadog, navigate to [**Security** > **App & API Protection** > **Findings**][1].
+1. In Datadog, navigate to [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Findings{{< /ui >}}][1].
 2. Select a finding to open a side panel with details about the finding and the affected endpoint.
-3. In the **Next Steps** > **Remediation** section, click **Fix with Bits**.
+3. In the {{< ui >}}Next Steps{{< /ui >}} > {{< ui >}}Remediation{{< /ui >}} section, click {{< ui >}}Fix with Bits{{< /ui >}}.
 
 This opens a Bits Code session to fix this single API finding. You can review the proposed diff, ask follow-up questions, edit the patch, and create a pull request to apply the remediation to your source code repository.
-View all Bits Code sessions on **Bits AI** > **Bits Code** > [**Sessions**][4].
+View all Bits Code sessions on {{< ui >}}Bits AI{{< /ui >}} > {{< ui >}}Bits Code{{< /ui >}} > [{{< ui >}}Sessions{{< /ui >}}][4].
 
 ### Remediation session details
 
@@ -54,11 +54,11 @@ Each Bits Code session shows the life cycle of an AI-generated fix so you can re
 - The original security finding and proposed code change
 - An explanation of how and why Bits Code generated the fix
 - CI results (if enabled) to validate the patch is safe to deploy
-- Options to refine the fix or **Create PR** to apply the changes to your source code repository
+- Options to refine the fix or {{< ui >}}Create PR{{< /ui >}} to apply the changes to your source code repository
 
-To open the remediation session, select the API finding from the [**Findings**][1] page to open the side panel, scroll to the **Remediation** section, and select **Expand & Chat**.
+To open the remediation session, select the API finding from the [{{< ui >}}Findings{{< /ui >}}][1] page to open the side panel, scroll to the {{< ui >}}Remediation{{< /ui >}} section, and select {{< ui >}}Expand & Chat{{< /ui >}}.
 
-You can also view all remediation sessions on [**Sessions**][4].
+You can also view all remediation sessions on [{{< ui >}}Sessions{{< /ui >}}][4].
 
 [1]: https://app.datadoghq.com/security/appsec/inventory/finding
 [2]: /security/application_security/policies/custom_rules/

--- a/content/en/security/application_security/api_posture/api_inventory/_index.md
+++ b/content/en/security/application_security/api_posture/api_inventory/_index.md
@@ -19,8 +19,8 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Inventory consists of two explorers:
 
-- **[API Endpoints][2]**: The API Endpoints explorer catalogs your individual endpoints, surfacing shadow APIs (undocumented endpoints with no API definition and not detected from Amazon API Gateway) and orphan APIs (documented endpoints without traffic), and helps you prioritize the endpoints most at risk.
-- **[Services][3]**: The Services explorer aggregates findings, vulnerabilities, and runtime signals by service, so you can assess each service's risk and security coverage.
+- [{{< ui >}}API Endpoints{{< /ui >}}][2]: The API Endpoints explorer catalogs your individual endpoints, surfacing shadow APIs (undocumented endpoints with no API definition and not detected from Amazon API Gateway) and orphan APIs (documented endpoints without traffic), and helps you prioritize the endpoints most at risk.
+- [{{< ui >}}Services{{< /ui >}}][3]: The Services explorer aggregates findings, vulnerabilities, and runtime signals by service, so you can assess each service's risk and security coverage.
 
 To detect and respond to weaknesses, attacks, or misconfigurations on these endpoints, use [API Findings][4]. In the API Endpoints explorer, each row displays a findings chip that opens the related finding in API Findings.
 

--- a/content/en/security/application_security/api_posture/api_inventory/api_endpoints.md
+++ b/content/en/security/application_security/api_posture/api_inventory/api_endpoints.md
@@ -11,15 +11,15 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 The [API Endpoints][1] explorer monitors your API traffic to provide visibility into the security posture of your APIs, including:
 
-- **Authentication**: Whether the API enforces authentication.
-- **Authentication Method**: Type of authentication used, such as Basic Auth and API key.
-- **Public Exposure**: Whether the API is processing traffic from the internet.
-- **Sensitive data flows**: Sensitive data handled by the API, and the flows between APIs.
-- **Attack Exposure**: If the endpoint is targeted by attacks.
-- **Business Logic**: Business logic and associated business logic suggestions for this API.
-- **Vulnerabilities**: If the endpoint contains a vulnerability (powered by [Code Security][2] and [Software Composition Analysis][3]).
-- **Findings**: Security findings identified on this API.
-- **Dependencies**: APIs and Databases the API depends on.
+- {{< ui >}}Authentication{{< /ui >}}: Whether the API enforces authentication.
+- {{< ui >}}Authentication Method{{< /ui >}}: Type of authentication used, such as Basic Auth and API key.
+- {{< ui >}}Public Exposure{{< /ui >}}: Whether the API is processing traffic from the internet.
+- {{< ui >}}Sensitive data flows{{< /ui >}}: Sensitive data handled by the API, and the flows between APIs.
+- {{< ui >}}Attack Exposure{{< /ui >}}: If the endpoint is targeted by attacks.
+- {{< ui >}}Business Logic{{< /ui >}}: Business logic and associated business logic suggestions for this API.
+- {{< ui >}}Vulnerabilities{{< /ui >}}: If the endpoint contains a vulnerability (powered by [Code Security][2] and [Software Composition Analysis][3]).
+- {{< ui >}}Findings{{< /ui >}}: Security findings identified on this API.
+- {{< ui >}}Dependencies{{< /ui >}}: APIs and Databases the API depends on.
 
 Using API Endpoints you can:
 
@@ -141,13 +141,13 @@ API Posture builds an OpenAPI schema for each endpoint from the traffic it obser
 
 ### View an endpoint's schema
 
-In [API Endpoints][1], click an endpoint to open its detail panel. The **Definition** section displays the endpoint's request parameters, request body, and responses. Fields that contain sensitive data are marked with the type of sensitive data observed.
+In [API Endpoints][1], click an endpoint to open its detail panel. The {{< ui >}}Definition{{< /ui >}} section displays the endpoint's request parameters, request body, and responses. Fields that contain sensitive data are marked with the type of sensitive data observed.
 
 {{< img src="/security/application_security/api/api_endpoint_definition_schema_cropped.png" alt="The Definition section of an endpoint's detail panel, showing its request parameters and the View Raw Schema and View Inferred Schemas buttons" style="width:100%;" >}}
 
-When the endpoint is associated with an API in Datadog Software Catalog, the **Definition** section displays the declared OpenAPI specification. Otherwise, it displays the schema inferred from live traffic.
+When the endpoint is associated with an API in Datadog Software Catalog, the {{< ui >}}Definition{{< /ui >}} section displays the declared OpenAPI specification. Otherwise, it displays the schema inferred from live traffic.
 
-In the **Definition** section, you can:
+In the {{< ui >}}Definition{{< /ui >}} section, you can:
 
 - {{< ui >}}View Raw Schema{{< /ui >}}: View the displayed schema as raw YAML.
 - {{< ui >}}View Inferred Schemas{{< /ui >}}: View the schema inferred from live traffic as a preview or YAML, even when a declared schema is available. The inferred schema can be exported as an OpenAPI file in YAML or JSON.

--- a/content/en/security/application_security/api_posture/compliance.md
+++ b/content/en/security/application_security/api_posture/compliance.md
@@ -47,11 +47,11 @@ The OWASP API Security Top 10 identifies the most critical security risks for AP
 
 - **Detection rules**: Each Datadog API security detection rule is tagged with the OWASP controls it covers. When a rule fires and generates a finding, the associated control is marked as **failing** for the affected service.
 - **Posture score**: The posture score reflects the ratio of controls that are fully passing versus those with at least one failing finding. The score is calculated using the same methodology as [Cloud Security posture scores][3].
-- **Compliance Frameworks page**: The [Compliance Frameworks page][4] lists all available frameworks for your API security context. For each framework you can examine control-level details, filter by severity, and open a finding side panel to investigate individual API security events.
+- **Compliance Frameworks page**: The [{{< ui >}}Compliance Frameworks{{< /ui >}} page][4] lists all available frameworks for your API security context. For each framework you can examine control-level details, filter by severity, and open a finding side panel to investigate individual API security events.
 
 ## View your compliance posture
 
-Navigate to [**Security > App & API Protection > Compliance**][4] to open the Compliance Frameworks page. You can:
+Navigate to [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Compliance{{< /ui >}}][4] to open the Compliance Frameworks page. You can:
 - Select a framework (for example, OWASP API Security Top 10) to see per-control pass/fail status.
 - Click a failing control to view the list of API security findings that caused it to fail.
 - Open a finding's side panel to see the affected endpoint, severity, and recommended remediation steps.

--- a/content/en/security/application_security/api_posture/endpoint_scanning.md
+++ b/content/en/security/application_security/api_posture/endpoint_scanning.md
@@ -21,10 +21,10 @@ Endpoint Scanning sends only `GET` requests. It does not call `POST`, `PUT`, `PA
 
 For each scanned endpoint, Datadog records:
 
-- **Authentication status**: Whether the endpoint requires authentication.
-- **Public visibility**: Whether the endpoint is reachable without credentials.
-- **HTTP response status**: The status code returned by the endpoint.
-- **Last evaluation timestamp**: When the endpoint was last scanned.
+- {{< ui >}}Authentication status{{< /ui >}}: Whether the endpoint requires authentication.
+- {{< ui >}}Public visibility{{< /ui >}}: Whether the endpoint is reachable without credentials.
+- {{< ui >}}HTTP response status{{< /ui >}}: The status code returned by the endpoint.
+- {{< ui >}}Last evaluation timestamp{{< /ui >}}: When the endpoint was last scanned.
 
 Use this information to prioritize exposed endpoints, confirm whether important APIs enforce authentication, and investigate API findings with stronger evidence about how the endpoint behaves.
 
@@ -32,7 +32,7 @@ Use this information to prioritize exposed endpoints, confirm whether important 
 
 Endpoint Scanning is off by default. To enable it:
 
-1. In App and API Protection settings, go to [API Security Testing][3].
+1. In App and API Protection settings, go to [{{< ui >}}API Security Testing{{< /ui >}}][3].
 2. Toggle {{< ui >}}Enable Endpoint Scanning{{< /ui >}} on.
 
 After you enable it, Datadog scans eligible endpoints in the background in batches. Endpoints are retested approximately every seven days.

--- a/content/en/security/application_security/api_posture/overview.md
+++ b/content/en/security/application_security/api_posture/overview.md
@@ -16,33 +16,33 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 </div>
 {{< /site-region >}}
 
-The **API Posture** overview page gives you a security-focused view of your API estate. It surfaces how well your endpoints are covered, the open findings affecting them, the endpoints most exposed to risk, and the policies that protect them. The following sections describe each area of the page.
+The {{< ui >}}API Posture{{< /ui >}} overview page gives you a security-focused view of your API estate. It surfaces how well your endpoints are covered, the open findings affecting them, the endpoints most exposed to risk, and the policies that protect them. The following sections describe each area of the page.
 
 {{< img src="security/application_security/overview/api_posture.png" alt="API Posture overview page" >}}
 
 ## Ask Bits panel
 
-The **Ask Bits** panel is a contextual entry point to Bits AI for questions about your API posture. It offers ready-made prompts such as **Top priorities**, **Summarize Last Week insights**, and **What I'm exposed to?** to help you start an investigation without writing a query. The panel appears when Bits AI is enabled and you have the required access. You can dismiss it.
+The {{< ui >}}Ask Bits{{< /ui >}} panel is a contextual entry point to Bits AI for questions about your API posture. It offers ready-made prompts such as {{< ui >}}Top priorities{{< /ui >}}, {{< ui >}}Summarize Last Week insights{{< /ui >}}, and {{< ui >}}What I'm exposed to?{{< /ui >}} to help you start an investigation without writing a query. The panel appears when Bits AI is enabled and you have the required access. You can dismiss it.
 
 ## Coverage
 
-The **Coverage** section provides an inventory overview of your API endpoints. It classifies endpoints as **Documented** (receiving traffic and described in your API definitions), **Orphan** (documented but receiving no traffic), and **Shadow** (receiving traffic but undocumented). It also breaks down the authentication posture of your endpoints across **Authenticated**, **Unauthenticated**, and **Undetected** states, and highlights the top sensitive data types observed across your endpoints.
+The {{< ui >}}Coverage{{< /ui >}} section provides an inventory overview of your API endpoints. It classifies endpoints as {{< ui >}}Documented{{< /ui >}} (receiving traffic and described in your API definitions), {{< ui >}}Orphan{{< /ui >}} (documented but receiving no traffic), and {{< ui >}}Shadow{{< /ui >}} (receiving traffic but undocumented). It also breaks down the authentication posture of your endpoints across {{< ui >}}Authenticated{{< /ui >}}, {{< ui >}}Unauthenticated{{< /ui >}}, and {{< ui >}}Undetected{{< /ui >}} states, and highlights the top sensitive data types observed across your endpoints.
 
 ## Open Findings
 
-The **Open Findings** section summarizes the API security findings that are open. Findings are broken down by severity (critical, high, medium, and low) and by the rules that generate them, so you can see which issues are most pressing and which rules account for the most findings. The counts reflect the selected time range, so you can compare findings at the start and end of the period.
+The {{< ui >}}Open Findings{{< /ui >}} section summarizes the API security findings that are open. Findings are broken down by severity (critical, high, medium, and low) and by the rules that generate them, so you can see which issues are most pressing and which rules account for the most findings. The counts reflect the selected time range, so you can compare findings at the start and end of the period.
 
 ## Threats Exposure
 
-The **Threats Exposure** section ranks the endpoints that are most exposed to risk, surfacing those with the highest number of critical and high-severity findings. From here you can examine a specific endpoint and the findings affecting it to prioritize remediation.
+The {{< ui >}}Threats Exposure{{< /ui >}} section ranks the endpoints that are most exposed to risk, surfacing those with the highest number of critical and high-severity findings. From here you can examine a specific endpoint and the findings affecting it to prioritize remediation.
 
 ## Policies Coverage
 
-The **Policies Coverage** section shows how your API protection is configured. It reports the deployment status of your API finding rules, including which rules are enabled and which are disabled, and it displays coverage across OWASP API Security categories so you can identify gaps in protection.
+The {{< ui >}}Policies Coverage{{< /ui >}} section shows how your API protection is configured. It reports the deployment status of your API finding rules, including which rules are enabled and which are disabled, and it displays coverage across OWASP API Security categories so you can identify gaps in protection.
 
 ## Customize Page
 
-Use the **Customize Page** button in the page header to tailor the page to your needs. In the popover, drag sections between the **Visible** and **Hidden** areas to control which sections appear, and reorder visible sections by dragging them. Your changes persist locally so the page keeps your layout on future visits.
+Use the {{< ui >}}Customize Page{{< /ui >}} button in the page header to tailor the page to your needs. In the popover, drag sections between the {{< ui >}}Visible{{< /ui >}} and {{< ui >}}Hidden{{< /ui >}} areas to control which sections appear, and reorder visible sections by dragging them. Your changes persist locally so the page keeps your layout on future visits.
 
 ## Further reading
 

--- a/content/en/security/application_security/api_posture/sensitive_data.md
+++ b/content/en/security/application_security/api_posture/sensitive_data.md
@@ -27,7 +27,7 @@ When the scanner detects sensitive data, it tags the API endpoint with the categ
 
 To create an API data scanner and view its results, do the following:
 
-1. In App and API Protection {{< ui >}}Policies{{< /ui >}}, go to [Sensitive Data Detection][3].
+1. In App and API Protection {{< ui >}}Policies{{< /ui >}}, go to [{{< ui >}}Sensitive Data Detection{{< /ui >}}][3].
 2. Click {{< ui >}}New Scanner{{< /ui >}}.
 3. In {{< ui >}}Select your scanner tags{{< /ui >}}, define the category and type to classify the sensitive data. The scanner tags API endpoints with the format `category:type`.
 4. In {{< ui >}}Define conditions on JSON keys and values{{< /ui >}}, define the JSON key or value conditions to trigger the scanner.

--- a/content/en/security/application_security/attack_summary.md
+++ b/content/en/security/application_security/attack_summary.md
@@ -23,36 +23,36 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 The App and API Protection (AAP) [Attack Summary][2] provides a quick view of your application and API posture. It highlights trends, service exposure, attack traffic, and the impact on business logic. You can pivot from widgets to their related traces.
 
-Each section of **Attack Summary** focuses on a different aspect of security with supporting information.
+Each section of {{< ui >}}Attack Summary{{< /ui >}} focuses on a different aspect of security with supporting information.
 
 ## Sections
 
-Attack Surface Area
+{{< ui >}}Attack Surface Area{{< /ui >}}
 : This section provides insights into the exposed services, the tools attackers are using, and the commercial scanners that identify potential vulnerabilities.
 
-Attack Traffic
+{{< ui >}}Attack Traffic{{< /ui >}}
 : These graphs identify the classification of attacks, such as SSRF, LFI, SQL, and command injection. They allow users to identify spikes in malicious traffic and patterns.
 
-Business Logic
+{{< ui >}}Business Logic{{< /ui >}}
 : This section focuses on fraud and business logic abuse such as account takeover attempts or any custom business logic events tracked by your application.
 
-Attack Traffic Sources
+{{< ui >}}Attack Traffic Sources{{< /ui >}}
 : A global heatmap indicating the sources of attack traffic, providing a visual representation of threats by region.
 
 ## Best practices
 
 1. Review trends and adopt a protection policy that meets your posture needs.
-2. Regularly review the **Exposed Services** widget in **Attack Surface Area** to ensure only the correct services are accessible and have a protection policy that meets your risk profile.
+2. Regularly review the {{< ui >}}Exposed Services{{< /ui >}} widget in {{< ui >}}Attack Surface Area{{< /ui >}} to ensure only the correct services are accessible and have a protection policy that meets your risk profile.
 3. Block attack tools and ensure that customer scanners are part of an authorized vulnerability management program.
 4. Monitor business logic for spikes in credential stuffing attacks or risky payment activity.
-5. Use **Attack Traffic Sources** to compare the attack traffic sources with your expected customer locations.
+5. Use {{< ui >}}Attack Traffic Sources{{< /ui >}} to compare the attack traffic sources with your expected customer locations.
 6. Use [Powerpacks](#using-powerpacks) to enhance your dashboards with the most relevant information.
 
 ### Using Powerpacks
 
-When adding a widget to a [new dashboard][1] in Datadog, choose the **Powerpacks** section in the tray. Filter on `tag:attack_summary` or type `Attack Summary` in the search box.
+When adding a widget to a [new dashboard][1] in Datadog, choose the {{< ui >}}Powerpacks{{< /ui >}} section in the tray. Filter on `tag:attack_summary` or type `Attack Summary` in the search box.
  
-Each section in the **Attack Summary** page corresponds to a dedicated powerpack.
+Each section in the {{< ui >}}Attack Summary{{< /ui >}} page corresponds to a dedicated powerpack.
 
 ## Further reading
 

--- a/content/en/security/application_security/guide/manage_account_theft_appsec.md
+++ b/content/en/security/application_security/guide/manage_account_theft_appsec.md
@@ -171,7 +171,7 @@ The actions covered in the next sections help you to identify and leverage detec
 
 1. Open [Create a new rule][18].  
 2. Enter a name for the rule.
-3. Select {{< ui >}}Signal{{< /ui >}} and remove all entries except {{< ui >}}App and API Protection{{< /ui >}}.
+3. Select {{< ui >}}Signal{{< /ui >}} and remove all entries except {{< ui >}}App & API Protection{{< /ui >}}.
 4. Restrict the rule to `category:account_takeover`, and expand the severities to include `Medium`.
 5. Add notification recipients (Slack, Teams, PagerDuty).
    To learn more, see [Notification channels][19].  

--- a/content/en/security/application_security/how-it-works/_index.md
+++ b/content/en/security/application_security/how-it-works/_index.md
@@ -19,7 +19,7 @@ Datadog App and API Protection (AAP) provides observability into application and
 
 - Detects and monitors application and API-level attacks
 - Flags traces containing attack attempts using APM data
-- Highlights exposed services in security views (Catalog, Service Page, Traces)
+- Highlights exposed services in security views ({{< ui >}}Catalog{{< /ui >}}, {{< ui >}}Service Page{{< /ui >}}, {{< ui >}}Traces{{< /ui >}})
 - Identifies bad actors by collecting client IPs and user info
 - Provides automatic threat pattern updates and security signals
 - Supports built-in protection and attack qualification
@@ -30,7 +30,7 @@ Datadog App and API Protection (AAP) provides observability into application and
 
 Datadog App and API Protection Threat Management uses the information APM is already collecting to flag traces containing attack attempts. While APM collects a sample of your application traffic, enabling App and API Protection in the SDK is necessary to effectively monitor and protect your services.
 
-Services exposed to application attacks are highlighted directly in the security views embedded in APM ([Catalog][2], [Service Page][3], [Traces][4]).
+Services exposed to application attacks are highlighted directly in the security views embedded in APM ([{{< ui >}}Catalog{{< /ui >}}][2], [{{< ui >}}Service Page{{< /ui >}}][3], [{{< ui >}}Traces{{< /ui >}}][4]).
 
 Datadog Threat Monitoring and Detection identifies bad actors by collecting client IP addresses, login account info (for example, user account/ID), and manually-added user tags on all requests.
 
@@ -117,7 +117,7 @@ Datadog App and API Protection includes over 100 attack signatures that help pro
 
 <div class="alert alert-info">API security is in Preview.</div>
 
-Datadog App and API Protection provides visibility into threats targeting your APIs. Use the [Endpoints list][27] in Catalog to monitor API health and performance metrics, where you can view attacks targeting your APIs. This view includes the attacker's IP and authentication information, as well as request headers showing details about how the attack was formed. Using both App and API Protection and API management, you can maintain a comprehensive view of your API attack surface, and respond to mitigate threats.
+Datadog App and API Protection provides visibility into threats targeting your APIs. Use the [{{< ui >}}Endpoints{{< /ui >}} list][27] in {{< ui >}}Catalog{{< /ui >}} to monitor API health and performance metrics, where you can view attacks targeting your APIs. This view includes the attacker's IP and authentication information, as well as request headers showing details about how the attack was formed. Using both App and API Protection and API management, you can maintain a comprehensive view of your API attack surface, and respond to mitigate threats.
 
 ## How Datadog App and API Protection protects against Log4Shell
 

--- a/content/en/security/application_security/how-it-works/add-user-info.md
+++ b/content/en/security/application_security/how-it-works/add-user-info.md
@@ -1112,7 +1112,7 @@ track_custom_event(tracer, event_name, metadata)
 
 If your service has AAP enabled and [Remote Configuration][1] enabled, you can create a custom WAF rule to flag any request it matches with a custom business logic tag. This doesn't require any modification to your application, and can be done entirely from Datadog.
 
-To get started, navigate to the [Custom WAF Rule page][2] and click on {{< ui >}}Create New Rule{{< /ui >}}.
+To get started, navigate to the [{{< ui >}}Custom WAF Rule{{< /ui >}} page][2] and click on {{< ui >}}Create New Rule{{< /ui >}}.
 
 {{< img src="security/application_security/threats/custom-waf-rule-menu.png" alt="Access the Custom WAF Rule Menu from the AAP homepage by clicking on Protection, then In-App WAF and Custom Rules" style="width:100%;" >}}
 
@@ -1179,7 +1179,7 @@ The following modes are deprecated:
 
 ## Disabling user activity event tracking
 
-To disable automated user activity detection through your [AAP Catalog][14], change the automatic tracking mode environment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled.
+To disable automated user activity detection through your AAP [{{< ui >}}Catalog{{< /ui >}}][14], change the automatic tracking mode environment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled.
 
 For manual configuration, you can set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog SDK, and not on the Datadog Agent.
 

--- a/content/en/security/application_security/how-it-works/threat-intelligence.md
+++ b/content/en/security/application_security/how-it-works/threat-intelligence.md
@@ -37,7 +37,7 @@ Datadog recommends _against_ the following:
 
 ## Filtering on threat intelligence in AAP
 
-Users can filter threat intelligence on the Signals and Traces explorers using facets and the search bar.
+Users can filter threat intelligence on the {{< ui >}}Signals{{< /ui >}} and {{< ui >}}Traces{{< /ui >}} explorers using facets and the search bar.
 
 To search for all traces flagged by a specific source, use the following query with the source name:
 
@@ -60,7 +60,7 @@ For more information, see the [Bring Your Own Threat Intelligence][14] guide.
 
 ## Threat intelligence in the user interface
 
-When viewing the traces in the AAP Traces Explorer, you can see threat intelligence data under the `@appsec` attribute. The `category` and `security_activity` attributes are both set.
+When viewing the traces in the AAP {{< ui >}}Traces Explorer{{< /ui >}}, you can see threat intelligence data under the `@appsec` attribute. The `category` and `security_activity` attributes are both set.
 
 <!-- {{< img src="security/application_security/threats/threat_intel/threat_intel_appsec.png" alt="Example of the appsec attribute containing threat intelligence data">}} -->
 

--- a/content/en/security/application_security/how-it-works/trace_qualification.md
+++ b/content/en/security/application_security/how-it-works/trace_qualification.md
@@ -14,7 +14,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 App and API Protection (AAP) provides observability into application-level attacks, and evaluates the conditions in which each trace was generated. AAP trace qualification then labels each attack as harmful or safe to help you take action on the most impactful attacks.
 
-Filter by the **Qualification** facet in the AAP [Traces Explorer][1] to view the possible qualification results:
+Filter by the {{< ui >}}Qualification{{< /ui >}} facet in the AAP [{{< ui >}}Traces Explorer{{< /ui >}}][1] to view the possible qualification results:
 
 
 ## Qualification outcomes
@@ -23,10 +23,10 @@ AAP runs qualification rules (closed-source) on every trace. There are four poss
 
 | Qualification result | Description |
 |------|-------------|
-| Unknown | AAP has qualification rules for this attack, but did not have enough information to make a qualification decision. |
-| None successful | AAP determined that attacks in this trace were not harmful. |
-| Harmful | At least one attack in the trace was successful. |
-| No value | AAP does not have qualification rules for this type of attack. |
+| {{< ui >}}Unknown{{< /ui >}} | AAP has qualification rules for this attack, but did not have enough information to make a qualification decision. |
+| {{< ui >}}None successful{{< /ui >}} | AAP determined that attacks in this trace were not harmful. |
+| {{< ui >}}Harmful{{< /ui >}} | At least one attack in the trace was successful. |
+| {{< ui >}}No value{{< /ui >}} | AAP does not have qualification rules for this type of attack. |
 
 ### Trace sidepanel
 

--- a/content/en/security/application_security/setup/aws/fargate/_index.md
+++ b/content/en/security/application_security/setup/aws/fargate/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/aws/lambda/dotnet.md
+++ b/content/en/security/application_security/setup/aws/lambda/dotnet.md
@@ -26,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack and would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack and would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][8], [AWS CDK][9], [Datadog Serverless Framework plugin][2], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 

--- a/content/en/security/application_security/setup/aws/lambda/go.md
+++ b/content/en/security/application_security/setup/aws/lambda/go.md
@@ -26,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][8], [AWS CDK][9], [Datadog Serverless Framework plugin][2], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 
@@ -200,7 +200,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
      DD_SERVERLESS_APPSEC_ENABLED: true
    ```
 
-4. Redeploy the function and invoke it. After a few minutes, it appears in [App and API protection views][1].
+4. Redeploy the function and invoke it. After a few minutes, it appears in [App and API Protection views][1].
 [1]: https://app.datadoghq.com/security/appsec?column=time&order=desc
 
 {{% /tab %}}

--- a/content/en/security/application_security/setup/aws/lambda/java.md
+++ b/content/en/security/application_security/setup/aws/lambda/java.md
@@ -26,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][9], [AWS CDK][10], [Datadog Serverless Framework plugin][2], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 

--- a/content/en/security/application_security/setup/aws/lambda/nodejs.md
+++ b/content/en/security/application_security/setup/aws/lambda/nodejs.md
@@ -26,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][9], [AWS CDK][10], [Datadog Serverless Framework plugin][2], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 
@@ -45,7 +45,7 @@ Threat Detection supports HTTP requests as function input only, as that channel 
 {{< tabs >}}
 {{% tab "Serverless Framework" %}}
 
-The [Datadog Serverless Framework plugin][1] can be used to automatically configure and deploy your lambda with App and API protection.
+The [Datadog Serverless Framework plugin][1] can be used to automatically configure and deploy your lambda with App and API Protection.
 
 To install and configure the Datadog Serverless Framework plugin:
 

--- a/content/en/security/application_security/setup/aws/lambda/python.md
+++ b/content/en/security/application_security/setup/aws/lambda/python.md
@@ -29,7 +29,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][2], [AWS CDK][3], [Datadog Serverless Framework plugin][4], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 
@@ -57,7 +57,7 @@ To install and configure the Datadog Serverless Framework plugin:
    serverless plugin install --name serverless-plugin-datadog
    ```
 
-2. Enable App and API protection by updating your `serverless.yml` with the `appSecMode` configuration parameter:
+2. Enable App and API Protection by updating your `serverless.yml` with the `appSecMode` configuration parameter:
    ```yaml
    custom:
      datadog:

--- a/content/en/security/application_security/setup/aws/lambda/ruby.md
+++ b/content/en/security/application_security/setup/aws/lambda/ruby.md
@@ -26,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 Configuring App and API Protection for AWS Lambda involves:
 
-1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the Security tab of your Catalog][1].
+1. Identifying functions that are vulnerable or are under attack, which would most benefit from App and API Protection. Find them on [the {{< ui >}}Security{{< /ui >}} tab of your Catalog][1].
 2. Setting up App and API Protection instrumentation by using either the [Datadog CLI][8], [AWS CDK][9], [Datadog Serverless Framework plugin][2], or manually by using the Datadog tracing layers.
 3. Triggering security signals in your application and seeing how Datadog displays the resulting information.
 

--- a/content/en/security/application_security/setup/aws/waf/_index.md
+++ b/content/en/security/application_security/setup/aws/waf/_index.md
@@ -49,7 +49,7 @@ First, **enable** the conversion of logs to traces on the [Settings page][4].
 
 Then, ensure the web ACLs table contains request metrics as well as logs and traces.
 
-Security traces are reported in the [AAP Traces Explorer][5] with service name `aws.waf`.
+Security traces are reported in the [AAP {{< ui >}}Traces Explorer{{< /ui >}}][5] with service name `aws.waf`.
 
 ## Block with AWS WAF IPsets
 
@@ -123,7 +123,7 @@ Ensure the AWS role attached to the [Connection][3] has the following permission
 {{% /tab %}}
 {{< /tabs >}}
 
-After setup is complete, click **Block New Attackers** on the App & API Protection [denylist page][6]. Select the web ACL and associated AWS connection to block IP addresses.
+After setup is complete, click {{< ui >}}Block New Attackers{{< /ui >}} on the {{< ui >}}App & API Protection{{< /ui >}} [denylist page][6]. Select the web ACL and associated AWS connection to block IP addresses.
 
 [1]: /integrations/amazon-web-services/
 [2]: /integrations/amazon_waf/

--- a/content/en/security/application_security/setup/azure/app-service/_index.md
+++ b/content/en/security/application_security/setup/azure/app-service/_index.md
@@ -44,7 +44,7 @@ Only *web applications* are supported. Azure Functions are not supported.
 
 ## Setup
 ### Set application settings
-To enable AAP on your application, begin by adding the following key-value pairs under **Application Settings** in your Azure configuration settings.
+To enable AAP on your application, begin by adding the following key-value pairs under {{< ui >}}Application Settings{{< /ui >}} in your Azure configuration settings.
 
 {{< img src="serverless/azure_app_service/application-settings.jpg" alt="Azure App Service Configuration: the Application Settings, under the Configuration section of Settings in the Azure UI. Three settings are listed: DD_API_KEY, DD_SERVICE, and DD_START_APP." style="width:80%;" >}}
 
@@ -80,7 +80,7 @@ Set these values in the `DD_START_APP` environment variable. Examples below are 
 
 {{< tabs >}}
 {{% tab "Node, .NET, PHP, Python" %}}
-Go to **General settings** and add the following to the **Startup Command** field:
+Go to {{< ui >}}General settings{{< /ui >}} and add the following to the {{< ui >}}Startup Command{{< /ui >}} field:
 
 ```
 curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.14.0/datadog_wrapper | bash
@@ -106,7 +106,7 @@ To see App and API Protection threat detection in action, send known attack patt
    ```sh
    curl -A 'dd-test-scanner-log' https://your-function-url/existing-route
    ```
-A few minutes after you enable your application and exercise it, **threat information appears in the [Application Signals Explorer][3]**.
+A few minutes after you enable your application and exercise it, **threat information appears in the [{{< ui >}}Application Signals Explorer{{< /ui >}}][3]**.
 
 ## Further reading
 

--- a/content/en/security/application_security/setup/docker/_index.md
+++ b/content/en/security/application_security/setup/docker/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/dotnet/dotnet.md
+++ b/content/en/security/application_security/setup/dotnet/dotnet.md
@@ -201,7 +201,7 @@ ENV DD_APPSEC_ENABLED=true
 
 ## Using AAP without APM tracing
 
-If you want to use Application & API Protection without APM tracing functionality, you can deploy with tracing disabled:
+If you want to use Application and API Protection without APM tracing functionality, you can deploy with tracing disabled:
 
 1. Configure your SDK with the `DD_APM_TRACING_ENABLED=false` environment variable in addition to the `DD_APPSEC_ENABLED=true` environment variable.
 2. This configuration will reduce the amount of APM data sent to Datadog to the minimum required by App and API Protection products.

--- a/content/en/security/application_security/setup/gcp/cloud-run/_index.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/gcp/service-extensions.md
+++ b/content/en/security/application_security/setup/gcp/service-extensions.md
@@ -79,18 +79,18 @@ To set up the App and API Protection Service Extension in GCP, use the Google Cl
 4. Add the instance group with the service extension VM as a backend to this backend service.
 
 5. Configure the Traffic Service Extension callout:
-    1. In the Google Cloud console, go to **Service Extensions** and create a new Service Extension.
+    1. In the Google Cloud console, go to {{< ui >}}Service Extensions{{< /ui >}} and create a new Service Extension.
     2. Select your load balancer type.
-    3. Select `Traffic extensions` as the type.
+    3. Select {{< ui >}}Traffic extensions{{< /ui >}} as the type.
     4. Select your forwarding rules.
   <br><br>
 
 6. Create an Extension Chain
 
-    1. To send all traffic to the extension, insert `true` in the **Match condition**.
-    2. For **Programability type**, select `Callouts`.
+    1. To send all traffic to the extension, insert `true` in the {{< ui >}}Match condition{{< /ui >}}.
+    2. For {{< ui >}}Programability type{{< /ui >}}, select {{< ui >}}Callouts{{< /ui >}}.
     3. Select the backend service you created in the previous step.
-    4. In **Events**, select **only** `Request Headers` and `Response Headers`. These are required. Do not select the bodies events. These are supported out-of-the-box by configuring the Service Extension callout with the body processing size limit.
+    4. In {{< ui >}}Events{{< /ui >}}, select **only** {{< ui >}}Request Headers{{< /ui >}} and {{< ui >}}Response Headers{{< /ui >}}. These are required. Do not select the bodies events. These are supported out-of-the-box by configuring the Service Extension callout with the body processing size limit.
     5. Optionally, enable the `fail_open` to still allow the traffic to pass through if the service extension fails or times out.
 
     <br>

--- a/content/en/security/application_security/setup/go/setup.md
+++ b/content/en/security/application_security/setup/go/setup.md
@@ -8,7 +8,7 @@ aliases:
 further_reading:
 - link: "/security/application_security/setup/go/sdk"
   tag: "Documentation"
-  text: "App & API Protection SDK for Go"
+  text: "App and API Protection SDK for Go"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Adding user information to traces"
@@ -90,7 +90,7 @@ Add the following environment variable value to your application container's Doc
 ENV DD_APPSEC_ENABLED=true
 ```
 
-For more information on how to create a fitting docker image, See <a href="/security/application_security/setup/go/dockerfile">Creating a Dockerfile for App & API Protection for Go</a>.
+For more information on how to create a fitting docker image, See <a href="/security/application_security/setup/go/dockerfile">Creating a Dockerfile for App and API Protection for Go</a>.
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}

--- a/content/en/security/application_security/setup/haproxy.md
+++ b/content/en/security/application_security/setup/haproxy.md
@@ -24,7 +24,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 {{< /site-region >}}
 
 {{< callout url="https://www.datadoghq.com/product-preview/haproxy-integration/">}}
-App and API Protection for HAProxy is in Preview. To sign up, click <strong>Request Access</strong> and complete the form.
+App and API Protection for HAProxy is in Preview. To sign up, click {{< ui >}}Request Access{{< /ui >}} and complete the form.
 {{< /callout >}}
 
 You can enable App and API Protection for your HAProxy instances. The Datadog HAProxy integration leverages HAProxy's Stream Processing Offload Engine (SPOE) to inspect and protect traffic for threat detection at the edge of your infrastructure.

--- a/content/en/security/application_security/setup/kubernetes/_index.md
+++ b/content/en/security/application_security/setup/kubernetes/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/kubernetes/gateway-api.md
+++ b/content/en/security/application_security/setup/kubernetes/gateway-api.md
@@ -28,7 +28,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 ## Overview
 
-The **Datadog AppSec Gateway API Request Mirror** enhances application security by leveraging the **RequestMirror** functionality in Kubernetes Gateway APIs to duplicate traffic to a Datadog App &API Protection endpoint. This enables real-time detection and analysis of potential application-level attacks, API endpoint discovery, and more, all without impacting the primary request flow.
+The **Datadog AppSec Gateway API Request Mirror** enhances application security by leveraging the **RequestMirror** functionality in Kubernetes Gateway APIs to duplicate traffic to a Datadog App and API Protection endpoint. This enables real-time detection and analysis of potential application-level attacks, API endpoint discovery, and more, all without impacting the primary request flow.
 
 ## Prerequisites
 
@@ -162,7 +162,7 @@ The Gateway API integration uses the [Datadog Go Tracer][6] and inherits all env
 
 ## Enabling APM tracing
 
-By default, the request mirror traces won't enable Datadog's APM product. If you want to use Application & API Protection without APM tracing functionality, this is the default behavior. 
+By default, the request mirror traces won't enable Datadog's APM product. If you want to use Application and API Protection without APM tracing functionality, this is the default behavior. 
 
 To enable APM tracing, set the environment variable `DD_APM_TRACING_ENABLED=true` in the request mirror deployment.
 

--- a/content/en/security/application_security/setup/linux/_index.md
+++ b/content/en/security/application_security/setup/linux/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/macos/_index.md
+++ b/content/en/security/application_security/setup/macos/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/setup/php/troubleshooting.md
+++ b/content/en/security/application_security/setup/php/troubleshooting.md
@@ -34,9 +34,9 @@ There are a series of steps that must run successfully for threat information to
 
 You can use the metric `datadog.apm.appsec_host` to check if AAP is running.
 
-1. Go to **Metrics > Summary** in Datadog.
+1. Go to {{< ui >}}Metrics{{< /ui >}} > {{< ui >}}Summary{{< /ui >}} in Datadog.
 2. Search for the metric `datadog.apm.appsec_host`. If the metric doesn't exist, then there are no services running AAP. If the metric exists, the services are reported with the metric tags `host` and `service`.
-3. Select the metric, and in the **Tags** section, search for `service` to see which services are running AAP.
+3. Select the metric, and in the {{< ui >}}Tags{{< /ui >}} section, search for `service` to see which services are running AAP.
 
 If you are not seeing `datadog.apm.appsec_host`, check the [in-app instructions][3] to confirm that all steps for the initial setup are complete.
 
@@ -167,22 +167,22 @@ If your service is a PHP service, explicitly set the environment variable to `DD
 
 ### Remote Configuration
 
-If AAP was activated using [Remote Configuration][16], do the following: 
-  1. Go to [Services][15].
-  2. Select **App & API Protection in Monitoring Mode**.
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+If AAP was activated using [{{< ui >}}Remote Configuration{{< /ui >}}][16], do the following: 
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. Select {{< ui >}}App & API Protection in Monitoring Mode{{< /ui >}}.
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   4. Click on a service.
-  5. In **Capabilities** > **App & API Protection** > **Threat Detection**, click **Deactivate**.
+  5. In {{< ui >}}Capabilities{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Threat Detection{{< /ui >}}, click {{< ui >}}Deactivate{{< /ui >}}.
 
-<div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">Remote Configuration</a>, you can use a <strong>Deactivate</strong> button. If AAP was activated using local configuration, the <strong>Deactivate</strong> button is not an option.</div>
+<div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">Remote Configuration</a>, you can use a {{< ui >}}Deactivate{{< /ui >}} button. If AAP was activated using local configuration, the {{< ui >}}Deactivate{{< /ui >}} button is not an option.</div>
 
 ### Bulk disable
 
 To disable AAP on your services in bulk, do the following: 
-  1. Go to [Services][15].
-  2. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   3. Select the checkboxes for the services where you want to disable threat detection.
-  4. In **Bulk Actions**, select **Deactivate threat detection on (number of) services**.
+  4. In {{< ui >}}Bulk Actions{{< /ui >}}, select {{< ui >}}Deactivate threat detection on (number of) services{{< /ui >}}.
 
 
 

--- a/content/en/security/application_security/setup/ruby/aws-fargate.md
+++ b/content/en/security/application_security/setup/ruby/aws-fargate.md
@@ -247,7 +247,7 @@ To verify that App and API Protection is working correctly:
 
 1. Send some traffic to your application.
 2. Check the [App and API Protection Service Inventory](https://app.datadoghq.com/security/appsec/inventory/services) in Datadog.
-3. Find your service and check that App and API protection is enabled in the **Coverage** column.
+3. Find your service and check that App and API Protection is enabled in the {{< ui >}}Coverage{{< /ui >}} column.
 
 ## Troubleshooting
 

--- a/content/en/security/application_security/setup/ruby/docker.md
+++ b/content/en/security/application_security/setup/ruby/docker.md
@@ -166,7 +166,7 @@ To verify that App and API Protection is working correctly:
 
 1. Send some traffic to your application.
 2. Check the [App and API Protection Service Inventory](https://app.datadoghq.com/security/appsec/inventory/services) in Datadog.
-3. Find your service and check that App and API protection is enabled in the **Coverage** column.
+3. Find your service and check that App and API Protection is enabled in the {{< ui >}}Coverage{{< /ui >}} column.
 
 ## Troubleshooting
 

--- a/content/en/security/application_security/setup/ruby/kubernetes.md
+++ b/content/en/security/application_security/setup/ruby/kubernetes.md
@@ -204,7 +204,7 @@ To verify that App and API Protection is working correctly:
 
 1. Send some traffic to your application.
 2. Check the [App and API Protection Service Inventory](https://app.datadoghq.com/security/appsec/inventory/services) in Datadog.
-3. Find your service and check that App and API protection is enabled in the **Coverage** column.
+3. Find your service and check that App and API Protection is enabled in the {{< ui >}}Coverage{{< /ui >}} column.
 
 ## Troubleshooting
 

--- a/content/en/security/application_security/setup/ruby/linux.md
+++ b/content/en/security/application_security/setup/ruby/linux.md
@@ -184,7 +184,7 @@ To verify that App and API Protection is working correctly:
 
 1. Send some traffic to your application.
 2. Check the [App and API Protection Service Inventory](https://app.datadoghq.com/security/appsec/inventory/services) in Datadog.
-3. Find your service and check that App and API protection is enabled in the **Coverage** column.
+3. Find your service and check that App and API Protection is enabled in the {{< ui >}}Coverage{{< /ui >}} column.
 
 ## Troubleshooting
 

--- a/content/en/security/application_security/setup/ruby/macos.md
+++ b/content/en/security/application_security/setup/ruby/macos.md
@@ -183,7 +183,7 @@ To verify that App and API Protection is working correctly:
 
 1. Send some traffic to your application.
 2. Check the [App and API Protection Service Inventory](https://app.datadoghq.com/security/appsec/inventory/services) in Datadog.
-3. Find your service and check that App and API protection is enabled in the **Coverage** column.
+3. Find your service and check that App and API Protection is enabled in the {{< ui >}}Coverage{{< /ui >}} column.
 
 ## Troubleshooting
 

--- a/content/en/security/application_security/setup/single_step/_index.md
+++ b/content/en/security/application_security/setup/single_step/_index.md
@@ -22,7 +22,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 ## Enabling in one step
 
-If you [install or update a Datadog Agent][1] with the **Enable Threat Protection (new)** option selected, the Agent is installed and configured to enable AAP. This allows you to automatically instrument your application, without any additional installation or configuration steps. Restart services for this instrumentation to take effect.
+If you [install or update a Datadog Agent][1] with the {{< ui >}}Enable Threat Protection (new){{< /ui >}} option selected, the Agent is installed and configured to enable AAP. This allows you to automatically instrument your application, without any additional installation or configuration steps. Restart services for this instrumentation to take effect.
 
 
 {{< img src="/security/application_security/single_step/asm_single_step_threat_detection_2.png" alt="Account settings Ubuntu setup page highlighting the toggle for Enabling APM instrumentation and Threat Protection." style="width:100%;" >}}

--- a/content/en/security/application_security/setup/windows/_index.md
+++ b/content/en/security/application_security/setup/windows/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog Application and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB Application and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting Application and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How Application and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/security/application_security/terms.md
+++ b/content/en/security/application_security/terms.md
@@ -36,7 +36,7 @@ detection rule
 
 passlist (formerly exclusion filter)
 : A mechanism for discarding security traces flagged through the Datadog App and API Protection library and the In-App WAF rules. Passlist is applied as requests are ingested into Datadog (intake). Passlist helps manage false positives and intake costs.
-: See [Exclusion filters][11] in the app.
+: See [{{< ui >}}Exclusion filters{{< /ui >}}][11] in the app.
 
 In-App WAF rules (formerly event rules)
 : A set of rules executed in the Datadog libraries to catch security activity. These include Web Application Firewall (WAF) patterns that monitor for attempts to exploit known vulnerabilities.
@@ -51,7 +51,7 @@ service
 
 signal
 : A detection of an application attack that impacts your services. Signals identify meaningful threats for you to review, and should be triaged with a high priority.
-: See [Signals Explorer][13] in the app.
+: See [{{< ui >}}Signals Explorer{{< /ui >}}][13] in the app.
 
 severity
 : An indicator of how quickly an attack attempt should be triaged and addressed. Based on a combination of factors, including the attack's potential impact and risk. Values are Critical, High, Medium, Low, Info.

--- a/content/en/security/application_security/threat_protection/_index.md
+++ b/content/en/security/application_security/threat_protection/_index.md
@@ -21,7 +21,7 @@ To get started, [set up AAP][2] on your services so they report security traces.
 
 Threat Protection brings together several capabilities, all built on live application traffic data. With Threat Protection, you can:
 
-- Detect and investigate threats with [Security Signals][3]. Datadog creates a security signal when it detects a threat from a detection rule, so you can triage, filter, and investigate attacks in the Signals Explorer.
+- Detect and investigate threats with [Security Signals][3]. Datadog creates a security signal when it detects a threat from a detection rule, so you can triage, filter, and investigate attacks in the {{< ui >}}Signals Explorer{{< /ui >}}.
 - Block attacks and attackers with [Policies][4]. Block malicious IP addresses and users in real time from the Datadog UI, manually or through automated rules.
 - Stop exploit attempts in code with [Exploit Prevention][5]. Detect and block attempts to exploit vulnerabilities, including zero-day attacks, from within the running application.
 - Extend protection to the perimeter with [WAF Integrations][6]. Combine in-app protection with edge defenses such as AWS WAF for a defense-in-depth approach.

--- a/content/en/security/application_security/threat_protection/account_takeover_protection.md
+++ b/content/en/security/application_security/threat_protection/account_takeover_protection.md
@@ -89,7 +89,7 @@ Those enrichment need to hold a user identifier (unique to a user, numeric or ot
 
 For steps on enabling tracking for events that are not automatically instrumented, go to [User Monitoring and Protection][1].
 
-For the latest list of relevant detections and instrumentation requirements, go to [Detection Rules][2] page.
+For the latest list of relevant detections and instrumentation requirements, go to the [{{< ui >}}Detection Rules{{< /ui >}}][2] page.
 
 [Automatic instrumentation][3] is a Datadog capability that automatically identifies user login success and failure for many authentication implementations.
 
@@ -112,17 +112,17 @@ AAP highlights the most relevant information and suggests actions to take based 
 
 **Compromised Users**
 
-Compromised and targeted users can be reviewed and blocked within **Signals** and **Traces**.
+Compromised and targeted users can be reviewed and blocked within {{< ui >}}Signals{{< /ui >}} and {{< ui >}}Traces{{< /ui >}}.
 
-**Signals**
+{{< ui >}}Signals{{< /ui >}}
 
-Individual users can be blocked in **Signals** using **Targeted Users**.
+Individual users can be blocked in {{< ui >}}Signals{{< /ui >}} using {{< ui >}}Targeted Users{{< /ui >}}.
 
 {{<img src="security/ato/compromised_users_signals2.png" alt="Compromised users shown on a security signal" style="width:100%;">}}
 
-**Traces**
+{{< ui >}}Traces{{< /ui >}}
 
-Individual users can be blocked on **Traces**, in **User**. Click on any user to show this option.
+Individual users can be blocked on {{< ui >}}Traces{{< /ui >}}, in {{< ui >}}User{{< /ui >}}. Click on any user to show this option.
 
 {{<img src="security/ato/traces_block_user.png" alt="Compromised users shown in the security trace explorer" style="width:100%;">}}
 
@@ -141,7 +141,7 @@ Identify trusted IPs, preventing them from being automatically blocked. This ste
 - Approved scanning sources that attempt to log in.
 - Corporate sites with large numbers of users behind single IP addresses.
 
-To configure trusted IPs, use [Passlist][12] and add a `Monitored` entry. Monitored entries are excluded from automated blocking.
+To configure trusted IPs, use [{{< ui >}}Passlist{{< /ui >}}][12] and add a `Monitored` entry. Monitored entries are excluded from automated blocking.
 
 {{<img src="security/ato/passlist2.png" alt="Monitored passlist" style="width:100%;">}}
 
@@ -185,7 +185,7 @@ Here are three critical components for success in mitigating these attacks:
 
 ### Know your trends
 
-Use the [Threats Overview][11] to monitor business logic trends, such as spikes in failed logins against your services.
+Use the [{{< ui >}}Threats Overview{{< /ui >}}][11] to monitor business logic trends, such as spikes in failed logins against your services.
 
 {{<img src="security/ato/threats_overview2.png" alt="Threats Overview" style="width:100%;">}}
 
@@ -241,13 +241,13 @@ Review the following best practices for protection.
 
 Evaluate the managed ruleset to determine which rules fit your internal automated blocking policies.
 
-If you do not have a policy, review your existing detections and start with the suggested responses in **Signals**. Build your policy based on the most relevant actions taken over time.
+If you do not have a policy, review your existing detections and start with the suggested responses in {{< ui >}}Signals{{< /ui >}}. Build your policy based on the most relevant actions taken over time.
 
 #### Users
 
-In **Signals**, the **What Happened** and **Targeted Users** sections provide examples of the attempted usernames.
+In {{< ui >}}Signals{{< /ui >}}, the {{< ui >}}What Happened{{< /ui >}} and {{< ui >}}Targeted Users{{< /ui >}} sections provide examples of the attempted usernames.
 
-The **Traces** section identifies if the users exist. Understanding if users exist can influence your incident response decisions.
+The {{< ui >}}Traces{{< /ui >}} section identifies if the users exist. Understanding if users exist can influence your incident response decisions.
 
 Develop an incident response plan using the following post compromise steps:
 
@@ -263,7 +263,7 @@ Consider blocking compromised users in addition to blocking the attacker.
 To export a list of compromised or targeted users from a signal:
 
 1. Go to the notification settings in a detection rule condition. 
-2. Add a recipient and turn on _Notify for every new `@usr.id` detected_. This allows you to export the list when updates occur.
+2. Add a recipient and turn on {{< ui >}}Notify for every new `@usr.id` detected{{< /ui >}}. This allows you to export the list when updates occur.
 
 {{<img src="security/application_security/threats/notify-on-update.png" alt="Notify on update toggle on detection rule editor" style="width:100%;">}}
 

--- a/content/en/security/application_security/threat_protection/exploit-prevention.md
+++ b/content/en/security/application_security/threat_protection/exploit-prevention.md
@@ -88,13 +88,13 @@ App and API Protection Exploit Prevention intercepts all SQL queries to determin
 ## Enabling Exploit Prevention
 
 
-1. Navigate to [In-App WAF][4].
+1. Navigate to [{{< ui >}}In-App WAF{{< /ui >}}][4].
 2. If you have applied a Datadog managed policy to your services, then follow these steps:
-   1. Clone the policy. For example, you can use the **Managed - Block attack tools** policy.
+   1. Clone the policy. For example, you can use the {{< ui >}}Managed - Block attack tools{{< /ui >}} policy.
    1. Add a policy name and description.
-   1. Click on the policy you created and select the **Local File Inclusion** ruleset. Enable blocking for the **Local File Inclusion exploit** rule.
-   1. Similarly, select the **Server-side Request Forgery** ruleset and enable blocking for the **Server-side request forgery** exploit rule.
-3. If you have applied a custom policy for your services, you can skip Steps 2.a and 2.b for cloning a policy and directly set the Exploit Prevention rules in **blocking** mode (Steps 2.c and 2.d).
+   1. Click on the policy you created and select the {{< ui >}}Local File Inclusion{{< /ui >}} ruleset. Enable blocking for the {{< ui >}}Local File Inclusion exploit{{< /ui >}} rule.
+   1. Similarly, select the {{< ui >}}Server-side Request Forgery{{< /ui >}} ruleset and enable blocking for the {{< ui >}}Server-side request forgery{{< /ui >}} exploit rule.
+3. If you have applied a custom policy for your services, you can skip Steps 2.a and 2.b for cloning a policy and directly set the Exploit Prevention rules in {{< ui >}}blocking{{< /ui >}} mode (Steps 2.c and 2.d).
 
 
 ## Reviewing exploit attempts in App and API Protection

--- a/content/en/security/application_security/threat_protection/overview.md
+++ b/content/en/security/application_security/threat_protection/overview.md
@@ -16,37 +16,37 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 </div>
 {{< /site-region >}}
 
-The **Threat Protection** overview page shows how well your services are instrumented and protected against attacks, the security signals they generate, the services most exposed to threats, and the trends in attack activity. The following sections describe each area of the page.
+The {{< ui >}}Threat Protection{{< /ui >}} overview page shows how well your services are instrumented and protected against attacks, the security signals they generate, the services most exposed to threats, and the trends in attack activity. The following sections describe each area of the page.
 
 {{< img src="security/application_security/overview/threat_protection.png" alt="Threat Protection overview page" >}}
 
 ## Ask Bits panel
 
-The **Ask Bits** panel is a contextual entry point to Bits AI for questions about your threat protection. It offers ready-made prompts such as **Top priorities**, **Summarize Last Week insights**, and **What I'm exposed to?** to help you start an investigation without writing a query. The panel appears when Bits AI is enabled and you have the required access. You can dismiss it.
+The {{< ui >}}Ask Bits{{< /ui >}} panel is a contextual entry point to Bits AI for questions about your threat protection. It offers ready-made prompts such as {{< ui >}}Top priorities{{< /ui >}}, {{< ui >}}Summarize Last Week insights{{< /ui >}}, and {{< ui >}}What I'm exposed to?{{< /ui >}} to help you start an investigation without writing a query. The panel appears when Bits AI is enabled and you have the required access. You can dismiss it.
 
 ## App Instrumentation
 
-The **App Instrumentation** section reports how broadly App and API Protection (AAP) is activated across your services. **Threat detection coverage** shows how many services are actively detecting threats in real time compared to your total services, and **Recommended services activated** tracks your progress in enabling AAP on at-risk services identified by known vulnerabilities and suspicious traffic. From this section you can protect additional services or view the services already protected.
+The {{< ui >}}App Instrumentation{{< /ui >}} section reports how broadly App and API Protection (AAP) is activated across your services. {{< ui >}}Threat detection coverage{{< /ui >}} shows how many services are actively detecting threats in real time compared to your total services, and {{< ui >}}Recommended services activated{{< /ui >}} tracks your progress in enabling AAP on at-risk services identified by known vulnerabilities and suspicious traffic. From this section you can protect additional services or view the services already protected.
 
 ## Attack Coverage
 
-The **Attack Coverage** section shows how well your services are protected against attack vectors. **Attack Tools** reports how many exposed services are protected from scanners, bots, and similar tooling through AAP monitoring and blocking, and **Exploit Prevention** reports how many services are protected from exploits through Runtime Application Self-Protection (RASP). The section also highlights services that need [Threat Protection][1] enabled or a tracing library upgrade.
+The {{< ui >}}Attack Coverage{{< /ui >}} section shows how well your services are protected against attack vectors. {{< ui >}}Attack Tools{{< /ui >}} reports how many exposed services are protected from scanners, bots, and similar tooling through AAP monitoring and blocking, and {{< ui >}}Exploit Prevention{{< /ui >}} reports how many services are protected from exploits through Runtime Application Self-Protection (RASP). The section also highlights services that need [Threat Protection][1] enabled or a tracing library upgrade.
 
 ## Open Signals
 
-The **Open Signals** section summarizes the security signals that are open. Signals are broken down by severity (critical, high, medium, and low) with a trend comparison to the previous time window of equal length, and they are shown across **Open** and **Under Review** states. The section also lists the top rules triggering signals so you can see what is driving activity.
+The {{< ui >}}Open Signals{{< /ui >}} section summarizes the security signals that are open. Signals are broken down by severity (critical, high, medium, and low) with a trend comparison to the previous time window of equal length, and they are shown across {{< ui >}}Open{{< /ui >}} and {{< ui >}}Under Review{{< /ui >}} states. The section also lists the top rules triggering signals so you can see what is driving activity.
 
 ## Threats Exposure
 
-The **Threats Exposure** section ranks the services that are most exposed to threats, surfacing those that have triggered the most signals. From here you can examine a specific service to investigate the activity targeting it.
+The {{< ui >}}Threats Exposure{{< /ui >}} section ranks the services that are most exposed to threats, surfacing those that have triggered the most signals. From here you can examine a specific service to investigate the activity targeting it.
 
 ## Threat Trends
 
-The **Threat Trends** section highlights patterns in attack activity. **Top attack types** shows the most common categories of detected attacks, and **Top countries** shows the geographic distribution of attack sources by origin country. You can pivot to the Traces Explorer for deeper analysis of the underlying activity.
+The {{< ui >}}Threat Trends{{< /ui >}} section highlights patterns in attack activity. {{< ui >}}Top attack types{{< /ui >}} shows the most common categories of detected attacks, and {{< ui >}}Top countries{{< /ui >}} shows the geographic distribution of attack sources by origin country. You can pivot to the Traces Explorer for deeper analysis of the underlying activity.
 
 ## Customize Page
 
-Use the **Customize Page** button in the page header to tailor the page to your needs. In the popover, drag sections between the **Visible** and **Hidden** areas to control which sections appear, and reorder visible sections by dragging them. Your changes persist locally so the page keeps your layout on future visits.
+Use the {{< ui >}}Customize Page{{< /ui >}} button in the page header to tailor the page to your needs. In the popover, drag sections between the {{< ui >}}Visible{{< /ui >}} and {{< ui >}}Hidden{{< /ui >}} areas to control which sections appear, and reorder visible sections by dragging them. Your changes persist locally so the page keeps your layout on future visits.
 
 ## Further reading
 

--- a/content/en/security/application_security/threat_protection/policies/_index.md
+++ b/content/en/security/application_security/threat_protection/policies/_index.md
@@ -28,7 +28,7 @@ To use protection capabilities with your service:
 
 ## Blocking attackers (IPs and authenticated users)
 
-You can block attackers that are flagged in AAP [Security Signals][5] temporarily or permanently. In the Signals Explorer, click into a signal to see what users and IP addresses are generating the signal, and optionally block them.
+You can block attackers that are flagged in AAP [Security Signals][5] temporarily or permanently. In the {{< ui >}}Signals Explorer{{< /ui >}}, click into a signal to see what users and IP addresses are generating the signal, and optionally block them.
 
 From there, all AAP-protected services block incoming requests performed by the blocked IP or user, for the specified duration. All blocked traces are tagged with `security_response.block_ip` or `security_response.block_user` and displayed in the [Trace Explorer][6]. Services where AAP is disabled aren't protected. See [Investigate Security Signals][20] for more information.
 
@@ -36,7 +36,7 @@ From there, all AAP-protected services block incoming requests performed by the 
 
 In addition to manually blocking attackers, you can configure automation rules to have AAP automatically block attackers that are flagged in Security Signals.
 
-To get started, navigate to **Security > App and API Protection > Protection > [Detection Rules][14]**. You can create a new rule or edit an existing rule with type _App and API Protection_. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
+To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Protection{{< /ui >}} > [{{< ui >}}Detection Rules{{< /ui >}}][14]. You can create a new rule or edit an existing rule with type {{< ui >}}App & API Protection{{< /ui >}}. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
 
 **Note**: You must instrument your services to be able to block authenticated attackers. See [User Monitoring and Protection][15] for more details.
 
@@ -47,11 +47,11 @@ Create workflows from the available [blueprints][18] and run them directly from 
 
 ## Denylist
 
-Attackers' IP addresses and authenticated users that are permanently or temporarily blocked are added to the _Denylist_. Manage the list on the [Denylist page][7]. A denylist supports blocking individual IPs as well as a range of IPs (CIDR blocks).
+Attackers' IP addresses and authenticated users that are permanently or temporarily blocked are added to the {{< ui >}}Denylist{{< /ui >}}. Manage the list on the [{{< ui >}}Denylist{{< /ui >}} page][7]. A denylist supports blocking individual IPs as well as a range of IPs (CIDR blocks).
 
 ## Passlist
 
-You can use the _Passlist_ to permanently allow specific IP addresses access to your application. For example, you may wish to add internal IP addresses to your passlist, or IP addresses that regularly run security audits on your application. You can also add specific paths to ensure uninterrupted access. Manage the list from the [Passlist page][8].
+You can use the {{< ui >}}Passlist{{< /ui >}} to permanently allow specific IP addresses access to your application. For example, you may wish to add internal IP addresses to your passlist, or IP addresses that regularly run security audits on your application. You can also add specific paths to ensure uninterrupted access. Manage the list from the [{{< ui >}}Passlist{{< /ui >}} page][8].
 
 ## Blocking attack attempts with In-App WAF
 
@@ -67,9 +67,9 @@ Managed policies define the mode in which each of the In-App WAF rules behave on
 
 For fine-grained control, you can clone a Datadog managed policy or create a custom policy and set the mode to meet your needs. If you set the policy to `auto-updating`, your applications are protected by the latest detections rolled out by Datadog. You also have the option to pin a policy to a specific version of the ruleset.
 
-As In-App WAF rules are toggled between modes, the changes are reflected in near real-time for services with [Remote Configuration enabled][2]. For other services, you can update the policy on the [In-App WAF page][9] and then [define In-App WAF rules][10] for the change in behavior to be applied.
+As In-App WAF rules are toggled between modes, the changes are reflected in near real-time for services with [Remote Configuration enabled][2]. For other services, you can update the policy on the [{{< ui >}}In-App WAF{{< /ui >}} page][9] and then [define In-App WAF rules][10] for the change in behavior to be applied.
 
-Manage In-App WAF by navigating to Security --> App and API Protection --> Configuration --> [In-App WAF][9].
+Manage {{< ui >}}In-App WAF{{< /ui >}} by navigating to {{< ui >}}Security{{< /ui >}} --> {{< ui >}}App & API Protection{{< /ui >}} --> {{< ui >}}Configuration{{< /ui >}} --> [{{< ui >}}In-App WAF{{< /ui >}}][9].
 
 View blocked security traces in the [Trace Explorer][11] by filtering on the facet `Blocked:true`.
 
@@ -79,11 +79,11 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 1. [**Enable Remote Configuration**][2] so that your AAP-enabled services show up under In-App WAF. This is required to securely push In-App WAF configuration from your Datadog backend to the SDK in your infrastructure.
 
-2. **Associate your AAP/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to **Security > App and API Protection > Protection > [In-App WAF][9]**. The service appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
+2. **Associate your AAP/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Protection{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][9]. The service appears under the {{< ui >}}Datadog Monitoring-only{{< /ui >}} policy by default. {{< ui >}}Datadog Monitoring-only{{< /ui >}} is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
 
    If you need granular control, clone one of the available policies to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
 
-   To change the policy applied by default to your services, you can update your default policy. From the In-App-WAF, click the policy you would like to set as default, then click **Actions** > **Set this policy as default**.
+   To change the policy applied by default to your services, you can update your default policy. From the In-App-WAF, click the policy you would like to set as default, then click {{< ui >}}Actions{{< /ui >}} > {{< ui >}}Set this policy as default{{< /ui >}}.
 
 ## Customize protection behavior
 
@@ -91,7 +91,7 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 {{% asm-protection-page-configuration %}}
 
-The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to **Security > App and API Protection > Protection > In-App Waf > [Custom Responses][16]**.
+The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Protection{{< /ui >}} > {{< ui >}}In-App Waf{{< /ui >}} > [{{< ui >}}Custom Responses{{< /ui >}}][16].
 
 You can optionally mask the fact that the attacker has been detected and blocked by overriding the response code to be `200 OK` or `404 NOT FOUND` when the deny page is served.
 
@@ -99,9 +99,9 @@ You can also optionally redirect attackers to a custom deny page and away from y
 
 ### Disable protection across all services (Disabling protection mode)
 
-Protection mode is **on** by default and is a toggle available to quickly disable blocking across **all** your services. Requests can be blocked from two sections in Datadog: all attacker requests from Security Signals, and security traces from In-App WAF.
+Protection mode is {{< ui >}}on{{< /ui >}} by default and is a toggle available to quickly disable blocking across **all** your services. Requests can be blocked from two sections in Datadog: all attacker requests from Security Signals, and security traces from In-App WAF.
 
-As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to **Security > App and API Protection > Protection > [In-App WAF][9]** and toggle **Allow Request Blocking** to off.
+As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Protection{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][9] and toggle {{< ui >}}Allow Request Blocking{{< /ui >}} to off.
 
 [1]: /security/application_security/setup/
 [2]: /tracing/guide/remote_config

--- a/content/en/security/application_security/threat_protection/policies/custom_rules.md
+++ b/content/en/security/application_security/threat_protection/policies/custom_rules.md
@@ -51,11 +51,11 @@ See the section below to see how to configure your rules.
 
 ## Configuration
 
-To customize an OOTB detection rule, you must first clone an existing rule. Navigate to your [Detection Rules][2] and select a rule. Scroll to the bottom of the rule and click the {{< ui >}}Clone Rule{{< /ui >}} button. This now enables you to edit the existing rule.
+To customize an OOTB detection rule, you must first clone an existing rule. Navigate to your [{{< ui >}}Detection Rules{{< /ui >}}][2] and select a rule. Scroll to the bottom of the rule and click the {{< ui >}}Clone Rule{{< /ui >}} button. This now enables you to edit the existing rule.
 
 ### Define an AAP query
 
-Construct an AAP query using the [same query syntax as in the AAP Trace Explorer][3]. For example, create a query to monitor login successes from outside of the United States: `@appsec.security_activity:business_logic.users.login.success -@actor.ip_details.country.iso_code:US`.
+Construct an AAP query using the [same query syntax as in the AAP {{< ui >}}Trace Explorer{{< /ui >}}][3]. For example, create a query to monitor login successes from outside of the United States: `@appsec.security_activity:business_logic.users.login.success -@actor.ip_details.country.iso_code:US`.
 
 Optionally, define a unique count and signal grouping. Count the number of unique values observed for an attribute in a given timeframe. The defined group-by generates a signal for each group-by value. Typically, the group-by is an entity (like user, IP, or service). The group-by is also used to [join the queries together](#joining-queries).
 

--- a/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
+++ b/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
@@ -52,13 +52,13 @@ An input represents which part of the request the operator is applied to. The fo
 
 ## Custom In-App WAF rules
 
-Custom In-App WAF rules enable users to log or block specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App and API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App WAF{{< /ui >}} > [{{< ui >}}Custom Rules{{< /ui >}}][4].
+Custom In-App WAF rules enable users to log or block specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App WAF{{< /ui >}} > [{{< ui >}}Custom Rules{{< /ui >}}][4].
 
 **Note:** Default rules in In-App WAF are read-only. To refine your In-App WAF behavior, modify the In-App WAF rules. Default rules cannot be modified, however, you can create a custom rule based on one of the default rules, and modify the match conditions to your needs. Be sure to disable the default rule so that you don't have two similar rules evaluating the same requests.
 
 ## Suggested rules
 
-Datadog's App and API Protection [Suggested Rules][5] feature automatically analyzes application traffic and proposes rules to help monitor and protect login and API flows. Rules are pre-built around common authentication patterns like `users.login.success` or `users.login.failure`, which are the most critical signals for detecting suspicious login behavior.
+Datadog's App and API Protection [{{< ui >}}Suggested Rules{{< /ui >}}][5] feature automatically analyzes application traffic and proposes rules to help monitor and protect login and API flows. Rules are pre-built around common authentication patterns like `users.login.success` or `users.login.failure`, which are the most critical signals for detecting suspicious login behavior.
 
 Suggested rules benefits include:
 
@@ -77,10 +77,10 @@ Suggested rules use cases include:
 
 To use a suggested rule, do one of the following:
 - Create a custom rule from a suggested rule:
-  1. In [Suggested Rules][5], select one or more rules and click {{< ui >}}Create Selected Suggested Rules{{< /ui >}}.
+  1. In [{{< ui >}}Suggested Rules{{< /ui >}}][5], select one or more rules and click {{< ui >}}Create Selected Suggested Rules{{< /ui >}}.
   2. In {{< ui >}}Create suggested custom In-App WAF rules{{< /ui >}}, click {{< ui >}}Create rules{{< /ui >}}. This creates custom In-App WAF rules to monitor the security activities of the rules you selected.
 - Modify a suggested rule to create a custom rule:
-  1. In [Suggested Rules][5], identify a rule you want to use and click {{< ui >}}View suggested rule{{< /ui >}}.
+  1. In [{{< ui >}}Suggested Rules{{< /ui >}}][5], identify a rule you want to use and click {{< ui >}}View suggested rule{{< /ui >}}.
   2. In {{< ui >}}Add a new Business Logic{{< /ui >}}, edit the rule as needed.
   3. Click {{< ui >}}Continue in In-App WAF{{< /ui >}}.
   4. In {{< ui >}}Define your custom rule{{< /ui >}}, make any further changes.
@@ -89,11 +89,11 @@ To use a suggested rule, do one of the following:
 
 ## Configure an AAP In-App WAF rule
 
-Blocking on a service is defined through the policy rules. Three Datadog default policies are included in the In-App WAF: *Datadog Recommended*, *Datadog Monitoring-only*, which monitors attacks only, and *Datadog Block Attack tools*, which blocks attack tools and monitors all other attacks.
+Blocking on a service is defined through the policy rules. Three Datadog default policies are included in the In-App WAF: {{< ui >}}Datadog Recommended{{< /ui >}}, {{< ui >}}Datadog Monitoring-only{{< /ui >}}, which monitors attacks only, and {{< ui >}}Datadog Block Attack tools{{< /ui >}}, which blocks attack tools and monitors all other attacks.
 
 Services using a policy are visible directly in the policy management page.
 
-1. In Datadog, navigate to [Security > App and API Protection > Policies > In-App WAF][2].
+1. In Datadog, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][2].
 
    {{< img src="security/application_security/threats/waf/in-app-waf.png" alt="In-App WAF configuration page, showing two default policies." style="width:100%;" >}}
 

--- a/content/en/security/application_security/threat_protection/policies/library_configuration.md
+++ b/content/en/security/application_security/threat_protection/policies/library_configuration.md
@@ -51,8 +51,8 @@ You can add an entry to the passlist, which ignore events from a rule, to elimin
 
 To add a passlist entry, do one of the following:
 
-- Click on a signal in [AAP Signals][4] and click the **Add Entry** link next to the **Add to passlist** suggested action. This method automatically adds an entry for the targeted service.
-- Navigate to [Passlist Configuration][5] and manually configure a new passlist entry based on your own criteria.
+- Click on a signal in [AAP {{< ui >}}Signals{{< /ui >}}][4] and click the {{< ui >}}Add Entry{{< /ui >}} link next to the {{< ui >}}Add to passlist{{< /ui >}} suggested action. This method automatically adds an entry for the targeted service.
+- Navigate to [{{< ui >}}Passlist Configuration{{< /ui >}}][5] and manually configure a new passlist entry based on your own criteria.
 
 **Note**: Requests (traces) that match a passlist entry are not billed.
 

--- a/content/en/security/application_security/threat_protection/security_signals/_index.md
+++ b/content/en/security/application_security/threat_protection/security_signals/_index.md
@@ -23,13 +23,13 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 
 ## Overview
 
-AAP security signals are created when Datadog detects a threat based on a detection rule. View, search, filter, and investigate security signals in the [Signals Explorer][2], or configure [Notification Rules][8] to send signals to third-party tools.
+AAP security signals are created when Datadog detects a threat based on a detection rule. View, search, filter, and investigate security signals in the [{{< ui >}}Signals Explorer{{< /ui >}}][2], or configure [Notification Rules][8] to send signals to third-party tools.
 
 <!-- {{< img src="security/application_security/threats/security_signals/appsec-threat-signals.png" alt="Overview of investigating threats in signals explorer with details side panel">}} -->
 
 ## Signals Explorer columns
 
-The Signals Explorer displays the following columns.
+The {{< ui >}}Signals Explorer{{< /ui >}} displays the following columns.
 
 {{< ui >}}Severity{{< /ui >}}
 : There are five severity states: {{< ui >}}Info{{< /ui >}}, {{< ui >}}Low{{< /ui >}}, {{< ui >}}Medium{{< /ui >}}, {{< ui >}}High{{< /ui >}}, and {{< ui >}}Critical{{< /ui >}}. {{< ui >}}High{{< /ui >}} and {{< ui >}}Critical{{< /ui >}} indicate a major impact to service availability or active compromise.
@@ -51,13 +51,13 @@ The Signals Explorer displays the following columns.
 
 ## Filter security signals
 
-To filter the security signals in the [Signals Explorer][2], use the search query `@workflow.triage.state:<status>`, where `<status>` is the state you want to filter on (`open`, `under_review`, or `archived`). You can also use the {{< ui >}}Signal State{{< /ui >}} facet on the facet panel.
+To filter the security signals in the [{{< ui >}}Signals Explorer{{< /ui >}}][2], use the search query `@workflow.triage.state:<status>`, where `<status>` is the state you want to filter on (`open`, `under_review`, or `archived`). You can also use the {{< ui >}}Signal State{{< /ui >}} facet on the facet panel.
 
 ## Triage a signal
 
 You can triage a signal by assigning it to a user for further investigation. The assigned user can then track their review by updating the signal's status.
 
-1. On the [Signals Explorer][2] page, click the user profile icon in the {{< ui >}}Triage State{{< /ui >}} column.
+1. On the [{{< ui >}}Signals Explorer{{< /ui >}}][2] page, click the user profile icon in the {{< ui >}}Triage State{{< /ui >}} column.
 2. Select a user to assign the signal.
 3. To update the status of the security signal, click the triage status dropdown menu and select a status. The default status is {{< ui >}}Open{{< /ui >}}.
     - {{< ui >}}Open{{< /ui >}}: The signal has not yet been resolved.
@@ -77,7 +77,7 @@ Declare an incident if:
 
 If you don't know whether you should declare an incident, notify other users and increase severity appropriately.
 
-1. On the [Signals Explorer][2] page, select a security signal to open its details panel.
+1. On the [{{< ui >}}Signals Explorer{{< /ui >}}][2] page, select a security signal to open its details panel.
 2. On the signal panel, click {{< ui >}}Declare Incident{{< /ui >}} or select the dropdown arrow and select {{< ui >}}Add to an existing incident{{< /ui >}}.
 3. When you declare a new incident, in the {{< ui >}}Declare Incident{{< /ui >}} settings, configure the incident by specifying details such as the severity level and incident commander.
    1. Estimate impact. Severity levels go from SEV-1 (critical) to SEV-5 (minor impact). When in doubt, always choose the higher severity.
@@ -88,7 +88,7 @@ If you don't know whether you should declare an incident, notify other users and
 Use [Workflow Automation][5] to manually trigger a workflow for a security signal.
 
 1. Make sure the workflow you want to run has a security trigger.
-2. On the [Signals Explorer][2] page, open a security signal.
+2. On the [{{< ui >}}Signals Explorer{{< /ui >}}][2] page, open a security signal.
 3. In the {{< ui >}}Respond{{< /ui >}} section, click {{< ui >}}Run Workflow{{< /ui >}}.
 4. In {{< ui >}}Run a workflow{{< /ui >}}, select the workflow you want to run or click {{< ui >}}New Workflow{{< /ui >}}.
    - Depending on the workflow you select, you might be required to enter additional input parameters.
@@ -97,7 +97,7 @@ Use [Workflow Automation][5] to manually trigger a workflow for a security signa
 
 ## Review and remediate
 
-1. On the [Signals Explorer][2] page, open a security signal.
+1. On the [{{< ui >}}Signals Explorer{{< /ui >}}][2] page, open a security signal.
 2. In the signal details, view each of the sections, such as {{< ui >}}What Happened{{< /ui >}}, {{< ui >}}Activity Summary{{< /ui >}}, and {{< ui >}}Detection Rule{{< /ui >}}.
 3. Review the {{< ui >}}Next Steps{{< /ui >}} and take action:
     -  Click {{< ui >}}Block all Attacking IPs{{< /ui >}} (by specific duration or permanently).
@@ -122,7 +122,7 @@ Select {{< ui >}}Remove all assignments{{< /ui >}} to reset the signal assignmen
 
 Datadog [Case Management][6] offers a centralized place to triage, track, and remediate issues detected by Datadog and third-party integrations.
 
-1. On the [Signals Explorer][2] page, select a security signal.
+1. On the [{{< ui >}}Signals Explorer{{< /ui >}}][2] page, select a security signal.
 2. In {{< ui >}}Bulk Actions{{< /ui >}}, select {{< ui >}}Create a case{{< /ui >}}.
 3. Select {{< ui >}}Create a case{{< /ui >}} or {{< ui >}}Add to an existing case{{< /ui >}} to add the signal to an existing case.
 4. Enter a title and optional description.
@@ -132,7 +132,7 @@ When you click {{< ui >}}Create Case{{< /ui >}}, you are directed to Case Manage
 
 ## Saved views
 
-You can save different configurations of the Signals Explorer as views. For example, you could filter the explorer to show all unassigned signals and then save that as a view.
+You can save different configurations of the {{< ui >}}Signals Explorer{{< /ui >}} as views. For example, you could filter the explorer to show all unassigned signals and then save that as a view.
 
 When a configuration is saved as a view, you and your teammates can use it later.
 

--- a/content/en/security/application_security/threat_protection/security_signals/attacker-explorer.md
+++ b/content/en/security/application_security/threat_protection/security_signals/attacker-explorer.md
@@ -21,16 +21,16 @@ This topic describes how to use {{< ui >}}Attackers Explorer{{< /ui >}} to inves
 
 ## Overview
 
-Datadog App and API Protection (AAP) identifies attackers as suspicious and flagged. With [Attackers Explorer][1], you can investigate and take action against the attackers. 
+Datadog App and API Protection (AAP) identifies attackers as suspicious and flagged. With [{{< ui >}}Attackers Explorer{{< /ui >}}][1], you can investigate and take action against the attackers. 
 
 
 ### Definitions
 
-- **Suspicious Attackers:** IP addresses that have sent attack traffic in the last 24 hours up to a maximum threshold.
+- {{< ui >}}Suspicious Attackers{{< /ui >}}: IP addresses that have sent attack traffic in the last 24 hours up to a maximum threshold.
 
-- **Flagged Attackers:** IP addresses that have sent attack traffic, exceeding the threshold of Suspicious Attackers, in the last 24 hours. Flagged Attackers should be reviewed and blocked.
+- {{< ui >}}Flagged Attackers{{< /ui >}}: IP addresses that have sent attack traffic, exceeding the threshold of Suspicious Attackers, in the last 24 hours. Flagged Attackers should be reviewed and blocked.
 
-<div class="alert alert-info"><strong>Flagged Attackers</strong> and <strong>Suspicious Attackers</strong> are mutually exclusive. An IP cannot be in both states at the same time.</a></div>
+<div class="alert alert-info">{{< ui >}}Flagged Attackers{{< /ui >}} and {{< ui >}}Suspicious Attackers{{< /ui >}} are mutually exclusive. An IP cannot be in both states at the same time.</a></div>
 
 ### How Attackers Explorer differs from Signal and Trace explorers
 
@@ -43,14 +43,14 @@ To understand the difference between the different explorers, review these appro
 
 Each explorer focuses on a specific use case:
 
-- **Signal Explorer**: List of actionable alerts such as Credential Stuffing Attack or Command Injection. Signals have workflow capabilities, a description, severity, and correlated Traces. Interactions include user assignment workflows, automated protection, analytics, search, and pivoting to Trace Explorer.
-- **Trace Explorer**: List of evidence for business logic events, such as logins, or attack payloads. Interactions include analytics and search.
-- **Users Explorer**: Lists authenticated users associated with one or more traces. Interactions include: 
+- {{< ui >}}Signal Explorer{{< /ui >}}: List of actionable alerts such as Credential Stuffing Attack or Command Injection. Signals have workflow capabilities, a description, severity, and correlated Traces. Interactions include user assignment workflows, automated protection, analytics, search, and pivoting to Trace Explorer.
+- {{< ui >}}Trace Explorer{{< /ui >}}: List of evidence for business logic events, such as logins, or attack payloads. Interactions include analytics and search.
+- {{< ui >}}Users Explorer{{< /ui >}}: Lists authenticated users associated with one or more traces. Interactions include: 
   - Bulk actions for user analytics and blocking
   - Drill-down into the history of any user
   - Search
   - Pivoting to other explorers
-- **Attackers Explorer**: List of Flagged and Suspicious Attackers. Interactions include: 
+- {{< ui >}}Attackers Explorer{{< /ui >}}: List of Flagged and Suspicious Attackers. Interactions include: 
   - Bulk actions for attacker analytics and blocking
   - Drill-down into the history of any attacker
   - Search
@@ -59,7 +59,7 @@ Each explorer focuses on a specific use case:
 
 ### Explore and filter attackers
 
-To start reviewing attackers, go to [Attackers Explorer][1].
+To start reviewing attackers, go to [{{< ui >}}Attackers Explorer{{< /ui >}}][1].
 
 <!-- {{< img src="security/application_security/threats/attacker-explorer/attacker_explorer_default_view2.png" alt="AAP Attackers Explorer"  >}} -->
 
@@ -83,7 +83,7 @@ An attacker can be blocked or added to the Passlist from its details.
 Details common to all attacker views:
 
 - {{< ui >}}Blocking Status{{< /ui >}}: Indicates whether the attacker IP is actively being blocked, helping you confirm if immediate action is needed.
-- {{< ui >}}Threat Intelligence{{< /ui >}}: Show Datadog definitions **Suspicious** or **Flagged**.
+- {{< ui >}}Threat Intelligence{{< /ui >}}: Show Datadog definitions {{< ui >}}Suspicious{{< /ui >}} or {{< ui >}}Flagged{{< /ui >}}.
 - {{< ui >}}Last Information{{< /ui >}}: Provides contextual network origin (for example, route, public/private status, geolocation), which helps you understand attacker infrastructure and scope.
 - {{< ui >}}Associated Users{{< /ui >}}: Shows which user accounts (if any) were affected or linked to the IP, assisting with lateral movement tracking and potential account compromise identification.
 - {{< ui >}}Security Traces{{< /ui >}}: Visualizes the timeline and volume of suspicious activity (for example, **151k AAP traces**), helping SOC teams correlate events and identify peaks in attack behavior.
@@ -161,13 +161,13 @@ When you select the {{< ui >}}Compare and Block{{< /ui >}} option, the {{< ui >}
 
 {{< img src="security/application_security/threats/attacker-explorer/attacker_explorer_review_groups2.png" alt="Screenshot of the AAP Attackers Explorer group blocking"  >}}
 
-<div class="alert alert-info">Metrics for <strong>Similarity Overview</strong> and <strong>Activity</strong> are scoped to the last 30 days.</a></div>
+<div class="alert alert-info">Metrics for {{< ui >}}Similarity Overview{{< /ui >}} and {{< ui >}}Activity{{< /ui >}} are scoped to the last 30 days.</a></div>
 
 The {{< ui >}}Block selected attackers{{< /ui >}} view metrics are explained in the following sections.
 
 ### Selected IPs
 
-Contains the IPs selected from the explorer. Deselecting an IP removes it from the metrics sections and **Block** action.
+Contains the IPs selected from the explorer. Deselecting an IP removes it from the metrics sections and {{< ui >}}Block{{< /ui >}} action.
 
 ### Similarity overview
 

--- a/content/en/security/application_security/threat_protection/security_signals/attacker_clustering.md
+++ b/content/en/security/application_security/threat_protection/security_signals/attacker_clustering.md
@@ -57,7 +57,7 @@ Attacker clustering is computed using the following request attributes:
 * HTTP request headers (for example, `accept-encoding`, `content-type`)
 * [Datadog attacker fingerprinting][2]
 
-When the attacker attributes are identified, they are displayed on the signal side panel and **Signals** page. Attacker attributes can be a combination of the attributes listed above.
+When the attacker attributes are identified, they are displayed on the signal side panel and {{< ui >}}Signals{{< /ui >}} page. Attacker attributes can be a combination of the attributes listed above.
 
 {{< img src="security/application_security/threats/attacker-attributes.png" alt="Screenshot of an AAP signals with attacker attributes identified"  >}}
 
@@ -97,14 +97,14 @@ After an attacker cluster is identified, you can directly generate an In-App WAF
 
 To block a cluster:
 
-1. Open the **Attacker Explorer** and select the **Cluster** grouping.
+1. Open the {{< ui >}}Attacker Explorer{{< /ui >}} and select the {{< ui >}}Cluster{{< /ui >}} grouping.
 2. Click a cluster to open its side panel.
-3. Click **Create In-App WAF rule** in the cluster header. The In-App WAF custom rule form opens pre-filled with the generated conditions, one condition per blocking attribute, combined with AND logic.
+3. Click {{< ui >}}Create In-App WAF rule{{< /ui >}} in the cluster header. The In-App WAF custom rule form opens pre-filled with the generated conditions, one condition per blocking attribute, combined with AND logic.
 4. Review the conditions and adjust if needed, then save the rule.
 
-Alternatively, inside a security signal, you can click the **Create In-App WAF rule** icon on the cluster row in the clusters table.
+Alternatively, inside a security signal, you can click the {{< ui >}}Create In-App WAF rule{{< /ui >}} icon on the cluster row in the clusters table.
 
-If a matching blocking rule already exists for a cluster, the button changes to **View In-App WAF rule** and links directly to the existing rule.
+If a matching blocking rule already exists for a cluster, the button changes to {{< ui >}}View In-App WAF rule{{< /ui >}} and links directly to the existing rule.
 
 {{< img src="security/application_security/threats/block-cluster-button.png" alt="The attacker cluster side panel with the Create In-App WAF rule button highlighted" >}}
 

--- a/content/en/security/application_security/threat_protection/security_signals/users_explorer.md
+++ b/content/en/security/application_security/threat_protection/security_signals/users_explorer.md
@@ -11,40 +11,40 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 </div>
 {{< /site-region >}}
 
-This topic describes how to use the App and API Protection [Users explorer][1] to investigate the risks associated with the users tracked by security [traces][3].
+This topic describes how to use the App and API Protection [{{< ui >}}Users explorer{{< /ui >}}][1] to investigate the risks associated with the users tracked by security [{{< ui >}}traces{{< /ui >}}][3].
 
 ## Overview
 
-Datadog populates the Users explorer by associating users with security traces from events like login attempts. This makes the Users explorer an inventory of tracked users. Users are identified by user ID (`@usr.id`) and, when available, user name and email address. See [Adding authenticated user information to traces and enabling user blocking capability][8].
+Datadog populates the {{< ui >}}Users explorer{{< /ui >}} by associating users with security traces from events like login attempts. This makes the {{< ui >}}Users explorer{{< /ui >}} an inventory of tracked users. Users are identified by user ID (`@usr.id`) and, when available, user name and email address. See [Adding authenticated user information to traces and enabling user blocking capability][8].
 
-Typically, users in the Users explorer are not a risk. However, the explorer helps you identify user accounts that are at risk or are actively being attacked (for example, through attempts to compromise an account).
+Typically, users in the {{< ui >}}Users explorer{{< /ui >}} are not a risk. However, the explorer helps you identify user accounts that are at risk or are actively being attacked (for example, through attempts to compromise an account).
 
-With the Users explorer, you can investigate and take action on the user accounts flagged as risks using **risk categories**.
+With the {{< ui >}}Users explorer{{< /ui >}}, you can investigate and take action on the user accounts flagged as risks using **risk categories**.
 
 ### Risk categories
 
-The Users explorer assigns one or more of the following risk categories to a user identified as a risk:
+The {{< ui >}}Users explorer{{< /ui >}} assigns one or more of the following risk categories to a user identified as a risk:
 
-- **New Geolocation:** User activity from an unfamiliar location might indicate unauthorized access or legitimate travel requiring verification.
-- **Impossible Travel:** Occurs when a user logs in from two distant locations in an unrealistically short time, indicating possible credential compromise. A caveat with this category is it can falsely identify users on the same VPN as impossible travel.
-- **Compromised User:** A user's credentials are stolen or hacked, allowing attackers to perform malicious activities with their identity.
-- **Disposable Email:** A disposable email is an email address that is temporary.
+- {{< ui >}}New Geolocation{{< /ui >}}: User activity from an unfamiliar location might indicate unauthorized access or legitimate travel requiring verification.
+- {{< ui >}}Impossible Travel{{< /ui >}}: Occurs when a user logs in from two distant locations in an unrealistically short time, indicating possible credential compromise. A caveat with this category is it can falsely identify users on the same VPN as impossible travel.
+- {{< ui >}}Compromised User{{< /ui >}}: A user's credentials are stolen or hacked, allowing attackers to perform malicious activities with their identity.
+- {{< ui >}}Disposable Email{{< /ui >}}: A disposable email is an email address that is temporary.
 
-<div class="alert alert-info">When a user ID, email, or name is associated with a trace, but does not match a risk category, it still appears in the Users explorer.</div>
+<div class="alert alert-info">When a user ID, email, or name is associated with a trace, but does not match a risk category, it still appears in the {{< ui >}}Users explorer{{< /ui >}}.</div>
 
 ### How the Users explorer differs from other explorers
 
 To understand the difference between the different explorers, review these security approaches they support:
 
 - **Protect:** Automatically block attackers (IPs and authenticated users) using App and API Protection [Policies][2]. Customers should block attack tools as their first automated blocking action. Blocking attack tools reduces common vulnerability discovery for OWASP threats such as SQLi, command injection, and SSRF.
-- **React:** Blocking attackers in response to observed threats using the [Signals][9], [Traces][3], Users, [Attackers][4] explorers.
+- **React:** Blocking attackers in response to observed threats using the [{{< ui >}}Signals{{< /ui >}}][9], [{{< ui >}}Traces{{< /ui >}}][3], {{< ui >}}Users{{< /ui >}}, [{{< ui >}}Attackers{{< /ui >}}][4] explorers.
 
 Each explorer focuses on a specific use case:
 
-- **Signals explorer**: Provides a list of actionable alerts such as `Credential Stuffing Attack` or `Command Injection`. Signals have workflow capabilities, a description, severity, and correlated Traces. Interactions include user assignment workflows, automated protection, analytics, search, and pivoting to Traces Explorer.
-- **Traces explorer**: Lists evidence for business logic events, such as logins, or attack payloads. Interactions include analytics and search.
-- **Attackers explorer**: Identifies attackers as `suspicious` (IP addresses that have attacked in the last 24 hours up to a threshold) and `flagged` (IP addresses that have exceeded that threshold).
-- **Users explorer**: Lists authenticated users associated with one or more traces. Interactions include: 
+- {{< ui >}}Signals explorer{{< /ui >}}: Provides a list of actionable alerts such as `Credential Stuffing Attack` or `Command Injection`. Signals have workflow capabilities, a description, severity, and correlated Traces. Interactions include user assignment workflows, automated protection, analytics, search, and pivoting to {{< ui >}}Traces Explorer{{< /ui >}}.
+- {{< ui >}}Traces explorer{{< /ui >}}: Lists evidence for business logic events, such as logins, or attack payloads. Interactions include analytics and search.
+- {{< ui >}}Attackers explorer{{< /ui >}}: Identifies attackers as `suspicious` (IP addresses that have attacked in the last 24 hours up to a threshold) and `flagged` (IP addresses that have exceeded that threshold).
+- {{< ui >}}Users explorer{{< /ui >}}: Lists authenticated users associated with one or more traces. Interactions include: 
   - Bulk actions for user analytics and blocking
   - Drill-down into the history of any user
   - Search
@@ -52,31 +52,31 @@ Each explorer focuses on a specific use case:
 
 ## Explore and filter users
 
-To start reviewing users, go to the [Users explorer][1].
+To start reviewing users, go to the [{{< ui >}}Users explorer{{< /ui >}}][1].
 
-The main sections in the Users explorer are:
+The main sections in the {{< ui >}}Users explorer{{< /ui >}} are:
 
 - Facets and search. These enable you to filter users by multiple user attributes.
 - The list of users with security metrics. 
   - Click a user to examine their risks, IPs, locations, endpoints, and signals. 
   - You can block an individual user from the list or its details drawer.
-  - To block multiple users, select one or more users and click **Compare and Block**.
+  - To block multiple users, select one or more users and click {{< ui >}}Compare and Block{{< /ui >}}.
 
 ## Block a user
 
 To block an individual user, do the following: 
 
-1. Click **Block** in the user's row, and choose a blocking duration.
-2. In **Select Security Responses**, select **Block with Datadog's Library**.
+1. Click {{< ui >}}Block{{< /ui >}} in the user's row, and choose a blocking duration.
+2. In {{< ui >}}Select Security Responses{{< /ui >}}, select {{< ui >}}Block with Datadog's Library{{< /ui >}}.
    
-   Permanently or temporarily blocked authenticated users are added to the [Denylist][6]. Manage the list on the Datadog [Denylist][7] page.
+   Permanently or temporarily blocked authenticated users are added to the [Denylist][6]. Manage the list on the Datadog [{{< ui >}}Denylist{{< /ui >}}][7] page.
 
 
 ## Compare and block multiple users
 
-When you select two or more users, you can use the **Compare and Block** button to compare datapoints across potentially compromised users.
+When you select two or more users, you can use the {{< ui >}}Compare and Block{{< /ui >}} button to compare datapoints across potentially compromised users.
 
-When you click **Compare and Block**, several metrics are displayed in **Block selected users**. These metrics help you detect whether you are dealing with **a single attacker**, **a larger coordinated campaign**, or **widespread credential exposure**.
+When you click {{< ui >}}Compare and Block{{< /ui >}}, several metrics are displayed in {{< ui >}}Block selected users{{< /ui >}}. These metrics help you detect whether you are dealing with **a single attacker**, **a larger coordinated campaign**, or **widespread credential exposure**.
 
 Here's a breakdown of the benefits of comparing each datapoint across two (or more) compromised users.
 

--- a/content/en/security/application_security/threat_protection/waf-integration.md
+++ b/content/en/security/application_security/threat_protection/waf-integration.md
@@ -56,12 +56,12 @@ There are two main use cases supported with this [integration][1]:
    2. Drill down and view individual AWS WAF logs (requires you to [ingest AWS WAF logs into Datadog][2]).
    3. How AWS WAF inspected the request: rules that were applied and the decision made (allow, block, or count).
 
-   <div class="alert alert-info">AAP converts AWS WAF logs into AAP Traces, enabling you to view application activity (traces) and AWS WAF activity (logs converted to AAP traces) in the AAP Trace Explorer.</div>
+   <div class="alert alert-info">AAP converts AWS WAF logs into AAP Traces, enabling you to view application activity (traces) and AWS WAF activity (logs converted to AAP traces) in the AAP {{< ui >}}Trace Explorer{{< /ui >}}.</div>
 
    <!-- {{< img src="security/application_security/threats/aws-waf-int-asm.png" alt="AWS WAF integration details in Datadog UI" style="width:100%;" >}} -->
 
 2. Leverage AWS WAF to block attackers:
-   1. Connect your AWS WAF IP set(s) with Datadog AAP. You can use an existing set or create a new one. Datadog will add blocked IP addresses to this IP set. You can block attackers from AAP [Signals][3] or [Traces][4] explorers.
+   1. Connect your AWS WAF IP set(s) with Datadog AAP. You can use an existing set or create a new one. Datadog will add blocked IP addresses to this IP set. You can block attackers from AAP [{{< ui >}}Signals{{< /ui >}}][3] or [{{< ui >}}Traces{{< /ui >}}][4] explorers.
 
    <!-- {{< img src="/security/application_security/threats/aws-waf-blocked-ips.png" alt="AAP denylist blocked IPs" style="width:100%;" >}} -->
 

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -27,15 +27,15 @@ AAP traces are rate-limited to 100 traces per second. Traces sent after the limi
 
 ## No security traces detected by AAP
 
-There are a series of steps that must run successfully for threat information to appear in the AAP [Trace and Signals Explorer][2]. It is important to check each step when investigating this issue. Additional troubleshooting steps for specific languages are in the language tab at the end.
+There are a series of steps that must run successfully for threat information to appear in the AAP [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][2]. It is important to check each step when investigating this issue. Additional troubleshooting steps for specific languages are in the language tab at the end.
 
 ### Confirm AAP is enabled
 
 You can use the metric `datadog.apm.appsec_host` to check if AAP is running.
 
-1. Go to **Metrics > Summary** in Datadog.
+1. Go to {{< ui >}}Metrics{{< /ui >}} > {{< ui >}}Summary{{< /ui >}} in Datadog.
 2. Search for the metric `datadog.apm.appsec_host`. If the metric doesn't exist, then there are no services running AAP. If the metric exists, the services are reported with the metric tags `host` and `service`.
-3. Select the metric, and in the **Tags** section, search for `service` to see which services are running AAP.
+3. Select the metric, and in the {{< ui >}}Tags{{< /ui >}} section, search for `service` to see which services are running AAP.
 
 If you are not seeing `datadog.apm.appsec_host`, check the [in-app instructions][3] to confirm that all steps for the initial setup are complete.
 
@@ -146,7 +146,7 @@ done
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
-A few minutes after you enable your application and exercise it, and if it's successful, threat information appears in the [Trace and Signals Explorer][2].
+A few minutes after you enable your application and exercise it, and if it's successful, threat information appears in the [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][2].
 
 {{< img src="/security/security_monitoring/explorer/signal_panel_v2.png" alt="Security Signal details page showing tags, metrics, suggested next steps, and attacker IP addresses associated with a threat." style="width:100%;" >}}
 
@@ -379,7 +379,7 @@ Enable debug logs with the environment variable `DD_TRACE_DEBUG=1`. The AAP libr
 
 Use this [migration guide][1] to assess any breaking changes if you upgraded your Node.js library from 1.x to 2.x.
 
-If you don't see AAP threat information in the [Trace and Signals Explorer][2] for your Node.js application, follow these steps to troubleshoot the issue:
+If you don't see AAP threat information in the [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][2] for your Node.js application, follow these steps to troubleshoot the issue:
 
 1. Confirm the latest version of AAP is running by checking that `appsec_enabled` is `true` in the [startup logs][3].
    1. If you don't see startup logs after a request has been sent, add the environment variable `DD_TRACE_STARTUP_LOGS=true` to enable startup logs. Check the startup logs for `appsec_enabled` is `true`.
@@ -405,7 +405,7 @@ If you don't see AAP threat information in the [Trace and Signals Explorer][2] f
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
-If you don't see AAP threat information in the [Trace and Signals Explorer][1] for your Python application, check that AAP is running and that your tracer is working.
+If you don't see AAP threat information in the [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][1] for your Python application, check that AAP is running and that your tracer is working.
 
 1. Set your application's log level to `DEBUG` to confirm that AAP is running:
 
@@ -432,7 +432,7 @@ If you don't see AAP threat information in the [Trace and Signals Explorer][1] f
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
-For Ruby, if you don't see AAP threat information in the [Trace and Signals Explorer][1] after a few minutes, enable tracer diagnostics for [debug logs][2]. For example:
+For Ruby, if you don't see AAP threat information in the [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][1] after a few minutes, enable tracer diagnostics for [debug logs][2]. For example:
 
 ```ruby
 Datadog.configure do |c|
@@ -525,7 +525,7 @@ Metrics: [
    _sampling_priority_v1 => 2.0]]
 ```
 
-Wait a minute for the agent to forward the traces, then check that the traces show up in the APM dashboard. The security information in the traces may take additional time to be processed by Datadog before showing up as security traces in the AAP [Trace and Signals Explorer][1].
+Wait a minute for the agent to forward the traces, then check that the traces show up in the APM dashboard. The security information in the traces may take additional time to be processed by Datadog before showing up as security traces in the AAP [{{< ui >}}Trace and Signals Explorer{{< /ui >}}][1].
 
 [1]: https://app.datadoghq.com/security/appsec/
 [2]: /tracing/troubleshooting/#tracer-debug-logs
@@ -545,7 +545,7 @@ Ensure the `DD_INSTRUMENTATION_TELEMETRY_ENABLED` environment variable (`DD_TRAC
 To disable AAP, use one of the following methods.
 
 If you enabled AAP using the `DD_APPSEC_ENABLED=true` environment variable, use the DD_APPSEC_ENABLED section below.
-If you enabled AAP using [Remote Configuration][16], use the Remote Configuration method below.
+If you enabled AAP using [{{< ui >}}Remote Configuration{{< /ui >}}][16], use the Remote Configuration method below.
 
 ### DD_APPSEC_ENABLED
 
@@ -555,22 +555,22 @@ If your service is a PHP service, explicitly set the environment variable to `DD
 
 ### Remote Configuration
 
-If AAP was activated using [Remote Configuration][16], do the following: 
-  1. Go to [Services][15].
-  2. Select **App & API Protection in Monitoring Mode**.
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+If AAP was activated using [{{< ui >}}Remote Configuration{{< /ui >}}][16], do the following: 
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. Select {{< ui >}}App & API Protection in Monitoring Mode{{< /ui >}}.
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   4. Click on a service.
-  5. In the service details, in **App & API Protection**, click **Deactivate**.
+  5. In the service details, in {{< ui >}}App & API Protection{{< /ui >}}, click {{< ui >}}Deactivate{{< /ui >}}.
 
-<div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">Remote Configuration</a>, you can use a <strong>Deactivate</strong> button. If AAP was activated using local configuration, the <strong>Deactivate</strong> button is not an option.</div>
+<div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">{{< ui >}}Remote Configuration{{< /ui >}}</a>, you can use a {{< ui >}}Deactivate{{< /ui >}} button. If AAP was activated using local configuration, the {{< ui >}}Deactivate{{< /ui >}} button is not an option.</div>
 
 ### Bulk disable
 
 To disable AAP on your services in bulk, do the following: 
-  1. Go to [Services][15].
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   3. Select the check boxes for the services where you want to disable threat detection.
-  4. In **Bulk Actions**, select **Deactivate Threat detection on (number of) services**.
+  4. In {{< ui >}}Bulk Actions{{< /ui >}}, select {{< ui >}}Deactivate Threat detection on (number of) services{{< /ui >}}.
 
   
 ## Need more help?


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15327

Normalizes App and API Protection naming across `/security/application_security/` and child pages:

- Use "App and API Protection" when referring to the product as an entity (prose, page titles, cross-references).
- Use "App & API Protection" wrapped in `{{< ui >}}` only when referring to a literal UI element (nav paths, breadcrumbs, buttons, filters).
- Removes stray bold/italic formatting on strings converted to `{{< ui >}}` tags.
- Also applies semantic `{{< ui >}}` tagging to other UI strings (buttons, tabs, fields, nav paths) found on these pages while auditing for the naming fix.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to audit and edit pages: normalized App and API Protection naming per the ticket's rules, and applied semantic UI tagging based on the repo's `mark-up-ui` skill guidelines. All changes were reviewed before commit.

### Additional notes