### PR TITLE
[reorg fix] Document Performance tab for custom LLM evals

### DIFF
--- a/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -512,11 +512,35 @@ Select a span to show JSON data available for use in an evaluation. Then, click 
 
 After you {{< ui >}}Save and Publish{{< /ui >}} your evaluation, Datadog automatically runs your evaluation on targeted spans. Alternatively, you can {{< ui >}}Save as Draft{{< /ui >}} and edit or enable your evaluation later.
 
-Results are available across Agent Observability in near-real-time for published evaluations.
+Results are available across Agent Observability in near-real-time for published evaluations. You can find your custom LLM-as-a-judge results for a specific span in the {{< ui >}}Evaluations{{< /ui >}} tab, alongside other evaluations.
+
+{{< img src="llm_observability/evaluations/custom_llm_judge_3-2.png" alt="The Evaluations tab of a trace, displaying custom evaluation results alongside managed evaluations." style="width:100%;" >}}
+
+Each evaluation result includes:
+
+- The evaluated value (for example `True`, `9`, or `Neutral`)
+- The reasoning (when enabled)
+- The pass/fail indicator (based on your assessment criteria)
+
+Use the syntax `@evaluation.<evaluation_name>.value` to query or visualize results.
+
+For example:
+```
+@evaluation.helpfulness-check.value
+```
+
+{{< img src="llm_observability/evaluations/custom_llm_judge_4.png" alt="The Agent Observability Traces view. In the search box, the user has entered `@evaluation.budget-guru-intent-classifier.value:budgeting_question` and results are populated below." style="width:100%;" >}}
+
+You can:
+- Filter traces by evaluation results (example, `@evaluation.helpfulness-check.value`)
+- Filter by pass/fail assessment status (example, `@evaluation.helpfulness-check.assessment:fail`)
+- Use evaluation results as [facets][3]
+- View aggregate results in the Agent Observability Overview page's Evaluation section
+- Create [monitors][4] to alert on performance changes or regression
 
 ### Performance tab
 
-The {{< ui >}}Performance{{< /ui >}} tab of an evaluation shows aggregate results over time. Use it to monitor an evaluation's health, examine common failure modes, and open matching spans in the Trace Explorer. Open the tab from an evaluation on the [Evaluations page][1].
+Use the {{< ui >}}Performance{{< /ui >}} tab to measure how your agentic service performs against an evaluation. Get a high-level overview, identify passing and failing traces, and find patterns in failure scenarios.
 
 #### Configuration summary
 
@@ -542,14 +566,6 @@ For all evaluations:
 
 - **Spans Evaluated Over Time**: The total number of evaluated spans over the selected time range, shown as a scalar with a prior-period trend. This card uses the same query as the evaluated spans list below it.
 
-#### Empty states
-
-When a card or the evaluated spans table has no data to show, the tab explains why:
-
-- **Draft**: If the evaluation is a draft, the tab prompts you to publish it and provides an {{< ui >}}Update Configuration{{< /ui >}} button.
-- **No data in the selected time range**: If the evaluation has data in the last 90 days but not in the selected time range, the tab suggests expanding the time range.
-- **Never evaluated**: If the evaluation has no data in the last 90 days, the tab notes that the configuration might not match any spans, traces, or sessions, and provides a {{< ui >}}View configuration{{< /ui >}} button.
-
 #### Evaluated spans
 
 The {{< ui >}}Evaluated Spans{{< /ui >}} table (or {{< ui >}}Evaluated Traces{{< /ui >}} for trace-scoped evaluations) lists the spans or traces that the evaluation ran on.
@@ -562,46 +578,12 @@ The {{< ui >}}Evaluated Spans{{< /ui >}} table (or {{< ui >}}Evaluated Traces{{<
 
 <div class="alert alert-info">Pattern Analysis is in Preview.</div>
 
-The {{< ui >}}Pattern Analysis{{< /ui >}} section, at the bottom of the {{< ui >}}Performance{{< /ui >}} tab, clusters the reasoning text from failed evaluations into ranked themes. This helps you identify the most common failure modes without reading each evaluation reason one by one.
+The {{< ui >}}Pattern Analysis{{< /ui >}} section clusters the reasoning text from failed evaluations into ranked themes. This helps you identify the most common failure modes without reading each evaluation reason one by one.
 
-- Before the first run, a panel describes the feature and shows a {{< ui >}}Set up pattern analysis{{< /ui >}} button. Use it to configure the LLM provider, account, model, time window, and sampling rate.
 - After you configure and run Pattern Analysis, the results panel shows ranked clusters of reasoning patterns with their interaction counts.
 - If no clusters are found, the panel prompts you to re-run with more spans or a higher sampling rate and provides a {{< ui >}}Re-run{{< /ui >}} button.
 
 Pattern Analysis is not available for session-scoped evaluations.
-
-#### Session-scoped evaluations
-
-For session-scoped evaluations, the {{< ui >}}Performance{{< /ui >}} tab shows an informational message that explains session scope, and the {{< ui >}}Pattern Analysis{{< /ui >}} section is hidden.
-
-### Span-level results
-
-You can find your custom LLM-as-a-judge results for a specific span in the {{< ui >}}Evaluations{{< /ui >}} tab, alongside other evaluations.
-
-{{< img src="llm_observability/evaluations/custom_llm_judge_3-2.png" alt="The Evaluations tab of a trace, displaying custom evaluation results alongside managed evaluations." style="width:100%;" >}}
-
-Each evaluation result includes:
-
-- The evaluated value (for example `True`, `9`, or `Neutral`)
-- The reasoning (when enabled)
-- The pass/fail indicator (based on your assessment criteria)
-
-Use the syntax `@evaluation.<evaluation_name>.value` to query or visualize results.
-
-For example:
-```
-@evaluation.helpfulness-check.value
-```
-
-{{< img src="llm_observability/evaluations/custom_llm_judge_4.png" alt="The Agent Observability Traces view. In the search box, the user has entered `@evaluation.budget-guru-intent-classifier.value:budgeting_question` and results are populated below." style="width:100%;" >}}
-
-
-You can:
-- Filter traces by evaluation results (example, `@evaluation.helpfulness-check.value`)
-- Filter by pass/fail assessment status (example, `@evaluation.helpfulness-check.assessment:fail`)
-- Use evaluation results as [facets][3]
-- View aggregate results in the Agent Observability Overview page's Evaluation section
-- Create [monitors][4] to alert on performance changes or regression
 
 ## Using in experiments
 

--- a/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -512,7 +512,71 @@ Select a span to show JSON data available for use in an evaluation. Then, click 
 
 After you {{< ui >}}Save and Publish{{< /ui >}} your evaluation, Datadog automatically runs your evaluation on targeted spans. Alternatively, you can {{< ui >}}Save as Draft{{< /ui >}} and edit or enable your evaluation later.
 
-Results are available across Agent Observability in near-real-time for published evaluations. You can find your custom LLM-as-a-judge results for a specific span in the {{< ui >}}Evaluations{{< /ui >}} tab, alongside other evaluations.
+Results are available across Agent Observability in near-real-time for published evaluations.
+
+### Performance tab
+
+The {{< ui >}}Performance{{< /ui >}} tab of an evaluation shows aggregate results over time. Use it to monitor an evaluation's health, examine common failure modes, and open matching spans in the Trace Explorer. Open the tab from an evaluation on the [Evaluations page][1].
+
+#### Configuration summary
+
+For custom LLM-as-a-judge evaluations, the top of the {{< ui >}}Performance{{< /ui >}} tab shows a configuration summary card that includes:
+
+- The evaluation name and a status indicator: a green {{< ui >}}Published{{< /ui >}} pill or a gray {{< ui >}}Draft{{< /ui >}} pill.
+- A collapsible panel that shows the metric, assessment, scope, model, sampling rate, and the time the configuration was last updated. Select the chevron to expand or collapse the panel.
+- An {{< ui >}}Edit Configuration{{< /ui >}} button that opens the {{< ui >}}Configuration{{< /ui >}} tab.
+- The evaluation's system and user prompt. Select {{< ui >}}Show full prompt{{< /ui >}} to expand it, or {{< ui >}}Show less{{< /ui >}} to collapse it.
+
+If the evaluation is saved as a draft, an informational banner below the configuration summary explains that Datadog does not collect performance data until you publish the evaluation.
+
+#### Performance cards
+
+The {{< ui >}}Performance{{< /ui >}} tab shows visualization cards that summarize results over the selected time range. Each card header includes a fullscreen button (the resize icon) to view the chart in full-screen mode.
+
+For boolean evaluations:
+
+- **% True**: The percentage of `true` results, shown as a scalar with a trend compared to the prior period. The {{< ui >}}True Spans{{< /ui >}} and {{< ui >}}False Spans{{< /ui >}} buttons open the Trace Explorer filtered to the matching boolean value.
+- **Result Distribution**: The true and false breakdown over time, shown as a line chart with a total-spans scalar and a prior-period trend. This card also includes {{< ui >}}True Spans{{< /ui >}} and {{< ui >}}False Spans{{< /ui >}} links to the Trace Explorer.
+
+For all evaluations:
+
+- **Spans Evaluated Over Time**: The total number of evaluated spans over the selected time range, shown as a scalar with a prior-period trend. This card uses the same query as the evaluated spans list below it.
+
+#### Empty states
+
+When a card or the evaluated spans table has no data to show, the tab explains why:
+
+- **Draft**: If the evaluation is a draft, the tab prompts you to publish it and provides an {{< ui >}}Update Configuration{{< /ui >}} button.
+- **No data in the selected time range**: If the evaluation has data in the last 90 days but not in the selected time range, the tab suggests expanding the time range.
+- **Never evaluated**: If the evaluation has no data in the last 90 days, the tab notes that the configuration might not match any spans, traces, or sessions, and provides a {{< ui >}}View configuration{{< /ui >}} button.
+
+#### Evaluated spans
+
+The {{< ui >}}Evaluated Spans{{< /ui >}} table (or {{< ui >}}Evaluated Traces{{< /ui >}} for trace-scoped evaluations) lists the spans or traces that the evaluation ran on.
+
+- A {{< ui >}}View in Trace Explorer{{< /ui >}} button in the table header opens the current filtered view in the Trace Explorer, mirroring the table's active filters (pass/fail assessment, boolean value, or category).
+- For boolean evaluations, {{< ui >}}True{{< /ui >}} and {{< ui >}}False{{< /ui >}} toggle filters appear above the table.
+- Assessment (pass/fail), boolean value, and category filters are disabled when there is no evaluated data in the selected time range.
+
+#### Pattern Analysis
+
+<div class="alert alert-info">Pattern Analysis is in Preview.</div>
+
+The {{< ui >}}Pattern Analysis{{< /ui >}} section, at the bottom of the {{< ui >}}Performance{{< /ui >}} tab, clusters the reasoning text from failed evaluations into ranked themes. This helps you identify the most common failure modes without reading each evaluation reason one by one.
+
+- Before the first run, a panel describes the feature and shows a {{< ui >}}Set up pattern analysis{{< /ui >}} button. Use it to configure the LLM provider, account, model, time window, and sampling rate.
+- After you configure and run Pattern Analysis, the results panel shows ranked clusters of reasoning patterns with their interaction counts.
+- If no clusters are found, the panel prompts you to re-run with more spans or a higher sampling rate and provides a {{< ui >}}Re-run{{< /ui >}} button.
+
+Pattern Analysis is not available for session-scoped evaluations.
+
+#### Session-scoped evaluations
+
+For session-scoped evaluations, the {{< ui >}}Performance{{< /ui >}} tab shows an informational message that explains session scope, and the {{< ui >}}Pattern Analysis{{< /ui >}} section is hidden.
+
+### Span-level results
+
+You can find your custom LLM-as-a-judge results for a specific span in the {{< ui >}}Evaluations{{< /ui >}} tab, alongside other evaluations.
 
 {{< img src="llm_observability/evaluations/custom_llm_judge_3-2.png" alt="The Evaluations tab of a trace, displaying custom evaluation results alongside managed evaluations." style="width:100%;" >}}
 

--- a/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -542,20 +542,9 @@ You can:
 
 Use the {{< ui >}}Performance{{< /ui >}} tab to measure how your agentic service performs against an evaluation. Get a high-level overview, identify passing and failing traces, and find patterns in failure scenarios.
 
-#### Configuration summary
-
-For custom LLM-as-a-judge evaluations, the top of the {{< ui >}}Performance{{< /ui >}} tab shows a configuration summary card that includes:
-
-- The evaluation name and a status indicator: a green {{< ui >}}Published{{< /ui >}} pill or a gray {{< ui >}}Draft{{< /ui >}} pill.
-- A collapsible panel that shows the metric, assessment, scope, model, sampling rate, and the time the configuration was last updated. Select the chevron to expand or collapse the panel.
-- An {{< ui >}}Edit Configuration{{< /ui >}} button that opens the {{< ui >}}Configuration{{< /ui >}} tab.
-- The evaluation's system and user prompt. Select {{< ui >}}Show full prompt{{< /ui >}} to expand it, or {{< ui >}}Show less{{< /ui >}} to collapse it.
-
-If the evaluation is saved as a draft, an informational banner below the configuration summary explains that Datadog does not collect performance data until you publish the evaluation.
-
 #### Performance cards
 
-The {{< ui >}}Performance{{< /ui >}} tab shows visualization cards that summarize results over the selected time range. Each card header includes a fullscreen button (the resize icon) to view the chart in full-screen mode.
+Cards summarize the results over the selected time range. Each card header includes a fullscreen button (the resize icon) to view the chart in full-screen mode.
 
 For boolean evaluations:
 
@@ -570,9 +559,9 @@ For all evaluations:
 
 The {{< ui >}}Evaluated Spans{{< /ui >}} table (or {{< ui >}}Evaluated Traces{{< /ui >}} for trace-scoped evaluations) lists the spans or traces that the evaluation ran on.
 
-- A {{< ui >}}View in Trace Explorer{{< /ui >}} button in the table header opens the current filtered view in the Trace Explorer, mirroring the table's active filters (pass/fail assessment, boolean value, or category).
 - For boolean evaluations, {{< ui >}}True{{< /ui >}} and {{< ui >}}False{{< /ui >}} toggle filters appear above the table.
 - Assessment (pass/fail), boolean value, and category filters are disabled when there is no evaluated data in the selected time range.
+- A {{< ui >}}View in Trace Explorer{{< /ui >}} button in the table header opens the current filtered view in the Trace Explorer, mirroring the table's active filters (pass/fail assessment, boolean value, or category).
 
 #### Pattern Analysis
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38403.

@briangreenbaumDatadog — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38403. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38403 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38403) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- dd-meta {"pullId":"3b18d457-64d3-4eac-8e9a-e0dafcc8f5d5","source":"chat","resourceId":"f3a431e2-82b2-459a-a728-b4670ab032d9","workflowId":"8d367265-d592-428d-9f00-8d14d38cbb2b","codeChangeId":"8d367265-d592-428d-9f00-8d14d38cbb2b","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the overhauled **Performance tab** for custom (BYOP) LLM-as-a-judge evaluations, which shipped in https://github.com/DataDog/web-ui/pull/329395. The existing "Viewing and using results" section mentioned the Performance tab only briefly and omitted the new UI, so this PR adds a dedicated "Performance tab" subsection to `content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md` covering:

- The performance cards (% True, Result Distribution, Spans Evaluated Over Time), their prior-period scalars, True/False Spans Trace Explorer links, and the fullscreen button.
- The evaluated spans table: boolean True/False filters, disabled-filter behavior when there is no data, and the View in Trace Explorer button that mirrors the table's active filters.
- The Pattern Analysis section (Preview): ranked reasoning clusters, the no-clusters re-run state, and that it is hidden for session-scoped evaluations.

### Changes

- Added a new `### Performance tab` subsection under "Viewing and using results", with `####` subsections for performance cards, evaluated spans, and Pattern Analysis.
- Kept the existing span-level results and querying content (per-span results, `@evaluation.<name>.value` query syntax, facets, monitors) in the section intro, unchanged.

### Testing

- Verified heading nesting (`##` -> `###` -> `####`), balanced `{{< ui >}}` shortcodes, that referenced images exist in the repo, and that link references remain defined.
- Checked the new prose against the Datadog Vale substitution rules (no banned or temporal terms).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (OpenCode) from the source PR description; content manually reviewed for style, accuracy, and structure.

### Additional notes

Text-only documentation update. No new screenshots were added; Performance tab UI screenshots can be added in a follow-up.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f3a431e2-82b2-459a-a728-b4670ab032d9)

Comment @datadog to request changes