### PR TITLE
Rename OSS Collector terminology to Community OTel Collector

### DIFF
--- a/hugo/content/en/opentelemetry/compatibility.md
+++ b/hugo/content/en/opentelemetry/compatibility.md
@@ -15,18 +15,18 @@ Datadog offers multiple setup options to accommodate various use cases, from ful
 
 Datadog supports several configurations for using OpenTelemetry. The primary difference between these setups is the choice of SDK (OpenTelemetry or Datadog) and the collector used to process and forward telemetry data.
 
-| Setup Type                                 | API                     | SDK         | Collector/Agent                               |
-|--------------------------------------------|-------------------------|-------------|-----------------------------------------------|
-| [**Datadog SDK + DDOT (Recommended)**][29] | Datadog API or OTel API | Datadog SDK | Datadog Distribution of OTel Collector (DDOT) |
-| [**OTel SDK + DDOT**][29]                  | OTel API                | OTel SDK    | Datadog Distribution of OTel Collector (DDOT) |
-| [**OTel SDK + OSS Collector**][7]          | OTel API                | OTel SDK    | OTel Collector (OSS)                          |
-| [**Direct OTLP Ingest**][28]                   | OTel API                | OTel SDK    | N/A (Direct to Datadog endpoint)              |
+| Setup Type                                           | API                     | SDK         | Collector/Agent                               |
+|------------------------------------------------------|-------------------------|-------------|-----------------------------------------------|
+| [**Datadog SDK + DDOT (Recommended)**][29]           | Datadog API or OTel API | Datadog SDK | Datadog Distribution of OTel Collector (DDOT) |
+| [**OTel SDK + DDOT**][29]                            | OTel API                | OTel SDK    | Datadog Distribution of OTel Collector (DDOT) |
+| [**OTel SDK + Community OTel Collector**][7]         | OTel API                | OTel SDK    | Community OTel Collector                      |
+| [**Direct OTLP Ingest**][28]                         | OTel API                | OTel SDK    | N/A (Direct to Datadog endpoint)              |
 
 ## Feature compatibility
 
 The following table shows feature compatibility across different setups:
 
-| Feature | Datadog SDK + DDOT (Recommended) | OTel SDK + DDOT | OTel SDK + OSS Collector | Direct OTLP Ingest |
+| Feature | Datadog SDK + DDOT (Recommended) | OTel SDK + DDOT | OTel SDK + Community OTel Collector | Direct OTLP Ingest |
 |---|---|---|---|---|
 | [Cloud SIEM][18] | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 | [Correlated Traces, Metrics, Logs][19] | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |

--- a/hugo/content/en/opentelemetry/guide/instrument_unsupported_runtimes.md
+++ b/hugo/content/en/opentelemetry/guide/instrument_unsupported_runtimes.md
@@ -26,7 +26,7 @@ This guide falls under the <strong>Custom Components</strong> <a href="/opentele
 
 ## Prerequisites
 
-- An OpenTelemetry-compatible backend configured to send data to Datadog. See [Send OpenTelemetry Data to Datadog][4] for setup options including the DDOT Collector, OSS Collector with Datadog Exporter, or direct OTLP ingest.
+- An OpenTelemetry-compatible backend configured to send data to Datadog. See [Send OpenTelemetry Data to Datadog][4] for setup options including the DDOT Collector, Community OTel Collector with Datadog Exporter, or direct OTLP ingest.
 - [Bun][2] installed (v1.0 or later).
 - A Bun application you want to instrument.
 
@@ -115,7 +115,7 @@ export OTEL_SERVICE_NAME="<YOUR_SERVICE_NAME>"
 ```
 
 The `OTEL_EXPORTER_OTLP_ENDPOINT` value depends on your setup:
-- **Local collector** (DDOT or OSS): `http://localhost:4318` (default HTTP) or `http://localhost:4317` (gRPC)
+- **Local collector** (DDOT or Community OTel Collector): `http://localhost:4318` (default HTTP) or `http://localhost:4317` (gRPC)
 - **Remote collector**: Use the collector's address and port
 
 For additional configuration options, see the [OpenTelemetry environment variable specification][5].

--- a/hugo/content/en/opentelemetry/setup/collector_exporter/community_collector.md
+++ b/hugo/content/en/opentelemetry/setup/collector_exporter/community_collector.md
@@ -1,7 +1,9 @@
 ---
-title: Set Up the OpenTelemetry Collector (OSS)
+title: Set Up the Community OpenTelemetry Collector
+aliases:
+- /opentelemetry/setup/collector_exporter/oss_setup/
 private: true
-description: 'Send OpenTelemetry data to Datadog using the OpenTelemetry Collector with standard OSS components'
+description: 'Send OpenTelemetry data to Datadog using the Community OpenTelemetry Collector'
 further_reading:
 - link: "https://opentelemetry.io/docs/collector/"
   tag: "External Site"
@@ -16,7 +18,7 @@ further_reading:
 
 ## Overview
 
-Send traces, metrics, and logs to Datadog using the [OpenTelemetry Collector Contrib][1] distribution with standard OpenTelemetry components. This setup uses the following key components:
+Send traces, metrics, and logs to Datadog using the Community OpenTelemetry Collector, which is based on the [OpenTelemetry Collector Contrib][1] distribution and standard OpenTelemetry components. This setup uses the following key components:
 
 - **OTLP HTTP exporter**: Sends telemetry to Datadog's OTLP intake endpoints.
 - **Span metrics connector**: Generates RED (Rate, Error, Duration) metrics from trace data to power APM features such as the Service Catalog and Service Page.
@@ -28,7 +30,9 @@ Send traces, metrics, and logs to Datadog using the [OpenTelemetry Collector Con
 
 ## Prerequisites
 
-This setup supports bare metal, VMs, Docker, and Kubernetes, including the managed distributions Amazon EKS (including Auto Mode), Google GKE (Standard and Autopilot), and Azure AKS (including Automatic). This setup does not support serverless or task-based container runtimes such as ECS Fargate or AWS Lambda. To see which Datadog features this setup supports, see the [feature compatibility table][7] under **OTel SDK + OSS Collector**.
+This setup supports bare metal, VMs, Docker, and Kubernetes. Supported managed Kubernetes distributions include Amazon EKS (including Auto Mode), Google GKE (Standard and Autopilot), and Azure AKS (including Automatic).
+
+This setup does not support serverless or task-based container runtimes such as ECS Fargate or AWS Lambda. For supported Datadog features, see the [feature compatibility table][7] under **OTel SDK + Community OTel Collector**.
 
 - [OpenTelemetry Collector Contrib][1] v0.154.0 or later
 - A [Datadog API key][2]
@@ -926,7 +930,7 @@ Example with instrumentation metrics enabled:
 }
 ```
 
-<div class="alert alert-info">The recommended OSS Collector configuration uses the <code>span_metrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable <code>instrumentation_metrics_calc</code> alongside the <code>span_metrics</code> connector, as this computes trace metrics from both sources.</div>
+<div class="alert alert-info">The recommended Community OTel Collector configuration uses the <code>span_metrics</code> connector to generate the RED metrics that power APM views. The <code>trace_metrics.instrumentation_metrics_calc</code> and <code>raw_instrumentation_metrics_drop</code> fields support an alternative configuration for setups that derive APM trace metrics from HTTP instrumentation metrics instead. Do not enable <code>instrumentation_metrics_calc</code> alongside the <code>span_metrics</code> connector, as this computes trace metrics from both sources.</div>
 
 ### Datadog extension
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Renames the user-facing **OSS Collector** terminology to **Community OTel Collector** across the OpenTelemetry docs.

"OSS Collector" does not clearly distinguish the community-maintained OpenTelemetry Collector Contrib distribution from DDOT, which is also open source. The new wording describes the ownership/distribution distinction instead of implying that only one Collector option is open source.

This PR:

- Renames the setup page to **Set Up the Community OpenTelemetry Collector** and defines it as the Contrib-based distribution.
- Updates the compatibility tables and related setup guidance with context-specific wording.
- Renames the page URL from `/opentelemetry/setup/collector_exporter/oss_setup/` to `/opentelemetry/setup/collector_exporter/community_collector/`.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

### Additional notes
