### PR TITLE
[DOCS-15338] Document default Session Replay retention via account team

### DIFF
--- a/hugo/content/en/session_replay/_index.md
+++ b/hugo/content/en/session_replay/_index.md
@@ -105,6 +105,8 @@ Refer to the below diagram to understand what data is retained with extended ret
 
 {{< img src="real_user_monitoring/session_replay/replay-extended-retention-1.png" alt="Diagram of what data is retained with extended retention" style="width:100%;" >}}
 
+To set the default retention period for all Session Replays to longer than 30 days, contact your account team.
+
 ## Playback history
 
 You can see who has watched a given session replay by clicking the **watched** count displayed on the player page. This feature allows you to check whether someone you'd like to share the recording with has already watched it.

--- a/hugo/content/en/session_replay/_index.md
+++ b/hugo/content/en/session_replay/_index.md
@@ -89,7 +89,7 @@ To find replays that need your attention, use the {{< ui >}}All mentions to me{{
 
 ## Extend data retention
 
-By default, Session Replay data is retained for 30 days.
+By default, Session Replay data is retained for 30 days. To set the default retention period for all Session Replays to longer than 30 days, contact your account team.
 
 To extend Session Replay data retention to 15 months, you can enable {{< ui >}}Extended Retention{{< /ui >}} on individual session replays. These sessions must be non-active (the user has completed their experience).
 
@@ -104,8 +104,6 @@ You can disable Extended Retention at any time. If the session replay is still w
 Refer to the below diagram to understand what data is retained with extended retention.
 
 {{< img src="real_user_monitoring/session_replay/replay-extended-retention-1.png" alt="Diagram of what data is retained with extended retention" style="width:100%;" >}}
-
-To set the default retention period for all Session Replays to longer than 30 days, contact your account team.
 
 ## Playback history
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15338

Adds a line to the Session Replay "Extend data retention" section noting that customers can contact their account team to set the default retention period for all Session Replays to longer than 30 days, in addition to the existing per-session extended retention option.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Change drafted and PR opened with Claude Code, based on a documentation request surfaced in Slack and tracked in DOCS-15338.

### Additional notes