### PR TITLE
Clarify .NET CommandType.StoredProcedure support

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -77,7 +77,7 @@ Datadog SDK integrations support a *Propagation Mode*, which controls the amount
 | **Java** | [dd-trace-java](https://github.com/DataDog/dd-trace-java) >= 1.11.0 | [jdbc](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) | `full`<br>`service` |
 | **.NET** | [dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet) >= 2.35.0 | [System.Data.SqlClient](https://learn.microsoft.com/sql/connect/ado-net/microsoft-ado-net-sql-server)<br>[Microsoft.Data.SqlClient](https://learn.microsoft.com/sql/connect/ado-net/introduction-microsoft-data-sqlclient-namespace) | `full`<br>`service` |
 
-**Note**: [CommandType.StoredProcedure](https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtype?view=dotnet-plat-ext-7.0#remarks:~:text=[…]%20should%20set) is not supported for .NET drivers.
+**Note**: [CommandType.StoredProcedure](https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtype?view=dotnet-plat-ext-7.0#remarks) requires .NET tracer 3.14.0 or later. On earlier versions, trace context is not injected for stored procedure calls.
 
 For `full` mode with Java and .NET:
 


### PR DESCRIPTION
Updated note regarding CommandType.StoredProcedure support for .NET drivers to specify .NET tracer version requirement.

Confirmed working for versions above 3.14.0, tested end to end.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
