### PR TITLE
[reorg fix] [DOCS-15196] Mark Download billable hosts as CSV unsupported on GovCloud sites

### DIFF
--- a/hugo/content/en/account_management/plan_and_usage/bill_overview.md
+++ b/hugo/content/en/account_management/plan_and_usage/bill_overview.md
@@ -24,7 +24,7 @@ The [**Bill Overview** page][1] gives administrators a single view of Datadog co
 
 The following filters apply to the {{< ui >}}Bill Overview{{< /ui >}} page:
 
-- {{< ui >}}Product Category{{< /ui >}}: Filter all views by broader product family, such as  Infrastructure, APM, Logs, Security, or AI/ML.
+- {{< ui >}}Product Category{{< /ui >}}: Filter all views by broader product family, such as Infrastructure, APM, Logs, Security, or AI/ML.
 - {{< ui >}}Billing Dimension{{< /ui >}}: Filter to a specific billing or metering dimension (for example, Infra Hosts, Indexed Logs, or Synthetic Browser Tests).
 - {{< ui >}}Sub-Org{{< /ui >}}: Filter to a specific child organization.
 - {{< ui >}}Group by Sub-Org{{< /ui >}}: Toggle to group costs by sub-organization.
@@ -110,6 +110,10 @@ Click {{< ui >}}View Details{{< /ui >}} on a Trends card or click any row in the
 - {{< ui >}}Download Billable Hosts as CSV{{< /ui >}}: For Infra Hosts, download the individual hosts that make up your billable total as a CSV.
 
 ### Download billable hosts as CSV
+
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-danger">Downloading billable hosts as a CSV is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 Download a CSV of the individual hosts that make up your billable Infra Hosts total for a given month. Use it to reconcile the total shown on the Bill Overview page, find the hosts driving the largest share of your count, attribute usage to teams by tag, or compare months to spot unexpected changes.
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38754.

@OliviaShoup — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38754. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38754 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38754) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15196
Fixes DOCS-15201

Adds a site-region banner to the **Download billable hosts as CSV** section of the Bill Overview page, noting that the feature is not supported on the US1-FED (`gov`) and US2-FED (`gov2`) sites.

DOCS-15196 and DOCS-15201 were filed separately for the GovCloud and US1-FED/US2-FED cases, but they describe the same gap on the same section, so one banner covers both.

The banner markup follows the existing pattern in `content/en/account_management/billing/incident_response.md`, the nearest sibling page in Plan & Usage.

Also fixes an unrelated double space in a bullet on the same page, which was the only Vale error in the file.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- :warning: Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- :robot: **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code drafted the banner wording and made the edit, including locating the existing site-region convention to match. Reviewed by me before commit.

### Additional notes

The `Usage Overview` bullet list higher on the page still describes the **Download Billable Hosts as CSV** button without site gating. I left it as-is: `site-region` inside a list item is fragile, and the inverse approach (enumerating every commercial site) breaks whenever a new site is added. The banner appears immediately below that list.

Please confirm on the preview that the banner renders as expected with the site selector set to US1-FED and US2-FED.