### PR TITLE
Document Node.js agent attribution

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -1289,7 +1289,7 @@ getRelevantDocs = llmobs.wrap({ kind: 'retrieval' }, getRelevantDocs)
 
 ## Nesting spans
 
-Starting a new span before the current span is finished automatically traces a parent-child relationship between the two spans. The parent span represents the larger operation, while the child span represents a smaller nested sub-operation within it.
+Starting a new span before the current span is finished automatically traces a parent-child relationship between the two spans. The parent span represents the larger operation, while the child span represents a smaller nested sub-operation within it. For Node.js traces, Agent Observability associates each span beneath an agent span with its nearest ancestor agent span. In multi-agent traces, Agent Observability associates a nested agent span with its enclosing agent span and associates the nested agent's descendants with the nested agent.
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -2987,7 +2987,7 @@ def server_process_request(request):
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-The `dd-trace` library provides out-of-the-box integrations that support distributed tracing for popular [web frameworks][1]. Requiring the tracer automatically enables these integrations, but you can disable them optionally with:
+The `dd-trace` library provides out-of-the-box integrations that support distributed tracing for popular [web frameworks][1]. Requiring the tracer automatically enables these integrations, so spans in downstream instrumented services stay associated with their nearest ancestor agent span in Agent Observability. Optionally, disable these integrations with:
 
 {{< code-block lang="javascript">}}
 const tracer = require('dd-trace').init({


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8595e35b-e296-4cc3-a1eb-e1323cecb49f","source":"chat","resourceId":"c70a2cf0-c292-4df6-83d1-923d8623657c","workflowId":"97372c28-da1e-431d-b71b-626b4defd505","codeChangeId":"97372c28-da1e-431d-b71b-626b4defd505","sourceType":"chat"} -->
### What does this PR do? What is the motivation?

Motivation: Document the Agent Observability behavior introduced by https://github.com/DataDog/dd-trace-js/pull/9175 so Node.js customers understand how spans are attributed in nested and distributed agent traces.

Changes:
- Added Node.js nesting guidance for nearest ancestor agent span association.
- Clarified that downstream instrumented services keep nearest-agent association in Agent Observability.

### Testing

- Ran `git diff --check`.
- Attempted `vale hugo/content/en/llm_observability/instrumentation/sdk.md`, but `vale` is not installed in this environment.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code powered by Codex CLI to draft and validate this documentation change.

### Additional notes

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/c70a2cf0-c292-4df6-83d1-923d8623657c)

Comment @datadog-staging to request changes