### PR TITLE
[reorg fix] [NO TICKET] Update DORA MCP tool names and descriptions

### DIFF
--- a/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/hugo/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -29,7 +29,7 @@ The Software Delivery MCP tools unlock AI-assisted workflows for:
 - **Analyzing CI performance**: Get aggregated statistics on pipeline durations, failure rates, and trends over time.
 - **Triaging test failures**: Understand which tests are failing, their ownership, and historical patterns.
 - **Reviewing code coverage**: Get coverage summaries for branches or commits, including patch coverage and breakdowns by service or code owner.
-- **Measuring DORA metrics**: Query deployment frequency, change lead time, change failure rate, and recovery time by service or team.
+- **Measuring DORA metrics**: Build delivery performance queries over deployments, commits, and pull requests, from deployment frequency and change failure rate to per-stage change lead time breakdowns.
 - **Checking test optimization settings**: See which Test Optimization features are active for a service, including Test Impact Analysis, Early Flake Detection, and Auto Test Retries.
 - **Retrying failed CI jobs**: Queue a retry for a failed GitHub Actions or GitLab job without leaving the agent session.
 - **Checking PR health**: Get a combined view of CI failures, code coverage, and quality or security violations for a pull request.
@@ -68,11 +68,14 @@ The `software-delivery` toolset includes the following tools:
 `get_datadog_flaky_tests_management_policies`
 : Retrieve the Flaky Tests Management policies configured for a repository, including auto-quarantine windows, branch rules, failure rate thresholds, disable policies, and retry settings.
 
-`search_dora_deployments`
-: Search DORA deployment events with filters, or fetch full details for a single deployment by ID. For aggregated trends (deployment frequency, change lead time, failure rate), use `aggregate_dora_deployments` instead.
+`search_dora_events`
+: Search DORA events with filters, or fetch full details for a single event by ID. Target either deployments or the pull requests behind them. For aggregated trends (deployment frequency, change lead time, failure rate), use `aggregate_dora_events` instead.
 
-`aggregate_dora_deployments`
-: Aggregate DORA metrics—deployment frequency, change lead time, change failure rate, and recovery time—as scalar values or timeseries. For a complete DORA summary, call this tool four times in parallel, once per metric.
+`aggregate_dora_events`
+: Aggregate DORA events into scalar values or timeseries using composable queries and formulas, the same model as `get_datadog_metric`. Each query selects a DORA index (`deployment`, `commit`, `pull_request`, or `failure`), a measure, an aggregation, and optional filters and grouping facets. Combine queries in a formula to derive ratios such as change failure rate.
+
+`get_dora_fields`
+: List the measures, facets, aggregations, and cardinality fields that `aggregate_dora_events` accepts for each DORA index. Call this tool first to pick a valid measure, grouping facet, or aggregation.
 
 `retry_datadog_ci_job`
 : Queue a retry for a failed CI job on GitHub Actions or GitLab. A write operation that modifies CI state, requiring `CiVisibilityWrite` permission. Server-side limits cap retries at two per job over seven days. For other CI providers, use the provider's UI to rerun.
@@ -89,6 +92,7 @@ After you are connected, try prompts like:
 - What's the code coverage on the `main` branch for `github.com/my-org/my-repo`?
 - Show me coverage metrics for commit `abc123abc123abc123abc123abc123abc123abcd`.
 - What is the deployment frequency and change failure rate for the `checkout` service over the last 30 days?
+- Where does change lead time go for the `payments` service — coding, review, merge, or deploy?
 - Which test optimization features are enabled for the `auth-service`?
 - Quarantine all active flaky tests in the `checkout-service` repository.
 

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -2139,23 +2139,33 @@ Retrieves the Flaky Tests Management policies configured for a repository, inclu
 - Show me the flaky test management policies for `github.com/my-org/my-repo`.
 - What auto-quarantine rules are configured for the checkout service repository?
 
-### `search_dora_deployments`
+### `search_dora_events`
 *Toolset: **software-delivery***\
 *Permissions Required: `DORA Metrics Read`*\
-Searches DORA deployment events with filters, or fetches full details for a single deployment by ID.
+Searches DORA events with filters, or fetches full details for a single event by ID. Set the target to `deployment` (the default) or `pull_request` to choose which event type to search. The `pull_request` target returns only pull requests that were merged and deployed, so you can analyze the coding, review, merge, and deploy phases behind change lead time. It does not return open pull requests, review status, or CI results. For trends and aggregates, use `aggregate_dora_events`.
 
 - Show me deployments for the `checkout` service in the last 7 days.
-- Get details for DORA deployment `abc123`.
 - Find failed deployments in the production environment this month.
+- Show me all rollbacks across environments.
+- Which pull requests took the longest to review last month?
 
-### `aggregate_dora_deployments`
+### `aggregate_dora_events`
 *Toolset: **software-delivery***\
 *Permissions Required: `Timeseries`*\
-Returns DORA metrics (deployment frequency, change lead time, change failure rate, recovery time) for a service, team, or repo, as scalar values or timeseries. Use for questions about software delivery performance over a time window.
+Aggregates DORA events into scalar values or timeseries using composable queries and formulas, the same model as `get_datadog_metric`. Each query selects a DORA index (`deployment`, `commit`, `pull_request`, or `failure`), an optional measure to aggregate, an aggregation, an optional Lucene filter, and optional grouping facets. Reference queries by name in a formula to derive ratios such as change failure rate. Call `get_dora_fields` first to discover the valid measures, facets, and aggregations for an index.
 
-- What is the deployment frequency and change failure rate for the `checkout` service over the last 30 days?
+- What is the change failure rate for the `checkout` service over the last 30 days?
 - Show me the change lead time trend for the `payments` service over the last quarter.
-- Get all four DORA metrics for the `auth-service` team.
+- Which team has the highest deployment frequency?
+- What is the median pull request cycle time for the `auth-service` repository?
+
+### `get_dora_fields`
+*Toolset: **software-delivery***\
+*Permissions Required: `DORA Metrics Read`*\
+Lists the measures, facets, aggregations, and cardinality fields that `aggregate_dora_events` accepts for each DORA index (`deployment`, `commit`, `pull_request`, and `failure`). Call this tool before `aggregate_dora_events` to pick a valid measure, grouping facet, or aggregation.
+
+- Which fields can I group DORA deployment metrics by?
+- What measures are available on the `pull_request` DORA index?
 
 ## Synthetics
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38557.

@lpenadiaz — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38557. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38557 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38557) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Datadog MCP Server's `software-delivery` toolset renamed its DORA tools; the docs still referenced the retired names. This PR updates the [MCP Server tools reference](https://docs.datadoghq.com/mcp_server/tools/) and the [Software Delivery MCP Tools getting-started page](https://docs.datadoghq.com/getting_started/software_delivery_mcp_tools/) to match what's actually registered:

- `search_dora_deployments` → `search_dora_events` (adds a `target` selector for deployments vs. pull requests)
- `aggregate_dora_deployments` → `aggregate_dora_events` (interface changed from a fixed metric type to composable queries and formulas, matching `get_datadog_metric`)
- Documents the new `get_dora_fields` introspection tool
- Updates the DORA use-case bullet and example prompts to match the new interface

### Merge instructions

Merge readiness:
- [ ] Ready for merge

