### PR TITLE
[WEBPS-8171] Document Entra SCIM roles attribute setup

### DIFF
--- a/hugo/content/en/account_management/scim/entra.md
+++ b/hugo/content/en/account_management/scim/entra.md
@@ -84,7 +84,7 @@ When using SAML and SCIM together, Datadog strongly recommends disabling SAML ju
 
 7. After you set your mappings, click {{< ui >}}Save{{< /ui >}}.
 
-To provision a user's Datadog role (built-in or custom), map the `roles` attribute as shown above, using the `AppRoleAssignmentsComplex([appRoleAssignments])` expression for the Microsoft Entra ID attribute. If `roles` is not available in the {{< ui >}}Target attribute (customappsso){{< /ui >}} dropdown, select {{< ui >}}Show advanced options{{< /ui >}} and click {{< ui >}}Edit attribute list for customappsso{{< /ui >}}. Add an attribute named `roles`, set {{< ui >}}Type{{< /ui >}} to {{< ui >}}String{{< /ui >}}, select {{< ui >}}Multi-Value?{{< /ui >}}, and save the attribute. Roles follow the SCIM multi-valued attribute convention defined in [RFC 7643][9]. If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
+To provision a user's Datadog role (built-in or custom), map the `roles` attribute as shown above, using the `AppRoleAssignmentsComplex([appRoleAssignments])` expression for the Microsoft Entra ID attribute. If `roles` is not available in the target attribute dropdown, add it as a **multi-valued** string attribute. For configuration instructions, see [Microsoft's attribute-mapping documentation][10]. Roles follow the SCIM multi-valued attribute convention defined in [RFC 7643][9]. If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
 
 ### Group attributes
 
@@ -99,3 +99,4 @@ Group mapping is not supported.
 [7]: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#cloud-application-administrator
 [8]: https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility#flags-to-alter-the-scim-behavior
 [9]: https://www.rfc-editor.org/rfc/rfc7643.html#section-4.1.2
+[10]: https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes#provisioning-a-role-to-a-scim-app

--- a/hugo/content/en/account_management/scim/entra.md
+++ b/hugo/content/en/account_management/scim/entra.md
@@ -84,7 +84,7 @@ When using SAML and SCIM together, Datadog strongly recommends disabling SAML ju
 
 7. After you set your mappings, click {{< ui >}}Save{{< /ui >}}.
 
-To provision a user's Datadog role (built-in or custom), map the `roles` attribute as shown above, using the `AppRoleAssignmentsComplex([appRoleAssignments])` expression for the Microsoft Entra ID attribute. Roles follow the SCIM multi-valued attribute convention defined in [RFC 7643][9]. If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
+To provision a user's Datadog role (built-in or custom), map the `roles` attribute as shown above, using the `AppRoleAssignmentsComplex([appRoleAssignments])` expression for the Microsoft Entra ID attribute. If `roles` is not available in the {{< ui >}}Target attribute (customappsso){{< /ui >}} dropdown, select {{< ui >}}Show advanced options{{< /ui >}} and click {{< ui >}}Edit attribute list for customappsso{{< /ui >}}. Add an attribute named `roles`, set {{< ui >}}Type{{< /ui >}} to {{< ui >}}String{{< /ui >}}, select {{< ui >}}Multi-Value?{{< /ui >}}, and save the attribute. Roles follow the SCIM multi-valued attribute convention defined in [RFC 7643][9]. If a SCIM request sends multiple roles, Datadog provisions only the roles that match a role in your organization. If none match, the user falls back to the org default role (Standard), and unmatched roles are logged to Audit Trail. For more details, see [SCIM][1].
 
 ### Group attributes
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Related Jira ticket: WEBPS-8171

Documents how to add the `roles` target attribute in Microsoft Entra ID when it is unavailable. This lets users configure the existing multi-value role mapping.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Codex helped draft the documentation change and run validation.

### Additional notes

Validation:

- Vale: 0 errors; only pre-existing warnings and suggestions on the page.
- `git diff --check`
