### PR TITLE
[reorg fix] Document OpenMetrics metric-limit Agent telemetry

### DIFF
--- a/hugo/content/en/data_security/agent.md
+++ b/hugo/content/en/data_security/agent.md
@@ -153,7 +153,7 @@ agent diagnose show-metadata agent-telemetry
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **Checks**                                  |                                                                                                                        |
 | checks.execution_time                       | Check's execution time in milliseconds                                                                                 |
-| openmetrics.max_returned_metrics_reached    | Number of OpenMetrics check runs that exceed the configured `max_returned_metrics` limit                               |
+| checks.max_returned_metrics_reached         | Number of OpenMetrics check runs that exceed the configured `max_returned_metrics` limit                               |
 | pymem.inuse                                 | Number of bytes allocated by the Python interpreter                                                                    |
 | **Logs and metrics**                        |                                                                                                                        |
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |

--- a/hugo/content/en/data_security/agent.md
+++ b/hugo/content/en/data_security/agent.md
@@ -153,6 +153,7 @@ agent diagnose show-metadata agent-telemetry
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **Checks**                                  |                                                                                                                        |
 | checks.execution_time                       | Check's execution time in milliseconds                                                                                 |
+| openmetrics.max_returned_metrics_reached    | Number of OpenMetrics check runs that exceed the configured `max_returned_metrics` limit                               |
 | pymem.inuse                                 | Number of bytes allocated by the Python interpreter                                                                    |
 | **Logs and metrics**                        |                                                                                                                        |
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |

--- a/hugo/content/en/data_security/agent.md
+++ b/hugo/content/en/data_security/agent.md
@@ -153,7 +153,7 @@ agent diagnose show-metadata agent-telemetry
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **Checks**                                  |                                                                                                                        |
 | checks.execution_time                       | Check's execution time in milliseconds                                                                                 |
-| checks.max_returned_metrics_reached         | Number of OpenMetrics check runs that exceed the configured `max_returned_metrics` limit                               |
+| checks.max_returned_metrics_reached         | Number of check runs that reached the configured `max_returned_metrics` limit and dropped metrics                      |
 | pymem.inuse                                 | Number of bytes allocated by the Python interpreter                                                                    |
 | **Logs and metrics**                        |                                                                                                                        |
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |

--- a/hugo/content/en/data_security/agent.md
+++ b/hugo/content/en/data_security/agent.md
@@ -153,7 +153,8 @@ agent diagnose show-metadata agent-telemetry
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **Checks**                                  |                                                                                                                        |
 | checks.execution_time                       | Check's execution time in milliseconds                                                                                 |
-| checks.max_returned_metrics_reached         | Number of check runs that reached the configured `max_returned_metrics` limit and dropped metrics                      |
+| checks.max_returned_metrics_reached         | Check runs exceeding `max_returned_metrics`, tagged by check name and effective limit type (`default` or `custom`)     |
+| checks.max_returned_metrics_dropped         | Metric contexts dropped past `max_returned_metrics`, tagged by check name and limit type (`default` or `custom`)       |
 | pymem.inuse                                 | Number of bytes allocated by the Python interpreter                                                                    |
 | **Logs and metrics**                        |                                                                                                                        |
 | dogstatsd.udp_packets_bytes                 | DogStatsD UDP packets bytes                                                                                            |


### PR DESCRIPTION
🤖 Auto-generated fix for #38477.

@nubtron — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38477. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38477 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38477) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?

Documents both AI-7012 metric-limit telemetry counters in the Agent Data Security telemetry collection table:

- `checks.max_returned_metrics_reached`: affected check runs.
- `checks.max_returned_metrics_dropped`: limiter-counted metric contexts dropped beyond the effective limit.

Both retain only bounded dimensions:

- `check_name`
- `limit_type`, exactly `default` or `custom`

`limit_type=default` means the effective limiter value equals the check class default; `custom` means an operator configured a different effective value. Endpoint, instance, numeric configuration value, customer tags, and arbitrary metric tags are not retained.

Implementation PRs:

- Producer: DataDog/integrations-core#24577
- Agent bridge and built-in telemetry profile: DataDog/datadog-agent#53751
- Tracking issue: https://datadoghq.atlassian.net/browse/AI-7012
- ASUP onboarding template: https://datadoghq.atlassian.net/browse/ASUP-46

No dedicated ASUP governance issue has been created yet.

**Do not merge until both code changes are merged and the first Agent release containing the complete path is GA.** Exact-current-head payload evidence, release tracking, and final `ddcoat` validation remain pending.

### Merge readiness

- [ ] Ready for merge
<!-- Blocked on DataDog/integrations-core#24577, DataDog/datadog-agent#53751, final payload validation, ASUP governance, and the emitting Agent release reaching GA. -->

## For Datadog employees:

### AI assistance

AI-assisted research and initial draft; metric names, semantics, bounded tags, and implementation links were verified against the active implementation PRs and manually reviewed.

### Additional notes

This change touches only `content/en/data_security/agent.md`. Both rows are in the **Checks** subsection directly below `checks.execution_time` and match the built-in profile entries in DataDog/datadog-agent#53751.
