### PR TITLE
[reorg fix] WIF: document Agent credential sources by version and component

### DIFF
--- a/hugo/content/en/account_management/workload_identity_federation.md
+++ b/hugo/content/en/account_management/workload_identity_federation.md
@@ -272,12 +272,14 @@ Workload Identity Federation for the Datadog Agent is available for customers on
 Workload Identity Federation for the Agent allows you to authenticate your Agent using AWS credentials instead of managing static API keys. The Agent exchanges an AWS authentication proof for a managed API key that Datadog automatically rotates.
 
 **Requirements**:
-- Version `7.78.0` or later of the Datadog Agent. The credential sources available to you depend on your Agent version and on which Agent component sends the data. See [Supported credential sources](#supported-credential-sources).
+- Version `7.78.0` or later of the Datadog Agent. The credential sources available to you depend on your Agent version and on which Agent component sends the data. See [Supported credential sources for the Agent](#supported-credential-sources-for-the-agent).
 - The Agent runs in an AWS environment with access to AWS credentials.
 - You have configured the [Datadog-AWS integration][4] and added your AWS account. See the [AWS Integration docs][3].
 - Your account has the `workload_identity_federation_config_read` and `workload_identity_federation_config_write` permissions.
 
-### Supported credential sources
+### Supported credential sources for the Agent
+
+<div class="alert alert-info">This section applies to the Datadog Agent only. The Datadog Terraform provider and the Datadog API clients resolve AWS credentials differently, and support a different set of sources.</div>
 
 The Agent looks for AWS credentials in the following sources, in this order. The first source that provides credentials is used.
 
@@ -288,7 +290,7 @@ The Agent looks for AWS credentials in the following sources, in this order. The
 | [EKS IAM roles for service accounts (IRSA)][8] | `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` | `7.82.0` |
 | [ECS task role][9] and [EKS Pod Identity][10] | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` | `7.82.0` |
 
-Shared AWS configuration files and named profiles (`AWS_PROFILE`, `~/.aws`) are not used.
+The Agent does not read shared AWS configuration files or named profiles (`AWS_PROFILE`, `~/.aws`). This differs from the Terraform provider, which does support AWS credential files.
 
 #### Agent component support
 

--- a/hugo/content/en/account_management/workload_identity_federation.md
+++ b/hugo/content/en/account_management/workload_identity_federation.md
@@ -272,10 +272,45 @@ Workload Identity Federation for the Datadog Agent is available for customers on
 Workload Identity Federation for the Agent allows you to authenticate your Agent using AWS credentials instead of managing static API keys. The Agent exchanges an AWS authentication proof for a managed API key that Datadog automatically rotates.
 
 **Requirements**:
-- Version `7.78.0` or later of the Datadog Agent.
-- The Agent runs in an AWS environment with access to AWS credentials (for example, an EC2 instance with an IAM role, ECS task, or EKS pod).
+- Version `7.78.0` or later of the Datadog Agent. The credential sources available to you depend on your Agent version and on which Agent component sends the data. See [Supported credential sources](#supported-credential-sources).
+- The Agent runs in an AWS environment with access to AWS credentials.
 - You have configured the [Datadog-AWS integration][4] and added your AWS account. See the [AWS Integration docs][3].
 - Your account has the `workload_identity_federation_config_read` and `workload_identity_federation_config_write` permissions.
+
+### Supported credential sources
+
+The Agent looks for AWS credentials in the following sources, in this order. The first source that provides credentials is used.
+
+| Credential source | Environment variables | Minimum Agent version |
+| --- | --- | --- |
+| [Static credentials][11] | `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` | `7.78.0` |
+| [EC2 instance role][7] (retrieved through IMDS) | None | `7.78.0` |
+| [EKS IAM roles for service accounts (IRSA)][8] | `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` | `7.82.0` |
+| [ECS task role][9] and [EKS Pod Identity][10] | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` | `7.82.0` |
+
+Shared AWS configuration files and named profiles (`AWS_PROFILE`, `~/.aws`) are not used.
+
+#### Agent component support
+
+In Agent `7.82.0` and earlier, only the following components can use the EC2 instance role, EKS IRSA, and ECS task role or EKS Pod Identity sources:
+
+- Core Agent (metrics, logs, and checks)
+- Cluster Agent
+- Process Agent
+- Security Agent
+- Datadog Installer
+
+The following components support Workload Identity Federation but are limited to static credentials supplied through environment variables:
+
+- APM (trace Agent)
+- Standalone DogStatsD
+- Private Action Runner
+- IoT Agent
+- Heroku Agent
+
+<div class="alert alert-warning">If you run APM on an EKS pod or an ECS task and do not supply static credentials through environment variables, the trace Agent cannot obtain a managed API key. It falls back to the <code>api_key</code> configured in <code>datadog.yaml</code>. See <a href="#fallback-behavior">Fallback behavior</a>.</div>
+
+Workload Identity Federation is not available in the OpenTelemetry Collector (DDOT) or the AWS Lambda extension. These require a statically configured `api_key`.
 
 Setting up Workload Identity Federation for the Agent involves two parts:
 1. [Configuring your AWS intake mapping in Datadog](#configure-aws-intake-mapping-in-datadog)
@@ -460,3 +495,8 @@ delegated_auth:
 [4]: https://app.datadoghq.com/integrations/amazon-web-services
 [5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html
 [6]: https://app.datadoghq.com/organization-settings/workload-identity-federation
+[7]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+[8]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+[10]: https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html
+[11]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

--- a/hugo/content/en/account_management/workload_identity_federation.md
+++ b/hugo/content/en/account_management/workload_identity_federation.md
@@ -283,34 +283,35 @@ Workload Identity Federation for the Agent allows you to authenticate your Agent
 
 The Agent looks for AWS credentials in the following sources, in this order. The first source that provides credentials is used.
 
-| Credential source | Environment variables | Minimum Agent version |
-| --- | --- | --- |
-| [Static credentials][11] | `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` | `7.78.0` |
-| [EC2 instance role][7] (retrieved through IMDS) | None | `7.78.0` |
-| [EKS IAM roles for service accounts (IRSA)][8] | `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` | `7.82.0` |
-| [ECS task role][9] and [EKS Pod Identity][10] | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` | `7.82.0` |
+| Credential source | Environment variables |
+| --- | --- |
+| [Static credentials][11] | `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` |
+| [EC2 instance role][7] (retrieved through IMDS) | None |
+| [EKS IAM roles for service accounts (IRSA)][8] | `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` |
+| [ECS task role][9] and [EKS Pod Identity][10] | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` |
 
 The Agent does not read shared AWS configuration files or named profiles (`AWS_PROFILE`, `~/.aws`). This differs from the Terraform provider, which does support AWS credential files.
 
-#### Agent component support
+#### Agent version support by component
 
-In Agent `7.82.0` and earlier, only the following components can use the EC2 instance role, EKS IRSA, and ECS task role or EKS Pod Identity sources:
+Which credential sources you can use depends on the Agent version and on the component that sends the data. Each cell is the first Agent version in which that combination works.
 
-- Core Agent (metrics, logs, and checks)
-- Cluster Agent
-- Process Agent
-- Security Agent
-- Datadog Installer
+| Agent component | Static credentials | EC2 instance role | EKS IRSA, ECS task role, EKS Pod Identity |
+| --- | --- | --- | --- |
+| Core Agent (metrics, logs, and checks) | `7.78.0` | `7.78.0` | `7.82.0` |
+| Cluster Agent | `7.78.0` | `7.78.0` | `7.82.0` |
+| Process Agent | `7.78.0` | `7.78.0` | `7.82.0` |
+| Security Agent | `7.78.0` | `7.78.0` | `7.82.0` |
+| Datadog Installer | `7.78.0` | `7.78.0` | `7.82.0` |
+| APM (trace Agent) | `7.78.0` | `7.83.0` | `7.83.0` |
+| Standalone DogStatsD | `7.78.0` | `7.83.0` | `7.83.0` |
+| Private Action Runner | `7.78.0` | `7.83.0` | `7.83.0` |
+| IoT Agent | `7.78.0` | `7.83.0` | `7.83.0` |
+| Heroku Agent | `7.78.0` | `7.83.0` | `7.83.0` |
 
-The following components support Workload Identity Federation but are limited to static credentials supplied through environment variables:
+<div class="alert alert-warning">Agent <code>7.83.0</code> has not been released yet. Entries referencing it describe expected behavior in an upcoming release and may change before it ships.</div>
 
-- APM (trace Agent)
-- Standalone DogStatsD
-- Private Action Runner
-- IoT Agent
-- Heroku Agent
-
-<div class="alert alert-warning">If you run APM on an EKS pod or an ECS task and do not supply static credentials through environment variables, the trace Agent cannot obtain a managed API key. It falls back to the <code>api_key</code> configured in <code>datadog.yaml</code>. See <a href="#fallback-behavior">Fallback behavior</a>.</div>
+If you run APM on an EKS pod or an ECS task on Agent `7.82.0` or earlier, and you do not supply static credentials through environment variables, the trace Agent cannot obtain a managed API key. It falls back to the `api_key` configured in `datadog.yaml`. See [Fallback behavior](#fallback-behavior).
 
 Workload Identity Federation is not available in the OpenTelemetry Collector (DDOT) or the AWS Lambda extension. These require a statically configured `api_key`.
 

--- a/hugo/content/en/account_management/workload_identity_federation.md
+++ b/hugo/content/en/account_management/workload_identity_federation.md
@@ -309,9 +309,9 @@ Which credential sources you can use depends on the Agent version and on the com
 | IoT Agent | `7.78.0` | `7.83.0` | `7.83.0` |
 | Heroku Agent | `7.78.0` | `7.83.0` | `7.83.0` |
 
-<div class="alert alert-warning">Agent <code>7.83.0</code> has not been released yet. Entries referencing it describe expected behavior in an upcoming release and may change before it ships.</div>
+<div class="alert alert-warning">Agent <code>7.83.0</code> is not released yet. These entries describe expected behavior and may change.</div>
 
-If you run APM on an EKS pod or an ECS task on Agent `7.82.0` or earlier, and you do not supply static credentials through environment variables, the trace Agent cannot obtain a managed API key. It falls back to the `api_key` configured in `datadog.yaml`. See [Fallback behavior](#fallback-behavior).
+On Agent `7.82.0` and earlier, APM on an EKS pod or ECS task requires static credentials in environment variables. Without them, the trace Agent falls back to the `api_key` in `datadog.yaml`. See [Fallback behavior](#fallback-behavior).
 
 Workload Identity Federation is not available in the OpenTelemetry Collector (DDOT) or the AWS Lambda extension. These require a statically configured `api_key`.
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38783.

@srosenthal-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38783. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38783 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38783) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What and why

Documents which AWS credential sources Workload Identity Federation supports **in the Datadog Agent**, by version and by component.

The current Requirements block is self-contradictory: it gives a `7.78.0` minimum while listing "ECS task, or EKS pod" as supported environments. Those sources only arrived in `7.82.0`, so the guidance has been wrong since April.

It also omits that support varies by component. Through `7.82.0`, APM cannot use IMDS, IRSA, or ECS/Pod Identity, so customers enabling WIF for APM silently keep using their static `api_key`.

### Changes

- Reworded the Requirements bullets.
- New **Supported credential sources for the Agent**: the four sources, their environment variables, and AWS documentation links.
- New **Agent version support by component**: a matrix of first supporting version per component and source.
- Noted the Agent does not read `~/.aws`, unlike the Terraform provider.
- Noted WIF is unavailable in DDOT and the AWS Lambda extension.

### Version scope

`7.78.0` and `7.82.0` are released behavior, verified against the Agent source (`tasks/build_tags.bzl`, the `core.WithSecrets()` and `delegatedauth/fx` call sites, and merged PR milestones).

`7.83.0` covers #54318, which lets every supported component use every credential source. The headline is APM on EKS and ECS without a static `api_key`. It is marked unreleased on the page. If the version changes, edit the matrix cells. If it is dropped, revert `21b8a30` and the rest still stands.

### Before merging

- [ ] Confirm #54318 merged and shipped in `7.83.0`. Expected within days.
- [ ] **Serverless: needs @wynbennett.** I found no delegated auth in the Lambda extension (`cmd/serverless`), so this PR says WIF is unavailable there. If serverless is supported, that is wrong and must be fixed first.

### Follow-ups (not blocking)

- [ ] Document credential sources for the Terraform provider.
- [ ] Document credential sources for the API clients (`datadog-api-client-go`, `-java`, `-python`).

### Note on scope

This page covers three surfaces with different credential handling: Terraform, the Agent, and the API clients. The first H2 is the Terraform section despite its generic name, so the new subsection is explicitly titled "for the Agent" and opens with a callout. This PR does not touch the Terraform section.
