### PR TITLE
[reorg fix] [DAL-834] Document OAuth scope restrictions

### DIFF
--- a/hugo/content/en/account_management/org_settings/mobile_third_party_access.md
+++ b/hugo/content/en/account_management/org_settings/mobile_third_party_access.md
@@ -49,15 +49,24 @@ Revoking a user's OAuth access to an application removes all access to that appl
 
 ### Application Scope Management
 
-Enable Application Scope Management to modify the allowed scopes for an application. Adding or removing a scope affects access to this application for all users in your organization. Disabling a scope revokes any existing authorizations for applications that have the scope granted.
+Enable Application Scope Management to modify the allowed scopes for an application. Application Scope Management is available for the Datadog Mobile App and MCP applications.
 
-Only MCP applications support Application Scope Management.
+Adding or removing a scope affects access to the application for all users in your organization. Disabling a scope revokes existing authorizations that include the scope. Affected users must re-authorize the application to regain access with the remaining allowed scopes.
+
+Use {{< ui >}}Automatically allow new scopes{{< /ui >}} to control how Application Scope Management handles scopes that the application requests in the future:
+
+- When selected, future scopes are allowed without an administrator updating the configuration. Only scopes that you disable remain blocked.
+- When cleared, future scopes are disabled until an administrator allows them.
+
+For the Datadog Mobile App, required scopes are always allowed and cannot be disabled.
 
 1. On the {{< ui >}}Mobile and Third-Party Access{{< /ui >}} page, click an application to open its detail view.
 
 2. Select the {{< ui >}}Scopes{{< /ui >}} tab and use the {{< ui >}}Allowed{{< /ui >}} checkbox for each scope to control whether to grant the application that scope.
 
-3. Click {{< ui >}}Enable{{< /ui >}} to save the scope configuration.
+3. Select or clear {{< ui >}}Automatically allow new scopes{{< /ui >}} to choose how to handle future scopes.
+
+4. Click {{< ui >}}Enable{{< /ui >}} or {{< ui >}}Save{{< /ui >}} to save the scope configuration.
 
 {{< img src="account_management/mobile_third_party_access/scope-restrictions-enable.png" alt="Application Scope Management view with Enable and Restore to Full Access buttons" style="width:100%;">}}
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38520.

@imaique — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38520. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38520 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38520) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?

Fixes DAL-834

Updates the Mobile and Third-Party Access documentation to:

- Describe how Application Scope Management handles future scopes.
- Clarify support for the Datadog Mobile App and MCP applications.
- Document required Mobile scopes and authorization revocation behavior.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Codex for source research, initial drafting, and style checks. The final wording was validated against shipped behavior.

### Additional notes

Validation:

- `git diff --check` passed.
- Added-content checks found no em dashes, restricted style terms, or internal references.
- Vale was not run locally because the binary is not installed in this environment.