### PR TITLE
[reorg fix] Update ListFeatureFlags pagination to page[limit]/page[offset]

### DIFF
--- a/hugo/data/api/v2/full_spec.yaml
+++ b/hugo/data/api/v2/full_spec.yaml
@@ -143370,20 +143370,20 @@ paths:
           name: is_archived
           schema:
             type: boolean
-        - description: Maximum number of results to return.
+        - description: Maximum number of feature flags to return.
           example: 10
           in: query
-          name: limit
+          name: page[limit]
           schema:
-            default: 100
+            default: 25
             format: int64
             maximum: 1000
             minimum: 1
             type: integer
-        - description: Number of results to skip.
+        - description: Number of feature flags to skip for pagination.
           example: 0
           in: query
-          name: offset
+          name: page[offset]
           schema:
             default: 0
             format: int64


### PR DESCRIPTION
🤖 Auto-generated fix for #37874.

@app/api-clients-generation-pipeline — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37874. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37874 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37874) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

See [DataDog/datadog-api-spec#6078](https://github.com/DataDog/datadog-api-spec/pull/6078) Test branch [datadog-api-spec/test/blake.thomas/update-get-flags](https://github.com/DataDog/documentation/compare/datadog-api-spec/test/blake.thomas/update-get-flags)