### PR TITLE
[SVLS-9609] Explicitly instruct setting 'Allow access to all app settings' in AAS Linux sidecar docs

### DIFF
--- a/hugo/content/en/serverless/azure_app_service/linux_code.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_code.md
@@ -442,10 +442,11 @@ Path to the instrumentation library loaded by the .NET runtime.<br>
       - {{< ui >}}Registry server URL{{< /ui >}}: `index.docker.io`
       - {{< ui >}}Image and tag{{< /ui >}}: `datadog/serverless-init:latest`
       - {{< ui >}}Port{{< /ui >}}: 8126
-   1. Select {{< ui >}}Apply{{< /ui >}}.
-   1. On the sidecar container's settings, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+      - Under {{< ui >}}Environment variables{{< /ui >}}, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
 
-      {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
+        {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
+
+   1. Select {{< ui >}}Apply{{< /ui >}}.
 
 3. **Restart your application**.
 

--- a/hugo/content/en/serverless/azure_app_service/linux_code.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_code.md
@@ -442,8 +442,10 @@ Path to the instrumentation library loaded by the .NET runtime.<br>
       - {{< ui >}}Registry server URL{{< /ui >}}: `index.docker.io`
       - {{< ui >}}Image and tag{{< /ui >}}: `datadog/serverless-init:latest`
       - {{< ui >}}Port{{< /ui >}}: 8126
-      - {{< ui >}}Environment Variables{{< /ui >}}: Include all previously configured Datadog environment variables.
    1. Select {{< ui >}}Apply{{< /ui >}}.
+   1. On the sidecar container's settings, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+
+      {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
 
 3. **Restart your application**.
 

--- a/hugo/content/en/serverless/azure_app_service/linux_container.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_container.md
@@ -487,9 +487,7 @@ See the [{{< ui >}}Manual{{< /ui >}} tab](?tab=manual#instrumentation) for descr
 
 #### Application settings
 
-In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables on your main container and enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
-
-{{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
+In your main container's {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables.
 
 - `DD_API_KEY`: Your [Datadog API key][701]
 - `DD_SERVICE`: How you want to tag your service. For example, `sidecar-azure`
@@ -498,6 +496,10 @@ In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environmen
 - `DD_SERVERLESS_LOG_PATH`: Where you write your logs. For example, `/home/LogFiles/*.log` or `/home/LogFiles/myapp/*.log`
 - `DD_AAS_INSTANCE_LOGGING_ENABLED`: When `true`, log collection is automatically configured for an additional file path: `/home/LogFiles/*$COMPUTERNAME*.log`
 - `DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR`: An optional file descriptor used for more precise file tailing. Recommended for scenarios with frequent log rotation. For example, setting `_default_docker` configures the log tailer to ignore rotated files and focus only on Azure's active log file.
+
+On the Datadog sidecar container's settings, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+
+{{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
 
 
    <div class="alert alert-info">If your application has multiple instances, make sure that your application's log filename includes the <code>$COMPUTERNAME</code> variable. This ensures that log tailing does not create duplicated logs from multiple instances reading the same file.</div>

--- a/hugo/content/en/serverless/azure_app_service/linux_container.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_container.md
@@ -483,6 +483,10 @@ See the [{{< ui >}}Manual{{< /ui >}} tab](?tab=manual#instrumentation) for descr
    - {{< ui >}}Registry server URL{{< /ui >}}: `index.docker.io`
    - {{< ui >}}Image and tag{{< /ui >}}: `datadog/serverless-init:latest`
    - {{< ui >}}Port{{< /ui >}}: 8126
+   - Under {{< ui >}}Environment variables{{< /ui >}}, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+
+     {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
+
 3. Select {{< ui >}}Apply{{< /ui >}}.
 
 #### Application settings
@@ -496,10 +500,6 @@ In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environmen
 - `DD_SERVERLESS_LOG_PATH`: Where you write your logs. For example, `/home/LogFiles/*.log` or `/home/LogFiles/myapp/*.log`
 - `DD_AAS_INSTANCE_LOGGING_ENABLED`: When `true`, log collection is automatically configured for an additional file path: `/home/LogFiles/*$COMPUTERNAME*.log`
 - `DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR`: An optional file descriptor used for more precise file tailing. Recommended for scenarios with frequent log rotation. For example, setting `_default_docker` configures the log tailer to ignore rotated files and focus only on Azure's active log file.
-
-On the Datadog sidecar container's settings, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
-
-{{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
 
 
    <div class="alert alert-info">If your application has multiple instances, make sure that your application's log filename includes the <code>$COMPUTERNAME</code> variable. This ensures that log tailing does not create duplicated logs from multiple instances reading the same file.</div>

--- a/hugo/content/en/serverless/azure_app_service/linux_container.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_container.md
@@ -487,7 +487,7 @@ See the [{{< ui >}}Manual{{< /ui >}} tab](?tab=manual#instrumentation) for descr
 
 #### Application settings
 
-In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables on both your main container and the sidecar container. Alternatively, set these variables on your main container and enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables on your main container and enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
 
 {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
 

--- a/hugo/content/en/serverless/azure_app_service/linux_container.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_container.md
@@ -487,7 +487,7 @@ See the [{{< ui >}}Manual{{< /ui >}} tab](?tab=manual#instrumentation) for descr
 
 #### Application settings
 
-In your main container's {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables.
+In your {{< ui >}}App settings{{< /ui >}} in Azure, set the following environment variables on your main container.
 
 - `DD_API_KEY`: Your [Datadog API key][701]
 - `DD_SERVICE`: How you want to tag your service. For example, `sidecar-azure`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Our public docs currently present "set required vars explicitly on both containers" and "enable Allow access to all app settings" as interchangeable alternatives. However, some reserved/platform-injected env vars like `WEBSITE_SITE_NAME` do not propagate to the sidecar if "Allow access to all app settings" is unchecked. This explicitly instructs customers to set this in the Azure portal.

https://datadoghq.atlassian.net/browse/SVLS-9609

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
