### PR TITLE
[reorg fix] [DBM Doc] Update MySQL replication documentation for MariaDB multi-channel support

### DIFF
--- a/hugo/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/hugo/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -90,6 +90,8 @@ GRANT PROCESS ON *.* TO datadog@'%';
 GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```
 
+**Note**: For MariaDB, the Agent automatically detects and monitors all replication channels when no specific `replication_channel` is configured. Each channel is tagged with `channel:<connection_name>`.
+
 {{% /tab %}}
 {{% tab "MySQL 5.6" %}}
 


### PR DESCRIPTION
🤖 Auto-generated fix for #37945.

@pierreln-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37945. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37945 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37945) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

**Confidence**: AUTO

**Source PR**: https://github.com/DataDog/integrations-core/pull/24178

**What changed**: The MySQL integration now properly supports MariaDB multi-channel replication by using `SHOW ALL REPLICAS STATUS` (or `SHOW ALL SLAVES STATUS` for older versions) when no specific replication channel is configured. Previously, MariaDB would report 0 channels in multi-channel replication setups.

**Why this matters**: Users monitoring MariaDB replication with multiple channels will now see correct replication metrics for all channels, tagged with `channel:<connection_name>`. The Agent now recognizes MariaDB's `Connection_name` field in addition to MySQL's `Channel_Name` field.

**Doc update**: Added a note to the replication configuration section explaining that MariaDB multi-channel replication is automatically detected when no specific channel is configured.