### PR TITLE
Fix off-by-one path index in check-section-index.py

### DIFF
--- a/.husky/check-section-index.py
+++ b/.husky/check-section-index.py
@@ -35,12 +35,12 @@ def get_staged_files():
 def get_top_level_dir(file_path):
     """Extract the top-level directory under content/en/ from a file path.
 
-    For example, 'content/en/new_section/sub/page.md' returns 'new_section'.
+    For example, 'hugo/content/en/new_section/sub/page.md' returns 'new_section'.
     """
     parts = Path(file_path).parts
-    # parts: ('content', 'en', 'new_section', ...)
-    if len(parts) > 2:
-        return parts[2]
+    # parts: ('hugo', 'content', 'en', 'new_section', ...)
+    if len(parts) > 3:
+        return parts[3]
     return None
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes a bug in the `check-section-index.py` pre-commit hook where `get_top_level_dir` read `parts[2]` from staged file paths. Staged paths are returned as `hugo/content/en/<section>/...`, so `parts[2]` resolved to `en` instead of the actual section name. This caused the hook to falsely report a missing `_index.md` for a nonexistent `hugo/content/en/en/` directory whenever a new file was added to an existing section.

Updated the index to `parts[3]` so it correctly extracts the top-level section name.