### PR TITLE
[reorg fix] Document pgx driver latency caveat with full DBM propagation mode

### DIFF
--- a/hugo/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/hugo/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -201,6 +201,10 @@ func main() {
 
 [1]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2
 
+<div class="alert alert-warning">
+The <code>pgx</code> driver caches prepared statements by query text. <code>full</code> propagation mode injects unique trace context into each query, which defeats this cache and forces the database to re-plan every query. Datadog recommends using <code>service</code> mode with the <code>pgx</code> driver.
+</div>
+
 {{% /tab %}}
 
 {{% tab "Java" %}}


### PR DESCRIPTION
🤖 Auto-generated fix for #38534.

@pierreln-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38534. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38534 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38534) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?

Adds a callout to the Go tab of Connect DBM and APM warning about a latency regression when using the `pgx` driver with `full` propagation mode.

`pgx` caches prepared statements by query text. Because `full` mode injects unique trace context into each query, it defeats this cache and forces the database to re-plan every query. Recommends `service` mode as a workaround.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes