### PR TITLE
Add Node.js image_parts annotation example to LLM Observability SDK docs

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -1525,11 +1525,11 @@ The `annotationOptions` object can contain the following:
 
 `inputData`
 : optional - _JSON serializable type or list of objects_
-<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{role: "...", content: "...", audioParts: [...]}` (for LLM spans). `audioParts` is an optional list of audio objects for multimodal (voice) spans, each with a required `mimeType` and a base64-encoded `content` string. **Note**: Embedding spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "..."}`.
+<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{role: "...", content: "...", audioParts: [...], imageParts: [...]}` (for LLM spans). `audioParts` and `imageParts` are optional lists of media objects for multimodal spans, each with a required `mimeType` and exactly one of `content` (base64-encoded media, carried inline) or `attachmentKey`. **Note**: Embedding spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "..."}`.
 
 `outputData`
 : optional - _JSON serializable type or list of objects_
-<br />Either a JSON serializable type (for non-LLM spans) or a list of objects with this format: `{role: "...", content: "...", audioParts: [...]}` (for LLM spans). `audioParts` is an optional list of audio objects for multimodal (voice) spans, each with a required `mimeType` and a base64-encoded `content` string. **Note**: Retrieval spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "...", name: "...", score: number, id: "..."}`.
+<br />Either a JSON serializable type (for non-LLM spans) or a list of objects with this format: `{role: "...", content: "...", audioParts: [...], imageParts: [...]}` (for LLM spans). `audioParts` and `imageParts` are optional lists of media objects for multimodal spans, each with a required `mimeType` and exactly one of `content` (base64-encoded media, carried inline) or `attachmentKey`. **Note**: Retrieval spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "...", name: "...", score: number, id: "..."}`.
 
 `metadata`
 : optional - _object_
@@ -1622,9 +1622,31 @@ function voiceTurn (userAudioBytes) {
 }
 voiceTurn = llmobs.wrap({ kind: 'llm', modelName: 'gpt-audio', modelProvider: 'openai' }, voiceTurn)
 
+function describeImage (imageBytes) {
+  const resp = ... // multimodal (vision) llm call here
+  llmobs.annotate({
+    inputData: [
+      {
+        role: "user",
+        content: "What is in this image?",
+        imageParts: [{ mimeType: "image/png", content: imageBytes.toString("base64") }]
+      }
+    ],
+    outputData: [{ role: "assistant", content: "The image shows a golden retriever puppy." }]
+  })
+  return resp
+}
+describeImage = llmobs.wrap({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }, describeImage)
+
 {{< /code-block >}}
 
-For OpenAI audio chat completions, `audioParts` are also captured automatically by [Datadog's LLM integrations](/llm_observability/instrumentation/auto_instrumentation/)—no manual annotation required.
+Messages annotated with `audioParts` or `imageParts` render as inline audio players and images in the trace view:
+
+{{< img src="llm_observability/instrumentation/audio_example.png" alt="An LLM span in the Agent Observability trace view. The input message from the USER shows an inline audio player with the transcript 'Hey, how are you?', and the output ASSISTANT message shows a 'Click to play audio' control with the transcript 'Hey! I'm doing great, thanks for asking. How about you?'." style="width:100%;" >}}
+
+{{< img src="llm_observability/instrumentation/image_example.png" alt="An LLM span in the Agent Observability trace view. The input USER message shows the prompt 'What is in this image?' with an inline photo of a black puppy, and the output ASSISTANT message describes it as a black Labrador Retriever puppy on a wooden surface." style="width:100%;" >}}
+
+For OpenAI audio chat completions, `audioParts` are also captured automatically by [Datadog's LLM integrations](/llm_observability/instrumentation/auto_instrumentation/)—no manual annotation required. `imageParts` require manual annotation.
 
 {{% /tab %}}
 {{% tab "Java" %}}

--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -1646,7 +1646,7 @@ Messages annotated with `audioParts` or `imageParts` render as inline audio play
 
 {{< img src="llm_observability/instrumentation/image_example.png" alt="An LLM span in the Agent Observability trace view. The input USER message shows the prompt 'What is in this image?' with an inline photo of a black puppy, and the output ASSISTANT message describes it as a black Labrador Retriever puppy on a wooden surface." style="width:100%;" >}}
 
-For OpenAI audio chat completions, `audioParts` are also captured automatically by [Datadog's LLM integrations](/llm_observability/instrumentation/auto_instrumentation/)—no manual annotation required. `imageParts` require manual annotation.
+For OpenAI audio chat completions, `audioParts` are also captured automatically by [Datadog's LLM integrations](/llm_observability/instrumentation/auto_instrumentation/)—no manual annotation required. Unlike `audioParts`, `imageParts` are not currently captured automatically and must be annotated manually; automatic capture is planned for a future release.
 
 {{% /tab %}}
 {{% tab "Java" %}}


### PR DESCRIPTION
### What does this PR do?

Adds a Node.js counterpart to the existing Python `image_parts` annotation example in the LLM Observability SDK docs.

- New `describeImage` snippet in the Node.js tab of **Annotating a span**, mirroring Python's `describe_image`, using `imageParts: [{ mimeType, content }]` on an `llm`-kind span.
- Documents `imageParts` alongside `audioParts` in the Node.js `inputData` / `outputData` argument descriptions, including the `mimeType` + exactly one of `content` / `attachmentKey` rule (matching the Python wording).
- Adds the "renders inline in the trace view" note and the two example screenshots to the Node.js tab, which previously only appeared under Python.
- Notes that unlike `audioParts`, `imageParts` are not captured by auto-instrumentation and must be annotated manually.

### Motivation

`imageParts` support shipped in `dd-trace` 6.10.0 ([dd-trace-js #9684](https://github.com/DataDog/dd-trace-js/pull/9684)), but the docs only showed the Python form, so Node.js users had no example for attaching images to spans.

Verified against `dd-trace@6.10.0` in a Node.js example app ([llm-observability #91](https://github.com/DataDog/llm-observability/pull/91)): a manually annotated `llm` span with `imageParts` renders the image inline in the LLM Observability trace view. Two behaviors confirmed there and reflected in this PR: image parts are ignored on non-`llm` span kinds, and auto-instrumented provider spans do not capture them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
