### PR TITLE
[reorg fix] Document include_scopes query param on GET /api/v2/permissions

### DIFF
--- a/hugo/data/api/v2/full_spec.yaml
+++ b/hugo/data/api/v2/full_spec.yaml
@@ -177566,6 +177566,19 @@ paths:
       description: |-
         Returns a list of all permissions, including name, description, and ID.
       operationId: ListPermissions
+      parameters:
+        - description: |-
+            Set to `true` to return all permissions, including both permissions
+            that can be assigned to user roles and permissions that can only be
+            used as scopes for OAuth clients and scoped credentials. When `false`
+            (default), only permissions that can be assigned to user roles are
+            returned.
+          example: false
+          in: query
+          name: include_scopes
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           content:


### PR DESCRIPTION
🤖 Auto-generated fix for #38785.

@app/api-clients-generation-pipeline — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38785. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38785 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38785) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

See [DataDog/datadog-api-spec#6318](https://github.com/DataDog/datadog-api-spec/pull/6318) Test branch [datadog-api-spec/test/stephen.rosenthal/document-include-scopes-permissions](https://github.com/DataDog/documentation/compare/datadog-api-spec/test/stephen.rosenthal/document-include-scopes-permissions)