### PR TITLE
[reorg fix] feat(statuspage): add filter[source_id] query param to ListDegradations

### DIFF
--- a/hugo/data/api/v2/full_spec.yaml
+++ b/hugo/data/api/v2/full_spec.yaml
@@ -205615,7 +205615,7 @@ paths:
           - status_pages_settings_write
   /api/v2/statuspages/degradations:
     get:
-      description: Lists all degradations for the organization. Optionally filter by status and page.
+      description: Lists all degradations for the organization. Optionally filter by status, page, and source ID.
       operationId: ListDegradations
       parameters:
         - description: Optional page id filter.
@@ -205645,6 +205645,11 @@ paths:
         - description: "Optional degradation status filter. Supported values: investigating, identified, monitoring, resolved."
           in: query
           name: filter[status]
+          schema:
+            type: string
+        - description: "Optional source ID filter. Returns only degradations whose source matches this ID (e.g. an incident ID)."
+          in: query
+          name: filter[source_id]
           schema:
             type: string
         - description: "Sort order. Prefix with '-' for descending. Supported values: created_at, -created_at, modified_at, -modified_at."

--- a/hugo/data/api/v2/translate_actions.json
+++ b/hugo/data/api/v2/translate_actions.json
@@ -6507,7 +6507,7 @@
     "request_schema_description": "Request object for creating a status page."
   },
   "ListDegradations": {
-    "description": "Lists all degradations for the organization. Optionally filter by status and page.",
+    "description": "Lists all degradations for the organization. Optionally filter by status, page, and source ID.",
     "summary": "List degradations"
   },
   "ListMaintenances": {


### PR DESCRIPTION
🤖 Auto-generated fix for #38074.

@app/api-clients-generation-pipeline — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38074. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38074 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38074) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

See [DataDog/datadog-api-spec#6134](https://github.com/DataDog/datadog-api-spec/pull/6134) Test branch [datadog-api-spec/test/ryan.peffers/STTSPG-1331](https://github.com/DataDog/documentation/compare/datadog-api-spec/test/ryan.peffers/STTSPG-1331)