### PR TITLE
[SVLS-9486] Document how to query durable executions in Datadog

### DIFF
--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,7 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions. Use the log attributes, span tags, and metrics below to query this data directly, or to build dashboards and monitors.
+The **Executions** tab on the Lambda function page lists durable executions. Use the log attributes, span tags, and metrics below to search for durable executions, or to build dashboards and monitors.
 
 ### Logs
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -70,7 +70,7 @@ The **Executions** tab on the Lambda function page lists durable executions. Use
 To scope a log query to one function, filter on the function ARN:
 
 ```text
-@lambda.arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"
+@lambda.arn:"<FUNCTION_ARN>"
 ```
 
 The Datadog Lambda Extension adds these attributes to a durable function's logs:
@@ -135,7 +135,7 @@ Terminal events are timestamped when the execution finished, so a time range sel
 To scope a span query to one function, filter on the function ARN:
 
 ```text
-@function_arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"
+@function_arn:"<FUNCTION_ARN>"
 ```
 
 **The durable execution span**

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -126,7 +126,7 @@ The AWS Lambda integration pipeline maps these events onto the same `@lambda.dur
 | `@lambda.durable_function.execution_start_time` | When the execution started, in UNIX milliseconds. |
 | `@lambda.durable_function.execution_end_time` | When the execution reached a terminal status, in UNIX milliseconds. |
 
-Treat these events as the source of truth for terminal status. An execution that timed out or was stopped may have no `END` or `REPORT` log at all. When it does, that log can report `FAILED` instead of `TIMED_OUT` or `STOPPED`.
+Treat these events as the source of truth for terminal status, as `END` and `REPORT` logs cannot report `TIMED_OUT` or `STOPPED`.
 
 A terminal status change event is timestamped from `detail.endTimestamp`, when the execution finished. A time range therefore selects executions that *finished* within it; in-flight executions fall outside it regardless of when they started. To find those, query the `START` logs.
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -212,7 +212,6 @@ The execution name joins the three sources, but its attribute name differs:
 |---|---|---|
 | Execution name | `@lambda.durable_function.execution_name` | `@aws.durable.execution_name` |
 | Execution ID | `@lambda.durable_function.execution_id` | `@aws.durable.execution_id` |
-| Full execution ARN | — | `@aws.durable.execution_arn` |
 
 ## Limitations and feedback
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -144,7 +144,7 @@ operation_name:aws.durable.execute
 |---|---|
 | `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the name as a separate tag. |
 | `@aws.durable.invocation_status` | The execution's state when this invocation ended: `succeeded`, `failed`, or `pending`. `pending` means the execution suspended and resumes in a later invocation. |
-| `@aws.durable.replayed` | `true` when the SDK ran this invocation in replay mode, re-running the handler over the execution's prior state instead of starting it fresh. |
+| `@aws.durable.replayed` | `false` on the invocation that starts an execution, `true` on each later invocation that resumes it after a suspend. |
 
 **The Lambda invocation span**
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -204,15 +204,6 @@ For example, to graph failed executions for one function:
 sum:aws.lambda.durable_execution_failed{functionname:<FUNCTION_NAME>}.as_count()
 ```
 
-### Correlating logs and traces
-
-The execution name joins the three sources, but its attribute name differs:
-
-| Concept | Logs and status events | Spans |
-|---|---|---|
-| Execution name | `@lambda.durable_function.execution_name` | `@aws.durable.execution_name` |
-| Execution ID | `@lambda.durable_function.execution_id` | `@aws.durable.execution_id` |
-
 ## Limitations and feedback
 
 Runtimes other than Node.js and Python are not supported. If you encounter an issue with another runtime, open an issue in the [datadog-lambda-extension GitHub repository][7].

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -112,7 +112,7 @@ The events forwarded by the CloudFormation stack arrive as logs, matched by:
 @detail-type:"Durable Execution Status Change"
 ```
 
-The AWS Lambda integration pipeline maps these events onto the same `@lambda.durable_function.*` attributes, plus two timestamps:
+The AWS Lambda integration pipeline maps these events onto the following attributes:
 
 | Log attribute | Description |
 |---|---|

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,7 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions for you. Use the queries below to search the underlying logs and traces directly, or to build dashboards and monitors.
+The **Executions** tab on the Lambda function page lists durable executions. Use the queries below to search the underlying logs and traces directly, or to build dashboards and monitors.
 
 ### Query reference
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,7 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions. Use the queries below to search the underlying logs and traces directly, or to build dashboards and monitors.
+The **Executions** tab on the Lambda function page lists durable executions. Use these queries to search the underlying logs and traces directly, or to build dashboards and monitors.
 
 ### Query reference
 
@@ -78,9 +78,9 @@ The **Executions** tab on the Lambda function page lists durable executions. Use
 | Execution trace | `operation_name:aws.durable.execute` |
 | Execution counts and duration | The `aws.lambda.durable_execution_*` metrics, tagged `functionname` |
 
-### The durable execution ARN and its identifiers
+### Execution identifiers
 
-A durable execution ARN has the following format:
+A durable execution ARN has the format:
 
 ```text
 arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-execution/<EXECUTION_NAME>/<EXECUTION_ID>
@@ -88,10 +88,10 @@ arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-
 
 | Identifier | Description |
 |---|---|
-| `<EXECUTION_NAME>` | A random UUID that uniquely identifies one durable execution. This is the correlation key across logs and traces. |
-| `<EXECUTION_ID>` | A deterministic, name-based UUID for the same execution. It differs from the execution name. Do not use it to correlate telemetry. |
+| `<EXECUTION_NAME>` | A random UUID identifying one durable execution. The correlation key across logs and traces. |
+| `<EXECUTION_ID>` | A deterministic, name-based UUID for the same execution. It differs from the execution name; do not use it to correlate telemetry. |
 
-One durable execution spans many Lambda invocations. The SDK suspends and resumes the execution across invocations, so every log and span for a single execution shares the same execution name.
+One durable execution spans many Lambda invocations, so every log and span for that execution shares the same execution name.
 
 ### Logs
 
@@ -101,14 +101,14 @@ To scope a log query to one function, filter on the function ARN:
 @lambda.arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"
 ```
 
-The Datadog Lambda Extension adds the following attributes to the logs of a durable function:
+The Datadog Lambda Extension adds these attributes to a durable function's logs:
 
 | Log attribute | Description |
 |---|---|
-| `@lambda.durable_function.execution_name` | The execution name. Use this to group all logs from one durable execution. |
+| `@lambda.durable_function.execution_name` | The execution name. Groups all logs from one execution. |
 | `@lambda.durable_function.execution_id` | The execution ID. |
-| `@lambda.durable_function.first_invocation` | `true` on the logs of the first invocation of an execution, `false` otherwise. |
-| `@lambda.durable_function.execution_status` | The execution status. Present on the logs that report a status, such as the `END` log. |
+| `@lambda.durable_function.first_invocation` | `true` on logs from the execution's first invocation, `false` otherwise. |
+| `@lambda.durable_function.execution_status` | The execution status, on logs that report one, such as the `END` log. |
 
 Example queries:
 
@@ -118,19 +118,19 @@ Example queries:
     @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
     ```
 
-- The `START` log of each execution, which marks when the execution began:
+- Each execution's `START` log, which marks when it began:
 
     ```text
     "START RequestId:" @lambda.durable_function.first_invocation:true
     ```
 
-- The last log of each execution, which marks when the execution ended:
+- Each execution's last log, which marks when it ended:
 
     ```text
     "END RequestId:" OR "REPORT RequestId:"
     ```
 
-    Only one of the two carries `execution_status`: the `END` log for most executions, and the `REPORT` log for executions on Lambda Managed Instances, which emit no `END` log.
+    Only one carries `execution_status`: `END` for most executions, `REPORT` for executions on Lambda Managed Instances, which emit no `END` log.
 
 - Failed executions:
 
@@ -140,13 +140,13 @@ Example queries:
 
 ### Status change events
 
-The events forwarded by the CloudFormation stack arrive as logs with the `@detail-type` attribute set to `Durable Execution Status Change`:
+The events forwarded by the CloudFormation stack arrive as logs with `@detail-type` set to `Durable Execution Status Change`:
 
 ```text
 @detail-type:"Durable Execution Status Change"
 ```
 
-The AWS Lambda integration pipeline maps these events onto the same `@lambda.durable_function.*` attributes as the logs above, plus two timestamps:
+The AWS Lambda integration pipeline maps these events onto the same `@lambda.durable_function.*` attributes, plus two timestamps:
 
 | Log attribute | Description |
 |---|---|
@@ -154,9 +154,9 @@ The AWS Lambda integration pipeline maps these events onto the same `@lambda.dur
 | `@lambda.durable_function.execution_start_time` | When the execution started, in UNIX milliseconds. |
 | `@lambda.durable_function.execution_end_time` | When the execution reached a terminal status, in UNIX milliseconds. |
 
-Treat these events as the source of truth for terminal status. The `END` log reports `FAILED` for an execution that timed out or was stopped. The status change event distinguishes `TIMED_OUT` from `STOPPED`. An execution that times out or is stopped while no runtime is active emits no `END` log at all. The status change event is then the only record.
+Treat these events as the source of truth for terminal status. The `END` log reports `FAILED` for an execution that timed out or was stopped. The status change event distinguishes `TIMED_OUT` from `STOPPED`. An execution that times out or is stopped while no runtime is active emits no `END` log, leaving the event as the only record.
 
-The timestamp of a terminal status change event is the time the execution finished, taken from the event's `detail.endTimestamp`. A time range therefore selects the executions that *finished* within it. Executions still in flight fall outside the range entirely, no matter when they started. To find them, query the `START` logs instead.
+A terminal status change event is timestamped from `detail.endTimestamp`, when the execution finished. A time range therefore selects executions that *finished* within it; in-flight executions fall outside it regardless of when they started. To find those, query the `START` logs.
 
 ### Traces
 
@@ -168,7 +168,7 @@ To scope a span query to one function, filter on `@function_arn`:
 
 **The durable execution span**
 
-The tracer creates one `aws.durable.execute` span per invocation of a durable execution, and stitches the invocations of an execution into a single trace.
+The tracer creates one `aws.durable.execute` span per invocation and stitches an execution's invocations into a single trace.
 
 ```text
 operation_name:aws.durable.execute
@@ -176,13 +176,13 @@ operation_name:aws.durable.execute
 
 | Span tag | Description |
 |---|---|
-| `@aws.durable.execution_arn` | The full durable execution ARN. This span carries no bare execution name, so parse the name out of the ARN: it is the segment after `/durable-execution/`. |
+| `@aws.durable.execution_arn` | The full durable execution ARN. This span carries no bare execution name; parse it from the segment after `/durable-execution/`. |
 | `@aws.durable.invocation_status` | The outcome of the execution: `succeeded`, `failed`, or `pending`. |
 | `@aws.durable.replayed` | `true` when the invocation replayed results from a prior checkpoint. |
 
 **The Lambda invocation span**
 
-Each invocation of a durable function also produces the standard `aws.lambda` span, tagged with the durable execution context:
+Each invocation also produces the standard `aws.lambda` span, tagged with the durable execution context:
 
 | Span tag | Description |
 |---|---|
@@ -209,17 +209,17 @@ Each operation called on the durable context produces a child span:
 
 | Span tag | Description |
 |---|---|
-| `@aws.durable.operation_name` | The name given to the operation. |
+| `@aws.durable.operation_name` | The operation's name. |
 | `@aws.durable.operation_id` | A hash of the operation's step ID. |
-| `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. It is numeric and counts prior failed attempts, so `0` is the original attempt and `1` is the first retry. |
-| `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed. A checkpoint counts as replayable when it is terminal, which includes a failed operation as well as a successful one. |
+| `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. It counts prior failed attempts, so `0` is the original attempt and `1` the first retry. |
+| `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed. Failed checkpoints count as well as successful ones. |
 | `@aws.durable.invoke.function_name` | The target function, on `aws.durable.invoke` spans. |
 
-Cross-invocation trace propagation adds synthetic `_datadog_<N>` step operations to your durable execution log. They carry the trace propagation headers. To turn this off, set `DD_DURABLE_CROSS_INVOCATION_TRACING_ENABLED=false`.
+Cross-invocation trace propagation adds synthetic `_datadog_<N>` step operations carrying the trace headers to your durable execution log. To turn it off, set `DD_DURABLE_CROSS_INVOCATION_TRACING_ENABLED=false`.
 
 ### Metrics
 
-AWS publishes the following durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5], not the Datadog Lambda Extension, and are tagged with `functionname`.
+AWS publishes these durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5], not the Datadog Lambda Extension, and are tagged with `functionname`.
 
 | Metric | Description | Aggregation |
 |---|---|---|
@@ -234,17 +234,17 @@ AWS publishes the following durable execution metrics to CloudWatch. They reach 
 | `aws.lambda.approximate_running_durable_executions` | Number of durable executions in the `RUNNING` state. | `avg` |
 | `aws.lambda.approximate_running_durable_executions_utilization` | Percentage of the durable execution quota in use. | `avg` |
 
-For example, to graph the rate of failed executions for one function:
+For example, to graph failed executions for one function:
 
 ```text
 sum:aws.lambda.durable_execution_failed{functionname:<FUNCTION_NAME>}.as_count()
 ```
 
-These metrics count whole executions, so they do not need the durable log enrichment described under [Setup](#setup). They come from a different source than `aws.lambda.enhanced.invocations`, which the Datadog Lambda Extension generates per invocation.
+These metrics count whole executions and do not depend on the durable log enrichment described under [Setup](#setup). They come from a different source than `aws.lambda.enhanced.invocations`, which the Datadog Lambda Extension generates per invocation.
 
 ### Correlating logs and traces
 
-The execution name is the key that joins the three sources, but the attribute name differs by source:
+The execution name joins the three sources, but its attribute name differs:
 
 | Concept | Logs and status events | Spans |
 |---|---|---|

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,21 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions. Use these queries to search the logs and traces, or to build dashboards and monitors.
-
-### Query reference
-
-| Purpose | Search in | Query |
-|---|---|---|
-| Scope to a function | Logs | `@lambda.arn:"<FUNCTION_ARN>"` |
-| Scope to a function | Traces | `@function_arn:"<FUNCTION_ARN>"` |
-| One execution | Logs | `@lambda.durable_function.execution_name:<EXECUTION_NAME>` |
-| Terminal status | Logs | `@lambda.durable_function.execution_status:<SUCCEEDED\|FAILED\|TIMED_OUT\|STOPPED>` |
-| Authoritative status events | Logs | `@detail-type:"Durable Execution Status Change"` |
-| Execution start | Logs | `"START RequestId:" @lambda.durable_function.first_invocation:true` |
-| Execution end | Logs | `"END RequestId:" OR "REPORT RequestId:"` |
-| Execution trace | Traces | `operation_name:aws.durable.execute` |
-| Execution counts and duration | Metrics | `aws.lambda.durable_execution_*`, tagged `functionname` |
+The **Executions** tab on the Lambda function page lists durable executions. Use the following attributes to query the logs, traces, and metrics directly, or to build dashboards and monitors.
 
 ### Execution identifiers
 
@@ -133,7 +119,7 @@ Example queries:
 
     Only one carries `execution_status`: `END` for most executions, `REPORT` for executions on Lambda Managed Instances, which emit no `END` log.
 
-- Failed executions:
+- Executions that reached a given terminal status, one of `SUCCEEDED`, `FAILED`, `TIMED_OUT`, or `STOPPED`:
 
     ```text
     @lambda.durable_function.execution_status:FAILED

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -161,17 +161,17 @@ Each invocation also produces the standard `aws.lambda` span, tagged with the du
 
 Each operation called on the durable context produces a child span:
 
-| Operation name | Durable context method |
-|---|---|
-| `aws.durable.step` | `step` |
-| `aws.durable.invoke` | `invoke` |
-| `aws.durable.wait` | `wait` |
-| `aws.durable.wait_for_condition` | `waitForCondition` |
-| `aws.durable.wait_for_callback` | `waitForCallback` |
-| `aws.durable.create_callback` | `createCallback` |
-| `aws.durable.map` | `map` |
-| `aws.durable.parallel` | `parallel` |
-| `aws.durable.child_context` | `runInChildContext` |
+| Operation name | Node.js method | Python method |
+|---|---|---|
+| `aws.durable.step` | `step` | `step` |
+| `aws.durable.invoke` | `invoke` | `invoke` |
+| `aws.durable.wait` | `wait` | `wait` |
+| `aws.durable.wait_for_condition` | `waitForCondition` | `wait_for_condition` |
+| `aws.durable.wait_for_callback` | `waitForCallback` | `wait_for_callback` |
+| `aws.durable.create_callback` | `createCallback` | `create_callback` |
+| `aws.durable.map` | `map` | `map` |
+| `aws.durable.parallel` | `parallel` | `parallel` |
+| `aws.durable.child_context` | `runInChildContext` | `run_in_child_context` |
 
 | Span tag | Description |
 |---|---|

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -181,8 +181,6 @@ Each operation called on the durable context produces a child span:
 | `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed, whether that stored result was a success or a failure. |
 | `@aws.durable.invoke.function_name` | The target function, on `aws.durable.invoke` spans. |
 
-Cross-invocation trace propagation adds synthetic `_datadog_<N>` step operations carrying the trace headers to your durable execution log. To turn it off, set `DD_DURABLE_CROSS_INVOCATION_TRACING_ENABLED=false`.
-
 ### Metrics
 
 AWS publishes these durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5], not the Datadog Lambda Extension, and are tagged with `functionname`.

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -126,7 +126,7 @@ The AWS Lambda integration pipeline maps these events onto the same `@lambda.dur
 | `@lambda.durable_function.execution_start_time` | When the execution started, in UNIX milliseconds. |
 | `@lambda.durable_function.execution_end_time` | When the execution reached a terminal status, in UNIX milliseconds. |
 
-Treat these events as the source of truth for terminal status. The `END` log reports `FAILED` for an execution that timed out or was stopped. The status change event distinguishes `TIMED_OUT` from `STOPPED`. An execution that times out or is stopped while no runtime is active emits no `END` log, leaving the event as the only record.
+Treat these events as the source of truth for terminal status. An execution that timed out or was stopped may have no `END` or `REPORT` log at all. When it does, that log can report `FAILED` instead of `TIMED_OUT` or `STOPPED`.
 
 A terminal status change event is timestamped from `detail.endTimestamp`, when the execution finished. A time range therefore selects executions that *finished* within it; in-flight executions fall outside it regardless of when they started. To find those, query the `START` logs.
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -204,8 +204,6 @@ For example, to graph failed executions for one function:
 sum:aws.lambda.durable_execution_failed{functionname:<FUNCTION_NAME>}.as_count()
 ```
 
-These metrics count whole executions and do not depend on the durable log enrichment described under [Setup](#setup). They come from a different source than `aws.lambda.enhanced.invocations`, which the Datadog Lambda Extension generates per invocation.
-
 ### Correlating logs and traces
 
 The execution name joins the three sources, but its attribute name differs:

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -87,19 +87,19 @@ Example queries:
 - All logs for one durable execution:
 
     ```text
-    @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
+    @lambda.arn:"<FUNCTION_ARN>" @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
     ```
 
 - Each execution's `START` log, which marks when it began:
 
     ```text
-    "START RequestId:" @lambda.durable_function.first_invocation:true
+    @lambda.arn:"<FUNCTION_ARN>" "START RequestId:" @lambda.durable_function.first_invocation:true
     ```
 
 - Each execution's last log, which marks when it ended:
 
     ```text
-    "END RequestId:" OR "REPORT RequestId:"
+    @lambda.arn:"<FUNCTION_ARN>" ("END RequestId:" OR "REPORT RequestId:")
     ```
 
     Lambda Managed Instances emit no `END` log, so query both.

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -73,7 +73,7 @@ Logs, traces, and status events all identify an execution by its execution name.
 arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-execution/<EXECUTION_NAME>/<EXECUTION_ID>
 ```
 
-The execution ID is a different value. Both are UUIDs, and correlating on the execution ID returns no matches.
+The execution name is the first segment after `/durable-execution/` and the execution ID is the second. The two are different values, so searching for one in the other's attribute returns no results.
 
 ### Logs
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -46,7 +46,7 @@ To forward durable execution status change events to Datadog, deploy the CloudFo
 3. Set `DdSite` to your [Datadog site][4]. The default is `datadoghq.com`.
 4. Optionally, restrict which events are forwarded:
 
-    - `Statuses`: a comma-separated list of execution statuses to forward. Valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, and `STOPPED`. Leave this empty to forward all statuses.
+    - `Statuses`: a comma-separated list of execution statuses to forward. Valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, and `STOPPED`. Leave this empty to forward all statuses. Only the four terminal statuses set the status Datadog reports for an execution; an execution with no terminal status is shown as running.
     - `FunctionArnFilter1` through `FunctionArnFilter5`: up to five unqualified Lambda function ARNs or EventBridge wildcard patterns, such as `arn:aws:lambda:us-east-2:123456789012:function:my-durable-*`. Do not include a version or alias suffix. Leave all five empty to forward events from every function in the region.
     - `BufferIntervalSeconds`: the Amazon Data Firehose buffer interval, in seconds (`60`-`900`, default `60`). Higher values reduce the number of outbound requests at the cost of freshness.
 
@@ -60,6 +60,197 @@ In Datadog, install the [AWS Lambda integration][5], which provides the out-of-t
 ### Create a trace retention filter
 
 Create a [trace retention filter][6] with the retention query `operation_name:aws.durable.execute`.
+
+## Querying durable executions in Datadog
+
+The **Executions** tab on the Lambda function page lists durable executions for you. Use the queries below to search the underlying logs and traces directly, or to build dashboards and monitors.
+
+### Query reference
+
+| Purpose | Query |
+|---|---|
+| Scope to a function | `@lambda.arn:"<FUNCTION_ARN>"` in logs, `@function_arn:"<FUNCTION_ARN>"` in spans |
+| One execution | `@lambda.durable_function.execution_name:<EXECUTION_NAME>` |
+| Terminal status | `@lambda.durable_function.execution_status:<SUCCEEDED\|FAILED\|TIMED_OUT\|STOPPED>` |
+| Authoritative status events | `@detail-type:"Durable Execution Status Change"` |
+| Execution start | `"START RequestId:" @lambda.durable_function.first_invocation:true` |
+| Execution end | `"END RequestId:" OR "REPORT RequestId:"` |
+| Execution trace | `operation_name:aws.durable.execute` |
+| Execution counts and duration | The `aws.lambda.durable_execution_*` metrics, tagged `functionname` |
+
+### The durable execution ARN and its identifiers
+
+A durable execution ARN has the following format:
+
+```text
+arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-execution/<EXECUTION_NAME>/<EXECUTION_ID>
+```
+
+| Identifier | Description |
+|---|---|
+| `<EXECUTION_NAME>` | A random UUID that uniquely identifies one durable execution. This is the correlation key across logs and traces. |
+| `<EXECUTION_ID>` | A deterministic, name-based UUID for the same execution. It differs from the execution name. Do not use it to correlate telemetry. |
+
+One durable execution spans many Lambda invocations. The SDK suspends and resumes the execution across invocations, so every log and span for a single execution shares the same execution name.
+
+### Logs
+
+To scope a log query to one function, filter on the function ARN:
+
+```text
+@lambda.arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"
+```
+
+The Datadog Lambda Extension adds the following attributes to the logs of a durable function:
+
+| Log attribute | Description |
+|---|---|
+| `@lambda.durable_function.execution_name` | The execution name. Use this to group all logs from one durable execution. |
+| `@lambda.durable_function.execution_id` | The execution ID. |
+| `@lambda.durable_function.first_invocation` | `true` on the logs of the first invocation of an execution, `false` otherwise. |
+| `@lambda.durable_function.execution_status` | The execution status. Present on the logs that report a status, such as the `END` log. |
+
+Example queries:
+
+- All logs for one durable execution:
+
+    ```text
+    @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
+    ```
+
+- The `START` log of each execution, which marks when the execution began:
+
+    ```text
+    "START RequestId:" @lambda.durable_function.first_invocation:true
+    ```
+
+- The last log of each execution, which marks when the execution ended:
+
+    ```text
+    "END RequestId:" OR "REPORT RequestId:"
+    ```
+
+    Only one of the two carries `execution_status`: the `END` log for most executions, and the `REPORT` log for executions on Lambda Managed Instances, which emit no `END` log.
+
+- Failed executions:
+
+    ```text
+    @lambda.durable_function.execution_status:FAILED
+    ```
+
+### Status change events
+
+The events forwarded by the CloudFormation stack arrive as logs with the `@detail-type` attribute set to `Durable Execution Status Change`:
+
+```text
+@detail-type:"Durable Execution Status Change"
+```
+
+The AWS Lambda integration pipeline maps these events onto the same `@lambda.durable_function.*` attributes as the logs above, plus two timestamps:
+
+| Log attribute | Description |
+|---|---|
+| `@lambda.durable_function.execution_status` | One of `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, or `STOPPED`. |
+| `@lambda.durable_function.execution_start_time` | When the execution started, in UNIX milliseconds. |
+| `@lambda.durable_function.execution_end_time` | When the execution reached a terminal status, in UNIX milliseconds. |
+
+Treat these events as the source of truth for terminal status. The `END` log reports `FAILED` for an execution that timed out or was stopped. The status change event distinguishes `TIMED_OUT` from `STOPPED`. An execution that times out or is stopped while no runtime is active emits no `END` log at all. The status change event is then the only record.
+
+The timestamp of a terminal status change event is the time the execution finished, taken from the event's `detail.endTimestamp`. A time range therefore selects the executions that *finished* within it. Executions still in flight fall outside the range entirely, no matter when they started. To find them, query the `START` logs instead.
+
+### Traces
+
+To scope a span query to one function, filter on `@function_arn`:
+
+```text
+@function_arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"
+```
+
+**The durable execution span**
+
+The tracer creates one `aws.durable.execute` span per invocation of a durable execution, and stitches the invocations of an execution into a single trace.
+
+```text
+operation_name:aws.durable.execute
+```
+
+| Span tag | Description |
+|---|---|
+| `@aws.durable.execution_arn` | The full durable execution ARN. This span carries no bare execution name, so parse the name out of the ARN: it is the segment after `/durable-execution/`. |
+| `@aws.durable.invocation_status` | The outcome of the execution: `succeeded`, `failed`, or `pending`. |
+| `@aws.durable.replayed` | `true` when the invocation replayed results from a prior checkpoint. |
+
+**The Lambda invocation span**
+
+Each invocation of a durable function also produces the standard `aws.lambda` span, tagged with the durable execution context:
+
+| Span tag | Description |
+|---|---|
+| `@aws.durable.execution_name` | The execution name. |
+| `@aws.durable.execution_id` | The execution ID. |
+| `@aws.durable.first_invocation` | `true` on the first invocation of an execution. |
+| `@aws.durable.execution_status` | The execution status. |
+
+**Operation spans**
+
+Each operation called on the durable context produces a child span:
+
+| Operation name | Durable context method |
+|---|---|
+| `aws.durable.step` | `step` |
+| `aws.durable.invoke` | `invoke` |
+| `aws.durable.wait` | `wait` |
+| `aws.durable.wait_for_condition` | `waitForCondition` |
+| `aws.durable.wait_for_callback` | `waitForCallback` |
+| `aws.durable.create_callback` | `createCallback` |
+| `aws.durable.map` | `map` |
+| `aws.durable.parallel` | `parallel` |
+| `aws.durable.child_context` | `runInChildContext` |
+
+| Span tag | Description |
+|---|---|
+| `@aws.durable.operation_name` | The name given to the operation. |
+| `@aws.durable.operation_id` | A hash of the operation's step ID. |
+| `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. It is numeric and counts prior failed attempts, so `0` is the original attempt and `1` is the first retry. |
+| `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed. A checkpoint counts as replayable when it is terminal, which includes a failed operation as well as a successful one. |
+| `@aws.durable.invoke.function_name` | The target function, on `aws.durable.invoke` spans. |
+
+Cross-invocation trace propagation adds synthetic `_datadog_<N>` step operations to your durable execution log. They carry the trace propagation headers. To turn this off, set `DD_DURABLE_CROSS_INVOCATION_TRACING_ENABLED=false`.
+
+### Metrics
+
+AWS publishes the following durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5], not the Datadog Lambda Extension, and are tagged with `functionname`.
+
+| Metric | Description | Aggregation |
+|---|---|---|
+| `aws.lambda.durable_execution_started` | Number of durable executions started. | `sum` as count |
+| `aws.lambda.durable_execution_succeeded` | Number of durable executions that completed successfully. | `sum` as count |
+| `aws.lambda.durable_execution_failed` | Number of durable executions that completed with failure. | `sum` as count |
+| `aws.lambda.durable_execution_timed_out` | Number of durable executions that exceeded their timeout. | `sum` as count |
+| `aws.lambda.durable_execution_stopped` | Number of durable executions stopped with the `StopDurableExecution` API. | `sum` as count |
+| `aws.lambda.durable_execution_duration` | Wall-clock time a durable execution spent in the `RUNNING` state, in milliseconds. | `avg` |
+| `aws.lambda.durable_execution_operations` | Cumulative number of operations performed by durable executions. | `sum` as count |
+| `aws.lambda.durable_execution_storage_written_bytes` | Cumulative amount of data persisted by durable executions, in bytes. | `sum` |
+| `aws.lambda.approximate_running_durable_executions` | Number of durable executions in the `RUNNING` state. | `avg` |
+| `aws.lambda.approximate_running_durable_executions_utilization` | Percentage of the durable execution quota in use. | `avg` |
+
+For example, to graph the rate of failed executions for one function:
+
+```text
+sum:aws.lambda.durable_execution_failed{functionname:<FUNCTION_NAME>}.as_count()
+```
+
+These metrics count whole executions, so they do not need the durable log enrichment described under [Setup](#setup). They come from a different source than `aws.lambda.enhanced.invocations`, which the Datadog Lambda Extension generates per invocation.
+
+### Correlating logs and traces
+
+The execution name is the key that joins the three sources, but the attribute name differs by source:
+
+| Concept | Logs and status events | Spans |
+|---|---|---|
+| Execution name | `@lambda.durable_function.execution_name` | `@aws.durable.execution_name`, or the first segment after `/durable-execution/` in `@aws.durable.execution_arn` |
+| Execution ID | `@lambda.durable_function.execution_id` | `@aws.durable.execution_id` |
+| Full execution ARN | — | `@aws.durable.execution_arn` |
 
 ## Limitations and feedback
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -112,7 +112,7 @@ Example queries:
 
 ### Status change events
 
-The events forwarded by the CloudFormation stack arrive as logs with `@detail-type` set to `Durable Execution Status Change`:
+The events forwarded by the CloudFormation stack arrive as logs, matched by:
 
 ```text
 @detail-type:"Durable Execution Status Change"
@@ -132,7 +132,7 @@ A terminal status change event is timestamped from `detail.endTimestamp`, when t
 
 ### Traces
 
-To scope a span query to one function, filter on `@function_arn`:
+To scope a span query to one function, filter on the function ARN:
 
 ```text
 @function_arn:"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>"

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -128,7 +128,7 @@ The AWS Lambda integration pipeline maps these events onto the same `@lambda.dur
 
 Treat these events as the source of truth for terminal status, as `END` and `REPORT` logs cannot report `TIMED_OUT` or `STOPPED`.
 
-A terminal status change event is timestamped from `detail.endTimestamp`, when the execution finished. A time range therefore selects executions that *finished* within it; in-flight executions fall outside it regardless of when they started. To find those, query the `START` logs.
+These events are timestamped when the execution finished, so a time range selects executions that finished within it, never in-flight ones.
 
 ### Traces
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -142,7 +142,7 @@ operation_name:aws.durable.execute
 
 | Span tag | Description |
 |---|---|
-| `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the name as a separate tag. |
+| `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the execution name as a separate tag. |
 | `@aws.durable.invocation_status` | The execution's state when this invocation ended: `succeeded`, `failed`, or `pending`. `pending` means the execution suspended and resumes in a later invocation. |
 | `@aws.durable.replayed` | `false` on the invocation that starts an execution, `true` on each later invocation that resumes it after a suspend. |
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -67,16 +67,17 @@ The **Executions** tab on the Lambda function page lists durable executions. Use
 
 ### Query reference
 
-| Purpose | Query |
-|---|---|
-| Scope to a function | `@lambda.arn:"<FUNCTION_ARN>"` in logs, `@function_arn:"<FUNCTION_ARN>"` in spans |
-| One execution | `@lambda.durable_function.execution_name:<EXECUTION_NAME>` |
-| Terminal status | `@lambda.durable_function.execution_status:<SUCCEEDED\|FAILED\|TIMED_OUT\|STOPPED>` |
-| Authoritative status events | `@detail-type:"Durable Execution Status Change"` |
-| Execution start | `"START RequestId:" @lambda.durable_function.first_invocation:true` |
-| Execution end | `"END RequestId:" OR "REPORT RequestId:"` |
-| Execution trace | `operation_name:aws.durable.execute` |
-| Execution counts and duration | The `aws.lambda.durable_execution_*` metrics, tagged `functionname` |
+| Purpose | Search in | Query |
+|---|---|---|
+| Scope to a function | Logs | `@lambda.arn:"<FUNCTION_ARN>"` |
+| Scope to a function | Traces | `@function_arn:"<FUNCTION_ARN>"` |
+| One execution | Logs | `@lambda.durable_function.execution_name:<EXECUTION_NAME>` |
+| Terminal status | Logs | `@lambda.durable_function.execution_status:<SUCCEEDED\|FAILED\|TIMED_OUT\|STOPPED>` |
+| Authoritative status events | Logs | `@detail-type:"Durable Execution Status Change"` |
+| Execution start | Logs | `"START RequestId:" @lambda.durable_function.first_invocation:true` |
+| Execution end | Logs | `"END RequestId:" OR "REPORT RequestId:"` |
+| Execution trace | Traces | `operation_name:aws.durable.execute` |
+| Execution counts and duration | Metrics | `aws.lambda.durable_execution_*`, tagged `functionname` |
 
 ### Execution identifiers
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -177,7 +177,7 @@ Each operation called on the durable context produces a child span:
 |---|---|
 | `@aws.durable.operation_name` | The operation's name. |
 | `@aws.durable.operation_id` | A hash of the operation's step ID. |
-| `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. It counts prior failed attempts, so `0` is the original attempt and `1` the first retry. |
+| `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. `0` is the original attempt, `1` the first retry. |
 | `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed. Failed checkpoints count as well as successful ones. |
 | `@aws.durable.invoke.function_name` | The target function, on `aws.durable.invoke` spans. |
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -178,7 +178,7 @@ Each operation called on the durable context produces a child span:
 | `@aws.durable.operation_name` | The operation's name. |
 | `@aws.durable.operation_id` | A hash of the operation's step ID. |
 | `@aws.durable.operation_attempt` | The attempt number, on the retryable operations `aws.durable.step` and `aws.durable.wait_for_condition`. `0` is the original attempt, `1` the first retry. |
-| `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed. Failed checkpoints count as well as successful ones. |
+| `@aws.durable.replayed` | `true` when the operation's result was served from a checkpoint instead of executed, whether that stored result was a success or a failure. |
 | `@aws.durable.invoke.function_name` | The target function, on `aws.durable.invoke` spans. |
 
 Cross-invocation trace propagation adds synthetic `_datadog_<N>` step operations carrying the trace headers to your durable execution log. To turn it off, set `DD_DURABLE_CROSS_INVOCATION_TRACING_ENABLED=false`.

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -80,7 +80,7 @@ The Datadog Lambda Extension adds these attributes to a durable function's logs:
 | `@lambda.durable_function.execution_name` | The execution name. Groups all logs from one execution. |
 | `@lambda.durable_function.execution_id` | The execution ID. |
 | `@lambda.durable_function.first_invocation` | `true` on logs from the execution's first invocation, `false` otherwise. |
-| `@lambda.durable_function.execution_status` | The execution status, on the `END` log, or on the `REPORT` log for executions on Lambda Managed Instances. |
+| `@lambda.durable_function.execution_status` | The execution's state when the invocation ended: `SUCCEEDED`, `FAILED`, or `PENDING`, where `PENDING` means the execution suspended and resumes in a later invocation. On the `END` log, or on the `REPORT` log for executions on Lambda Managed Instances. |
 
 Example queries:
 
@@ -104,11 +104,13 @@ Example queries:
 
     Lambda Managed Instances emit no `END` log, so query both.
 
-- Executions that reached a given terminal status, one of `SUCCEEDED`, `FAILED`, `TIMED_OUT`, or `STOPPED`:
+- Executions with a given status:
 
     ```text
     @lambda.durable_function.execution_status:FAILED
     ```
+
+    `TIMED_OUT` and `STOPPED` come only from the status change events described below.
 
 ### Status change events
 
@@ -161,7 +163,7 @@ Each invocation also produces the standard `aws.lambda` span, tagged with the du
 | `@aws.durable.execution_name` | The execution name. |
 | `@aws.durable.execution_id` | The execution ID. |
 | `@aws.durable.first_invocation` | `true` on the first invocation of an execution. |
-| `@aws.durable.execution_status` | The execution status. |
+| `@aws.durable.execution_status` | The execution's state when the invocation ended: `SUCCEEDED`, `FAILED`, or `PENDING`. |
 
 **Operation spans**
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,7 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions. Use the following attributes to query the logs, traces, and metrics directly, or to build dashboards and monitors.
+The **Executions** tab on the Lambda function page lists durable executions. Use the log attributes, span tags, and metrics below to query this data directly, or to build dashboards and monitors.
 
 ### Execution identifiers
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -128,7 +128,7 @@ The AWS Lambda integration pipeline maps these events onto the same `@lambda.dur
 
 Treat these events as the source of truth for terminal status, as `END` and `REPORT` logs cannot report `TIMED_OUT` or `STOPPED`.
 
-These events are timestamped when the execution finished, so a time range selects executions that finished within it, never in-flight ones.
+Terminal events are timestamped when the execution finished, so a time range selects executions that finished within it.
 
 ### Traces
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -144,7 +144,7 @@ operation_name:aws.durable.execute
 |---|---|
 | `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the name as a separate tag. |
 | `@aws.durable.invocation_status` | The execution's state when this invocation ended: `succeeded`, `failed`, or `pending`. `pending` means the execution suspended and resumes in a later invocation. |
-| `@aws.durable.replayed` | `true` when the invocation replayed results from a prior checkpoint. |
+| `@aws.durable.replayed` | `true` when the SDK ran this invocation in replay mode, re-running the handler over the execution's prior state instead of starting it fresh. |
 
 **The Lambda invocation span**
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -183,7 +183,7 @@ Each operation called on the durable context produces a child span:
 
 ### Metrics
 
-AWS publishes these durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5], not the Datadog Lambda Extension, and are tagged with `functionname`.
+AWS publishes these durable execution metrics to CloudWatch. They reach Datadog through the [AWS Lambda integration][5] and are tagged with `functionname`.
 
 | Metric | Description | Aggregation |
 |---|---|---|

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -63,7 +63,7 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 ## Querying durable executions in Datadog
 
-The **Executions** tab on the Lambda function page lists durable executions. Use these queries to search the underlying logs and traces directly, or to build dashboards and monitors.
+The **Executions** tab on the Lambda function page lists durable executions. Use these queries to search the logs and traces, or to build dashboards and monitors.
 
 ### Query reference
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -80,7 +80,7 @@ The Datadog Lambda Extension adds these attributes to a durable function's logs:
 | `@lambda.durable_function.execution_name` | The execution name. Groups all logs from one execution. |
 | `@lambda.durable_function.execution_id` | The execution ID. |
 | `@lambda.durable_function.first_invocation` | `true` on logs from the execution's first invocation, `false` otherwise. |
-| `@lambda.durable_function.execution_status` | The execution's state when the invocation ended: `SUCCEEDED`, `FAILED`, or `PENDING`, where `PENDING` means the execution suspended and resumes in a later invocation. On the `END` log, or on the `REPORT` log for executions on Lambda Managed Instances. |
+| `@lambda.durable_function.execution_status` | The execution's state when the invocation ended: `SUCCEEDED`, `FAILED`, or `PENDING`, where `PENDING` means the execution suspended and resumes in a later invocation. On the `END` log, or on the `REPORT` log for executions on [Lambda Managed Instances][10]. |
 
 Example queries (add `@lambda.arn:"<FUNCTION_ARN>"` to scope to one function):
 
@@ -215,3 +215,4 @@ If you encounter an issue with the CloudFormation stack, open an issue in the [c
 [7]: https://github.com/DataDog/datadog-lambda-extension
 [8]: https://github.com/DataDog/cloudformation-template/tree/master/aws_durable_function_event_forwarder
 [9]: /serverless/aws_lambda/logs/#enable-log-collection
+[10]: /serverless/aws_lambda/managed_instances/

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -61,7 +61,7 @@ In Datadog, install the [AWS Lambda integration][5], which provides the out-of-t
 
 Create a [trace retention filter][6] with the retention query `operation_name:aws.durable.execute`.
 
-## Querying durable executions in Datadog
+## Querying in Datadog
 
 The **Executions** tab on the Lambda function page lists durable executions. Use the log attributes, span tags, and metrics below to search for durable executions, or to build dashboards and monitors.
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -65,16 +65,6 @@ Create a [trace retention filter][6] with the retention query `operation_name:aw
 
 The **Executions** tab on the Lambda function page lists durable executions. Use the log attributes, span tags, and metrics below to query this data directly, or to build dashboards and monitors.
 
-### Execution identifiers
-
-Logs, traces, and status events all identify an execution by its execution name. Spans carry it inside the execution ARN:
-
-```text
-arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-execution/<EXECUTION_NAME>/<EXECUTION_ID>
-```
-
-The execution name is the first segment after `/durable-execution/` and the execution ID is the second. The two are different values, so searching for one in the other's attribute returns no results.
-
 ### Logs
 
 To scope a log query to one function, filter on the function ARN:

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -104,14 +104,6 @@ Example queries:
 
     Lambda Managed Instances emit no `END` log, so query both.
 
-- Executions with a given status:
-
-    ```text
-    @lambda.durable_function.execution_status:FAILED
-    ```
-
-    `TIMED_OUT` and `STOPPED` come only from the status change events described below.
-
 ### Status change events
 
 The events forwarded by the CloudFormation stack arrive as logs, matched by:

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -136,10 +136,6 @@ To scope a span query to one function, filter on the function ARN:
 
 The tracer creates one `aws.durable.execute` span per invocation and stitches an execution's invocations into a single trace.
 
-```text
-operation_name:aws.durable.execute
-```
-
 | Span tag | Description |
 |---|---|
 | `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the execution name as a separate tag. |

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -46,7 +46,7 @@ To forward durable execution status change events to Datadog, deploy the CloudFo
 3. Set `DdSite` to your [Datadog site][4]. The default is `datadoghq.com`.
 4. Optionally, restrict which events are forwarded:
 
-    - `Statuses`: a comma-separated list of execution statuses to forward. Valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, and `STOPPED`. Leave this empty to forward all statuses. Only the four terminal statuses set the status Datadog reports for an execution; an execution with no terminal status is shown as running.
+    - `Statuses`: a comma-separated list of execution statuses to forward. Valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, and `STOPPED`. Leave this empty to forward all statuses.
     - `FunctionArnFilter1` through `FunctionArnFilter5`: up to five unqualified Lambda function ARNs or EventBridge wildcard patterns, such as `arn:aws:lambda:us-east-2:123456789012:function:my-durable-*`. Do not include a version or alias suffix. Leave all five empty to forward events from every function in the region.
     - `BufferIntervalSeconds`: the Amazon Data Firehose buffer interval, in seconds (`60`-`900`, default `60`). Higher values reduce the number of outbound requests at the cost of freshness.
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -82,24 +82,24 @@ The Datadog Lambda Extension adds these attributes to a durable function's logs:
 | `@lambda.durable_function.first_invocation` | `true` on logs from the execution's first invocation, `false` otherwise. |
 | `@lambda.durable_function.execution_status` | The execution's state when the invocation ended: `SUCCEEDED`, `FAILED`, or `PENDING`, where `PENDING` means the execution suspended and resumes in a later invocation. On the `END` log, or on the `REPORT` log for executions on Lambda Managed Instances. |
 
-Example queries:
+Example queries (add `@lambda.arn:"<FUNCTION_ARN>"` to scope to one function):
 
 - All logs for one durable execution:
 
     ```text
-    @lambda.arn:"<FUNCTION_ARN>" @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
+    @lambda.durable_function.execution_name:"<EXECUTION_NAME>"
     ```
 
 - Each execution's `START` log, which marks when it began:
 
     ```text
-    @lambda.arn:"<FUNCTION_ARN>" "START RequestId:" @lambda.durable_function.first_invocation:true
+    "START RequestId:" @lambda.durable_function.first_invocation:true
     ```
 
 - Each execution's last log, which marks when it ended:
 
     ```text
-    @lambda.arn:"<FUNCTION_ARN>" ("END RequestId:" OR "REPORT RequestId:")
+    "END RequestId:" OR "REPORT RequestId:"
     ```
 
     Lambda Managed Instances emit no `END` log, so query both.

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -142,7 +142,7 @@ operation_name:aws.durable.execute
 
 | Span tag | Description |
 |---|---|
-| `@aws.durable.execution_arn` | The full durable execution ARN. This span carries no bare execution name; parse it from the segment after `/durable-execution/`. |
+| `@aws.durable.execution_arn` | The full durable execution ARN, which contains the execution name. This span does not carry the name as a separate tag. |
 | `@aws.durable.invocation_status` | The execution's state when this invocation ended: `succeeded`, `failed`, or `pending`. `pending` means the execution suspended and resumes in a later invocation. |
 | `@aws.durable.replayed` | `true` when the invocation replayed results from a prior checkpoint. |
 
@@ -214,7 +214,7 @@ The execution name joins the three sources, but its attribute name differs:
 
 | Concept | Logs and status events | Spans |
 |---|---|---|
-| Execution name | `@lambda.durable_function.execution_name` | `@aws.durable.execution_name`, or the first segment after `/durable-execution/` in `@aws.durable.execution_arn` |
+| Execution name | `@lambda.durable_function.execution_name` | `@aws.durable.execution_name` |
 | Execution ID | `@lambda.durable_function.execution_id` | `@aws.durable.execution_id` |
 | Full execution ARN | — | `@aws.durable.execution_arn` |
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -67,18 +67,13 @@ The **Executions** tab on the Lambda function page lists durable executions. Use
 
 ### Execution identifiers
 
-A durable execution ARN has the format:
+Logs, traces, and status events all identify an execution by its execution name. Spans carry it inside the execution ARN:
 
 ```text
 arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:<FUNCTION_NAME>:<VERSION>/durable-execution/<EXECUTION_NAME>/<EXECUTION_ID>
 ```
 
-| Identifier | Description |
-|---|---|
-| `<EXECUTION_NAME>` | A random UUID identifying one durable execution. The correlation key across logs and traces. |
-| `<EXECUTION_ID>` | A deterministic, name-based UUID for the same execution. It differs from the execution name; do not use it to correlate telemetry. |
-
-One durable execution spans many Lambda invocations, so every log and span for that execution shares the same execution name.
+The execution ID is a different value. Both are UUIDs, and correlating on the execution ID returns no matches.
 
 ### Logs
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -149,7 +149,7 @@ operation_name:aws.durable.execute
 | Span tag | Description |
 |---|---|
 | `@aws.durable.execution_arn` | The full durable execution ARN. This span carries no bare execution name; parse it from the segment after `/durable-execution/`. |
-| `@aws.durable.invocation_status` | The outcome of the execution: `succeeded`, `failed`, or `pending`. |
+| `@aws.durable.invocation_status` | The execution's state when this invocation ended: `succeeded`, `failed`, or `pending`. `pending` means the execution suspended and resumes in a later invocation. |
 | `@aws.durable.replayed` | `true` when the invocation replayed results from a prior checkpoint. |
 
 **The Lambda invocation span**

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -80,7 +80,7 @@ The Datadog Lambda Extension adds these attributes to a durable function's logs:
 | `@lambda.durable_function.execution_name` | The execution name. Groups all logs from one execution. |
 | `@lambda.durable_function.execution_id` | The execution ID. |
 | `@lambda.durable_function.first_invocation` | `true` on logs from the execution's first invocation, `false` otherwise. |
-| `@lambda.durable_function.execution_status` | The execution status, on logs that report one, such as the `END` log. |
+| `@lambda.durable_function.execution_status` | The execution status, on the `END` log, or on the `REPORT` log for executions on Lambda Managed Instances. |
 
 Example queries:
 
@@ -102,7 +102,7 @@ Example queries:
     "END RequestId:" OR "REPORT RequestId:"
     ```
 
-    Only one carries `execution_status`: `END` for most executions, `REPORT` for executions on Lambda Managed Instances, which emit no `END` log.
+    Lambda Managed Instances emit no `END` log, so query both.
 
 - Executions that reached a given terminal status, one of `SUCCEEDED`, `FAILED`, `TIMED_OUT`, or `STOPPED`:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The AWS Lambda durable functions page covered setup only. 

This PR adds a section **Querying in Datadog**, explaining how to query:
- function logs
- durable execution status change event logs
- traces
- metrics

for durable functions.

It's aimed to be usable by both humans readers and AI agents (such as by Bits AI to investigate issues on durable functions)

### Merge readiness

- [x] Ready for merge