### PR TITLE
[reorg fix] Add is_deleted query parameter to ListSLOs

### DIFF
--- a/hugo/data/api/v1/full_spec.yaml
+++ b/hugo/data/api/v1/full_spec.yaml
@@ -39059,6 +39059,15 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: |-
+            Whether to return only deleted service level objective objects.
+          example: true
+          in: query
+          name: is_deleted
+          required: false
+          schema:
+            default: false
+            type: boolean
       responses:
         "200":
           content:


### PR DESCRIPTION
🤖 Auto-generated fix for #38676.

@app/api-clients-generation-pipeline — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38676. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38676 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38676) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

See [DataDog/datadog-api-spec#6305](https://github.com/DataDog/datadog-api-spec/pull/6305) Test branch [datadog-api-spec/test/richie.ippoliti/slo-list-is-deleted-param](https://github.com/DataDog/documentation/compare/datadog-api-spec/test/richie.ippoliti/slo-list-is-deleted-param)