### PR TITLE
[reorg fix] [DOCS-XXXXX] Document the retry_datadog_ci_job MCP tool

### DIFF
--- a/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -74,12 +74,6 @@ The `software-delivery` toolset includes the following tools:
 `aggregate_dora_deployments`
 : Aggregate DORA metrics—deployment frequency, change lead time, change failure rate, and recovery time—as scalar values or timeseries. For a complete DORA summary, call this tool four times in parallel, once per metric.
 
-`get_prs_by_head_branch`
-: Find all pull requests for a repository that have a specific head branch, such as the pull request for the feature branch you are working on.
-
-`search_pr_insights`
-: Retrieve the issues blocking a pull request, including failed tests, flaky tests, code quality problems, security vulnerabilities, and failed CI jobs.
-
 `retry_datadog_ci_job`
 : Queue a retry for a failed CI job on GitHub Actions or GitLab. A write operation that modifies CI state, requiring `CiVisibilityWrite` permission. Server-side limits cap retries at two per workflow run over seven days. For other CI providers, use the provider's UI to rerun.
 
@@ -95,7 +89,6 @@ After you are connected, try prompts like:
 - What's the code coverage on the `main` branch for `github.com/my-org/my-repo`?
 - Show me coverage metrics for commit `abc123abc123abc123abc123abc123abc123abcd`.
 - What is the deployment frequency and change failure rate for the `checkout` service over the last 30 days?
-- What's blocking the pull request for my branch?
 - Which test optimization features are enabled for the `auth-service`?
 - Quarantine all active flaky tests in the `checkout-service` repository.
 

--- a/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -74,8 +74,14 @@ The `software-delivery` toolset includes the following tools:
 `aggregate_dora_deployments`
 : Aggregate DORA metrics—deployment frequency, change lead time, change failure rate, and recovery time—as scalar values or timeseries. For a complete DORA summary, call this tool four times in parallel, once per metric.
 
+`get_prs_by_head_branch`
+: Find all pull requests for a repository that have a specific head branch, such as the pull request for the feature branch you are working on.
+
+`search_pr_insights`
+: Retrieve the issues blocking a pull request, including failed tests, flaky tests, code quality problems, security vulnerabilities, and failed CI jobs.
+
 `retry_datadog_ci_job`
-: Queue a retry for a failed CI job on GitHub Actions or GitLab. A write operation that modifies CI state, requiring `CiVisibilityWrite` permission. Server-side limits cap retries at two per job over seven days. For other CI providers, use the provider's UI to rerun.
+: Queue a retry for a failed CI job on GitHub Actions or GitLab. A write operation that modifies CI state, requiring `CiVisibilityWrite` permission. Server-side limits cap retries at two per workflow run over seven days. For other CI providers, use the provider's UI to rerun.
 
 ## Example prompts
 
@@ -89,6 +95,7 @@ After you are connected, try prompts like:
 - What's the code coverage on the `main` branch for `github.com/my-org/my-repo`?
 - Show me coverage metrics for commit `abc123abc123abc123abc123abc123abc123abcd`.
 - What is the deployment frequency and change failure rate for the `checkout` service over the last 30 days?
+- What's blocking the pull request for my branch?
 - Which test optimization features are enabled for the `auth-service`?
 - Quarantine all active flaky tests in the `checkout-service` repository.
 

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -2157,22 +2157,6 @@ Returns DORA metrics (deployment frequency, change lead time, change failure rat
 - Show me the change lead time trend for the `payments` service over the last quarter.
 - Get all four DORA metrics for the `auth-service` team.
 
-### `get_prs_by_head_branch`
-*Toolset: **software-delivery***\
-*Permissions Required: `Repository Info Read`*\
-Retrieves all pull requests for a repository that have a specific head branch. Use it to find the pull requests associated with a feature or development branch.
-
-- Is there an open pull request for my branch `feat/add-retry-logic`?
-- Show me the pull requests for the `release/1.x` branch of `github.com/my-org/my-repo`.
-
-### `search_pr_insights`
-*Toolset: **software-delivery***\
-*Permissions Required: `Repository Info Read`*\
-Retrieves the issues blocking a pull request, including failed tests, flaky tests, code quality problems, security vulnerabilities, and failed CI jobs.
-
-- What's blocking PR #123 in `github.com/my-org/my-repo`?
-- Show me the code quality and security violations on my pull request.
-
 ### `retry_datadog_ci_job`
 *Toolset: **software-delivery***\
 *Permissions Required: `CI Visibility Write`*\

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -2157,6 +2157,30 @@ Returns DORA metrics (deployment frequency, change lead time, change failure rat
 - Show me the change lead time trend for the `payments` service over the last quarter.
 - Get all four DORA metrics for the `auth-service` team.
 
+### `get_prs_by_head_branch`
+*Toolset: **software-delivery***\
+*Permissions Required: `Repository Info Read`*\
+Retrieves all pull requests for a repository that have a specific head branch. Use it to find the pull requests associated with a feature or development branch.
+
+- Is there an open pull request for my branch `feat/add-retry-logic`?
+- Show me the pull requests for the `release/1.x` branch of `github.com/my-org/my-repo`.
+
+### `search_pr_insights`
+*Toolset: **software-delivery***\
+*Permissions Required: `Repository Info Read`*\
+Retrieves the issues blocking a pull request, including failed tests, flaky tests, code quality problems, security vulnerabilities, and failed CI jobs.
+
+- What's blocking PR #123 in `github.com/my-org/my-repo`?
+- Show me the code quality and security violations on my pull request.
+
+### `retry_datadog_ci_job`
+*Toolset: **software-delivery***\
+*Permissions Required: `CI Visibility Write`*\
+Queues a retry for a failed CI job on GitHub Actions or GitLab. This is a write operation that requires explicit user approval. Server-side limits cap retries at two per workflow run over seven days. The response confirms that the retry was queued, not that it ran, so confirm the new run with `search_datadog_ci_pipeline_events`. On GitHub Actions, every failed job in the workflow run is retried, not only the job you specify. For other CI providers, use the provider's UI to rerun.
+
+- Retry the failed `integration-test` job on my branch.
+- The `build` job failed because of a network timeout; queue a retry.
+
 ## Synthetics
 
 Tools for interacting with Datadog [Synthetic tests][47].


### PR DESCRIPTION
🤖 Auto-generated fix for #38559.

@lpenadiaz — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38559. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38559 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38559) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

`retry_datadog_ci_job` is registered in the `software-delivery` MCP toolset and already documented on the [Software Delivery MCP Tools getting-started page](/getting_started/software_delivery_mcp_tools/), but was missing from the [MCP Server tools reference](/mcp_server/tools/). This PR adds it there, and corrects the retry limit wording on the getting-started page (two retries per **workflow run**, not per job).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Scoped to CI/CD tool documentation only. Companion PRs cover DORA (documentation#38557) and Code Coverage (documentation#38558) tool documentation in the same section.
