### PR TITLE
[reorg fix] add SGC windows regkey documentation

### DIFF
--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1493,7 +1493,7 @@ secret_backend_config:
 
 ##### Set up the registry key
 
-Run the following in PowerShell as Administrator after installing the Datadog Agent:
+Here is an example PowerShell shell script that demostrate how to setup a registry (to be run as Administrator after installing).
 
 ```powershell
 # Create the key and set the secret value

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -24,6 +24,7 @@ The Datadog Agent helps you securely manage your secrets by integrating with the
 - [File Text](#id-for-json-yaml-text)
 - [File JSON](#id-for-json-yaml-text)
 - [File YAML](#id-for-json-yaml-text)
+- [Windows Registry Key](#id-for-windows-regkey)
 
 Instead of hardcoding sensitive values like API keys or passwords in plaintext within configuration files, the Agent can retrieve them dynamically at runtime. To reference a secret in your configuration, use the `ENC[<secret_id>]` notation. The secret is fetched and loaded in memory but is never written to disk or sent to the Datadog backend.
 
@@ -1452,6 +1453,64 @@ secret_backend_config:
 
 {{% /tab %}}
 {{< /tabs >}}
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="Windows Registry Key" level="h4" expanded=false id="id-for-windows-regkey" %}}
+
+**Available in Agent version 7.82+**
+
+The following Windows services are supported:
+
+| secret_backend_type value | Service |
+|---------------------------|---------|
+| `windows.regkey` | Windows Registry |
+
+##### Prerequisites
+
+This backend is supported on Windows only. The registry key must be readable by `ddagentuser`, the account the Agent runs under. Keys under `HKLM` are readable by all local users by default. Datadog recommends restricting the ACL so only `ddagentuser` and `SYSTEM` can read the key.
+
+##### Configuration example
+
+Configure the Datadog Agent to use the Windows Registry Key backend with the following configuration:
+
+```yaml
+# datadog.yaml
+secret_backend_type: windows.regkey
+
+api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
+```
+
+Reference secrets using the format `ENC[<registry-path>:<value-name>]`, where `registry-path` is the subpath beneath the root key and `value-name` is the registry value to read.
+
+By default the root key is `HKLM`. To use a different hive, set `root_key` — accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
+
+```yaml
+secret_backend_type: windows.regkey
+secret_backend_config:
+  root_key: HKCU
+```
+
+##### Set up the registry key
+
+Run the following in PowerShell as Administrator after installing the Datadog Agent:
+
+```powershell
+# Create the key and set the secret value
+New-Item -Path "HKLM:\SOFTWARE\Datadog\secrets" -Force
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Datadog\secrets" -Name "api_key" -Value "<YOUR_API_KEY>"
+
+# Restrict read access to ddagentuser and SYSTEM (recommended)
+$acl = Get-Acl "HKLM:\SOFTWARE\Datadog\secrets"
+$acl.SetAccessRuleProtection($true, $false)
+$rules = @(
+    New-Object System.Security.AccessControl.RegistryAccessRule("SYSTEM", "ReadKey", "Allow"),
+    New-Object System.Security.AccessControl.RegistryAccessRule("ddagentuser", "ReadKey", "Allow"),
+    New-Object System.Security.AccessControl.RegistryAccessRule("Administrators", "FullControl", "Allow")
+)
+$rules | ForEach-Object { $acl.SetAccessRule($_) }
+Set-Acl "HKLM:\SOFTWARE\Datadog\secrets" $acl
+```
 
 {{% /collapse-content %}}
 

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1512,6 +1512,15 @@ $rules | ForEach-Object { $acl.SetAccessRule($_) }
 Set-Acl "HKLM:\SOFTWARE\Datadog\secrets" $acl
 ```
 
+Then configure the Agent to read from that key:
+
+```yaml
+# datadog.yaml
+secret_backend_type: windows.regkey
+
+api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
+```
+
 {{% /collapse-content %}}
 
 #### Multiple backends

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1505,12 +1505,9 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Datadog\secrets" -Name "api_key" -Value "
 # Restrict read access to ddagentuser and SYSTEM (recommended)
 $acl = Get-Acl "HKLM:\SOFTWARE\Datadog\secrets"
 $acl.SetAccessRuleProtection($true, $false)
-$rules = @(
-    New-Object System.Security.AccessControl.RegistryAccessRule("SYSTEM", "ReadKey", "Allow"),
-    New-Object System.Security.AccessControl.RegistryAccessRule("ddagentuser", "ReadKey", "Allow"),
-    New-Object System.Security.AccessControl.RegistryAccessRule("Administrators", "FullControl", "Allow")
-)
-$rules | ForEach-Object { $acl.SetAccessRule($_) }
+$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "SYSTEM", "ReadKey", "Allow"))
+$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "ddagentuser", "ReadKey", "Allow"))
+$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "Administrators", "FullControl", "Allow"))
 Set-Acl "HKLM:\SOFTWARE\Datadog\secrets" $acl
 ```
 

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1483,7 +1483,7 @@ api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
 
 Reference secrets using the format `ENC[<registry-path>:<value-name>]`, where `registry-path` is the subpath beneath the root key and `value-name` is the registry value to read.
 
-By default the root key is `HKLM`. To use a different hive, set `root_key`. Accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
+By default, the root key is `HKLM`. To use a different hive, set `root_key`. Accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
 
 ```yaml
 secret_backend_type: windows.regkey

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1511,15 +1511,6 @@ $acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule 
 Set-Acl "HKLM:\SOFTWARE\Datadog\secrets" $acl
 ```
 
-Then configure the Agent to read from that key:
-
-```yaml
-# datadog.yaml
-secret_backend_type: windows.regkey
-
-api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
-```
-
 {{% /collapse-content %}}
 
 #### Multiple backends

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1483,7 +1483,7 @@ api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
 
 Reference secrets using the format `ENC[<registry-path>:<value-name>]`, where `registry-path` is the subpath beneath the root key and `value-name` is the registry value to read.
 
-By default the root key is `HKLM`. To use a different hive, set `root_key` — accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
+By default the root key is `HKLM`. To use a different hive, set `root_key`. Accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
 
 ```yaml
 secret_backend_type: windows.regkey

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1468,7 +1468,7 @@ The following Windows services are supported:
 
 ##### Prerequisites
 
-This backend is supported on Windows only. The registry key must be readable by `ddagentuser`, the account the Agent runs under. Keys under `HKLM` are readable by all local users by default. Datadog recommends restricting the ACL so only `ddagentuser` and `SYSTEM` can read the key.
+This backend is supported on Windows only. The registry key must be readable by the account the Datadog Agent runs under (by default `ddagentuser`). Keys under `HKLM` are readable by all local users by default. Datadog recommends restricting the ACL so only `ddagentuser` and `SYSTEM` can read the key.
 
 ##### Configuration example
 

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1483,7 +1483,9 @@ api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
 
 Reference secrets using the format `ENC[<registry-path>:<value-name>]`, where `registry-path` is the subpath beneath the root key and `value-name` is the registry value to read.
 
-By default, the root key is `HKLM`. To use a different hive, set `root_key`. Accepted values are `HKLM`, `HKCU`, `HKCR`, `HKU`, and `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also accepted):
+By default, the root key is `HKLM`. To use a different hive, set `root_key`. Only the following values are accepted (any other value returns an error):
+
+`HKLM`, `HKCU`, `HKCR`, `HKU`, `HKCC` (long forms such as `HKEY_LOCAL_MACHINE` are also supported)
 
 ```yaml
 secret_backend_type: windows.regkey

--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1493,7 +1493,7 @@ secret_backend_config:
 
 ##### Set up the registry key
 
-Here is an example PowerShell shell script that demostrate how to setup a registry (to be run as Administrator after installing).
+This example PowerShell shell script demonstrates how to set up a registry (to be run as Administrator after installing):
 
 ```powershell
 # Create the key and set the secret value


### PR DESCRIPTION
🤖 Auto-generated fix for #37669.

@s-alad — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37669. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37669 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37669) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [x] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?
Adds windows registry key documentation for this SGC PR: https://github.com/DataDog/datadog-agent/pull/52339

### Merge readiness
- [x] 7.82.0 released

### AI assistance
- used claude code for initial draft

### QA

create a windows VM (I just used some pipeline ID which had SGC changes)
```
dda inv aws.create-vm \
  --os-family=windows \
  --pipeline-id=127562068 \
  --stack-name=win-regkey-qa
```

SSH in and verify the Agent is running
```
ssh Administrator@<VM_IP>
Get-Service datadogagent
& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" version
```

Set up the registry key and secret value
```
New-Item -Path "HKLM:\SOFTWARE\Datadog\secrets" -Force
Set-ItemProperty -Path "HKLM:\SOFTWARE\Datadog\secrets" -Name "api_key" -Value "<YOUR_API_KEY>"

$acl = Get-Acl "HKLM:\SOFTWARE\Datadog\secrets"
$acl.SetAccessRuleProtection($true, $false)
$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "SYSTEM", "ReadKey", "Allow"))
$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "ddagentuser", "ReadKey", "Allow"))
$acl.SetAccessRule((New-Object System.Security.AccessControl.RegistryAccessRule -ArgumentList "Administrators", "FullControl", "Allow"))
Set-Acl "HKLM:\SOFTWARE\Datadog\secrets" $acl
```

Confirm the ACL:
```
Get-Acl "HKLM:\SOFTWARE\Datadog\secrets" | Format-List
# Access : NT AUTHORITY\SYSTEM       Allow  ReadKey
#          BUILTIN\Administrators    Allow  FullControl
#          <host>\ddagentuser        Allow  ReadKey
```

Configure `datadog.yaml`
```
secret_backend_type: windows.regkey
api_key: 'ENC[SOFTWARE\Datadog\secrets:api_key]'
```

Restart the agent  
`Restart-Service -Force datadogagent`

Confirm resolution (`agent secret`)
```
 Secret backend type: windows.regkey
    Using embedded executable: ...\secret-generic-connector.exe
    Number of secrets resolved: 1
```

Tear Down
`dda inv aws.destroy-vm --stack-name=win-regkey-qa`
### Additional notes
