### PR TITLE
[reorg fix] [WIP] Fix minimum-permissions and custom-tag documentation gaps

### DIFF
--- a/hugo/content/en/data_observability/jobs_monitoring/airflow.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/airflow.md
@@ -631,6 +631,9 @@ with DAG(
 
 With `user_defined_macros` set on the DAG, the `{{ lineage_*() }}` and `{{ lineage_root_*() }}` calls in your task templates resolve to values that match the built-in macros shipped with provider 2.3.0+, so downstream Spark or dbt jobs can link to the Airflow root parent in Datadog.
 
+### Custom tags
+
+DAG-level `tags` (the `tags=[...]` parameter on your DAG definition) are captured automatically and appear as filterable tags on the corresponding job in Jobs Monitoring — no additional configuration is required. Airflow doesn't have a native task-level tagging concept, so there's nothing to configure at the task level.
 
 ## Further Reading
 

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -14,6 +14,10 @@ further_reading:
 
 [Data Observability: Jobs Monitoring][7] gives visibility into the performance and reliability of your Databricks jobs and workflows running on clusters or serverless compute.
 
+## Prerequisites
+
+**Note**: Jobs Monitoring requires the connecting service principal (or token principal) to be a Databricks **Workspace Admin** for the recommended Datadog-managed global init script install path. This is different from [Quality Monitoring][30], which does not require Workspace Admin. If you can't grant Workspace Admin, see [Permissions](#permissions) below for a more limited set of permissions that work with a self-managed init script.
+
 ## Setup
 
 <div class="alert alert-info">If your Databricks workspace has <a href="https://docs.databricks.com/en/security/network/front-end/index.html">Networking Restrictions</a> enabled, add Datadog's {{< region-param key="ip_ranges_url_webhooks" link="true" text="webhook IP ranges" >}} to your allow-list. If your workspace uses Private Link, see the <strong>Private Link Connectivity</strong> tab below.</div>
@@ -565,3 +569,4 @@ To monitor workspaces that use [Databricks Private Link][14] connectivity, see [
 [27]: https://docs.databricks.com/aws/en/admin/system-tables/
 [28]: /getting_started/tagging/
 [29]: https://docs.databricks.com/aws/en/compute/configure#compute-log-delivery
+[30]: /data_observability/quality_monitoring/data_warehouses/databricks/

--- a/hugo/content/en/data_observability/jobs_monitoring/dbt.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/dbt.md
@@ -73,6 +73,15 @@ Use this option if you want Datadog to create and maintain the webhook in dbt Cl
 
 This mode requires a dbt Cloud token with {{< ui >}}Developer{{< /ui >}} permissions for the dbt Cloud Enterprise plan or {{< ui >}}Account Admin{{< /ui >}} permissions for the dbt Cloud Team plan.
 
+## Troubleshooting
+
+### Job run or lineage data stops appearing
+
+If your dbt Cloud token's permission set is lowered after setup (for example, someone rotates it with a more restrictive scope), the webhook or connection can fail silently rather than showing an obvious error. If data that was previously showing up stops appearing:
+
+1. Confirm the token still has the required scope: {{< ui >}}Stakeholder/Read-Only{{< /ui >}} (self-managed webhook) or {{< ui >}}Developer{{< /ui >}}/{{< ui >}}Account Admin{{< /ui >}} (Datadog-managed webhook), matching the requirements above.
+1. If the token's scope is insufficient, generate a new token with the correct permission set and update the connection in Datadog.
+
 ## What's next
 
 After your next dbt job run, you should start seeing job run and lineage data in [Datadog Data Observability][2], as shown below.

--- a/hugo/content/en/data_observability/jobs_monitoring/glue.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/glue.md
@@ -55,6 +55,7 @@ The Data Observability crawler requires additional permissions to monitor Glue j
         "glue:GetJobs",
         "glue:GetTable",
         "glue:GetTables",
+        "glue:GetTags",
         "glue:ListJobs",
         "s3:ListBucket",
         "kms:Decrypt",
@@ -78,6 +79,8 @@ The Data Observability crawler requires additional permissions to monitor Glue j
 ```
 
 Some of these permissions are related to monitoring Iceberg tables in Glue. For more details on dataset-related IAM permissions, see the [AWS Glue Data Quality Monitoring documentation][7].
+
+**Note**: If the connected role is missing `glue:GetTags`, jobs still sync, but without their AWS tags — you can spot this by a crawler warning stating "Access denied fetching tags for Glue job... Grant glue:GetTags to the integration role." Add the permission and it's picked up on the next crawl.
 
 ## Configure the crawler
 

--- a/hugo/content/en/data_observability/jobs_monitoring/kubernetes.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/kubernetes.md
@@ -286,6 +286,15 @@ spark.driver.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.versio
 spark.executor.extraJavaOptions=-Ddd.service=<JOB_NAME> -Ddd.env=<ENV> -Ddd.version=<VERSION>
 ```
 
+### Add custom tags
+
+To add arbitrary custom tags, pass a comma-separated list of `key:value` pairs with the `-Ddd.tags` JVM option, the same way as the tags above:
+
+```
+spark.driver.extraJavaOptions=-Ddd.tags=team:data_engineering,cost_center:analytics
+spark.executor.extraJavaOptions=-Ddd.tags=team:data_engineering,cost_center:analytics
+```
+
 ### Tag spans at runtime
 
 {{% djm-runtime-tagging %}}


### PR DESCRIPTION
🤖 Auto-generated fix for #37965.

@kevinzenghu — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37965. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37965 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37965) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

## Summary
Sourced from mining ~5 months of Slack support/sales archives for recurring patterns (see linked analysis): "minimum permissions" confusion (17 threads) and "custom tags not propagating" (recurring since Nov 2025). Each fix is grounded in crawler/processor code, not just the reported symptom.

## Fixes
1. **Glue IAM policy missing `glue:GetTags`** — confirmed via `libs/glue/client.go` (crawler calls GetTags) and a dedicated crawler warning path for exactly this access-denied case.
2. **Databricks Jobs Monitoring Workspace Admin requirement** — added a Prerequisites section; this was previously buried in an Advanced Configuration subsection and never contrasted with Quality Monitoring (which doesn't need it).
3. **dbt Cloud silent token-scope failures** — added Troubleshooting, grounded in `DbtCloudHealthWorker`'s existing authorization-error checks.
4. **Airflow DAG-tag auto-propagation** — documented that this already works with zero config (confirmed via `GetAirflowTags()`), previously undocumented.
5. **Kubernetes missing `-Ddd.tags`** — added, matching the pattern already documented for EMR/Dataproc.

## Found but explicitly not fixed here
- **Databricks custom-tag auto-capture already shipped a doc fix on 2026-06-01** (commit `bcef0674fd`) — reps in Slack are giving a now-stale "no auto-propagation" answer. This is a team-communication gap, not a doc gap — flagging for whoever owns support enablement, not fixing here.
- **BigQuery Drive/Sheets external tables** needing extra credentials — confirmed unhandled and undocumented, but I couldn't determine the exact required role/scope from code. Needs the BigQuery crawler owner's input before writing content.

## Status
**Work in progress — not ready for review yet.** Draft, no reviewers requested.

## AI assistance
Found and fixed by Claude Code via a targeted research pass grounded in dd-source code for each specific gap — flagging per the AI-assistance disclosure in CONTRIBUTING.md.