### PR TITLE
Fix Edit button GitHub link after hugo directory migration

### DIFF
--- a/hugo/layouts/partials/page-edit.html
+++ b/hugo/layouts/partials/page-edit.html
@@ -38,7 +38,7 @@
 {{/* Not in integrations edit existing docs file */}}
 
     {{ with $ctx.File }}
-        {{ $editLink = ( printf "https://github.com/DataDog/documentation/edit/master/content/%s/%s/" $ctx.Page.Lang $ctx.File.Path ) }}
+        {{ $editLink = ( printf "https://github.com/DataDog/documentation/edit/master/hugo/content/%s/%s/" $ctx.Page.Lang $ctx.File.Path ) }}
         {{ partial "page-edit-body.html" (dict "ctx" $ctx "link" $editLink "type" $type) }}
     {{ end }}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The site's Edit button generates a GitHub link to the source file for the current page, but it pointed to `content/<lang>/<path>`. Content was recently moved into a `hugo/` directory, so the generated link 404s. This updates the link to point to `hugo/content/<lang>/<path>`.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the Edit button link generation logic and update the path.

### Additional notes