### PR TITLE
[reorg fix] [RUM] Add resource OOTB metrics to RUM without Limits metrics table

### DIFF
--- a/hugo/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/hugo/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -35,8 +35,8 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.error.anr` | Count of ANRs (an Android freeze) | Default, Is Crash, View Name | Mobile only |
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |
 | `rum.measure.error.hang.duration` | Duration of hangs (an iOS freeze) | Default, View Name | Mobile only |
-| `rum.measure.resource` | Count of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
-| `rum.measure.resource.duration` | Duration of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource` | Count of resources | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource.duration` | Duration of resources | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
 | `rum.measure.session` | Count of sessions | Default | Mobile & Browser |
 | `rum.measure.session.action` | Count of actions | Default | Mobile & Browser |
 | `rum.measure.session.crash_free` | Count of crash-free sessions | Default | Mobile only |

--- a/hugo/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/hugo/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -35,6 +35,8 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.error.anr` | Count of ANRs (an Android freeze) | Default, Is Crash, View Name | Mobile only |
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |
 | `rum.measure.error.hang.duration` | Duration of hangs (an iOS freeze) | Default, View Name | Mobile only |
+| `rum.measure.resource` | Count of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
+| `rum.measure.resource.duration` | Duration of resources (REST and GraphQL network calls) | Default, Status Code, URL Path Group, Resource Type, GraphQL Operation Name, GraphQL Operation Type, GraphQL Has Errors | Mobile & Browser |
 | `rum.measure.session` | Count of sessions | Default | Mobile & Browser |
 | `rum.measure.session.action` | Count of actions | Default | Mobile & Browser |
 | `rum.measure.session.crash_free` | Count of crash-free sessions | Default | Mobile only |


### PR DESCRIPTION
🤖 Auto-generated fix for #38450.

@qsellem — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38450. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38450 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38450) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do?

Adds two new out-of-the-box metrics to the [RUM without Limits metrics table](https://docs.datadoghq.com/real_user_monitoring/rum_without_limits/metrics):

- `rum.measure.resource` — Count of resources (REST and GraphQL network calls)
- `rum.measure.resource.duration` — Duration of resources (REST and GraphQL network calls)

These are the first OOTB metrics targeting resources. Both are available on Mobile & Browser and share the same dimensions:

- Default
- Status Code (`resource.status_code`)
- URL Path Group (`resource.url_path_group`)
- Resource Type (`resource.type`)
- GraphQL Operation Name (`resource.graphql.operationName`)
- GraphQL Operation Type (`resource.graphql.operationType`)
- GraphQL Has Errors (`resource.graphql.has_errors`)

### Motivation

These metrics are going GA. Documenting them alongside the existing OOTB RUM metrics.

### Additional Notes

Rows inserted in alphabetical order (after `rum.measure.error.*`, before `rum.measure.session`), matching the table's existing ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)