### PR TITLE
[reorg fix] [DOCS-15270] Add guide for managing Incident Management with Terraform

### DIFF
--- a/hugo/content/en/incident_response/incident_management/guides/_index.md
+++ b/hugo/content/en/incident_response/incident_management/guides/_index.md
@@ -20,6 +20,7 @@ cascade:
 
 {{< header-list header="General guides" >}}
     {{< nextlink href="incident_response/incident_management/guides/test_incidents" >}}Using test incidents for training and testing{{< /nextlink >}}
+    {{< nextlink href="incident_response/incident_management/guides/manage_with_terraform" >}}Manage Incident Management with Terraform{{< /nextlink >}}
 {{< /header-list >}}
 
 

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -1,6 +1,6 @@
 ---
 title: Manage Incident Management with Terraform
-description: "Use Terraform to manage Incident Management configuration, including incident types, property fields, responder types, notification rules, postmortem templates, and notification templates.
+description: Use Terraform to manage Incident Management configuration, including incident types, property fields, responder types, notification rules, postmortem templates, and notification templates.
 disable_toc: false
 further_reading:
 - link: "/incident_response/incident_management/"

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -1,344 +1,91 @@
 ---
 title: Manage Incident Management with Terraform
-description: "Use the Datadog Terraform provider to manage incident types, custom fields, responder roles, notification templates, notification rules, and postmortem templates."
+description: "Use Terraform to manage Incident Management configuration, including incident types, custom fields, responder roles, notification templates and rules, and postmortem templates."
+disable_toc: false
 further_reading:
-- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs"
+- link: "/incident_response/incident_management/"
   tag: "Documentation"
-  text: "Terraform provider for Datadog"
-- link: "/incident_response/incident_management/setup_and_configuration/"
-  tag: "Documentation"
-  text: "Incident Management setup and configuration"
+  text: "Learn more about Incident Management"
 - link: "/incident_response/incident_management/guides/test_incidents/"
   tag: "Documentation"
   text: "Using test incidents for training and testing"
-- link: "/account_management/api-app-keys/"
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs"
   tag: "Documentation"
-  text: "Datadog API and Application Keys"
+  text: "Terraform provider for Datadog"
 ---
 
 ## Overview
 
-Datadog Incident Management lets you standardize how your organization declares, triages, and resolves incidents. As your usage grows, with more teams, incident types, custom fields, and routing rules, managing that configuration by hand in the UI becomes hard to review, replicate across orgs, and keep consistent. The [Terraform provider for Datadog][1] lets you manage Incident Management configuration the same way you manage your infrastructure: version-controlled, peer-reviewed, and reproducible across environments.
+You can use Terraform to manage your Incident Management configuration through the Datadog API. This guide covers the Incident Management resources available in the [Terraform registry][1] and links to the corresponding Datadog documentation for each.
 
-This guide covers common scenarios for adopting Incident Management with Terraform. These include defining incident types, adding custom fields and roles, and configuring notification templates, notification rules, and postmortem templates.
+Configuring incident types, fields, roles, and notification rules by hand in the UI works well for a handful of teams. It becomes harder to scale as your organization grows, for example, when standardizing configuration across hundreds of teams or migrating from another incident management tool. Terraform lets you define this configuration as code, so you can create and update it programmatically and keep it consistent across your organization.
+
+You can also [import][2] your existing incident type, notification, and postmortem template configurations into Terraform, and reference existing configurations as Terraform [data sources][3].
 
 ### What you can manage with Terraform
 
 | Resource | Purpose |
 | --- | --- |
-| `datadog_incident_type` | The category of incident (for example, "Security Incident" or "Customer Impacting"). Anchors everything else below. |
-| `datadog_incident_user_defined_field` | Custom fields responders fill out on an incident (dropdowns, text, autocomplete, and more). |
-| `datadog_incident_user_defined_role` | Custom responder roles beyond the built-in Incident Commander and Responder roles. |
-| `datadog_incident_notification_template` | Reusable message templates for incident notifications. |
-| `datadog_incident_notification_rule` | Rules that decide when and who gets notified as incidents change. |
-| `datadog_incident_postmortem_template` | Templates that control where and how postmortem documents are generated for an incident type. |
-
-Every one of these resources is scoped to a `datadog_incident_type`, so that's where you start.
-
-## Prerequisites
-
-- A Datadog account with [Incident Management][2] enabled.
-- An [API key and Application key][3] with permission to manage incident settings.
-- [Terraform][4] version 1.0 or later.
-- The Datadog Terraform provider. Add it to your configuration:
-
-{{< code-block lang="terraform" >}}
-terraform {
-  required_providers {
-    datadog = {
-      source  = "DataDog/datadog"
-      version = ">= 4.17.0" # use the latest version that ships datadog_incident_postmortem_template
-    }
-  }
-}
-
-provider "datadog" {
-  api_key = var.datadog_api_key
-  app_key = var.datadog_app_key
-}
-{{< /code-block >}}
-
-<div class="alert alert-info">Pass <code>api_key</code> and <code>app_key</code> using environment variables (<code>DD_API_KEY</code>, <code>DD_APP_KEY</code>) or a secrets manager rather than hardcoding them in <code>.tf</code> files.</div>
-
-## Define an incident type
-
-An incident type is the anchor resource: every custom field, role, notification template, and notification rule is scoped to one. Start with the simplest possible definition:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_type" "security" {
-  name        = "Security Incident"
-  description = "Security-related incidents requiring immediate attention"
-}
-{{< /code-block >}}
-
-### Add stricter controls to an incident type
-
-For your highest-severity incident type, you likely want tighter controls: no deleting incidents, no accidental test-incident noise, and timestamps that stay locked after they're set. The `configuration` attribute controls this behavior. Every field is optional and falls back to the default shown below if omitted:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_type" "customer_impacting" {
-  name        = "Customer Impacting"
-  description = "Incidents that impact customers"
-
-  configuration = {
-    private_incidents             = false
-    private_incidents_by_default  = false
-    allow_workflows                = true
-    allow_incident_deletion        = false # prevent accidental deletion of customer-impacting incidents
-    editable_timestamps            = false
-    test_incidents                 = false # don't allow test incidents of this type
-    create_message                 = "Confirm customer impact before declaring. Page #on-call-leads if unsure."
-    slug_source                    = "default"
-  }
-}
-{{< /code-block >}}
-
-<div class="alert alert-info"><code>configuration</code> is applied through a separate API call after the incident type itself is created. As a result, the first <code>terraform apply</code> on a new incident type shows two operations, even though it's one resource block.</div>
-
-## Add custom fields to an incident type
-
-Custom fields (user-defined fields) show up on the incident details page and let responders capture structured data, such as root cause, affected region, or customer impact tier.
-
-The following example adds a root-cause dropdown:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_user_defined_field" "root_cause" {
-  name          = "root_cause"
-  display_name  = "Root Cause"
-  type          = "dropdown"
-  category      = "why_it_happened"
-  default_value = "unknown"
-  incident_type = datadog_incident_type.customer_impacting.id
-
-  valid_value {
-    display_name = "Service Bug"
-    value        = "service_bug"
-    description  = "A bug in the service code."
-  }
-
-  valid_value {
-    display_name = "Human Error"
-    value        = "human_error"
-  }
-
-  valid_value {
-    display_name = "Unknown"
-    value        = "unknown"
-  }
-}
-{{< /code-block >}}
+| [Incident types](#incident-types) (`datadog_incident_type`) | The category of incident (for example, "Security Incident" or "Customer Impacting"). Anchors everything else in this table. |
+| [Custom fields](#custom-fields) (`datadog_incident_user_defined_field`) | Structured data responders fill out on an incident, such as root cause or affected region. |
+| [Responder roles](#responder-roles) (`datadog_incident_user_defined_role`) | Custom roles beyond the built-in Incident Commander and Responder. |
+| [Notification templates](#notification-templates) (`datadog_incident_notification_template`) | Reusable message content for incident notifications. |
+| [Notification rules](#notification-rules) (`datadog_incident_notification_rule`) | Rules that decide when and who gets notified as incidents change. |
+| [Postmortem templates](#postmortem-templates) (`datadog_incident_postmortem_template`) | Where and how a postmortem document is generated for an incident type. |
 
-Supported `type` values are `dropdown`, `multiselect`, `textbox`, `textarray`, `metrictag`, `autocomplete`, `number`, and `datetime`. `category` places the field in the **What Happened** or **Why It Happened** section of the incident timeline; leave it unset to have the field appear under **Attributes** instead.
+## Set up the Datadog Terraform provider
 
-For example, this required multiselect for affected regions places the field under **What Happened**:
+If you haven't already, configure the [Datadog Terraform provider][4] to interact with Datadog APIs through a Terraform configuration.
 
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_user_defined_field" "affected_regions" {
-  name          = "affected_regions"
-  display_name  = "Affected Regions"
-  type          = "multiselect"
-  category      = "what_happened"
-  required      = true
-  incident_type = datadog_incident_type.customer_impacting.id
+## Incident types
 
-  valid_value {
-    display_name = "US-East"
-    value        = "us-east"
-  }
+Incident types let you apply different settings, fields, roles, and notification behavior to different classes of incidents, such as security incidents versus customer-impacting incidents. Every other resource on this page is scoped to an incident type, so define your incident types first. Use the [incident type resource][6] to create and configure incident types, including settings such as incident deletion, [test incidents][7], and [private incidents][8].
 
-  valid_value {
-    display_name = "US-West"
-    value        = "us-west"
-  }
+To learn how this works in Datadog, see [Incident Types][5].
 
-  valid_value {
-    display_name = "EU"
-    value        = "eu"
-  }
-}
-{{< /code-block >}}
+## Custom fields
 
-## Add a custom responder role
-
-Beyond the built-in Incident Commander and Responder roles, you can define roles specific to your incident process, such as a Tech Lead, a Comms Lead, or a Customer Liaison.
-
-The following example defines a single-assignee Tech Lead role:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_user_defined_role" "tech_lead" {
-  name          = "Tech Lead"
-  description   = "The technical lead driving the investigation."
-  incident_type = datadog_incident_type.customer_impacting.id
+Custom fields let responders capture structured data on an incident, for example, root cause or affected region. Use the [incident user-defined field resource][10] to create custom fields and scope them to an incident type.
 
-  policy = {
-    is_single = true # only one responder can hold this role at a time
-  }
-}
-{{< /code-block >}}
+For background on custom fields, see [Property Fields][9].
 
-Omit `policy` to default to a multi-assignee role, such as a Comms Lead who can have multiple responders assigned at once:
+## Responder roles
 
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_user_defined_role" "comms" {
-  name          = "Comms Lead"
-  description   = "Owns external and internal incident communications."
-  incident_type = datadog_incident_type.customer_impacting.id
-}
-{{< /code-block >}}
+Responder roles define the roles people can be assigned during an incident. Examples include Incident Commander or a custom role like Comms Lead. Use the [incident user-defined role resource][12] to create custom responder roles. Scope each role to an incident type.
 
-<div class="alert alert-info">Role names can't collide with the reserved names "Incident Commander" or "Responder".</div>
+To learn how responder roles work in Datadog, see [Responder Types][11].
 
-## Create a notification template
+## Notification templates
 
-Notification templates define reusable message content for incident notifications, so you don't have to hand-write the same Slack or email message every time.
+Notification templates define reusable message content for incident notifications. Use the [incident notification template resource][14] to create templates scoped to an incident type.
 
-The following example creates a SEV-1 alert template:
+For background, see [Notification Templates][13].
 
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_notification_template" "sev1_alert" {
-  name          = "SEV-1 Customer Impact Template"
-  subject       = "SEV-1 Incident: {{incident.title}}"
-  category      = "alert" # alert, incident, or recovery
-  incident_type = datadog_incident_type.customer_impacting.id
+## Notification rules
 
-  content = <<-EOF
-A SEV-1 customer-impacting incident has been declared.
+Notification rules determine when a notification fires, who it's sent to, and which template it uses. Use the [incident notification rule resource][16] to create rules based on triggers such as incident creation or a saved change. Conditions on a rule can include severity or affected services.
 
-Title: {{incident.title}}
-Severity: {{incident.severity}}
-Status: {{incident.status}}
+To learn how this works in Datadog, see [Notification Rules][15].
 
-Join the incident channel for updates.
-EOF
-}
-{{< /code-block >}}
+## Postmortem templates
 
-## Create a notification rule
+Postmortem templates control where a postmortem document is generated for an incident type—a Datadog Notebook, a Confluence page, or a Google Doc. They also control what content the document starts with. Use the [incident postmortem template resource][18] to configure this per incident type.
 
-Notification rules decide when a notification fires, who it goes to, and which template it uses. They wire templates up to real-world triggers, such as "a SEV-1 was created" or "severity changed on a saved incident."
-
-The following example notifies on-call responders when a SEV-1 or SEV-2 customer-impacting incident is created:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_notification_rule" "sev1_sev2_created" {
-  enabled    = true
-  trigger    = "incident_created_trigger" # incident_created_trigger or incident_saved_trigger
-  visibility = "organization"             # all, organization, or private
-
-  handles = [
-    "@pagerduty-on-call",
-    "@slack-incident-response",
-  ]
-
-  conditions {
-    field  = "severity"
-    values = ["SEV-1", "SEV-2"]
-  }
-
-  # Re-notify the same handles if status or severity changes later
-  renotify_on = ["status", "severity"]
-
-  incident_type         = datadog_incident_type.customer_impacting.id
-  notification_template = datadog_incident_notification_template.sev1_alert.id
-}
-{{< /code-block >}}
-
-To narrow a rule to specific services, add a second `conditions` block. Values within a single `conditions` block are ORed; multiple `conditions` blocks are ANDed together:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_notification_rule" "prod_services_only" {
-  enabled    = true
-  trigger    = "incident_created_trigger"
-  visibility = "organization"
-  handles    = ["@team-payments-oncall"]
-
-  conditions {
-    field  = "severity"
-    values = ["SEV-1", "SEV-2"]
-  }
-
-  conditions {
-    field  = "services"
-    values = ["payments-api", "payments-worker"]
-  }
-
-  incident_type = datadog_incident_type.customer_impacting.id
-}
-{{< /code-block >}}
-
-## Create a postmortem template
-
-Postmortem templates control where a postmortem document is created for incidents of a given type (a Datadog Notebook, a Confluence page, or a Google Doc) and what content it starts with.
-
-The following example creates a default Datadog Notebook postmortem template:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_postmortem_template" "default_notebook" {
-  name          = "Standard Postmortem"
-  incident_type = datadog_incident_type.customer_impacting.id
-  location      = "datadog_notebooks" # datadog_notebooks (default), confluence, or google_docs
-  is_default    = true
-
-  content = <<-EOF
-# Postmortem: {{incident.title}}
-
-## Summary
-
-## Timeline
-
-## Root Cause
-
-## Action Items
-EOF
-}
-{{< /code-block >}}
-
-To write postmortems to a Confluence space instead, set `location` to `confluence` and provide `confluence_postmortem_settings`:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_postmortem_template" "confluence" {
-  name          = "Confluence Postmortem"
-  incident_type = datadog_incident_type.customer_impacting.id
-  location      = "confluence"
-
-  confluence_postmortem_settings {
-    account_id = var.confluence_connected_account_id # Datadog connected-account UUID
-    space_id   = "ENG"                                # Confluence space key, not a numeric ID
-    parent_id  = "393217"                              # numeric parent page ID
-  }
-}
-{{< /code-block >}}
-
-To write postmortems to Google Docs instead, set `location` to `google_docs` and provide `google_docs_postmortem_settings`:
-
-{{< code-block lang="terraform" >}}
-resource "datadog_incident_postmortem_template" "google_docs" {
-  name          = "Google Docs Postmortem"
-  incident_type = datadog_incident_type.customer_impacting.id
-  location      = "google_docs"
-
-  google_docs_postmortem_settings {
-    account_id       = var.google_drive_connected_account_id # Datadog connected-account UUID
-    parent_folder_id = "1eCqLAKQqRHt49J2aqQLGUcnPMzGHkt2B"    # taken from the Drive folder URL
-  }
-}
-{{< /code-block >}}
-
-<div class="alert alert-info"><code>confluence_postmortem_settings</code> is required when <code>location = "confluence"</code>, and <code>google_docs_postmortem_settings</code> is required when <code>location = "google_docs"</code>; the provider validates this pairing at plan time. <code>incident_type</code> is immutable, so changing it forces recreation of the template. <code>is_default</code> maps to a server-side timestamp: the template with the most recently set default timestamp is the effective default for its incident type.</div>
+For background, see [Postmortem Templates][17].
 
 ## Full configuration example
 
-A realistic setup wires an incident type to its fields, roles, template, and rule in one module:
+The following example combines several of these resources into one configuration:
+
+- A `datadog_incident_type`
+- A `datadog_incident_user_defined_field` and `datadog_incident_user_defined_role`, both scoped to that type
+- A `datadog_incident_notification_template`
+- A `datadog_incident_notification_rule` that uses the template
 
 {{< code-block lang="terraform" >}}
 resource "datadog_incident_type" "customer_impacting" {
   name        = "Customer Impacting"
   description = "Incidents that impact customers"
-
-  configuration = {
-    allow_incident_deletion = false
-    test_incidents           = false
-  }
 }
 
 resource "datadog_incident_user_defined_field" "root_cause" {
@@ -350,18 +97,11 @@ resource "datadog_incident_user_defined_field" "root_cause" {
     display_name = "Service Bug"
     value        = "service_bug"
   }
-  valid_value {
-    display_name = "Human Error"
-    value        = "human_error"
-  }
 }
 
 resource "datadog_incident_user_defined_role" "tech_lead" {
   name          = "Tech Lead"
   incident_type = datadog_incident_type.customer_impacting.id
-  policy = {
-    is_single = true
-  }
 }
 
 resource "datadog_incident_notification_template" "sev1_alert" {
@@ -387,62 +127,25 @@ resource "datadog_incident_notification_rule" "sev1_sev2_created" {
 }
 {{< /code-block >}}
 
-## Reference existing configuration with data sources
-
-If an incident type, notification template, or notification rule already exists (created in the UI, or in another Terraform root you don't want to import into this one), read it with a data source instead of managing it directly:
-
-{{< code-block lang="terraform" >}}
-data "datadog_incident_type" "existing" {
-  id = "01234567-89ab-cdef-0123-456789abcdef"
-}
-
-data "datadog_incident_notification_template" "existing" {
-  id = "52600bb1-e83a-48a1-aa77-6889ddb269b2"
-}
-
-resource "datadog_incident_notification_rule" "extra_rule" {
-  enabled                = true
-  trigger                = "incident_saved_trigger"
-  visibility              = "organization"
-  handles                = ["@security-team"]
-  incident_type           = data.datadog_incident_type.existing.id
-  notification_template   = data.datadog_incident_notification_template.existing.id
-
-  conditions {
-    field  = "status"
-    values = ["resolved"]
-  }
-}
-{{< /code-block >}}
-
-## Import existing resources
-
-If you already created incident types, fields, roles, templates, or rules in the UI, bring them under Terraform management with `terraform import` rather than recreating them:
-
-{{< code-block lang="bash" >}}
-terraform import datadog_incident_type.customer_impacting "12345678-1234-1234-1234-1234567890ab"
-terraform import datadog_incident_user_defined_field.root_cause "12345678-1234-1234-1234-1234567890ab"
-terraform import datadog_incident_user_defined_role.tech_lead "12345678-1234-1234-1234-1234567890ab"
-terraform import datadog_incident_notification_template.sev1_alert "11111111-2222-3333-4444-555555555555"
-terraform import datadog_incident_notification_rule.sev1_sev2_created "00000000-0000-0000-0000-000000000000"
-terraform import datadog_incident_postmortem_template.default_notebook "<template-id>"
-{{< /code-block >}}
-
-Find each resource's ID in the Datadog UI ([**Incidents** > **Settings**][5]) or through the corresponding API endpoint, then write a matching resource block before running `terraform plan` to confirm there's no diff.
-
-## Best practices
-
-- **Model one incident type per Terraform module.** Since every other resource in this guide is scoped to an incident type, grouping by incident type keeps blast radius small when you change fields, roles, or notification rules for one incident category.
-- **Let Terraform resolve resource order.** Terraform resolves the dependency graph from resource references (for example, `incident_type = datadog_incident_type.x.id`), so you don't need to order blocks by hand. Make sure every child resource references its parent's `id`.
-- **Treat `configuration` changes as behavior changes, not cosmetic ones.** Flipping `allow_incident_deletion` or `test_incidents` changes what responders can do. Call these out explicitly in pull request descriptions rather than bundling them with unrelated field additions.
-- **Use `terraform plan` before enabling new notification rules.** A misconfigured `conditions` block or wrong `trigger` can page the wrong team. Validate the plan output, and consider rolling out with `enabled = false` first, then enabling it once reviewed.
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs
-[2]: /incident_response/incident_management/
-[3]: /account_management/api-app-keys/
-[4]: https://developer.hashicorp.com/terraform/install
-[5]: https://app.datadoghq.com/incidents/settings
+[2]: https://developer.hashicorp.com/terraform/cli/import
+[3]: https://developer.hashicorp.com/terraform/language/data-sources
+[4]: /integrations/terraform/
+[5]: /incident_response/incident_management/setup_and_configuration/#incident-types
+[6]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_type
+[7]: /incident_response/incident_management/guides/test_incidents/
+[8]: /incident_response/incident_management/setup_and_configuration/information/#private-incidents-incident-visibility
+[9]: /incident_response/incident_management/setup_and_configuration/property_fields/
+[10]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_user_defined_field
+[11]: /incident_response/incident_management/setup_and_configuration/responder_types/
+[12]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_user_defined_role
+[13]: /incident_response/incident_management/setup_and_configuration/templates/#messages
+[14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_notification_template
+[15]: /incident_response/incident_management/setup_and_configuration/notification_rules/
+[16]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_notification_rule
+[17]: /incident_response/incident_management/setup_and_configuration/templates/#postmortems
+[18]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_postmortem_template

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -1,6 +1,6 @@
 ---
 title: Manage Incident Management with Terraform
-description: "Use Terraform to manage Incident Management configuration, including incident types, custom fields, responder roles, notification templates and rules, and postmortem templates."
+description: "Use Terraform to manage Incident Management configuration, including incident types, property fields, responder types, notification templates and rules, and postmortem templates."
 disable_toc: false
 further_reading:
 - link: "/incident_response/incident_management/"
@@ -26,12 +26,12 @@ You can also [import][2] your existing incident type, notification, and postmort
 
 | Resource | Purpose |
 | --- | --- |
-| [Incident types](#incident-types) (`datadog_incident_type`) | The category of incident (for example, "Security Incident" or "Customer Impacting"). Anchors everything else in this table. |
-| [Custom fields](#custom-fields) (`datadog_incident_user_defined_field`) | Structured data responders fill out on an incident, such as root cause or affected region. |
-| [Responder roles](#responder-roles) (`datadog_incident_user_defined_role`) | Custom roles beyond the built-in Incident Commander and Responder. |
-| [Notification templates](#notification-templates) (`datadog_incident_notification_template`) | Reusable message content for incident notifications. |
+| [Incident types](#incident-types) (`datadog_incident_type`) | The category of incident (for example, "Security Incident" or "Customer Impacting"). Also includes the settings on the [Information][19] page, such as private incidents and incident deletion. Anchors everything else in this table. |
+| [Property fields](#property-fields) (`datadog_incident_user_defined_field`) | Structured data responders fill out on an incident, such as root cause or affected region. Also used to configure severity and status levels on the [Information][19] page. |
+| [Responder types](#responder-types) (`datadog_incident_user_defined_role`) | Custom roles beyond the built-in Incident Commander and Responder. |
 | [Notification rules](#notification-rules) (`datadog_incident_notification_rule`) | Rules that decide when and who gets notified as incidents change. |
 | [Postmortem templates](#postmortem-templates) (`datadog_incident_postmortem_template`) | Where and how a postmortem document is generated for an incident type. |
+| [Notification templates](#notification-templates) (`datadog_incident_notification_template`) | Reusable message content for incident notifications. |
 
 ## Set up the Datadog Terraform provider
 
@@ -39,27 +39,21 @@ If you haven't already, configure the [Datadog Terraform provider][4] to interac
 
 ## Incident types
 
-Incident types let you apply different settings, fields, roles, and notification behavior to different classes of incidents, such as security incidents versus customer-impacting incidents. Every other resource on this page is scoped to an incident type, so define your incident types first. Use the [incident type resource][6] to create and configure incident types, including settings such as incident deletion, [test incidents][7], and [private incidents][8].
+Incident types let you apply different settings, fields, roles, and notification behavior to different classes of incidents, such as security incidents versus customer-impacting incidents. Every other resource on this page is scoped to an incident type, so define your incident types first. Use the `configuration` block on the [incident type resource][6] to create incident types and set the toggles found on the [Information][19] page, such as incident deletion, [test incidents][7], and [private incidents][8]. Severity and status levels, also found on the [Information][19] page, are configured with the [incident user-defined field resource][10].
 
 To learn how this works in Datadog, see [Incident Types][5].
 
-## Custom fields
+## Property fields
 
-Custom fields let responders capture structured data on an incident, for example, root cause or affected region. Use the [incident user-defined field resource][10] to create custom fields and scope them to an incident type.
+Property fields let responders capture structured data on an incident, for example, root cause or affected region. Use the [incident user-defined field resource][10] to create property fields and scope them to an incident type.
 
-For background on custom fields, see [Property Fields][9].
+To learn how this works in Datadog, see [Property Fields][9].
 
-## Responder roles
+## Responder types
 
-Responder roles define the roles people can be assigned during an incident. Examples include Incident Commander or a custom role like Comms Lead. Use the [incident user-defined role resource][12] to create custom responder roles. Scope each role to an incident type.
+Responder types define the roles people can be assigned during an incident. Examples include Incident Commander or a custom role like Comms Lead. Use the [incident user-defined role resource][12] to create custom responder types. Scope each one to an incident type.
 
-To learn how responder roles work in Datadog, see [Responder Types][11].
-
-## Notification templates
-
-Notification templates define reusable message content for incident notifications. Use the [incident notification template resource][14] to create templates scoped to an incident type.
-
-For background, see [Notification Templates][13].
+To learn how this works in Datadog, see [Responder Types][11].
 
 ## Notification rules
 
@@ -69,15 +63,21 @@ To learn how this works in Datadog, see [Notification Rules][15].
 
 ## Postmortem templates
 
-Postmortem templates control where a postmortem document is generated for an incident type—a Datadog Notebook, a Confluence page, or a Google Doc. They also control what content the document starts with. Use the [incident postmortem template resource][18] to configure this per incident type.
+Postmortem templates control where a postmortem document is generated for an incident type. Templates standardize the content a postmortem writer is expected to populate by defining specific sections and headers in the document. Use the [incident postmortem template resource][18] to configure this per incident type.
 
-For background, see [Postmortem Templates][17].
+To learn how this works in Datadog, see [Postmortem Templates][17].
+
+## Notification templates
+
+Notification templates define reusable message content for incident notifications. Use the [incident notification template resource][14] to create templates scoped to an incident type.
+
+To learn how this works in Datadog, see [Notification Templates][13].
 
 ## Full configuration example
 
 The following example combines several of these resources into one configuration:
 
-- A `datadog_incident_type`
+- A `datadog_incident_type` with a `configuration` block that disables incident deletion and enables test incidents
 - A `datadog_incident_user_defined_field` and `datadog_incident_user_defined_role`, both scoped to that type
 - A `datadog_incident_notification_template`
 - A `datadog_incident_notification_rule` that uses the template
@@ -86,6 +86,16 @@ The following example combines several of these resources into one configuration
 resource "datadog_incident_type" "customer_impacting" {
   name        = "Customer Impacting"
   description = "Incidents that impact customers"
+  configuration = {
+    private_incidents            = false
+    private_incidents_by_default = false
+    allow_workflows              = true
+    allow_incident_deletion      = false
+    editable_timestamps          = false
+    test_incidents               = true
+    create_message               = ""
+    slug_source                  = "default"
+  }
 }
 
 resource "datadog_incident_user_defined_field" "root_cause" {
@@ -149,3 +159,4 @@ resource "datadog_incident_notification_rule" "sev1_sev2_created" {
 [16]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_notification_rule
 [17]: /incident_response/incident_management/setup_and_configuration/templates/#postmortems
 [18]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/incident_postmortem_template
+[19]: /incident_response/incident_management/setup_and_configuration/information/

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -1,6 +1,6 @@
 ---
 title: Manage Incident Management with Terraform
-description: "Use Terraform to manage Incident Management configuration, including incident types, property fields, responder types, notification templates and rules, and postmortem templates."
+description: "Use Terraform to manage Incident Management configuration, including incident types, property fields, responder types, notification rules, postmortem templates, and notification templates.
 disable_toc: false
 further_reading:
 - link: "/incident_response/incident_management/"

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -1,0 +1,448 @@
+---
+title: Manage Incident Management with Terraform
+description: "Use the Datadog Terraform provider to manage incident types, custom fields, responder roles, notification templates, notification rules, and postmortem templates."
+further_reading:
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs"
+  tag: "Documentation"
+  text: "Terraform provider for Datadog"
+- link: "/incident_response/incident_management/setup_and_configuration/"
+  tag: "Documentation"
+  text: "Incident Management setup and configuration"
+- link: "/incident_response/incident_management/guides/test_incidents/"
+  tag: "Documentation"
+  text: "Using test incidents for training and testing"
+- link: "/account_management/api-app-keys/"
+  tag: "Documentation"
+  text: "Datadog API and Application Keys"
+---
+
+## Overview
+
+Datadog Incident Management lets you standardize how your organization declares, triages, and resolves incidents. As your usage grows, with more teams, incident types, custom fields, and routing rules, managing that configuration by hand in the UI becomes hard to review, replicate across orgs, and keep consistent. The [Terraform provider for Datadog][1] lets you manage Incident Management configuration the same way you manage your infrastructure: version-controlled, peer-reviewed, and reproducible across environments.
+
+This guide covers common scenarios for adopting Incident Management with Terraform. These include defining incident types, adding custom fields and roles, and configuring notification templates, notification rules, and postmortem templates.
+
+### What you can manage with Terraform
+
+| Resource | Purpose |
+| --- | --- |
+| `datadog_incident_type` | The category of incident (for example, "Security Incident" or "Customer Impacting"). Anchors everything else below. |
+| `datadog_incident_user_defined_field` | Custom fields responders fill out on an incident (dropdowns, text, autocomplete, and more). |
+| `datadog_incident_user_defined_role` | Custom responder roles beyond the built-in Incident Commander and Responder roles. |
+| `datadog_incident_notification_template` | Reusable message templates for incident notifications. |
+| `datadog_incident_notification_rule` | Rules that decide when and who gets notified as incidents change. |
+| `datadog_incident_postmortem_template` | Templates that control where and how postmortem documents are generated for an incident type. |
+
+Every one of these resources is scoped to a `datadog_incident_type`, so that's where you start.
+
+## Prerequisites
+
+- A Datadog account with [Incident Management][2] enabled.
+- An [API key and Application key][3] with permission to manage incident settings.
+- [Terraform][4] version 1.0 or later.
+- The Datadog Terraform provider. Add it to your configuration:
+
+{{< code-block lang="terraform" >}}
+terraform {
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.17.0" # use the latest version that ships datadog_incident_postmortem_template
+    }
+  }
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
+  app_key = var.datadog_app_key
+}
+{{< /code-block >}}
+
+<div class="alert alert-info">Pass <code>api_key</code> and <code>app_key</code> using environment variables (<code>DD_API_KEY</code>, <code>DD_APP_KEY</code>) or a secrets manager rather than hardcoding them in <code>.tf</code> files.</div>
+
+## Define an incident type
+
+An incident type is the anchor resource: every custom field, role, notification template, and notification rule is scoped to one. Start with the simplest possible definition:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_type" "security" {
+  name        = "Security Incident"
+  description = "Security-related incidents requiring immediate attention"
+}
+{{< /code-block >}}
+
+### Add stricter controls to an incident type
+
+For your highest-severity incident type, you likely want tighter controls: no deleting incidents, no accidental test-incident noise, and timestamps that stay locked after they're set. The `configuration` attribute controls this behavior. Every field is optional and falls back to the default shown below if omitted:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_type" "customer_impacting" {
+  name        = "Customer Impacting"
+  description = "Incidents that impact customers"
+
+  configuration = {
+    private_incidents             = false
+    private_incidents_by_default  = false
+    allow_workflows                = true
+    allow_incident_deletion        = false # prevent accidental deletion of customer-impacting incidents
+    editable_timestamps            = false
+    test_incidents                 = false # don't allow test incidents of this type
+    create_message                 = "Confirm customer impact before declaring. Page #on-call-leads if unsure."
+    slug_source                    = "default"
+  }
+}
+{{< /code-block >}}
+
+<div class="alert alert-info"><code>configuration</code> is applied through a separate API call after the incident type itself is created. As a result, the first <code>terraform apply</code> on a new incident type shows two operations, even though it's one resource block.</div>
+
+## Add custom fields to an incident type
+
+Custom fields (user-defined fields) show up on the incident details page and let responders capture structured data, such as root cause, affected region, or customer impact tier.
+
+The following example adds a root-cause dropdown:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_user_defined_field" "root_cause" {
+  name          = "root_cause"
+  display_name  = "Root Cause"
+  type          = "dropdown"
+  category      = "why_it_happened"
+  default_value = "unknown"
+  incident_type = datadog_incident_type.customer_impacting.id
+
+  valid_value {
+    display_name = "Service Bug"
+    value        = "service_bug"
+    description  = "A bug in the service code."
+  }
+
+  valid_value {
+    display_name = "Human Error"
+    value        = "human_error"
+  }
+
+  valid_value {
+    display_name = "Unknown"
+    value        = "unknown"
+  }
+}
+{{< /code-block >}}
+
+Supported `type` values are `dropdown`, `multiselect`, `textbox`, `textarray`, `metrictag`, `autocomplete`, `number`, and `datetime`. `category` places the field in the **What Happened** or **Why It Happened** section of the incident timeline; leave it unset to have the field appear under **Attributes** instead.
+
+For example, this required multiselect for affected regions places the field under **What Happened**:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_user_defined_field" "affected_regions" {
+  name          = "affected_regions"
+  display_name  = "Affected Regions"
+  type          = "multiselect"
+  category      = "what_happened"
+  required      = true
+  incident_type = datadog_incident_type.customer_impacting.id
+
+  valid_value {
+    display_name = "US-East"
+    value        = "us-east"
+  }
+
+  valid_value {
+    display_name = "US-West"
+    value        = "us-west"
+  }
+
+  valid_value {
+    display_name = "EU"
+    value        = "eu"
+  }
+}
+{{< /code-block >}}
+
+## Add a custom responder role
+
+Beyond the built-in Incident Commander and Responder roles, you can define roles specific to your incident process, such as a Tech Lead, a Comms Lead, or a Customer Liaison.
+
+The following example defines a single-assignee Tech Lead role:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_user_defined_role" "tech_lead" {
+  name          = "Tech Lead"
+  description   = "The technical lead driving the investigation."
+  incident_type = datadog_incident_type.customer_impacting.id
+
+  policy = {
+    is_single = true # only one responder can hold this role at a time
+  }
+}
+{{< /code-block >}}
+
+Omit `policy` to default to a multi-assignee role, such as a Comms Lead who can have multiple responders assigned at once:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_user_defined_role" "comms" {
+  name          = "Comms Lead"
+  description   = "Owns external and internal incident communications."
+  incident_type = datadog_incident_type.customer_impacting.id
+}
+{{< /code-block >}}
+
+<div class="alert alert-info">Role names can't collide with the reserved names "Incident Commander" or "Responder".</div>
+
+## Create a notification template
+
+Notification templates define reusable message content for incident notifications, so you don't have to hand-write the same Slack or email message every time.
+
+The following example creates a SEV-1 alert template:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_notification_template" "sev1_alert" {
+  name          = "SEV-1 Customer Impact Template"
+  subject       = "SEV-1 Incident: {{incident.title}}"
+  category      = "alert" # alert, incident, or recovery
+  incident_type = datadog_incident_type.customer_impacting.id
+
+  content = <<-EOF
+A SEV-1 customer-impacting incident has been declared.
+
+Title: {{incident.title}}
+Severity: {{incident.severity}}
+Status: {{incident.status}}
+
+Join the incident channel for updates.
+EOF
+}
+{{< /code-block >}}
+
+## Create a notification rule
+
+Notification rules decide when a notification fires, who it goes to, and which template it uses. They wire templates up to real-world triggers, such as "a SEV-1 was created" or "severity changed on a saved incident."
+
+The following example notifies on-call responders when a SEV-1 or SEV-2 customer-impacting incident is created:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_notification_rule" "sev1_sev2_created" {
+  enabled    = true
+  trigger    = "incident_created_trigger" # incident_created_trigger or incident_saved_trigger
+  visibility = "organization"             # all, organization, or private
+
+  handles = [
+    "@pagerduty-on-call",
+    "@slack-incident-response",
+  ]
+
+  conditions {
+    field  = "severity"
+    values = ["SEV-1", "SEV-2"]
+  }
+
+  # Re-notify the same handles if status or severity changes later
+  renotify_on = ["status", "severity"]
+
+  incident_type         = datadog_incident_type.customer_impacting.id
+  notification_template = datadog_incident_notification_template.sev1_alert.id
+}
+{{< /code-block >}}
+
+To narrow a rule to specific services, add a second `conditions` block. Values within a single `conditions` block are ORed; multiple `conditions` blocks are ANDed together:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_notification_rule" "prod_services_only" {
+  enabled    = true
+  trigger    = "incident_created_trigger"
+  visibility = "organization"
+  handles    = ["@team-payments-oncall"]
+
+  conditions {
+    field  = "severity"
+    values = ["SEV-1", "SEV-2"]
+  }
+
+  conditions {
+    field  = "services"
+    values = ["payments-api", "payments-worker"]
+  }
+
+  incident_type = datadog_incident_type.customer_impacting.id
+}
+{{< /code-block >}}
+
+## Create a postmortem template
+
+Postmortem templates control where a postmortem document is created for incidents of a given type (a Datadog Notebook, a Confluence page, or a Google Doc) and what content it starts with.
+
+The following example creates a default Datadog Notebook postmortem template:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_postmortem_template" "default_notebook" {
+  name          = "Standard Postmortem"
+  incident_type = datadog_incident_type.customer_impacting.id
+  location      = "datadog_notebooks" # datadog_notebooks (default), confluence, or google_docs
+  is_default    = true
+
+  content = <<-EOF
+# Postmortem: {{incident.title}}
+
+## Summary
+
+## Timeline
+
+## Root Cause
+
+## Action Items
+EOF
+}
+{{< /code-block >}}
+
+To write postmortems to a Confluence space instead, set `location` to `confluence` and provide `confluence_postmortem_settings`:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_postmortem_template" "confluence" {
+  name          = "Confluence Postmortem"
+  incident_type = datadog_incident_type.customer_impacting.id
+  location      = "confluence"
+
+  confluence_postmortem_settings {
+    account_id = var.confluence_connected_account_id # Datadog connected-account UUID
+    space_id   = "ENG"                                # Confluence space key, not a numeric ID
+    parent_id  = "393217"                              # numeric parent page ID
+  }
+}
+{{< /code-block >}}
+
+To write postmortems to Google Docs instead, set `location` to `google_docs` and provide `google_docs_postmortem_settings`:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_postmortem_template" "google_docs" {
+  name          = "Google Docs Postmortem"
+  incident_type = datadog_incident_type.customer_impacting.id
+  location      = "google_docs"
+
+  google_docs_postmortem_settings {
+    account_id       = var.google_drive_connected_account_id # Datadog connected-account UUID
+    parent_folder_id = "1eCqLAKQqRHt49J2aqQLGUcnPMzGHkt2B"    # taken from the Drive folder URL
+  }
+}
+{{< /code-block >}}
+
+<div class="alert alert-info"><code>confluence_postmortem_settings</code> is required when <code>location = "confluence"</code>, and <code>google_docs_postmortem_settings</code> is required when <code>location = "google_docs"</code>; the provider validates this pairing at plan time. <code>incident_type</code> is immutable, so changing it forces recreation of the template. <code>is_default</code> maps to a server-side timestamp: the template with the most recently set default timestamp is the effective default for its incident type.</div>
+
+## Full configuration example
+
+A realistic setup wires an incident type to its fields, roles, template, and rule in one module:
+
+{{< code-block lang="terraform" >}}
+resource "datadog_incident_type" "customer_impacting" {
+  name        = "Customer Impacting"
+  description = "Incidents that impact customers"
+
+  configuration = {
+    allow_incident_deletion = false
+    test_incidents           = false
+  }
+}
+
+resource "datadog_incident_user_defined_field" "root_cause" {
+  name          = "root_cause"
+  type          = "dropdown"
+  incident_type = datadog_incident_type.customer_impacting.id
+
+  valid_value {
+    display_name = "Service Bug"
+    value        = "service_bug"
+  }
+  valid_value {
+    display_name = "Human Error"
+    value        = "human_error"
+  }
+}
+
+resource "datadog_incident_user_defined_role" "tech_lead" {
+  name          = "Tech Lead"
+  incident_type = datadog_incident_type.customer_impacting.id
+  policy = {
+    is_single = true
+  }
+}
+
+resource "datadog_incident_notification_template" "sev1_alert" {
+  name          = "SEV-1 Customer Impact Template"
+  subject       = "SEV-1 Incident: {{incident.title}}"
+  category      = "alert"
+  incident_type = datadog_incident_type.customer_impacting.id
+  content       = "SEV-1 declared: {{incident.title}}. Status: {{incident.status}}."
+}
+
+resource "datadog_incident_notification_rule" "sev1_sev2_created" {
+  enabled                = true
+  trigger                = "incident_created_trigger"
+  visibility              = "organization"
+  handles                = ["@pagerduty-on-call"]
+  incident_type           = datadog_incident_type.customer_impacting.id
+  notification_template   = datadog_incident_notification_template.sev1_alert.id
+
+  conditions {
+    field  = "severity"
+    values = ["SEV-1", "SEV-2"]
+  }
+}
+{{< /code-block >}}
+
+## Reference existing configuration with data sources
+
+If an incident type, notification template, or notification rule already exists (created in the UI, or in another Terraform root you don't want to import into this one), read it with a data source instead of managing it directly:
+
+{{< code-block lang="terraform" >}}
+data "datadog_incident_type" "existing" {
+  id = "01234567-89ab-cdef-0123-456789abcdef"
+}
+
+data "datadog_incident_notification_template" "existing" {
+  id = "52600bb1-e83a-48a1-aa77-6889ddb269b2"
+}
+
+resource "datadog_incident_notification_rule" "extra_rule" {
+  enabled                = true
+  trigger                = "incident_saved_trigger"
+  visibility              = "organization"
+  handles                = ["@security-team"]
+  incident_type           = data.datadog_incident_type.existing.id
+  notification_template   = data.datadog_incident_notification_template.existing.id
+
+  conditions {
+    field  = "status"
+    values = ["resolved"]
+  }
+}
+{{< /code-block >}}
+
+## Import existing resources
+
+If you already created incident types, fields, roles, templates, or rules in the UI, bring them under Terraform management with `terraform import` rather than recreating them:
+
+{{< code-block lang="bash" >}}
+terraform import datadog_incident_type.customer_impacting "12345678-1234-1234-1234-1234567890ab"
+terraform import datadog_incident_user_defined_field.root_cause "12345678-1234-1234-1234-1234567890ab"
+terraform import datadog_incident_user_defined_role.tech_lead "12345678-1234-1234-1234-1234567890ab"
+terraform import datadog_incident_notification_template.sev1_alert "11111111-2222-3333-4444-555555555555"
+terraform import datadog_incident_notification_rule.sev1_sev2_created "00000000-0000-0000-0000-000000000000"
+terraform import datadog_incident_postmortem_template.default_notebook "<template-id>"
+{{< /code-block >}}
+
+Find each resource's ID in the Datadog UI ([**Incidents** > **Settings**][5]) or through the corresponding API endpoint, then write a matching resource block before running `terraform plan` to confirm there's no diff.
+
+## Best practices
+
+- **Model one incident type per Terraform module.** Since every other resource in this guide is scoped to an incident type, grouping by incident type keeps blast radius small when you change fields, roles, or notification rules for one incident category.
+- **Let Terraform resolve resource order.** Terraform resolves the dependency graph from resource references (for example, `incident_type = datadog_incident_type.x.id`), so you don't need to order blocks by hand. Make sure every child resource references its parent's `id`.
+- **Treat `configuration` changes as behavior changes, not cosmetic ones.** Flipping `allow_incident_deletion` or `test_incidents` changes what responders can do. Call these out explicitly in pull request descriptions rather than bundling them with unrelated field additions.
+- **Use `terraform plan` before enabling new notification rules.** A misconfigured `conditions` block or wrong `trigger` can page the wrong team. Validate the plan output, and consider rolling out with `enabled = false` first, then enabling it once reviewed.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs
+[2]: /incident_response/incident_management/
+[3]: /account_management/api-app-keys/
+[4]: https://developer.hashicorp.com/terraform/install
+[5]: https://app.datadoghq.com/incidents/settings

--- a/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
+++ b/hugo/content/en/incident_response/incident_management/guides/manage_with_terraform.md
@@ -123,12 +123,12 @@ resource "datadog_incident_notification_template" "sev1_alert" {
 }
 
 resource "datadog_incident_notification_rule" "sev1_sev2_created" {
-  enabled                = true
-  trigger                = "incident_created_trigger"
-  visibility              = "organization"
-  handles                = ["@pagerduty-on-call"]
-  incident_type           = datadog_incident_type.customer_impacting.id
-  notification_template   = datadog_incident_notification_template.sev1_alert.id
+  enabled               = true
+  trigger               = "incident_created_trigger"
+  visibility            = "organization"
+  handles               = ["@pagerduty-on-call"]
+  incident_type         = datadog_incident_type.customer_impacting.id
+  notification_template = datadog_incident_notification_template.sev1_alert.id
 
   conditions {
     field  = "severity"


### PR DESCRIPTION
🤖 Auto-generated fix for #38743.

@estherk15 — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38743. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38743 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38743) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [x] Ready for merge
**The original was approved by Rosa, but I couldn't get it in before the reorg :(**
---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [DOCS-15270](https://datadoghq.atlassian.net/browse/DOCS-15270)

Adds a new guide, "Manage Incident Management with Terraform,". 
The guide summarizes the Incident Management resources available in the Datadog Terraform provider, linking out to the Terraform registry for resource reference and to the corresponding Datadog docs for feature background. 
Also links the new guide from the Incident Management guides index page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

[DOCS-15270]: https://datadoghq.atlassian.net/browse/DOCS-15270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ