### PR TITLE
[reorg fix] poc(api): redesign the API changelog page

### DIFF
--- a/hugo/assets/scripts/components/api.js
+++ b/hugo/assets/scripts/components/api.js
@@ -171,6 +171,101 @@ if (dataVersionToggles.length) {
     });
 }
 
+// API changelog filter bar (/api/changelog)
+const changelogRoot = document.querySelector('.api-changelog');
+
+if (changelogRoot) {
+    const filterTabs = changelogRoot.querySelectorAll('[data-changelog-filter]');
+    const productSelect = document.getElementById('api-changelog-product-filter');
+    const versionSelect = document.getElementById('api-changelog-version-filter');
+    const versionSections = changelogRoot.querySelectorAll('.api-changelog-version');
+    const shownCountEl = document.getElementById('api-changelog-shown-count');
+    const versionCountEl = document.getElementById('api-changelog-version-count');
+    const clearButtons = document.querySelectorAll('#api-changelog-clear-filters, [data-changelog-reset]');
+    const emptyState = document.getElementById('api-changelog-empty-state');
+
+    let activeBucket = 'all';
+    let activeProduct = 'all';
+    let activeVersionFloor = 'all';
+
+    function applyChangelogFilters() {
+        let shownCount = 0;
+        let shownVersionCount = 0;
+
+        versionSections.forEach((section) => {
+            const versionHidden = activeVersionFloor !== 'all' && section.dataset.version < activeVersionFloor;
+            let visibleInSection = 0;
+            let breakingInSection = 0;
+
+            section.querySelectorAll('.api-changelog-entry').forEach((entry) => {
+                const matches = !versionHidden
+                    && (activeBucket === 'all' || entry.dataset.bucket === activeBucket)
+                    && (activeProduct === 'all' || entry.dataset.tag === activeProduct);
+                entry.classList.toggle('d-none', !matches);
+
+                if (matches) {
+                    visibleInSection += 1;
+                    if (entry.dataset.type === 'breaking') breakingInSection += 1;
+                }
+            });
+
+            section.classList.toggle('d-none', visibleInSection === 0);
+
+            const breakingBadge = section.querySelector('[data-breaking-badge]');
+            if (breakingBadge) {
+                breakingBadge.classList.toggle('d-none', breakingInSection === 0);
+                breakingBadge.textContent = `${breakingInSection} breaking ${breakingInSection === 1 ? 'change' : 'changes'}`;
+            }
+
+            if (visibleInSection > 0) shownVersionCount += 1;
+            shownCount += visibleInSection;
+        });
+
+        if (shownCountEl) shownCountEl.textContent = shownCount;
+        if (versionCountEl) versionCountEl.textContent = shownVersionCount;
+        if (emptyState) emptyState.classList.toggle('d-none', shownCount !== 0);
+
+        const isFiltered = activeBucket !== 'all' || activeProduct !== 'all' || activeVersionFloor !== 'all';
+        clearButtons.forEach((button) => {
+            if (button.id === 'api-changelog-clear-filters') button.classList.toggle('d-none', !isFiltered);
+        });
+    }
+
+    filterTabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            activeBucket = tab.dataset.changelogFilter;
+            filterTabs.forEach((t) => t.classList.toggle('is-active', t === tab));
+            applyChangelogFilters();
+        });
+    });
+
+    if (productSelect) {
+        productSelect.addEventListener('change', () => {
+            activeProduct = productSelect.value;
+            applyChangelogFilters();
+        });
+    }
+
+    if (versionSelect) {
+        versionSelect.addEventListener('change', () => {
+            activeVersionFloor = versionSelect.value;
+            applyChangelogFilters();
+        });
+    }
+
+    clearButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            activeBucket = 'all';
+            activeProduct = 'all';
+            activeVersionFloor = 'all';
+            filterTabs.forEach((t) => t.classList.toggle('is-active', t.dataset.changelogFilter === 'all'));
+            if (productSelect) productSelect.value = 'all';
+            if (versionSelect) versionSelect.value = 'all';
+            applyChangelogFilters();
+        });
+    });
+}
+
 // Scroll the active top level nav item into view below Docs search input
 if (bodyClassContains('api')) {
     setSidenavMaxHeight();

--- a/hugo/assets/scripts/components/api.js
+++ b/hugo/assets/scripts/components/api.js
@@ -176,7 +176,6 @@ const changelogRoot = document.querySelector('.api-changelog');
 
 if (changelogRoot) {
     const filterTabs = changelogRoot.querySelectorAll('[data-changelog-filter]');
-    const productSelect = document.getElementById('api-changelog-product-filter');
     const versionSelect = document.getElementById('api-changelog-version-filter');
     const versionSections = changelogRoot.querySelectorAll('.api-changelog-version');
     const shownCountEl = document.getElementById('api-changelog-shown-count');
@@ -185,7 +184,6 @@ if (changelogRoot) {
     const emptyState = document.getElementById('api-changelog-empty-state');
 
     let activeBucket = 'all';
-    let activeProduct = 'all';
     let activeVersionFloor = 'all';
 
     function applyChangelogFilters() {
@@ -199,8 +197,7 @@ if (changelogRoot) {
 
             section.querySelectorAll('.api-changelog-entry').forEach((entry) => {
                 const matches = !versionHidden
-                    && (activeBucket === 'all' || entry.dataset.bucket === activeBucket)
-                    && (activeProduct === 'all' || entry.dataset.tag === activeProduct);
+                    && (activeBucket === 'all' || entry.dataset.bucket === activeBucket);
                 entry.classList.toggle('d-none', !matches);
 
                 if (matches) {
@@ -225,7 +222,7 @@ if (changelogRoot) {
         if (versionCountEl) versionCountEl.textContent = shownVersionCount;
         if (emptyState) emptyState.classList.toggle('d-none', shownCount !== 0);
 
-        const isFiltered = activeBucket !== 'all' || activeProduct !== 'all' || activeVersionFloor !== 'all';
+        const isFiltered = activeBucket !== 'all' || activeVersionFloor !== 'all';
         clearButtons.forEach((button) => {
             if (button.id === 'api-changelog-clear-filters') button.classList.toggle('d-none', !isFiltered);
         });
@@ -239,13 +236,6 @@ if (changelogRoot) {
         });
     });
 
-    if (productSelect) {
-        productSelect.addEventListener('change', () => {
-            activeProduct = productSelect.value;
-            applyChangelogFilters();
-        });
-    }
-
     if (versionSelect) {
         versionSelect.addEventListener('change', () => {
             activeVersionFloor = versionSelect.value;
@@ -256,10 +246,8 @@ if (changelogRoot) {
     clearButtons.forEach((button) => {
         button.addEventListener('click', () => {
             activeBucket = 'all';
-            activeProduct = 'all';
             activeVersionFloor = 'all';
             filterTabs.forEach((t) => t.classList.toggle('is-active', t.dataset.changelogFilter === 'all'));
-            if (productSelect) productSelect.value = 'all';
             if (versionSelect) versionSelect.value = 'all';
             applyChangelogFilters();
         });

--- a/hugo/assets/styles/pages/_api.scss
+++ b/hugo/assets/styles/pages/_api.scss
@@ -320,16 +320,18 @@ $ddpurple: #632ca6;
     .api-changelog-intro {
         max-width: 720px;
         color: $gray-dark;
+        font-size: 16px;
+        line-height: 1.6;
     }
 
     .api-changelog-note {
-        max-width: 720px;
+        width: 100%;
         padding: 14px 16px;
         margin-bottom: 28px;
         background: #eef6fc;
         border-left: 3px solid $brand-info;
         border-radius: 4px;
-        font-size: 13px;
+        font-size: 16px;
         line-height: 1.6;
         color: $gray-dark;
     }
@@ -361,7 +363,7 @@ $ddpurple: #632ca6;
     }
 
     .api-changelog-filter-label {
-        font-size: 11px;
+        font-size: 13px;
         font-weight: 700;
         letter-spacing: 0.06em;
         color: $gray-darkish;
@@ -384,13 +386,13 @@ $ddpurple: #632ca6;
     .api-changelog-tab {
         display: inline-flex;
         align-items: center;
-        height: 28px;
+        height: 32px;
         padding: 0 14px;
         border: none;
         border-right: 1px solid $gray-border;
         background: $white;
         color: $gray-darkish;
-        font-size: 12px;
+        font-size: 14px;
         font-weight: 600;
         cursor: pointer;
         transition: all .12s ease;
@@ -410,13 +412,13 @@ $ddpurple: #632ca6;
     }
 
     .api-changelog-select {
-        height: 28px;
+        height: 32px;
         padding: 0 8px;
         border: 1px solid $gray-border;
         border-radius: 4px;
         background: $white;
         color: $gray-dark;
-        font-size: 12px;
+        font-size: 14px;
         font-weight: 600;
         cursor: pointer;
     }
@@ -426,7 +428,7 @@ $ddpurple: #632ca6;
         align-items: center;
         justify-content: space-between;
         margin: 16px 0;
-        font-size: 12px;
+        font-size: 16px;
         color: $gray-darkish;
 
         strong {
@@ -443,12 +445,12 @@ $ddpurple: #632ca6;
     .api-changelog-clear {
         display: inline-flex;
         align-items: center;
-        height: 24px;
+        height: 30px;
         padding: 0 10px;
         border: 1px solid $gray-border;
         border-radius: 4px;
         background: $white;
-        font-size: 12px;
+        font-size: 14px;
         color: $gray-dark;
         cursor: pointer;
 
@@ -520,10 +522,10 @@ $ddpurple: #632ca6;
     .api-changelog-badge {
         display: inline-flex;
         align-items: center;
-        height: 22px;
+        height: 26px;
         padding: 0 10px;
         border-radius: 4px;
-        font-size: 11px;
+        font-size: 13px;
         font-weight: 700;
         letter-spacing: 0.03em;
 
@@ -551,13 +553,13 @@ $ddpurple: #632ca6;
     }
 
     .api-changelog-why-upgrade {
-        max-width: 720px;
+        width: 100%;
         padding: 12px 16px;
         margin-bottom: 14px;
         background: #f5f0fc;
         border-left: 3px solid $ddpurple;
         border-radius: 4px;
-        font-size: 13px;
+        font-size: 16px;
         line-height: 1.6;
         color: $gray-dark;
 
@@ -586,12 +588,12 @@ $ddpurple: #632ca6;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 84px;
-        height: 22px;
+        width: 96px;
+        height: 26px;
         padding: 0 9px;
         border-radius: 4px;
         color: $white;
-        font-size: 11px;
+        font-size: 13px;
         font-weight: 700;
         letter-spacing: 0.02em;
         white-space: nowrap;
@@ -608,10 +610,10 @@ $ddpurple: #632ca6;
         align-items: center;
         gap: 8px;
         margin-bottom: 6px;
-        font-size: 12px;
+        font-size: 14px;
 
         code {
-            font-size: 12px;
+            font-size: 14px;
         }
     }
 
@@ -630,14 +632,14 @@ $ddpurple: #632ca6;
         padding: 0 6px;
         border-radius: 3px;
         font-family: monospace;
-        font-size: 11px;
+        font-size: 13px;
         font-weight: 700;
     }
 
     .api-changelog-entry p {
         margin: 0;
-        font-size: 13px;
-        line-height: 1.55;
+        font-size: 16px;
+        line-height: 1.6;
         color: $gray-dark;
     }
 
@@ -650,13 +652,13 @@ $ddpurple: #632ca6;
 
         .api-changelog-empty-title {
             margin: 0 0 4px;
-            font-size: 15px;
+            font-size: 18px;
             font-weight: 600;
         }
 
         .api-changelog-empty-subtitle {
             margin: 0 0 16px;
-            font-size: 13px;
+            font-size: 16px;
             color: $gray-darkish;
         }
     }

--- a/hugo/assets/styles/pages/_api.scss
+++ b/hugo/assets/styles/pages/_api.scss
@@ -312,3 +312,352 @@ $ddpurple: #632ca6;
         }
     }
 }
+
+// API Changelog (/api/changelog) — POC for the D3 design ask
+.api-changelog {
+    max-width: 900px;
+
+    .api-changelog-intro {
+        max-width: 720px;
+        color: $gray-dark;
+    }
+
+    .api-changelog-note {
+        max-width: 720px;
+        padding: 14px 16px;
+        margin-bottom: 28px;
+        background: #eef6fc;
+        border-left: 3px solid $brand-info;
+        border-radius: 4px;
+        font-size: 13px;
+        line-height: 1.6;
+        color: $gray-dark;
+    }
+
+    .api-changelog-filterbar {
+        z-index: 5;
+        display: flex;
+
+        @include media-breakpoint-up(lg) {
+            position: sticky;
+            // Sits directly under the sticky .api-toolbar (top: 65px, height: 65px)
+            top: 130px;
+        }
+
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 20px;
+        padding: 14px 0;
+        margin-bottom: 8px;
+        background: $white;
+        border-bottom: 1px solid $gray-border;
+    }
+
+    .api-changelog-filter-group {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .api-changelog-filter-label {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        color: $gray-darkish;
+        margin-right: 2px;
+    }
+
+    .api-changelog-filter-divider {
+        width: 1px;
+        height: 22px;
+        background: $gray-border;
+    }
+
+    .api-changelog-tabs {
+        display: inline-flex;
+        border: 1px solid $gray-border;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+
+    .api-changelog-tab {
+        display: inline-flex;
+        align-items: center;
+        height: 28px;
+        padding: 0 14px;
+        border: none;
+        border-right: 1px solid $gray-border;
+        background: $white;
+        color: $gray-darkish;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all .12s ease;
+
+        &:last-child {
+            border-right: none;
+        }
+
+        &:hover {
+            background: $gray-lightest;
+        }
+
+        &.is-active {
+            background: $ddpurple;
+            color: $white;
+        }
+    }
+
+    .api-changelog-select {
+        height: 28px;
+        padding: 0 8px;
+        border: 1px solid $gray-border;
+        border-radius: 4px;
+        background: $white;
+        color: $gray-dark;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    .api-changelog-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin: 16px 0;
+        font-size: 12px;
+        color: $gray-darkish;
+
+        strong {
+            color: $gray-dark;
+        }
+    }
+
+    .api-changelog-summary-actions {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .api-changelog-clear {
+        display: inline-flex;
+        align-items: center;
+        height: 24px;
+        padding: 0 10px;
+        border: 1px solid $gray-border;
+        border-radius: 4px;
+        background: $white;
+        font-size: 12px;
+        color: $gray-dark;
+        cursor: pointer;
+
+        &:hover {
+            border-color: $gray-light;
+        }
+    }
+
+    .api-changelog-timeline {
+        position: relative;
+    }
+
+    .api-changelog-version {
+        position: relative;
+        padding-left: 26px;
+        padding-bottom: 32px;
+        border-left: 2px solid $gray-border;
+        margin-left: 6px;
+
+        &:last-child {
+            border-left-color: transparent;
+        }
+
+        &::before {
+            content: "";
+            position: absolute;
+            left: -7px;
+            top: 6px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: $white;
+            border: 3px solid $gray-light;
+        }
+
+        &--default::before {
+            border-color: $ddpurple;
+        }
+    }
+
+    .api-changelog-version-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 14px;
+
+        // Reset the site-wide scroll-anchor offset hack (.main-api h2) — these
+        // headings aren't anchor targets, so the large padding-top just breaks layout.
+        h2 {
+            font-size: 22px;
+            font-weight: 700;
+            margin: 0;
+            padding: 0;
+            font-family: monospace;
+            pointer-events: auto;
+            background-clip: border-box;
+        }
+    }
+
+    .api-changelog-version-header-badges {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .api-changelog-badge {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 10px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.03em;
+
+        // D2 pill vocabulary, reused here for version-level status.
+        &--recommended {
+            background: rgba($brand-success, 0.1);
+            color: $brand-success;
+        }
+
+        &--base {
+            background: $ddpurple;
+            color: $white;
+        }
+
+        &--deprecated,
+        &--eol {
+            background: rgba($brand-warning, 0.15);
+            color: darken($brand-warning, 15%);
+        }
+
+        &--breaking {
+            background: rgba($brand-danger, 0.1);
+            color: $brand-danger;
+        }
+    }
+
+    .api-changelog-why-upgrade {
+        max-width: 720px;
+        padding: 12px 16px;
+        margin-bottom: 14px;
+        background: #f5f0fc;
+        border-left: 3px solid $ddpurple;
+        border-radius: 4px;
+        font-size: 13px;
+        line-height: 1.6;
+        color: $gray-dark;
+
+        strong {
+            color: $ddpurple;
+        }
+    }
+
+    .api-changelog-entries {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .api-changelog-entry {
+        display: flex;
+        gap: 14px;
+        padding: 14px 16px;
+        background: $white;
+        border: 1px solid $gray-border;
+        border-radius: 6px;
+    }
+
+    .api-changelog-pill {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 84px;
+        height: 22px;
+        padding: 0 9px;
+        border-radius: 4px;
+        color: $white;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        white-space: nowrap;
+    }
+
+    .api-changelog-entry-body {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .api-changelog-entry-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+        font-size: 12px;
+
+        code {
+            font-size: 12px;
+        }
+    }
+
+    .api-changelog-tag {
+        color: $gray-darkish;
+
+        strong {
+            color: $gray-dark;
+        }
+    }
+
+    .api-changelog-method {
+        display: inline-flex;
+        align-items: center;
+        height: 18px;
+        padding: 0 6px;
+        border-radius: 3px;
+        font-family: monospace;
+        font-size: 11px;
+        font-weight: 700;
+    }
+
+    .api-changelog-entry p {
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.55;
+        color: $gray-dark;
+    }
+
+    .api-changelog-empty {
+        text-align: center;
+        padding: 56px 20px;
+        border: 1px dashed $gray-light;
+        border-radius: 8px;
+        margin-top: 20px;
+
+        .api-changelog-empty-title {
+            margin: 0 0 4px;
+            font-size: 15px;
+            font-weight: 600;
+        }
+
+        .api-changelog-empty-subtitle {
+            margin: 0 0 16px;
+            font-size: 13px;
+            color: $gray-darkish;
+        }
+    }
+}

--- a/hugo/config/_default/menus/api.en.yaml
+++ b/hugo/config/_default/menus/api.en.yaml
@@ -18,11 +18,6 @@ menu:
       parent: API overview
       weight: 7
       identifier: rate-limits
-    - name: Changelog
-      url: /api/changelog/
-      parent: API overview
-      weight: 8
-      identifier: api-changelog
     - name: AWS Integration
       url: /api/latest/aws-integration/
       identifier: aws-integration

--- a/hugo/config/_default/menus/api.en.yaml
+++ b/hugo/config/_default/menus/api.en.yaml
@@ -18,6 +18,11 @@ menu:
       parent: API overview
       weight: 7
       identifier: rate-limits
+    - name: Changelog
+      url: /api/changelog/
+      parent: API overview
+      weight: 8
+      identifier: api-changelog
     - name: AWS Integration
       url: /api/latest/aws-integration/
       identifier: aws-integration

--- a/hugo/content/en/api/changelog/_index.md
+++ b/hugo/content/en/api/changelog/_index.md
@@ -1,0 +1,9 @@
+---
+title: Changelog
+type: api
+layout: changelog
+build:
+  render: always
+  list: never
+  publishResources: false
+---

--- a/hugo/data/api/changelog.yaml
+++ b/hugo/data/api/changelog.yaml
@@ -1,0 +1,102 @@
+# Placeholder changelog data for the /api/changelog POC.
+# In a real implementation this would be generated from the x-datadog-api-versioning
+# extension in the OpenAPI spec rather than hand-authored here.
+versions:
+  - date: "2026-09-01"
+    why_upgrade: >-
+      Removes the deprecated monitor `notify_no_data` boolean and adds ordered log search, at
+      the cost of one breaking change for existing monitor-update integrations.
+    entries:
+      - type: breaking
+        tag: Monitors
+        method: patch
+        path: /api/v1/monitor/{id}
+        description: >-
+          Removed the deprecated `notify_no_data` boolean. Use `no_data_timeframe` to control
+          no-data alerting; requests sending `notify_no_data` return a 400.
+      - type: addition
+        tag: Logs
+        method: post
+        path: /api/v2/logs/events/search
+        description: >-
+          Added a `sort` parameter to log search, allowing results to be ordered by any indexed
+          attribute in ascending or descending order.
+      - type: deprecation
+        tag: Dashboards
+        method: put
+        path: /api/v1/dashboard/{id}
+        description: >-
+          `is_read_only` is deprecated in favor of `restricted_roles`. It continues to work but
+          is scheduled for removal in a future version.
+  - date: "2026-08-01"
+    why_upgrade: >-
+      Renames the incident `state` enum and adds bulk metric tag configuration plus
+      suppression details on detection rules. Update stored incident state values before adopting.
+    entries:
+      - type: breaking
+        tag: Incidents
+        method: patch
+        path: /api/v2/incidents/{id}
+        description: >-
+          The `state` enum was renamed: `active` becomes `declared` and `stable` becomes `resolved`.
+          Update stored values before adopting this version.
+      - type: addition
+        tag: Metrics
+        method: post
+        path: /api/v2/metrics/config/bulk-tags
+        description: >-
+          New bulk tag configuration endpoint lets you add or remove tag keys across multiple
+          metrics in a single request.
+      - type: addition
+        tag: Security
+        method: get
+        path: /api/v2/security_monitoring/rules
+        description: >-
+          Detection rule responses include a `suppressions` field describing exclusion
+          queries applied to the rule.
+  - date: "2026-07-01"
+    why_upgrade: >-
+      Nests dashboard widgets under `attributes.widgets` to align with the v2 resource format,
+      and lets monitor edit permissions be scoped to specific roles at creation time.
+    entries:
+      - type: breaking
+        tag: Dashboards
+        method: get
+        path: /api/v1/dashboard/{id}
+        description: >-
+          The response envelope changed — widgets are nested under `attributes.widgets`
+          rather than at the top level, aligning with the v2 resource format.
+      - type: deprecation
+        tag: APM
+        method: get
+        path: /api/v2/apm/services
+        description: >-
+          The `env` query parameter is deprecated. Use `filter[env]` instead; the old parameter
+          is honored but no longer documented.
+      - type: addition
+        tag: Monitors
+        method: post
+        path: /api/v1/monitor
+        description: >-
+          Added `restricted_roles` to monitor payloads so monitor edit permissions can be scoped
+          to specific roles at creation time.
+  - date: "2026-06-01"
+    default: true
+    why_upgrade: >-
+      Establishes the stable baseline for date-based versioning, including the `service_account`
+      user type for programmatic access not tied to an individual person.
+    entries:
+      - type: addition
+        tag: Users
+        method: post
+        path: /api/v2/users
+        description: >-
+          Introduced the `service_account` user type for programmatic access that is not tied to
+          an individual person.
+      - type: addition
+        tag: Logs
+        method: post
+        path: /api/v2/logs/events/search
+        description: >-
+          Established the stable baseline for date-based versioning. All subsequent versions are
+          derived from this default.

--- a/hugo/layouts/api/changelog.html
+++ b/hugo/layouts/api/changelog.html
@@ -1,0 +1,153 @@
+{{ define "api-main" }}
+
+{{ $versions := .Site.Data.api.changelog.versions | default (slice) }}
+{{/* Sort newest-first so the "Recommended" badge (first entry), the timeline order,
+     and the version-range filter don't depend on changelog.yaml being hand-ordered. */}}
+{{ $versions = sort $versions "date" "desc" }}
+
+{{ $typeMeta := dict
+  "breaking"    (dict "label" "Breaking"    "color" "danger")
+  "addition"    (dict "label" "Addition"    "color" "success")
+  "deprecation" (dict "label" "Deprecation" "color" "warning")
+}}
+
+{{/* Flatten all entries once so we can compute counts and the product list. */}}
+{{ $allEntries := slice }}
+{{ range $versions }}
+  {{ range .entries }}
+    {{ $allEntries = $allEntries | append . }}
+  {{ end }}
+{{ end }}
+
+{{ $allTags := slice }}
+{{ range $allEntries }}
+  {{ if not (in $allTags .tag) }}
+    {{ $allTags = $allTags | append .tag }}
+  {{ end }}
+{{ end }}
+{{ $allTags = sort $allTags }}
+
+<div class="col-12 api-changelog py-3">
+
+  <div class="api-intro-header d-flex flex-wrap align-items-start justify-content-between">
+    <h2 id="changelog">
+      <a href="#changelog">{{ .Title }}</a>
+    </h2>
+    {{ partial "api/api-copy-btn.html" . }}
+  </div>
+
+  <p class="api-changelog-intro">
+    The Datadog API uses date-based versioning to manage breaking changes.
+    Specify the API version by sending a <code>DD-API-VERSION</code> header with a version date.
+  </p>
+
+  <div class="api-changelog-note">
+    <strong>Note:</strong> Requests without a <code>DD-API-VERSION</code> header use the default version.
+  </div>
+
+  {{ if not $versions }}
+    <div class="alert alert-info">
+      No versioning information found. Make sure <code>data/api/changelog.yaml</code> is populated.
+    </div>
+  {{ else }}
+
+    <div class="api-changelog-filterbar">
+      <div class="api-changelog-tabs" role="tablist" aria-label="Filter by change type">
+        <button type="button" class="api-changelog-tab is-active" data-changelog-filter="all">All</button>
+        <button type="button" class="api-changelog-tab" data-changelog-filter="breaking">Breaking</button>
+        <button type="button" class="api-changelog-tab" data-changelog-filter="addition">Addition</button>
+        <button type="button" class="api-changelog-tab" data-changelog-filter="deprecation">Deprecation</button>
+      </div>
+      <div class="api-changelog-filter-divider"></div>
+      <div class="api-changelog-filter-group">
+        <label for="api-changelog-product-filter" class="api-changelog-filter-label">Product</label>
+        <select id="api-changelog-product-filter" class="api-changelog-select">
+          <option value="all">All products</option>
+          {{ range $allTags }}
+            <option value="{{ . }}">{{ . }}</option>
+          {{ end }}
+        </select>
+      </div>
+      <div class="api-changelog-filter-group">
+        <label for="api-changelog-version-filter" class="api-changelog-filter-label">Version range</label>
+        <select id="api-changelog-version-filter" class="api-changelog-select">
+          <option value="all">All versions</option>
+          {{ range $versions }}
+            <option value="{{ .date }}">Since {{ .date }}</option>
+          {{ end }}
+        </select>
+      </div>
+    </div>
+
+    <div class="api-changelog-summary">
+      <span>Showing <strong id="api-changelog-shown-count">{{ len $allEntries }}</strong> changes across
+        <strong id="api-changelog-version-count">{{ len $versions }}</strong> versions</span>
+      <div class="api-changelog-summary-actions">
+        <button type="button" id="api-changelog-clear-filters" class="api-changelog-clear d-none">Clear filters</button>
+      </div>
+    </div>
+
+    <div id="api-changelog-versions" class="api-changelog-timeline">
+      {{ range $index, $version := $versions }}
+        {{ $breakingCount := len (where .entries "type" "breaking") }}
+        <section id="{{ .date }}" class="api-changelog-version {{ if .default }}api-changelog-version--default{{ end }}" data-version="{{ .date }}">
+          <div class="api-changelog-version-header">
+            <h2>{{ .date }}</h2>
+            <div class="api-changelog-version-header-badges">
+              {{ if eq $index 0 }}
+                <span class="api-changelog-badge api-changelog-badge--recommended">Recommended</span>
+              {{ end }}
+              {{ if .default }}
+                <span class="api-changelog-badge api-changelog-badge--base">Base</span>
+              {{ end }}
+              {{ if .deprecated }}
+                <span class="api-changelog-badge api-changelog-badge--deprecated">Deprecated</span>
+              {{ end }}
+              {{ if .eol }}
+                <span class="api-changelog-badge api-changelog-badge--eol">EOL {{ .eol }}</span>
+              {{ end }}
+              <span class="api-changelog-badge api-changelog-badge--breaking {{ if eq $breakingCount 0 }}d-none{{ end }}" data-breaking-badge>
+                {{ $breakingCount }} breaking {{ if eq $breakingCount 1 }}change{{ else }}changes{{ end }}
+              </span>
+            </div>
+          </div>
+
+          {{ if .why_upgrade }}
+            <div class="api-changelog-why-upgrade">
+              <strong>Why upgrade.</strong> {{ .why_upgrade | markdownify }}
+            </div>
+          {{ end }}
+
+          <div class="api-changelog-entries">
+            {{ range .entries }}
+              {{/* Fall back to a labeled, neutral pill for any unrecognized/missing type
+                   instead of rendering an empty "bg-" class with no label. */}}
+              {{ $meta := index $typeMeta .type | default (dict "label" (.type | default "Change") "color" "info") }}
+              <article class="api-changelog-entry" data-type="{{ .type }}" data-bucket="{{ .type }}" data-tag="{{ .tag }}">
+                <span class="api-changelog-pill bg-{{ $meta.color }}">{{ $meta.label }}</span>
+                <div class="api-changelog-entry-body">
+                  <div class="api-changelog-entry-meta">
+                    <span class="api-changelog-tag">tag: <strong>{{ .tag }}</strong></span>
+                    <span class="api-changelog-method text-api-{{ .method }} bg-bg-api-{{ .method }}">{{ .method | upper }}</span>
+                    <code>{{ .path }}</code>
+                  </div>
+                  <p>{{ .description | markdownify }}</p>
+                </div>
+              </article>
+            {{ end }}
+          </div>
+        </section>
+      {{ end }}
+    </div>
+
+    <div id="api-changelog-empty-state" class="api-changelog-empty d-none">
+      <p class="api-changelog-empty-title">No changes match your filters</p>
+      <p class="api-changelog-empty-subtitle">Try removing a type or product filter.</p>
+      <button type="button" class="api-changelog-clear" data-changelog-reset>Clear filters</button>
+    </div>
+
+  {{ end }}
+
+</div>
+
+{{ end }}

--- a/hugo/layouts/api/changelog.html
+++ b/hugo/layouts/api/changelog.html
@@ -11,21 +11,13 @@
   "deprecation" (dict "label" "Deprecation" "color" "warning")
 }}
 
-{{/* Flatten all entries once so we can compute counts and the product list. */}}
+{{/* Flatten all entries once so we can compute the total change count. */}}
 {{ $allEntries := slice }}
 {{ range $versions }}
   {{ range .entries }}
     {{ $allEntries = $allEntries | append . }}
   {{ end }}
 {{ end }}
-
-{{ $allTags := slice }}
-{{ range $allEntries }}
-  {{ if not (in $allTags .tag) }}
-    {{ $allTags = $allTags | append .tag }}
-  {{ end }}
-{{ end }}
-{{ $allTags = sort $allTags }}
 
 <div class="col-12 api-changelog py-3">
 
@@ -59,15 +51,6 @@
         <button type="button" class="api-changelog-tab" data-changelog-filter="deprecation">Deprecation</button>
       </div>
       <div class="api-changelog-filter-divider"></div>
-      <div class="api-changelog-filter-group">
-        <label for="api-changelog-product-filter" class="api-changelog-filter-label">Product</label>
-        <select id="api-changelog-product-filter" class="api-changelog-select">
-          <option value="all">All products</option>
-          {{ range $allTags }}
-            <option value="{{ . }}">{{ . }}</option>
-          {{ end }}
-        </select>
-      </div>
       <div class="api-changelog-filter-group">
         <label for="api-changelog-version-filter" class="api-changelog-filter-label">Version range</label>
         <select id="api-changelog-version-filter" class="api-changelog-select">
@@ -123,7 +106,7 @@
               {{/* Fall back to a labeled, neutral pill for any unrecognized/missing type
                    instead of rendering an empty "bg-" class with no label. */}}
               {{ $meta := index $typeMeta .type | default (dict "label" (.type | default "Change") "color" "info") }}
-              <article class="api-changelog-entry" data-type="{{ .type }}" data-bucket="{{ .type }}" data-tag="{{ .tag }}">
+              <article class="api-changelog-entry" data-type="{{ .type }}" data-bucket="{{ .type }}">
                 <span class="api-changelog-pill bg-{{ $meta.color }}">{{ $meta.label }}</span>
                 <div class="api-changelog-entry-body">
                   <div class="api-changelog-entry-meta">
@@ -142,7 +125,7 @@
 
     <div id="api-changelog-empty-state" class="api-changelog-empty d-none">
       <p class="api-changelog-empty-title">No changes match your filters</p>
-      <p class="api-changelog-empty-subtitle">Try removing a type or product filter.</p>
+      <p class="api-changelog-empty-subtitle">Try removing a type or version filter.</p>
       <button type="button" class="api-changelog-clear" data-changelog-reset>Clear filters</button>
     </div>
 

--- a/hugo/layouts/api/changelog.rss.xml
+++ b/hugo/layouts/api/changelog.rss.xml
@@ -1,0 +1,26 @@
+{{- $versions := .Site.Data.api.changelog.versions | default (slice) -}}
+{{- $versions = sort $versions "date" "desc" -}}
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Title }} on {{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent changes to the Datadog API, grouped by version</description>
+    <generator>Hugo</generator>
+    <language>{{ .Site.LanguageCode }}</language>
+    <atom:link href="{{ .Permalink }}index.xml" rel="self" type="application/rss+xml" />
+    {{- range $versions }}
+      {{- $version := . }}
+      {{- $pubDate := time.AsTime .date }}
+      {{- range .entries }}
+    <item>
+      <title>{{ $version.date }} &middot; {{ .tag }} &middot; {{ .method | upper }} {{ .path }}</title>
+      <link>{{ $.Permalink }}#{{ $version.date }}</link>
+      <pubDate>{{ $pubDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
+      <guid isPermaLink="false">{{ $.Permalink }}#{{ $version.date }}-{{ .tag }}-{{ .method }}-{{ .path }}</guid>
+      <description>{{ .description | plainify }}</description>
+    </item>
+      {{- end }}
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
🤖 Auto-generated fix for #38028.

@walidcavelius — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38028. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38028 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38028) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the ready for merge checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

## Summary

Draft POC for the redesigned /api/changelog page. The per-operation API versioning work was split into #38300.

- Adds filter tabs for all changes, breaking changes, additions, and deprecations.
- Adds a minimum-version filter with result counts, clear-filter actions, and an empty state.
- Adds a version timeline with lifecycle and breaking-change badges, upgrade guidance, and method/type pills.
- Adds an RSS representation and a Changelog entry to the API sidenav.
- Keeps hand-authored placeholder content in data/api/changelog.yaml for the POC; a production implementation would generate it from the OpenAPI versioning extension.

This is a design POC for reviewer walkthrough, not intended to merge as-is.

## Test plan

- [ ] Visit /api/changelog/ on the preview build.
- [ ] Toggle the change-type tabs and confirm entries, version sections, counts, and breaking-change badges update.
- [ ] Select the version filter and confirm Clear filters appears.
- [ ] Filter to an empty result and confirm the empty state renders.
- [ ] Confirm the filter bar remains below the sticky API toolbar without overlap on desktop widths.
- [ ] Confirm the Changelog entry appears in the API sidenav and the RSS output renders newest-first.