### PR TITLE
[reorg fix] [DBM Doc] Add automatic diagnostics feature for Postgres

### DIFF
--- a/hugo/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/hugo/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -362,6 +362,15 @@ After you enable logging collection:
 
 [Run the Agent's status subcommand][13] and look for `postgres` under the Checks section. Or visit the [Databases][14] page to get started!
 
+**Note:** The Postgres check includes an automatic diagnostics feature that can periodically run setup diagnostics and report results as Agent Health events. This feature is disabled by default. If enabled by support or for troubleshooting, configure it in your `postgres.d/conf.yaml`:
+
+```yaml
+instances:
+  - automatic_diagnostics:
+      enabled: true
+      interval: 600  # seconds between diagnostic runs
+```
+
 ## Example Agent Configurations
 {{% dbm-postgres-agent-config-examples %}}
 


### PR DESCRIPTION
🤖 Auto-generated fix for #37883.

@pierreln-dd — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37883. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37883 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37883) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

## Confidence: DISCUSSION

**Source PR:** https://github.com/DataDog/integrations-core/pull/23645

### What changed

The Postgres integration now includes an automatic diagnostics feature that:
- Runs setup diagnostics on check initialization
- Periodically re-runs diagnostics (configurable interval, default 600 seconds)
- Emits diagnostic results as Agent Health events

This is a new user-facing feature controlled by the `automatic_diagnostics` configuration option (disabled by default).

### Why this might need documentation

This is a new diagnostic capability that users could enable. However, the feature is:
1. Hidden in the config spec (`hidden: true`, `fleet_configurable: false`)
2. Disabled by default (`enabled: false`)
3. Not clear if this is intended for general user consumption or internal/support use

The draft edit below adds a minimal mention in the "Verify Agent setup" section. **Please review whether this feature should be documented at all** — if it's intended only for internal use or support-assisted troubleshooting, no documentation may be preferable.