### PR TITLE
[reorg fix] Document Evaluation Traces table in Health tab

### DIFF
--- a/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/hugo/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -539,6 +539,54 @@ You can:
 - View aggregate results in the Agent Observability Overview page's Evaluation section
 - Create [monitors][4] to alert on performance changes or regression
 
+### Evaluation Traces table (Health tab)
+
+The **Health** tab of a published custom LLM-as-a-judge evaluation includes an **Evaluation Traces** table at the bottom of the page. This table shows one row per individual LLM-as-Judge run, so you can inspect, search, and debug each evaluation run directly without leaving the Health tab.
+
+Each row in the table contains the following columns:
+
+| Column | Description |
+|---|---|
+| **Status** | Blank for successful runs; a red error icon on failure. Hover over the icon to see the error message. |
+| **Evaluated At** | Timestamp of when the judge ran. |
+| **Evaluated** | The name (or ID) of the span, trace, or session that was judged. |
+| **Result** | Pass/fail pill with the evaluation value; a **View JSON** link for JSON-type evaluations. |
+| **Duration** | How long the judge LLM call took. |
+| **Total Tokens** | Total token count for the judge run. |
+| **Cost** | Estimated cost of the judge run. |
+
+The following columns are hidden by default and can be toggled through the **Columns** menu in the table toolbar:
+
+- **Input** (input token count)
+- **Output** (output token count)
+- **Model** (model name and provider badge)
+
+#### Filtering and searching
+
+Above the table, use the following controls to narrow results:
+
+- **Search bar**: Filter by facets or free-text queries using Datadog query syntax (for example, `@meta.metadata.assessment:fail`).
+- **Status** toggle: Filter to **All**, **OK**, or **Errors**.
+- **Pass/Fail** toggle: Filter to **All**, **Pass**, or **Fail** assessments.
+- **Category** dropdown (categorical evaluations only): Appears once category values have loaded; filter to a specific categorical result value.
+
+All filters apply server-side over the full time range, so paging and sorting reflect the full filtered result set.
+
+#### Sorting
+
+Click any sortable column header (Evaluated At, Status, Duration, Total Tokens, Cost, Input, Output) to sort the full result set server-side. Sorting is performed over the complete time window, not only the loaded page.
+
+#### Inspecting individual judge runs
+
+Click any row to open that judge run's trace in a side panel. From there you can review the full judge span, including the input sent to the judge LLM, the structured output, the reasoning (if enabled), and links to the evaluated span, trace, or session.
+
+For JSON-type evaluations, click **View JSON** in the **Result** column to open a formatted JSON viewer side panel.
+
+#### Empty and error states
+
+- If no judge runs match the active filters and time range, the table shows a descriptive empty-state message explaining which filters are active.
+- If the table fails to load or takes longer than expected, an error or "still loading" message appears with a **Retry** button.
+
 ## Using in experiments
 
 To reuse a custom LLM-as-a-judge evaluation in a local [LLM Experiment][8], reference it by name using `RemoteEvaluator` from the SDK:


### PR DESCRIPTION
🤖 Auto-generated fix for #38402.

@ebrevan — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38402. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38402 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38402) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- dd-meta {"pullId":"f313ee64-6f42-4bfe-9b0e-acadddc73f37","source":"chat","resourceId":"3f50e27b-baa6-439c-920d-54a3958fefa7","workflowId":"e6925cf8-baba-4e87-a7e8-1870c5cff68f","codeChangeId":"e6925cf8-baba-4e87-a7e8-1870c5cff68f","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a new "Evaluation Traces table (Health tab)" subsection to the **Viewing and using results** section of the custom LLM-as-a-judge evaluations page. This documents the `JudgeTracesList` component added to the Health tab in https://github.com/DataDog/web-ui/pull/328846 and https://github.com/DataDog/web-ui/pull/329906.

The new subsection covers:
- Column descriptions (Status, Evaluated At, Evaluated, Result, Duration, Total Tokens, Cost) and hidden columns (Input, Output, Model)
- Filtering and searching controls (search bar, Status toggle, Pass/Fail toggle, Category dropdown)
- Server-side sorting behavior
- Row click to open a judge run's trace in a side panel, and the View JSON panel for JSON-type evaluations
- Empty and error states

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude (Bits Code) to draft and insert the new subsection.

### Additional notes

Source PRs: https://github.com/DataDog/web-ui/pull/328846, https://github.com/DataDog/web-ui/pull/329906

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/3f50e27b-baa6-439c-920d-54a3958fefa7)

Comment @datadog-staging to request changes