### PR TITLE
[reorg fix] [DBM Doc] Document single_endpoint_mode for ClickHouse Cloud per-node metrics

### DIFF
--- a/hugo/content/en/database_monitoring/setup_clickhouse/_index.md
+++ b/hugo/content/en/database_monitoring/setup_clickhouse/_index.md
@@ -22,6 +22,12 @@ This feature is in preview and requires Datadog Agent v7.78 or later. Customers 
 | ClickHouse 24.x              | {{< X >}}   | {{< X >}}        |
 | ClickHouse 25.x              | {{< X >}}   | {{< X >}}        |
 
+### ClickHouse Cloud configuration note
+
+If your ClickHouse Cloud service sits behind a single load-balanced endpoint, set `single_endpoint_mode: true` in your Agent configuration. This tells the Agent (version 7.83.0 or later) to query system-table metrics across all nodes behind that endpoint using `clusterAllReplicas()`, tagging each resulting series with `clickhouse_node` so you can still distinguish per-node data.
+
+Without this setting, the Agent may hit a different node on each collection cycle. For cumulative per-node counters like `clickhouse.query.failed.count`, that inconsistency produces inaccurate values, since the counter isn't being read from the same source each time.
+
 ### Setup instructions by hosting type
 
 To learn how to set up Database Monitoring on a ClickHouse database, select your hosting type:


### PR DESCRIPTION
🤖 Auto-generated fix for #38214.

@pierreln-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38214. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38214 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38214) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

**Confidence:** AUTO

**Source PR:** https://github.com/DataDog/integrations-core/pull/24509

**What changed:**
The ClickHouse integration README now documents a new configuration option `single_endpoint_mode` for ClickHouse Cloud deployments that sit behind a single load-balanced endpoint. When enabled (requires Agent 7.83.0+), this tells the Agent to query system-table metrics across all nodes using `clusterAllReplicas()` and tag each series with `clickhouse_node`, ensuring accurate per-node cumulative counter metrics.

**Why:**
Without this setting, the Agent may hit different nodes on each collection cycle, producing inaccurate values for cumulative per-node counters like `clickhouse.query.failed.count` since the counter isn't read from the same source consistently.

**Edits:**
- Add documentation of the `single_endpoint_mode` configuration option and its purpose to the ClickHouse setup page