### PR TITLE
Remove config_template.yaml build dependency ahead of its deletion in datadog-agent

### DIFF
--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -55,7 +55,9 @@ To begin collecting logs from a server:
 
 2. Collecting logs is **not enabled** by default in the Datadog Agent. To enable log collection, set `logs_enabled` to `true` in your `datadog.yaml` file.
 
-    {{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}
+    ```yaml
+    logs_enabled: true
+    ```
 
 3. Restart the [Datadog Agent][7].
 

--- a/content/es/getting_started/logs/_index.md
+++ b/content/es/getting_started/logs/_index.md
@@ -62,7 +62,9 @@ Para empezar a recopilar logs desde un servidor:
 
 2. La recopilación de logs **no está activada** de forma predeterminada en el Datadog Agent. Para activarla, establece `logs_enabled` como `true` en tu archivo `datadog.yaml`.
 
-    {{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}
+    ```yaml
+    logs_enabled: true
+    ```
 
 3. Reinicia el [Datadog Agent][7].
 

--- a/content/fr/getting_started/logs/_index.md
+++ b/content/fr/getting_started/logs/_index.md
@@ -60,7 +60,9 @@ Pour commencer à recueillir des logs à partir d'un serveur :
 
 2. La collecte de logs n'est **pas activée** par défaut dans l'Agent Datadog. Pour activer la collecte de logs, définissez `logs_enabled` sur `true` dans votre fichier `datadog.yaml`.
 
-    {{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}
+    ```yaml
+    logs_enabled: true
+    ```
 
 3. Redémarrez l'[Agent Datadog][7].
 

--- a/content/ja/getting_started/logs/_index.md
+++ b/content/ja/getting_started/logs/_index.md
@@ -61,7 +61,9 @@ logs:
 
 2. Datadog Agent では、ログの収集はデフォルトで**有効になっていません**。ログ収集を有効にするには、`datadog.yaml` ファイルで `logs_enabled` を `true` に設定してください。
 
-    {{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}
+    ```yaml
+    logs_enabled: true
+    ```
 
 3. [Datadog Agent を再起動][7]します。
 

--- a/content/ko/getting_started/logs/_index.md
+++ b/content/ko/getting_started/logs/_index.md
@@ -61,7 +61,9 @@ logs:
 
 2. Datadog Agent의 기본 설정에서는 로그 수집이 **활성화되지 않은 상태**입니다. 로그 수집을 활성화하려면 `datadog.yaml` 파일에서 `logs_enabled`를 `true`로 설정하세요.
 
-    {{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}
+    ```yaml
+    logs_enabled: true
+    ```
 
 3. [Datadog Agent][7]를 재시작합니다.
 

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -380,13 +380,6 @@
 
       - repo_name: datadog-agent
         contents:
-        - action: pull-and-push-file
-          branch: main
-          globs:
-            - "pkg/config/config_template.yaml"
-          options:
-            file_name: 'agent_config.yaml'
-            output_content: false
         - action: pull-and-push-folder
           branch: 7.78.x
           globs:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -381,13 +381,6 @@
 
       - repo_name: datadog-agent
         contents:
-        - action: pull-and-push-file
-          branch: main
-          globs:
-            - "pkg/config/config_template.yaml"
-          options:
-            file_name: 'agent_config.yaml'
-            output_content: false
         - action: pull-and-push-folder
           branch: 7.78.x
           globs:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

[datadog-agent#54160](https://github.com/DataDog/datadog-agent/pull/54160) makes the Agent configuration schema the source of truth and deletes `pkg/config/config_template.yaml`. It is scheduled to merge on August 10.

Our build depends on that file, so its deletion turns the production build red. This PR removes the dependency ahead of time. It is forward-compatible: the changes are safe to merge while the upstream file still exists, so this does not need to be synchronized with the Agent merge.

The dependency chain being removed:

1. `pull_config.yaml` and `pull_config_preview.yaml` pull `config_template.yaml` from `main`.
2. `pull_and_push_file.py` passes it to `process_agent_config.py`, which writes `data/agent_config.json`.
3. The `agent-config` shortcode reads that data and calls `errorf` when the requested type is missing, which fails the build in every environment except `development`.

Changes:

- Replace the `{{< agent-config >}}` call on the Getting Started with Logs page with a static `logs_enabled: true` code block. The surrounding step already tells the reader to set `logs_enabled` to `true`, so the rendered template was not carrying information the prose lacked, and a two-line snippet is easier to scan than a collapsible block of commented-out YAML.
- Remove the `config_template.yaml` entry from `pull_config.yaml` and `pull_config_preview.yaml`. The Cloud Workload Security globs for the same repo are untouched.

Note on translated content: the `es`, `fr`, `ja`, and `ko` versions of the same page used the identical shortcode, so an English-only change would still have failed the build. Per the PR Review Guide's guidance for build breakage in translated docs, these are fixed directly on the branch. **A follow-up LCLZTN card is needed** so the change is reflected in Phrase and not reintroduced on the next translation sync.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code traced the dependency chain, made the edits, and drafted this description.

### Additional notes

Deliberately kept minimal to reduce risk. Left as follow-up cleanup, now that nothing consumes them:

- `layouts/shortcodes/agent-config.html`
- `process_agent_config.py` and the `config_template.yaml` special case in `pull_and_push_file.py`
- The Agent config shortcode's entry in the Markdown & Shortcode Reference

The shortcode is now unused but still present. If someone calls it, they get a build-time error rather than a silent failure, which is the safer of the two while the cleanup is pending.
