### PR TITLE
[reorg fix] Clarify managed identity Client ID in DBM Entra ID auth guide

### DIFF
--- a/hugo/content/en/database_monitoring/guide/managed_authentication.md
+++ b/hugo/content/en/database_monitoring/guide/managed_authentication.md
@@ -527,7 +527,7 @@ SECURITY DEFINER;
 ```
 
 
-5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the managed identity's Client ID (also called the Application (client) ID), found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
+5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the managed identity's Client ID, also called the Application (client) ID. This ID is found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
 
 
 ```yaml
@@ -592,7 +592,7 @@ CREATE USER <MANAGED_IDENTITY_NAME> FOR LOGIN <MANAGED_IDENTITY_NAME>;
 ```
 
 
-5. Update your instance config with the `managed_identity` config block, where `client_id` is the managed identity's Client ID (also called the Application (client) ID), found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
+5. Update your instance config with the `managed_identity` config block, where `client_id` is the managed identity's Client ID, also called the Application (client) ID. This ID is found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
 
 
 **Note**: [ODBC Driver 17 for SQL Server][18] or greater is required to use this feature.

--- a/hugo/content/en/database_monitoring/guide/managed_authentication.md
+++ b/hugo/content/en/database_monitoring/guide/managed_authentication.md
@@ -527,7 +527,9 @@ SECURITY DEFINER;
 ```
 
 
-5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the Client ID of the Managed Identity:
+5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the Client ID of the Managed Identity, found on the managed identity's **Overview** blade in the Azure Portal.
+
+   **Note**: The `CLIENT_ID` is **not** the managed identity's Object (principal) ID, and it is **not** an App Registration's Application (client) ID. Using either of those values instead of the managed identity's own Client ID results in an `AADSTS700016` error from Microsoft Entra ID.
 
 
 ```yaml
@@ -592,7 +594,7 @@ CREATE USER <MANAGED_IDENTITY_NAME> FOR LOGIN <MANAGED_IDENTITY_NAME>;
 ```
 
 
-5. Update your instance config with the `managed_identity` config block:
+5. Update your instance config with the `managed_identity` config block, where `client_id` is the Client ID of the Managed Identity, found on the managed identity's **Overview** blade in the Azure Portal. This is **not** the managed identity's Object (principal) ID, and it is **not** an App Registration's Application (client) ID. Using either of those values instead of the managed identity's own Client ID results in an `AADSTS700016` error from Microsoft Entra ID.
 
 
 **Note**: [ODBC Driver 17 for SQL Server][18] or greater is required to use this feature.

--- a/hugo/content/en/database_monitoring/guide/managed_authentication.md
+++ b/hugo/content/en/database_monitoring/guide/managed_authentication.md
@@ -527,9 +527,7 @@ SECURITY DEFINER;
 ```
 
 
-5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the Client ID of the Managed Identity, found on the managed identity's **Overview** blade in the Azure Portal.
-
-   **Note**: The `CLIENT_ID` is **not** the managed identity's Object (principal) ID, and it is **not** an App Registration's Application (client) ID. Using either of those values instead of the managed identity's own Client ID results in an `AADSTS700016` error from Microsoft Entra ID.
+5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the managed identity's Client ID (also called the Application (client) ID), found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
 
 
 ```yaml
@@ -594,7 +592,7 @@ CREATE USER <MANAGED_IDENTITY_NAME> FOR LOGIN <MANAGED_IDENTITY_NAME>;
 ```
 
 
-5. Update your instance config with the `managed_identity` config block, where `client_id` is the Client ID of the Managed Identity, found on the managed identity's **Overview** blade in the Azure Portal. This is **not** the managed identity's Object (principal) ID, and it is **not** an App Registration's Application (client) ID. Using either of those values instead of the managed identity's own Client ID results in an `AADSTS700016` error from Microsoft Entra ID.
+5. Update your instance config with the `managed_identity` config block, where `client_id` is the managed identity's Client ID (also called the Application (client) ID), found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
 
 
 **Note**: [ODBC Driver 17 for SQL Server][18] or greater is required to use this feature.

--- a/hugo/content/en/database_monitoring/guide/managed_authentication.md
+++ b/hugo/content/en/database_monitoring/guide/managed_authentication.md
@@ -527,7 +527,7 @@ SECURITY DEFINER;
 ```
 
 
-5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the managed identity's Client ID, also called the Application (client) ID. This ID is found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
+5. Configure your instance config with the `azure.managed_authentication` YAML block, where the `CLIENT_ID` is the Client ID on this managed identity's own **Overview** blade in the Azure Portal, also labeled Application (client) ID there. Don't use the managed identity's Object (principal) ID, and don't use the Application (client) ID of a different App Registration.
 
 
 ```yaml
@@ -592,7 +592,7 @@ CREATE USER <MANAGED_IDENTITY_NAME> FOR LOGIN <MANAGED_IDENTITY_NAME>;
 ```
 
 
-5. Update your instance config with the `managed_identity` config block, where `client_id` is the managed identity's Client ID, also called the Application (client) ID. This ID is found on the managed identity's **Overview** blade in the Azure Portal. This is different from the Object (principal) ID.
+5. Update your instance config with the `managed_identity` config block, where `client_id` is the Client ID on this managed identity's own **Overview** blade in the Azure Portal, also labeled Application (client) ID there. Don't use the managed identity's Object (principal) ID, and don't use the Application (client) ID of a different App Registration.
 
 
 **Note**: [ODBC Driver 17 for SQL Server][18] or greater is required to use this feature.


### PR DESCRIPTION
🤖 Auto-generated fix for #38550.

@pierreln-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38550. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38550 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38550) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Postgres and SQL Server sections of the Microsoft Entra ID managed authentication guide (`content/en/database_monitoring/guide/managed_authentication.md`) told readers to set `client_id` to "the Client ID of the Managed Identity," without distinguishing that value from two other Azure identifiers that are easy to confuse with it: the managed identity's Object (principal) ID, and an App Registration's Application (client) ID.

This ambiguity was a contributing factor in a support case (SDBM-2844) where a customer set up Postgres DBM Entra ID authentication and hit an `AADSTS700016` ("Application with identifier '<id>' was not found in the directory") error from Microsoft Entra ID — the classic symptom of supplying the wrong ID type for `client_id`.

This PR adds an explicit callout in both the Postgres and SQL Server sections stating that `client_id` must be the value shown on the managed identity's **Overview** blade in the Azure Portal, and that it is *not* the Object (principal) ID and *not* an App Registration's Application (client) ID, and that using either of those results in `AADSTS700016`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Related internal ticket: SDBM-2844.

Note: `integrations-core/postgres/datadog_checks/postgres/data/conf.yaml.example` (around lines 856-866) has similar ambiguous wording ("client_id: The client ID of the managed identity or app registration.") but lives in a different repo, so it's out of scope for this PR and flagged separately for a follow-up.