### PR TITLE
[reorg fix] Correct custom rule message formatting docs (remove References, demote Rationale)

### DIFF
--- a/hugo/content/en/security/cloud_security_management/misconfigurations/custom_rules.md
+++ b/hugo/content/en/security/cloud_security_management/misconfigurations/custom_rules.md
@@ -78,7 +78,7 @@ Describe how to remediate it.
 Keep the following in mind:
 
 - All sections are optional and can appear in any order. A typical message uses only `## Description` and `## Remediation`.
-- You can also include a `## Rationale` section. Its content appears within **What Happened**, after the description, without its own labeled section.
+- You can also include a `## Rationale` section. Its content appears within **What Happened**, after the description.
 - Use level-2 (`##`) headers for each section. Deeper headers (for example, `###`) are treated as sub-points within a section, not as new sections.
 - Header matching is case-insensitive, but the section names must match exactly (for example, `Remediation`, not `Fix`).
 - Give each section content. A header immediately followed by another header may not render as expected.

--- a/hugo/content/en/security/cloud_security_management/misconfigurations/custom_rules.md
+++ b/hugo/content/en/security/cloud_security_management/misconfigurations/custom_rules.md
@@ -60,12 +60,10 @@ To create a rule from scratch:
 
 The text you enter in {{< ui >}}Say what's happening{{< /ui >}} is displayed in the finding side panel. When you write it as Markdown using the following section headers, each section is shown in a dedicated area of the finding:
 
-| Header        | Where it appears in the finding                |
-|---------------|------------------------------------------------|
-| `Description` | **What Happened**                              |
-| `Rationale`   | **What Happened** (shown with the description) |
-| `Remediation` | **Remediation** section                        |
-| `References`  | Shown separately                               |
+| Header        | Where it appears in the finding |
+|---------------|---------------------------------|
+| `Description` | **What Happened**               |
+| `Remediation` | **Remediation** section         |
 
 For example:
 
@@ -80,6 +78,7 @@ Describe how to remediate it.
 Keep the following in mind:
 
 - All sections are optional and can appear in any order. A typical message uses only `## Description` and `## Remediation`.
+- You can also include a `## Rationale` section. Its content appears within **What Happened**, after the description, without its own labeled section.
 - Use level-2 (`##`) headers for each section. Deeper headers (for example, `###`) are treated as sub-points within a section, not as new sections.
 - Header matching is case-insensitive, but the section names must match exactly (for example, `Remediation`, not `Fix`).
 - Give each section content. A header immediately followed by another header may not render as expected.


### PR DESCRIPTION
🤖 Auto-generated fix for #38001.

@BeatrizFeliciano — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #38001. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #38001 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#38001) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

### What does this PR do? What is the motivation?

Follow-up correction to #37983, which documented how a custom cloud configuration rule's message renders in the finding side panel. Two items were inaccurate:

1. It listed a **References** section as "shown separately." It is not rendered — the parsed `references` section has no consumer in the frontend (the constant exists but is never read), so a `## References` heading renders nowhere. Removed entirely.
2. It listed **Rationale** as a peer placement row, implying its own labeled area. It does not get one — Rationale content is folded into **What Happened** after the description, with its heading stripped. Demoted to a clarifying note.

The placement table now lists only `Description` and `Remediation` (the two headers that map to distinct visible areas).

### Additional notes

- Single page changed: `content/en/security/cloud_security_management/misconfigurations/custom_rules.md`.
- Companion Terraform provider correction: https://github.com/DataDog/terraform-provider-datadog/pull/3940