### PR TITLE
Document Python agent versioning in SDK reference

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -855,17 +855,25 @@ To trace an agent execution, use the function decorator `ddtrace.llmobs.decorato
 `ml_app`
 : optional - _string_
 <br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
+`version`
+: optional - _string_
+<br/>The version of the agent. Applies only to this agent span and does not propagate to child spans.
 {{% /collapse-content %}}
 
 #### Example
 
 {{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs.decorators import agent
 
-@agent
+@agent(version="v3")
 def react_agent():
     ... # user application logic
     return
+
+with LLMObs.agent(name="react_agent", version="v3") as agent_span:
+    ... # user application logic
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -1397,6 +1405,10 @@ The `LLMObs.annotate()` method accepts the following arguments:
 : optional - _list of strings_
 <br />A list of tag keys (already set with `tags` or annotated previously on the same span) to propagate as custom tags on the generated LLM cost and token metrics. Entries that don't reference an existing tag key are skipped. See [Cost monitoring](#cost-monitoring) for details.
 
+`agent`
+: optional - _dictionary_
+<br />A dictionary for annotating agent spans. Accepts `{"version": "..."}`, where the `"version"` key is a string that identifies the agent version. You can also pass a `ddtrace.llmobs.Agent` object. Applies only to agent spans.
+
 {{% /collapse-content %}}
 
 #### Example
@@ -1915,6 +1927,10 @@ The `LLMObs.annotation_context()` method accepts the following arguments:
 : optional - _list of strings_
 <br />A list of tag keys to propagate as custom tags on the generated LLM cost and token metrics. Each entry must reference a key present in `tags` at span start (supplied to the same context or a parent context); tag keys added later with `LLMObs.annotate()` are not retained. See [Cost monitoring](#cost-monitoring) for details.
 
+`agent`
+: optional - _dictionary_
+<br />A dictionary for annotating agent spans started within the context. Accepts `{"version": "..."}`, where the `"version"` key is a string that identifies the agent version. You can also pass a `ddtrace.llmobs.Agent` object. Applies only to agent spans.
+
 {{% /collapse-content %}}
 
 #### Example
@@ -1940,7 +1956,8 @@ def rag_workflow(user_question):
         tags = {
             "retrieval_strategy": "semantic_similarity"
         },
-        name = "augmented_generation"
+        name = "augmented_generation",
+        agent = {"version": "v3"},
     ):
         completion = openai_client.chat.completions.create(...)
     return completion.choices[0].message.content


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2124b3bb-336c-4c1e-9ccc-229356db6c23","source":"chat","resourceId":"d7f8faf6-f8d4-49ca-9816-db39656a18bb","workflowId":"99795f32-f525-4a03-8d7f-ec6504d128c5","codeChangeId":"99795f32-f525-4a03-8d7f-ec6504d128c5","sourceType":"chat"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the `version` argument added to the Python Agent Observability SDK for agent spans, introduced in https://github.com/DataDog/dd-trace-py/pull/19490.

Customers can now set a version string on individual agent spans using the `@agent(version="v3")` decorator or the inline `LLMObs.agent(..., version="v3")` method, annotate existing agent spans with `LLMObs.annotate(agent={"version": "v3"})`, and apply versioning to auto-instrumented agent spans through `LLMObs.annotation_context(agent={"version": "v3"})`.

Changes are confined to the Python tab because the source PR adds Python SDK support only.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code (Bits) to draft the documentation changes.

### Additional notes

Source PR: https://github.com/DataDog/dd-trace-py/pull/19490

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/d7f8faf6-f8d4-49ca-9816-db39656a18bb)

Comment @datadog-staging to request changes