### PR TITLE
[reorg fix] DSM Ruby: note that JRuby is not supported

### DIFF
--- a/hugo/content/en/data_streams/setup/language/ruby.md
+++ b/hugo/content/en/data_streams/setup/language/ruby.md
@@ -14,7 +14,7 @@ aliases:
 ### Prerequisites
 
 * [Datadog Agent v7.34.0 or later][10]
-* [MRI (CRuby)][11]. Data Streams Monitoring is not supported on JRuby.
+* [MRI (CRuby)][11]. Other Ruby implementations are not supported.
 
 ### Supported libraries
 

--- a/hugo/content/en/data_streams/setup/language/ruby.md
+++ b/hugo/content/en/data_streams/setup/language/ruby.md
@@ -14,6 +14,7 @@ aliases:
 ### Prerequisites
 
 * [Datadog Agent v7.34.0 or later][10]
+* [MRI (CRuby)][11]. Data Streams Monitoring is not supported on JRuby.
 
 ### Supported libraries
 
@@ -49,3 +50,4 @@ Data Streams Monitoring propagates context through message headers. If you are u
 [3]: https://pypi.org/project/confluent-kafka/
 [5]: https://pypi.org/project/kombu/
 [6]: /data_streams/manual_instrumentation/?tab=ruby
+[11]: https://www.ruby-lang.org/


### PR DESCRIPTION
🤖 Auto-generated fix for #38648.

@robcarlan-datadog — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38648. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38648 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38648) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

## Summary
- DSM was only built to support the main Ruby implementation, there was some confusion about JRuby not working as it was in the process of being sunset in the main ruby tracer
- Make it explicit that we only support MRI / CRuby 

## Test plan
- [ ] Docs preview renders correctly (link reference `[11]` resolves)