### PR TITLE
Document automation output controls

### DIFF
--- a/hugo/content/en/bits_ai/bits_code/automations.md
+++ b/hugo/content/en/bits_ai/bits_code/automations.md
@@ -26,6 +26,7 @@ To set up a Bits Code automation, each of the following must be true:
 - You have the [`Bits Code Write` (`bits_dev_write`) permission][6] in Datadog.
 - You have completed the Bits Code [setup][2].
 - If you plan to have your automations [output Slack notifications](#slack-message-output), you have set up the [Slack integration][4].
+- If you plan to use [{{< ui >}}Auto-fix CI for pull requests{{< /ui >}}](#pull-or-merge-request-output), you have set up [CI logs in Datadog][8] and enabled [auto-push][9].
 
 ## Create an automation
 You can [create a custom automation](#create-a-custom-automation), or [use a Datadog-provided automation template](#create-an-automation-from-a-template).
@@ -88,7 +89,7 @@ An output defines what Bits Code does after a [session][1] completes. An automat
 You can configure your automation to:
 - {{< ui >}}Create a PR or MR{{< /ui >}}: Open a pull or merge request with the proposed changes
 - {{< ui >}}Draft a PR or MR{{< /ui >}}: Open a draft pull or merge request with the proposed changes
-- {{< ui >}}Auto-fix CI for pull requests{{< /ui >}}: When creating a pull request, use CI logs to fix CI failures automatically; requires [CI logs in Datadog][8] and [auto-push][9]
+- {{< ui >}}Auto-fix CI for pull requests{{< /ui >}}: When creating a pull request, use CI logs to fix CI failures automatically
 
 Datadog administrators can configure pull or merge request authorship through the {{< ui >}}Create pull and merge requests as Bits Code{{< /ui >}} setting in [Bits Code settings][7]. When this setting is enabled, the Bits Code integration identity for the source control provider (for example, the `datadog[bot]` GitHub App account) is the author. When it's disabled, the session creator's connected source control account is the author.
 

--- a/hugo/content/en/bits_ai/bits_code/automations.md
+++ b/hugo/content/en/bits_ai/bits_code/automations.md
@@ -88,13 +88,16 @@ An output defines what Bits Code does after a [session][1] completes. An automat
 You can configure your automation to:
 - {{< ui >}}Create a PR or MR{{< /ui >}}: Open a pull or merge request with the proposed changes
 - {{< ui >}}Draft a PR or MR{{< /ui >}}: Open a draft pull or merge request with the proposed changes
+- {{< ui >}}Auto-fix CI for pull requests{{< /ui >}}: When creating a pull request, use CI logs to fix CI failures automatically; requires [CI logs in Datadog][8] and [auto-push][9]
 
 Datadog administrators can configure pull or merge request authorship through the {{< ui >}}Create pull and merge requests as Bits Code{{< /ui >}} setting in [Bits Code settings][7]. When this setting is enabled, the Bits Code integration identity for the source control provider (for example, the `datadog[bot]` GitHub App account) is the author. When it's disabled, the session creator's connected source control account is the author.
 
 ### Slack message output
 You can configure your automation to send a Slack message summarizing the [session][1] and code changes. If you use a pull or merge request output in addition to a Slack output, Bits Code includes a link to the pull or merge request in the Slack message.
 
-When you add a Slack message output, by default, Bits Code sends the message to the channel configured for the affected service in [Catalog][5]. You can set a fallback Slack channel, which is used when no channel is set in Catalog.
+When you add a Slack message output, choose one of the following destinations:
+- {{< ui >}}Notify the owning team{{< /ui >}} (default): Send the message to the affected service's Slack channel in [Catalog][5], or to the configured fallback Slack channel when no Catalog channel is set.
+- {{< ui >}}Send to a specific channel{{< /ui >}}: Send the message to the Slack destination you select.
 
 ## Manage automations
 On [{{< ui >}}Automations{{< /ui >}}][3], view the automations you created on the {{< ui >}}My Automations{{< /ui >}} tab. Switch to {{< ui >}}All{{< /ui >}} to see automations created by anyone in your organization.
@@ -111,3 +114,5 @@ You can pause or resume any automation, but you can only edit or delete automati
 [5]: /internal_developer_portal/catalog/
 [6]: /account_management/rbac/permissions/#bits-ai
 [7]: https://app.datadoghq.com/code/settings
+[8]: /bits_ai/bits_code/setup/#setup
+[9]: /bits_ai/bits_code/setup/#enable-auto-push


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b26f5e64-6c4c-4fd7-a9a1-77b350ced36e","source":"chat","resourceId":"469729b2-3bdf-49e3-aa6a-eb96311f62d8","workflowId":"5976bf9e-29fb-4597-869e-9a1461edd708","codeChangeId":"5976bf9e-29fb-4597-869e-9a1461edd708","sourceType":"llm-obs-docs-agent"} -->
<!-- dd-meta {"pullId":"b26f5e64-6c4c-4fd7-a9a1-77b350ced36e","source":"chat","resourceId":"469729b2-3bdf-49e3-aa6a-eb96311f62d8","workflowId":"8d150479-8f93-4f46-bba8-05424c4482ff","codeChangeId":"8d150479-8f93-4f46-bba8-05424c4482ff","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

WHY: Documents automation output controls added in https://github.com/DataDog/web-ui/pull/339020 so customers can select CI auto-fix and Slack routing options.

WHAT:
- Added Auto-fix CI for pull requests to the pull or merge request output options.
- Added the Auto-fix CI setup requirements to Prerequisites, matching the existing output-specific prerequisite pattern.
- Replaced the Slack output default-only description with the owning-team and specific-channel destination choices.

HOW verified:
- Reviewed CLAUDE.md and the available page context.
- Reviewed PR 38997 review comments with GitHub review thread context.
- Ran `git diff --check`.
- Ran `vale hugo/content/en/bits_ai/bits_code/automations.md` (not available: `vale` command was not found).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code powered by Codex CLI to draft and validate this documentation edit.

### Additional notes

Source PR: https://github.com/DataDog/web-ui/pull/339020

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](#removed-for-safety)

Comment @datadog-staging to request changes

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/469729b2-3bdf-49e3-aa6a-eb96311f62d8)

Comment @datadog-staging to request changes