### PR TITLE
[reorg fix] [CCC-2177] Document filter[enabled_metrics_only] on tag metadata metrics endpoint

### DIFF
--- a/hugo/data/api/v2/full_spec.yaml
+++ b/hugo/data/api/v2/full_spec.yaml
@@ -137238,6 +137238,12 @@ paths:
           name: filter[provider]
           schema:
             type: string
+        - description: When `true`, only return metrics for currently enabled accounts. When omitted or `false`, return all metrics present in tag metadata. Metrics not recognized by Cloud Cost Management are always excluded.
+          example: true
+          in: query
+          name: filter[enabled_metrics_only]
+          schema:
+            type: boolean
       responses:
         "200":
           content:


### PR DESCRIPTION
🤖 Auto-generated fix for #37655.

@app/api-clients-generation-pipeline — the [docs repo reorg](https://github.com/DataDog/documentation/blob/master/REPO_REORG.md) created merge conflicts in your PR #37655. This is an auto-generated replacement with the file paths fixed; please use it instead of the original.

This PR replays the commits from #37655 with file paths translated to the post-reorg `hugo/` layout. The original commits are preserved — same messages and authorship.

The original PR (#37655) will be closed in favor of this one.

**Next steps:**

1. Verify that this PR looks correct in the browser.
2. Remove the `WORK IN PROGRESS` label from this PR.
3. Wait for the standard docs team approval before merging. Optionally, you can check the 'ready for merge' checkbox below if you would like the docs team to merge it for you.

- [ ] Ready for merge

---

**Original PR description:**

See [DataDog/datadog-api-spec#6031](https://github.com/DataDog/datadog-api-spec/pull/6031) Test branch [datadog-api-spec/test/jahanzeb.hassan/document-enabled-metrics-only-param](https://github.com/DataDog/documentation/compare/datadog-api-spec/test/jahanzeb.hassan/document-enabled-metrics-only-param)