### PR TITLE
[reorg fix] [CRED-2815] Document PAT/SAT scope, TTL, and app-key restrictions

### DIFF
--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -66,6 +66,16 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 
 **Note:** When a valid PAT is provided in the `dd-application-key` header, Datadog authenticates with the PAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
+## Restrictions
+
+To limit how a PAT can escalate its own access, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
+
+- **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Scopes on new tokens**: A PAT can create or update another PAT or a SAT only if the new token's scopes are a subset of its own scopes.
+- **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that outlives itself.
+
+These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+
 ## Manage Personal Access Tokens
 
 ### View your tokens

--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -71,7 +71,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 To limit how a PAT can escalate its own access, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
 
 - **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
-- **Scopes on new tokens**: A PAT can create or update another PAT or a SAT only if the new token's scopes are a subset of its own scopes.
+- **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.
 - **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that outlives itself.
 
 These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -91,6 +91,16 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 **Note:** When a valid SAT is provided in the `dd-application-key` header, Datadog authenticates
 with the SAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
+## Restrictions
+
+To limit how a SAT can escalate its own access, Datadog restricts what an API call authenticated with a SAT can do, regardless of the API client making the call:
+
+- **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Scopes on new tokens**: A SAT can create or update another SAT or a PAT only if the new token's scopes are a subset of its own scopes.
+- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT or a PAT with a TTL that outlives itself.
+
+These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+
 ## Manage Service Access Tokens
 
 ### View tokens

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -96,8 +96,8 @@ with the SAT only. The `dd-api-key` header is optional and its value is not eval
 To limit how a SAT can escalate its own access, Datadog restricts what an API call authenticated with a SAT can do, regardless of the API client making the call:
 
 - **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
-- **Scopes on new tokens**: A SAT can create or update another SAT or a PAT only if the new token's scopes are a subset of its own scopes.
-- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT or a PAT with a TTL that outlives itself.
+- **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.
+- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that outlives itself.
 
 These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
 


### PR DESCRIPTION
🤖 Auto-generated fix for #38326.

@emubello — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38326. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38326 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38326) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a **Restrictions** section to the Personal Access Tokens and Service Access Tokens pages documenting new containment rules for API calls authenticated with a PAT or SAT:

- Cannot create or update application keys (revoke is still allowed)
- Cannot mint or update another PAT/SAT with scopes broader than its own
- Cannot create a PAT/SAT with a longer TTL than its own

Calls that violate these restrictions return a `403 Forbidden` response.