### PR TITLE
[reorg fix] Fix drifted widget configuration doc details

### DIFF
--- a/hugo/content/en/dashboards/widgets/configuration/_index.md
+++ b/hugo/content/en/dashboards/widgets/configuration/_index.md
@@ -145,10 +145,9 @@ View the graph in [full screen mode](#full-screen).
 
 Click on the export icon of any dashboard graph to open an options menu:
 
-| Option         | Description                               |
-|----------------|-------------------------------------------|
-| Copy           | Create a copy of the dashboard graph.     |
-| Share snapshot | Create and send a snapshot of your graph. |
+| Option | Description                           |
+|--------|----------------------------------------|
+| Copy   | Create a copy of the dashboard graph. |
 
 #### Use within Datadog
 

--- a/hugo/content/en/dashboards/widgets/configuration/_index.md
+++ b/hugo/content/en/dashboards/widgets/configuration/_index.md
@@ -44,18 +44,17 @@ You could join your payment logs with a reference table (lookup table) containin
 Supported data sources for joins include (but are not limited to):
 
 - Logs
-- Metrics
 - RUM
-- Cloud Cost Recommendations
-- Netflow
+- Cloud Cost
+- Recommendations
+- NetFlow
 - APM Spans
-- APM Traces
 - Profiles
 - Synthetics CI Batches
-- Synthetics Run
-- Static Analysis
+- Synthetics Runs
+- Static Code Analysis
 - CI Tests
-- Compliance Findings
+- Security Findings
 - Product Analytics
 - Reference Tables
 
@@ -90,9 +89,10 @@ On a metric graph, click the context menu (three vertical dots) to find the {{< 
 ## Unit override
 
 Unit overrides are a key display option that allows you to customize how data values are presented on widgets, adding meaningful context to your data. For more use cases and information, see the [Customize your visualizations with unit overrides][3].
-- {{< ui >}}Unit override{{< /ui >}}: choose to display units in the family of 'memory', and have Datadog take care of displaying the appropriate scale depending on data (such as megabytes or gigabytes).
-- {{< ui >}}Unit and scale override{{< /ui >}}: fix units to a single scale (display data in megabytes regardless of value).
-- {{< ui >}}Define custom units{{< /ui >}}: define completely custom units (like 'tests' instead of a generic count).
+
+In the {{< ui >}}Unit Override{{< /ui >}} section of the widget editor:
+- **Unit**: choose a unit family (such as 'memory') and Datadog displays the appropriate scale depending on the data (such as megabytes or gigabytes), or define a custom unit (like 'tests' instead of a generic count).
+- **Scale To**: for unit families that support scaling, fix the unit to a single scale (for example, megabytes regardless of value) instead of scaling automatically.
 
 This is not an alternative for assigning units to your data.
 {{< whatsnext desc="Set units at the organization level: ">}}


### PR DESCRIPTION
🤖 Auto-generated fix for #38389.

@estherk15 — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38389. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38389 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38389) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

No associated Jira ticket — found while auditing this page against current product behavior.

Corrects several places where this page had drifted from the current product UI:

- **Data Preview join sources**: fixed several stale/incorrect source labels (for example, "Netflow" → "NetFlow", "Synthetics Run" → "Synthetics Runs", "Static Analysis" → "Static Code Analysis", "Compliance Findings" → "Security Findings"), split the non-existent combined "Cloud Cost Recommendations" entry into its two real sources ("Cloud Cost" and "Recommendations"), and removed "APM Traces" and "Metrics", which are not valid joinable sources in this feature.
- **Unit override**: replaced the description of three separate named override options with an accurate description of the single "Unit Override" section (a unit selector plus an optional "Scale To" control for unit families that support scaling).
- **Export options table**: removed "Share snapshot," which is no longer a real menu option in the product.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Verified each correction against the current product implementation rather than assuming the prior text was accurate.