### PR TITLE
Node.js agent span attribution in nesting

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -1323,6 +1323,8 @@ function extractData (document) {
 }
 extractData = llmobs.wrap({ kind: 'workflow' }, extractData)
 {{< /code-block >}}
+
+When spans are nested inside an `agent` span, the SDK automatically associates each descendant span with its nearest enclosing agent, including spans that continue in a downstream service through distributed tracing. A nested `agent` span is associated with its enclosing agent, while spans nested beneath it are associated with that nested agent.
 {{% /tab %}}
 {{% tab "Java" %}}
 {{< code-block lang="java" >}}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5d4f20dd-399c-4c08-91a0-4aff4da15d17","source":"chat","resourceId":"ee55507f-d47e-4452-8787-1aa92ff444b0","workflowId":"0e4a5d3d-cb85-4c6a-8228-60222ba54447","codeChangeId":"0e4a5d3d-cb85-4c6a-8228-60222ba54447","sourceType":"chat"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a brief explanation to the Node.js tab of the **Nesting spans** section in the LLM Observability SDK instrumentation docs. The Node.js SDK (dd-trace-js) gained logic that automatically associates descendant spans with their nearest enclosing `agent` span, including across distributed traces. Without this documentation, customers have no way to know this attribution happens or how the hierarchy works when agents are nested.

Source PR: https://github.com/DataDog/dd-trace-js/pull/9175

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code (Claude Sonnet) to draft and apply the documentation change.

### Additional notes

The added text describes two behaviors:
1. Descendant spans under an `agent` span are automatically associated with their nearest enclosing agent, including spans propagated to downstream services via distributed tracing.
2. In multi-agent nesting, a nested `agent` is associated with its enclosing agent; spans beneath the inner agent are associated with the inner agent.

No internal implementation details, propagation headers, or intake metadata fields are exposed.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/ee55507f-d47e-4452-8787-1aa92ff444b0)

Comment @datadog-staging to request changes