### PR TITLE
WEB-7877 - remove mount deduped imgs

### DIFF
--- a/hugo/config/_default/config.yaml
+++ b/hugo/config/_default/config.yaml
@@ -142,8 +142,6 @@ module:
         - 'shortcodes/mdoc/*'
     - source: data
       target: data
-    - source: static
-      target: assets
     - source: assets
       target: assets
     - source: i18n

--- a/hugo/layouts/actioncatalog/list.html
+++ b/hugo/layouts/actioncatalog/list.html
@@ -46,7 +46,7 @@
     </span>
   {{ else }}
     {{/*  Using default INTEGRATION Agent logo  */}}
-    <img height="17" src='{{ partial "img-resource.html" (dict "context" .page_ctx "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x' />
+    <img height="17" src='{{ partial "img-resource.html" (dict "context" .page_ctx "src" (print "images/svg-icons/agent.svg")) }}&w=80&auto-enhance 2x' />
   {{ end }}
 {{ end }}
 {{/*  Local Partials end  */}}

--- a/hugo/layouts/partials/grouped-item-listings.html
+++ b/hugo/layouts/partials/grouped-item-listings.html
@@ -46,7 +46,7 @@
             {{ if $int_logo }}
               <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
             {{ else }}
-              <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
+              <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}&w=80&auto-enhance 2x" />
             {{ end }}
           {{ end }}
         </div>

--- a/hugo/layouts/partials/img-resource.html
+++ b/hugo/layouts/partials/img-resource.html
@@ -1,14 +1,4 @@
-{{- /*  We need to replace preview branchname due to issue in the new hugo appending it twice */ -}}
 {{- /*  Do not add extra empty lines or spaces to this render hook. will cause a space to render after anchor */ -}}
 {{- $dot := .context -}}
-
-{{- with resources.Get .src -}}
-{{- $full_permalink := ( . | resources.Fingerprint "md5").RelPermalink }}
-
-{{- if and (eq hugo.Environment "preview") ($dot.Site.Params.branch) -}}
-{{- $branch_name := (print $dot.Site.Params.branch "/") -}}
-{{- $full_permalink = replace $full_permalink $branch_name ""}}
-{{- end -}}
-
-{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) $full_permalink -}}
-{{- end -}}
+{{- $hash := os.ReadFile (printf "static/%s" .src) | crypto.MD5 -}}
+{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) "/" .src "?v=" $hash -}}

--- a/hugo/layouts/shortcodes/img.html
+++ b/hugo/layouts/shortcodes/img.html
@@ -42,8 +42,8 @@
 {{- $img_param := $.Scratch.Get "img_param" -}}
 {{- $pop_param := $.Scratch.Get "pop_param" -}}
 {{- $figure_class :=  .Get "figure_class" -}}
-{{- $e := (print $img_resource "?auto=format&fit=max&w=" $img_w | safeURL) -}}
-{{- $e2x := (print $img_resource "?auto=format&fit=max&w=" $img_w "&dpr=2" | safeURL) -}}
+{{- $e := (print $img_resource "&auto=format&fit=max&w=" $img_w | safeURL) -}}
+{{- $e2x := (print $img_resource "&auto=format&fit=max&w=" $img_w "&dpr=2" | safeURL) -}}
 {{- if not (eq $img_inline "true")}}
   <div class="shortcode-wrapper shortcode-img expand {{- if $wide -}}wide-parent{{- end -}}"><figure class="text-center {{- if $wide -}}wide {{- end -}}{{ $figure_class -}}" {{- if .Get "figure_style" -}}style="{{- with .Get "figure_style" -}}{{- . | safeCSS -}}{{- end -}}"{{- end -}}>
     {{- if $video -}}
@@ -61,7 +61,7 @@
       </video>
   {{- else -}}
     {{- if (and (eq $isPopup "true") (ne $image_ext "gif")) -}}
-    <a href="{{ print $img_resource $pop_param | relURL }}" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal">
+    <a href="{{ print $img_resource (replace $pop_param "?" "&" 1) | relURL }}" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal">
   {{- else if .Get "href" -}}
     <a href="{{- with .Get "href" -}}{{- . -}}{{- end -}}"
       {{- if .Get "target" -}}target="{{- with .Get "target" -}}{{- . -}}{{- end -}}"{{- end -}} >


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

**What?**
Changes image references to `foo.png?v=<hash>` instead of the current `foo.<hash>.png?` 

**Why?**
To avoid duplication of images in the public folder by a bad hugo mount configuration used for fingerprinting images.
(mounting static as assets meaning fingerprinted images are put in public/ and files in static are put in public/ too)

**Impact?**
- Local build I/O and disk improvement - 50% reduction in images in the public/ dir, less copies etc
- Bucket storage growth - Stops storage growth 2x is being stored in the bucket lets halt this now
- Easier to reason about as we make future image changes

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

https://docs-staging.datadoghq.com/david.jones/web-7877/
