### PR TITLE
Document 7-day SDS example log retention for gov sites

### DIFF
--- a/hugo/content/en/data_security/data_retention_periods.md
+++ b/hugo/content/en/data_security/data_retention_periods.md
@@ -116,7 +116,7 @@ attributes:
   - product: Log Management
     data_type: |
        - **Logs**: Determined by customer plan
-       - <span class="d-none site-region-container" data-region="gov,gov2">**SDS example findings**: 7 days</span>
+       - <span class="d-none site-region-container" data-region="gov,gov2">**Sensitive Data Scanner Findings (Example Logs)**: 7 days</span>
   - product: Metrics
     data_type: |
        - **Tags and values**: 15 months

--- a/hugo/content/en/data_security/data_retention_periods.md
+++ b/hugo/content/en/data_security/data_retention_periods.md
@@ -116,6 +116,7 @@ attributes:
   - product: Log Management
     data_type: |
        - **Logs**: Determined by customer plan
+       - <span class="d-none site-region-container" data-region="gov,gov2">**SDS example findings**: 7 days</span>
   - product: Metrics
     data_type: |
        - **Tags and values**: 15 months

--- a/hugo/content/en/data_security/data_retention_periods.md
+++ b/hugo/content/en/data_security/data_retention_periods.md
@@ -116,7 +116,7 @@ attributes:
   - product: Log Management
     data_type: |
        - **Logs**: Determined by customer plan
-       - <span class="d-none site-region-container" data-region="gov,gov2">**Sensitive Data Scanner Findings (Example Logs)**: 7 days</span>
+       - **Sensitive Data Scanner example logs**: <span class="d-none site-region-container" data-region="us,us3,us5,eu,ap1,ap2,uk1">3 days</span><span class="d-none site-region-container" data-region="gov,gov2">7 days</span>
   - product: Metrics
     data_type: |
        - **Tags and values**: 15 months

--- a/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -50,12 +50,7 @@ To investigate a log finding:
 3. At the top of the panel, check {{< ui >}}First Detected{{< /ui >}} and {{< ui >}}Last Detected{{< /ui >}} to understand how long the exposure has been active.
 4. In the summary section, review {{< ui >}}Match State{{< /ui >}}, {{< ui >}}Service{{< /ui >}}, {{< ui >}}Environment{{< /ui >}}, and {{< ui >}}Total matches{{< /ui >}} to understand the scope of the exposure.
 5. Review the {{< ui >}}Logs Pattern{{< /ui >}} to understand the format of the log line where sensitive data was detected.
-{{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}
-6. In the {{< ui >}}Example Logs{{< /ui >}} section, review up to 5 representative examples of affected logs. When an example log expires it is replaced with the next matching event. Click {{< ui >}}Show log{{< /ui >}} to expand an example and inspect its log message, fields, and attributes inline. By default, example logs are stored for 3 days and are accessible to all users with the Data Scanner Read permission. To store these representative logs for a different period, contact [Support][1].
-{{< /site-region >}}
-{{< site-region region="gov,gov2" >}}
-6. In the {{< ui >}}Example Logs{{< /ui >}} section, review up to 5 representative examples of affected logs. When an example log expires it is replaced with the next matching event. Click {{< ui >}}Show log{{< /ui >}} to expand an example and inspect its log message, fields, and attributes inline. By default, example logs are stored for 7 days and are accessible to all users with the Data Scanner Read permission. To store these representative logs for a different period, contact [Support][1].
-{{< /site-region >}}
+6. In the {{< ui >}}Example Logs{{< /ui >}} section, review up to 5 representative examples of affected logs. When an example log expires it is replaced with the next matching event. Click {{< ui >}}Show log{{< /ui >}} to expand an example and inspect its log message, fields, and attributes inline. By default, example logs are stored for <span class="d-none site-region-container" data-region="us,us3,us5,eu,ap1,ap2,uk1">3 days</span><span class="d-none site-region-container" data-region="gov,gov2">7 days</span> and are accessible to all users with the Data Scanner Read permission. To store these representative logs for a different period, contact [Support][1].
 7. Review {{< ui >}}Matches Trend{{< /ui >}} to see how match volume has changed over the past week. Use {{< ui >}}Related Access and Configuration Events{{< /ui >}} to check whether recent access events or changes to the scanning group or scanning rule line up with changes in match volume.
 
 Additionally, you can:

--- a/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -50,7 +50,12 @@ To investigate a log finding:
 3. At the top of the panel, check {{< ui >}}First Detected{{< /ui >}} and {{< ui >}}Last Detected{{< /ui >}} to understand how long the exposure has been active.
 4. In the summary section, review {{< ui >}}Match State{{< /ui >}}, {{< ui >}}Service{{< /ui >}}, {{< ui >}}Environment{{< /ui >}}, and {{< ui >}}Total matches{{< /ui >}} to understand the scope of the exposure.
 5. Review the {{< ui >}}Logs Pattern{{< /ui >}} to understand the format of the log line where sensitive data was detected.
+{{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}
 6. In the {{< ui >}}Example Logs{{< /ui >}} section, review up to 5 representative examples of affected logs. When an example log expires it is replaced with the next matching event. Click {{< ui >}}Show log{{< /ui >}} to expand an example and inspect its log message, fields, and attributes inline. By default, example logs are stored for 3 days and are accessible to all users with the Data Scanner Read permission. To store these representative logs for a different period, contact [Support][1].
+{{< /site-region >}}
+{{< site-region region="gov,gov2" >}}
+6. In the {{< ui >}}Example Logs{{< /ui >}} section, review up to 5 representative examples of affected logs. When an example log expires it is replaced with the next matching event. Click {{< ui >}}Show log{{< /ui >}} to expand an example and inspect its log message, fields, and attributes inline. By default, example logs are stored for 7 days and are accessible to all users with the Data Scanner Read permission. To store these representative logs for a different period, contact [Support][1].
+{{< /site-region >}}
 7. Review {{< ui >}}Matches Trend{{< /ui >}} to see how match volume has changed over the past week. Use {{< ui >}}Related Access and Configuration Events{{< /ui >}} to check whether recent access events or changes to the scanning group or scanning rule line up with changes in match volume.
 
 Additionally, you can:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the SDS example finding log retention change from 3 days to 7 days for Datadog for Government (gov, gov2) sites only. Commercial sites are not affected by this change and continue to reference the 3-day retention period.

Changes:
- Adds a gov-only row to the [Data Retention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/) page noting the 7-day SDS example finding retention.
- Updates the Logs tab of the [Investigate Sensitive Data Findings](https://docs.datadoghq.com/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings/) guide so gov sites see "7 days" while commercial sites keep "3 days".

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft the gov-scoped wording changes based on an internal wording-proposal doc.

### Additional notes