### PR TITLE
Java SDK: document embedding/retrieval annotation

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -1654,9 +1654,9 @@ The SDK provides several methods to annotate spans with inputs, outputs, metrics
 
 ### Annotating inputs and outputs
 
-Use the `annotateIO()` member method of the `LLMObsSpan` interface to add structured input and output data to an `LLMObsSpan`. This includes optional arguments and LLM message objects.
+The `LLMObsSpan` interface provides three methods for annotating span inputs and outputs. Use `annotateIO()` for LLM, task, agent, workflow, and tool spans. Use `annotateEmbeddingIO()` to annotate an embedding span's inputs with document objects, and `annotateRetrievalIO()` to annotate a retrieval span's outputs with document objects. `annotateEmbeddingIO()` and `annotateRetrievalIO()` require `dd-trace-java` 1.66.0 or later.
 
-#### Arguments
+#### annotateIO() arguments
 
 If an argument is null or empty, nothing happens. For example, if `inputData` is a non-empty string while `outputData` is null, then only `inputData` is recorded.
 
@@ -1667,6 +1667,30 @@ If an argument is null or empty, nothing happens. For example, if `inputData` is
 `outputData`
 : optional - _String_ or _List<LLMObs.LLMMessage>_
 <br />Either a string (for non-LLM spans) or a list of `LLMObs.LLMMessage`s for LLM spans.
+
+#### annotateEmbeddingIO() arguments
+
+If an argument is null or empty, nothing happens.
+
+`inputDocuments`
+: optional - _List<LLMObs.Document>_
+<br />A list of documents passed to the embedding model as input.
+
+`outputData`
+: optional - _String_
+<br />The embedding output as a string.
+
+#### annotateRetrievalIO() arguments
+
+If an argument is null or empty, nothing happens.
+
+`inputData`
+: optional - _String_
+<br />The retrieval query as a string.
+
+`outputDocuments`
+: optional - _List<LLMObs.Document>_
+<br />A list of documents returned by the retrieval operation.
 
 #### LLM Messages
 LLM spans must be annotated with LLM Messages using the `LLMObs.LLMMessage` object.
@@ -1681,7 +1705,28 @@ The `LLMObs.LLMMessage` object can be instantiated by calling `LLMObs.LLMMessage
 : required - _String_
 <br />A string containing the content of the message.
 
-#### Example
+#### Documents
+Embedding and retrieval spans use the `LLMObs.Document` class to represent individual documents.
+
+The `LLMObs.Document` object can be instantiated by calling `LLMObs.Document.from()` with the following arguments:
+
+`text`
+: required - _String_
+<br />The text content of the document.
+
+`name`
+: optional - _String_
+<br />A name for the document.
+
+`id`
+: optional - _String_
+<br />A unique identifier for the document.
+
+`score`
+: optional - _Double_
+<br />A relevance score for the document.
+
+#### Examples
 
 ```java
 import datadog.trace.api.llmobs.LLMObs;
@@ -1702,6 +1747,42 @@ public class MyJavaClass {
     );
     llmSpan.finish();
     return chatResponse;
+  }
+}
+```
+
+```java
+import datadog.trace.api.llmobs.LLMObs;
+
+public class MyJavaClass {
+  public float[] performEmbedding(String inputText) {
+    LLMObsSpan embeddingSpan = LLMObs.startEmbeddingSpan("embed-text", "text-embedding-3", "openai", null, "session-141");
+    float[] embeddings = ... // user application logic to generate embeddings
+    embeddingSpan.annotateEmbeddingIO(
+      Arrays.asList(LLMObs.Document.from(inputText, null, null, null)),
+      null
+    );
+    embeddingSpan.finish();
+    return embeddings;
+  }
+}
+```
+
+```java
+import datadog.trace.api.llmobs.LLMObs;
+
+public class MyJavaClass {
+  public List<Document> retrieveDocuments(String query) {
+    LLMObsSpan retrievalSpan = LLMObs.startRetrievalSpan("retrieve-docs", null, "session-141");
+    List<Document> docs = ... // user application logic to retrieve documents
+    retrievalSpan.annotateRetrievalIO(
+      query,
+      Arrays.asList(
+        LLMObs.Document.from(docs.get(0).text, docs.get(0).name, docs.get(0).id, docs.get(0).score)
+      )
+    );
+    retrievalSpan.finish();
+    return docs;
   }
 }
 ```


### PR DESCRIPTION
<!-- dd-meta {"pullId":"60bf2f6f-6851-4358-9587-6a0481dbbe45","source":"chat","resourceId":"a9a3dd49-2c14-40c0-91bd-07002a874c14","workflowId":"df155e30-ddfb-43cc-a521-8fa4c6506184","codeChangeId":"df155e30-ddfb-43cc-a521-8fa4c6506184","sourceType":"chat"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds documentation for two new Java SDK methods, `annotateEmbeddingIO()` and `annotateRetrievalIO()`, introduced in [dd-trace-java#12149](#removed-for-safety). These methods let customers annotate embedding and retrieval spans with structured document objects (`LLMObs.Document`) rather than plain strings, giving the trace view richer context for those span types.

The changes land in the **Java** tab of **Enriching spans > Annotating inputs and outputs** in the LLM Observability SDK reference page.

**Changes:**
- Updates the section intro to cover all three annotation methods and states which span kind each targets.
- Renames the existing `#### Arguments` heading to `#### annotateIO() arguments` for clarity.
- Adds `#### annotateEmbeddingIO() arguments` and `#### annotateRetrievalIO() arguments` subsections, each documenting its parameters and preserving the existing null/empty-argument behavior guidance.
- Adds a `#### Documents` subsection documenting how to construct `LLMObs.Document` values (required `text`; optional `name`, `id`, `score`), parallel to the existing `#### LLM Messages` subsection.
- Expands `#### Example` to `#### Examples` and adds concise embedding-span and retrieval-span code examples alongside the existing LLM-span example.
- Notes that `annotateEmbeddingIO()` and `annotateRetrievalIO()` require `dd-trace-java` 1.66.0 or later.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code (Bits Code) to draft, structure, and write the documentation changes.

### Additional notes

Source PR: https://github.com/DataDog/dd-trace-java/pull/12149

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/a9a3dd49-2c14-40c0-91bd-07002a874c14)

Comment @datadog-staging to request changes