### PR TITLE
[reorg fix] [PROF-14294] Document cross-profile variability (IQR) in flame graph and timeseries

### DIFF
--- a/hugo/content/en/profiler/profile_visualizations.md
+++ b/hugo/content/en/profiler/profile_visualizations.md
@@ -65,8 +65,8 @@ Flame graphs can be included in Dashboards and Notebooks with the [Profiling Fla
 
 When viewing an aggregated profile (averaged across multiple profiles), the flame graph shows how consistent the displayed values are across the individual profiles that make up the aggregate.
 
-- **Root frame**: The average value is followed by `±N%` — for example, `123ms ±32%`. This is half the interquartile range (IQR/2) expressed as a percentage of the average. Click the **?** icon on the root frame for a full explanation.
-- **Individual frames**: Frames with moderate or high variability show a `!` advisory in their tooltip — for example, `Variability: ±32% (IQR/2). Individual profiles differ substantially.` — signaling that the aggregated value may not be representative of every profile in the aggregate.
+- **Root frame**: The average value is followed by `±N%`, such as `123ms ±32%`. This is half the interquartile range (IQR/2) expressed as a percentage of the average. Click the **?** icon on the root frame for a full explanation.
+- **Individual frames**: Frames with moderate or high variability show a `!` advisory in their tooltip, such as `Variability: ±32% (IQR/2). Individual profiles differ substantially.`, signaling that the aggregated value may not be representative of every profile in the aggregate.
 
 A low `±N%` means individual profiles behave consistently. A high value suggests the service behavior differs significantly between profiles; try filtering by a tag (such as `version` or `host`) or examining individual profiles to isolate the source of variability.
 
@@ -171,7 +171,7 @@ Timeline view is currently not supported for Full Host profiling
 
 For each runtime, there is a broad set of metrics available, which you can see [listed by timeseries][3].
 
-When viewing an aggregated timeseries, a shaded band is drawn around the metric line to represent cross-profile variability. Hovering a data point shows the value and its variability — for example, `123ms ±10% (IQR/2)`. The band width and percentage represent half the interquartile range (IQR/2): a robust measure of how much individual profiles vary around the displayed average, expressed as a percentage of that average.
+When viewing an aggregated timeseries, a shaded band is drawn around the metric line to represent cross-profile variability. Hovering over a datapoint shows the value and its variability, such as `123ms ±10% (IQR/2)`. The band width and percentage represent half the interquartile range (IQR/2): a robust measure of how much individual profiles vary around the displayed average, expressed as a percentage of that average.
 
 ### Call graph
 

--- a/hugo/content/en/profiler/profile_visualizations.md
+++ b/hugo/content/en/profiler/profile_visualizations.md
@@ -61,6 +61,15 @@ By default, darker frames indicate higher CPU usage, while lighter frames signif
 
 Flame graphs can be included in Dashboards and Notebooks with the [Profiling Flame Graph Widget][5].
 
+#### Cross-profile variability
+
+When viewing an aggregated profile (averaged across multiple profiles), the flame graph shows how consistent the displayed values are across the individual profiles that make up the aggregate.
+
+- **Root frame**: The average value is followed by `±N%` — for example, `123ms ±32%`. This is half the interquartile range (IQR/2) expressed as a percentage of the average. Click the **?** icon on the root frame for a full explanation.
+- **Individual frames**: Frames with moderate or high variability show a `!` advisory in their tooltip — for example, `Variability: ±32% (IQR/2). Individual profiles differ substantially.` — signaling that the aggregated value may not be representative of every profile in the aggregate.
+
+A low `±N%` means individual profiles behave consistently. A high value suggests the service behavior differs significantly between profiles; try filtering by a tag (such as `version` or `host`) or examining individual profiles to isolate the source of variability.
+
 ### Timeline view
 
 The timeline view is equivalent to the flame graph, with time-based patterns and work distribution over [the period of a single profile](#single-profile), a single process in [profiling explorer][7] and [a trace][6].
@@ -161,6 +170,8 @@ Timeline view is currently not supported for Full Host profiling
 ### Timeseries and Table
 
 For each runtime, there is a broad set of metrics available, which you can see [listed by timeseries][3].
+
+When viewing an aggregated timeseries, a shaded band is drawn around the metric line to represent cross-profile variability. Hovering a data point shows the value and its variability — for example, `123ms ±10% (IQR/2)`. The band width and percentage represent half the interquartile range (IQR/2): a robust measure of how much individual profiles vary around the displayed average, expressed as a percentage of that average.
 
 ### Call graph
 


### PR DESCRIPTION
🤖 Auto-generated fix for #37693.

@mar-kolya — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37693. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37693 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37693) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

## What does this PR do?

Adds documentation for the cross-profile variability (IQR) feature in the Continuous Profiler, covering both the flame graph and timeseries visualizations.

Note: the feature is currently behind FF and is enabled only for org2. This PR is meant to be merged once FF is enabled for everyone.

## Motivation

The variability indicators were recently shipped in web-ui but were not yet documented.

## Changes

In `profile_visualizations.md`:

**Flame graph** — new `#### Cross-profile variability` subsection explaining:
- The `±N%` badge on the root frame (IQR/2 as a percentage of the average) and the `?` help icon
- The `\!` advisory on individual frames for moderate/high variability
- Guidance on what to do when variability is high (filter by tag, open individual profiles)

**Timeseries and Table** — new paragraph explaining:
- The shaded variability band around the metric line
- The `123ms ±10% (IQR/2)` tooltip format
- What the figure measures (half the interquartile range as a % of the average)

## Preview

Changes only affect `content/en/profiler/profile_visualizations.md`.