### PR TITLE
📱 Add Samsung Galaxy A15 5G to supported Mobile App Testing devices

### DIFF
--- a/content/en/synthetics/mobile_app_testing/devices.md
+++ b/content/en/synthetics/mobile_app_testing/devices.md
@@ -148,6 +148,11 @@ multifiltersearch:
       platform: Android
       eu: 'No'
       us: 'Yes'
+    - device: Samsung Galaxy A15 5G
+      os: Android 14
+      platform: Android
+      eu: 'No'
+      us: 'Yes'
     - device: Samsung Galaxy A71
       os: Android 11
       platform: Android


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds the **Samsung Galaxy A15 5G** (Android 14) to the [Supported Mobile App Testing Devices](https://docs.datadoghq.com/synthetics/mobile_app_testing/devices/) list so it matches what customers see in-product.

Net change: 71 -> 72 devices.

Added:
- Samsung Galaxy A15 5G (Android 14)

The device is available in the US region only (Sauce Labs `us-east-4`), so it is listed with **EU: No / US: Yes**. Only the English source is updated; localized copies are handled by the localization pipeline.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI-assisted (Claude Code): added the device to the English devices source following the structure of #38002, and validated the output (YAML parse, quoted eu/us flags).

### Additional notes
