### PR TITLE
[reorg fix] Add note on iOS single-crash-reporter limitation

### DIFF
--- a/hugo/content/en/error_tracking/frontend/mobile/ios.md
+++ b/hugo/content/en/error_tracking/frontend/mobile/ios.md
@@ -690,7 +690,7 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 
 3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [{{< ui >}}Error Tracking{{< /ui >}}][1].
 
-**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other. The tool that loses might not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
+**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other can capture it. The tool that does not capture the crash does not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
 
 ## Advanced Error Tracking features
 

--- a/hugo/content/en/error_tracking/frontend/mobile/ios.md
+++ b/hugo/content/en/error_tracking/frontend/mobile/ios.md
@@ -690,6 +690,8 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 
 3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [{{< ui >}}Error Tracking{{< /ui >}}][1].
 
+**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other. The tool that loses might not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
+
 ## Advanced Error Tracking features
 
 {{% collapse-content title="Set tracking consent (GDPR compliance)" level="h4" expanded=false id="set-tracking-consent" %}}

--- a/hugo/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/hugo/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -462,7 +462,7 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 
 3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [{{< ui >}}Error Tracking{{< /ui >}}][1].
 
-**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other. The tool that loses might not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
+**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other can capture it. The tool that does not capture the crash does not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
 
 **Note:** RUM supports symbolication of system symbol files for iOS v14+ arm64 and arm64e architecture.
 

--- a/hugo/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/hugo/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -462,6 +462,8 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 
 3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [{{< ui >}}Error Tracking{{< /ui >}}][1].
 
+**Note**: Only one crash reporting tool can capture native crashes on iOS at a time. If another tool is also configured to capture native crashes, one tool intercepts the crash before the other. The tool that loses might not report it. If you don't see expected crash data in Error Tracking, confirm no other tool is also configured for native iOS crash capture.
+
 **Note:** RUM supports symbolication of system symbol files for iOS v14+ arm64 and arm64e architecture.
 
 ## Further Reading

--- a/hugo/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/hugo/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -57,6 +57,8 @@ const config = new DatadogProviderConfiguration(
 );
 ```
 
+**Note**: This limitation applies to native iOS crash capture only. If you use another tool alongside Datadog for native crash reporting on iOS, see [iOS Crash Reporting and Error Tracking][18] for more information.
+
 ## Get deobfuscated stack traces
 
 Debug symbols are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding debug symbols. This ensures that regardless of when the debug symbols were uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
@@ -511,3 +513,4 @@ if (project.tasks.findByName("minify${variant.name.capitalize()}WithR8")) {
 [15]: https://plugins.gradle.org/plugin/com.datadoghq.dd-sdk-android-gradle-plugin
 [16]: https://app.datadoghq.com/source-code/setup/rum
 [17]: https://github.com/DataDog/datadog-ci/blob/master/packages/datadog-ci/src/commands/react-native/README.md#inject-debug-id
+[18]: /error_tracking/frontend/mobile/ios/


### PR DESCRIPTION
🤖 Auto-generated fix for #38417.

@mxderouet — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38417. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38417 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38417) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?

On iOS, only one crash reporting tool can register to capture native crashes at a time. If Datadog and another crash reporting or monitoring tool are both configured to capture native crashes, one intercepts the crash before the other, and the tool that loses may not report it. This is a platform limitation, not a Datadog issue, and it was not previously documented publicly.

This PR adds a short note explaining the limitation to both current iOS Crash Reporting and Error Tracking pages, and adds a cross-reference note to the React Native Crash Reporting and Error Tracking page, since React Native apps commonly pair Datadog with a separate tool for JS-side error tracking.

No third-party vendor is named; the note refers generically to "another crash reporting or monitoring tool."

### Pages changed

- `content/en/error_tracking/frontend/mobile/ios.md`
- `content/en/real_user_monitoring/error_tracking/mobile/ios.md`
- `content/en/real_user_monitoring/error_tracking/mobile/reactnative.md`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Both iOS pages were updated since both are currently live in the site navigation.