### PR TITLE
Rewrite Private Actions Overview for Execution Policies

### DIFF
--- a/hugo/content/en/actions/private_actions/_index.md
+++ b/hugo/content/en/actions/private_actions/_index.md
@@ -1,58 +1,95 @@
 ---
 title: Private Actions Overview
-description: Allow workflows and apps to interact with private network services using private action runners with secure authentication.
+description: Run actions against services in your private network from Datadog products, using a private action runner as the execution and authorization layer for on-premises actions.
 disable_toc: false
 aliases:
 - service_management/workflows/private_actions/
 - service_management/app_builder/private_actions/
 further_reading:
+- link: "actions/private_actions/set_up_agent_based"
+  tag: "Documentation"
+  text: "Set up a private action runner"
+- link: "actions/private_actions/enroll_runner"
+  tag: "Documentation"
+  text: "Enrollment and ownership"
+- link: "actions/private_actions/execution_policies"
+  tag: "Documentation"
+  text: "Execution Policies"
 - link: "actions/connections"
   tag: "Documentation"
-  text: "App Builder Connections"
-- link: "actions/connections"
-  tag: "Documentation"
-  text: "Workflow Connections"
-- link: "actions/private_actions/use_private_actions"
-  tag: "Documentation"
-  text: "Use Private Actions"
-- link: "actions/private_actions/run_script"
-  tag: "Documentation"
-  text: "Run a Script with the Private Action Runner"
-- link: "actions/private_actions/private_action_credentials"
-  tag: "Documentation"
-  text: "Handling Private Action Credentials"
-- link: "https://www.datadoghq.com/blog/private-actions/"
-  tag: "Blog"
-  text: "Remediate Kubernetes incidents faster using private actions in your apps and workflows"
-- link: "https://www.datadoghq.com/blog/pm-app-automation/"
-  tag: "Blog"
-  text: "How we created a single app to automate repetitive tasks with Datadog Workflow Automation, Datastore, and App Builder"
+  text: "Connections"
 ---
 
-Private actions allow your Datadog workflows and apps to interact with services hosted on your private network without exposing them to the public internet. To use private actions, you must install a private action runner on a host in your network and pair the runner with a [connection][1].
+Private actions allow you to run actions against services in your private network, such as Kubernetes
+clusters, internal hosts, databases, and internal APIs, without exposing those services to the public
+internet. You run them through a private action runner that you deploy in your environment, either
+inside the Datadog Agent (recommended) or as a standalone runner. Datadog products that use private
+actions include Workflow Automation, App Builder, Datadog MCP, and Bits AI investigations.
 
-The recommended way to install a private action runner is through the [Datadog Agent][2] (version `7.77.0` or later). This method supports Linux, Windows, and Kubernetes environments. Alternatively, you can install the runner as a standalone Docker container or [Kubernetes][3] deployment. See [Use Private Actions][4] for installation instructions.
+To go from zero to running your first private action, see [Get started with private actions][8].
 
-<div class="alert alert-danger">To install a private action runner, your organization must have <a href="/remote_configuration">Remote Configuration</a> enabled.</div>
+Private actions rely on two layers:
 
-When you first start the runner, it generates a private key for authentication with Datadog's servers. This private key is never accessible by Datadog and ensures you exclusive access. Datadog uses a public key derived from the private key as the means to authenticate specific runners.
+- **The authorization layer** is managed in Datadog. It defines which users and products can run which
+  actions on which runners, and grants or denies each action before it reaches a runner. The actions a
+  runner is allowed to run are also restricted on the Agent side, by the actions allowlist in the Agent
+  configuration (`datadog.yaml`).
+- **Private action runner** executes the actions. It runs in your network, receives action tasks
+  from Datadog, runs each task against the target service, and returns the result to Datadog. 
+For how authorization works, see [How private actions are authorized](#how-private-actions-are-authorized).
 
-## How it works
+## The private action runner
 
-The private action runner continuously polls for tasks from your Datadog account, executes them by interacting with your internal service, and reports the result back to Datadog.
+The private action runner is the component you deploy in your environment to run private actions. It opens
+an outbound connection to Datadog, polls for action tasks, runs each task against the target service, and
+returns the result. 
 
-{{< img src="actions/private_actions/private_action_runner_-_diagram_workflow.png" alt="Overview diagram illustrating how Private actions work" style="width:90%;" >}}
+## Choose how to run the runner
 
-## Monitor your Private Action Runners with Datadog Metrics
+The private action runner is available in two forms: a standalone runner that you deploy and manage
+yourself, or a runner built into the Datadog Agent.
 
-While setting up your Private Action Runners, you can enable observability metrics to monitor your runners' health and private action usage. These metrics can be used in Datadog products like Dashboards and Monitors. To get started quickly, you can use the provided [out-of-the-box Dashboard][5].
+| | Runner in the Datadog Agent | Standalone runner |
+|---|---|---|
+| **What it is** | A component of the Datadog Agent, turned on with a single configuration flag. | A dedicated container you can install and manage independently of the Datadog Agent. |
+| **Best when** | You already run the Datadog Agent and want to manage the runner through the Agent life cycle. | You need an integration that is not yet available in the Agent. |
+| **Status** | Recommended for new deployments. | Supported (maintenance mode). |
+
+For most users, running the private action runner in the Datadog Agent is the recommended path. For
+installation steps, see [Set up a private action runner in the Datadog Agent][1] or
+[Set up a standalone runner][7].
+
+## How private actions are authorized
+
+Datadog offers two authorization models. The model a runner uses is set when the runner is enrolled, and
+it follows from the runner's ownership. For details, see [Enrollment and ownership][2].
+
+- **Execution Policies** apply to runners in the Datadog Agent and are built for managing access at scale.
+  Instead of creating a separate connection for each integration on each runner, you use Agent tags to
+  target one or more sets of runners. Execution Policies also give you fine-grained control: you can allow
+  or deny specific actions or sets of actions, and apply integration-specific scopes, such as the target
+  Kubernetes namespaces for a Kubernetes action.
+- **Connections** are available for both the runner in the Agent and the standalone runner. They can be
+  attached to at most a single runner. A connection can store credentials for a service.
+
+To compare the two models and decide which one applies to your runner, see [Authorize private actions][3].
+
+## Choose your setup
+
+- To use the recommended, Agent-managed setup with fleet-wide access control, run the runner in the
+  Datadog Agent and authorize it with Execution Policies. Start with:
+    1. [Set up a private action runner][1]
+    2. then [Execution Policies][4].
+- Or use Connections with a runner in the Agent or a standalone runner. See [Connections][5].
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /actions/connections/
-[2]: /agent/
-[3]: https://github.com/DataDog/helm-charts/tree/main/charts/private-action-runner
-[4]: /actions/private_actions/use_private_actions
-[5]: https://app.datadoghq.com/dash/integration/private_actions_runner
+[1]: /actions/private_actions/set_up_agent_based/
+[2]: /actions/private_actions/enroll_runner/
+[3]: /actions/private_actions/authorize_private_actions/
+[4]: /actions/private_actions/execution_policies/
+[5]: /actions/connections/
+[7]: /actions/private_actions/set_up_standalone/
+[8]: /actions/private_actions/getting_started/

--- a/hugo/content/en/actions/private_actions/_index.md
+++ b/hugo/content/en/actions/private_actions/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Private Actions Overview
+title: Private Actions
 description: Run actions against services in your private network from Datadog products, using a private action runner as the execution and authorization layer for on-premises actions.
 disable_toc: false
 aliases:
@@ -12,42 +12,25 @@ further_reading:
 - link: "actions/private_actions/enroll_runner"
   tag: "Documentation"
   text: "Enrollment and ownership"
-- link: "actions/private_actions/execution_policies"
+- link: "/actions/private_actions/authorize_private_actions/"
   tag: "Documentation"
-  text: "Execution Policies"
-- link: "actions/connections"
-  tag: "Documentation"
-  text: "Connections"
+  text: "Authorize Private Actions"
 ---
 
-Private actions allow you to run actions against services in your private network, such as Kubernetes
-clusters, internal hosts, databases, and internal APIs, without exposing those services to the public
-internet. You run them through a private action runner that you deploy in your environment, either
-inside the Datadog Agent (recommended) or as a standalone runner. Datadog products that use private
-actions include Workflow Automation, App Builder, Datadog MCP, and Bits AI investigations.
+## Overview
 
-To go from zero to running your first private action, see [Get started with private actions][8].
+Private actions allow you to run actions against services in your private network, such as Kubernetes clusters, internal hosts, databases, and internal APIs, without exposing those services to the public internet. You run them through a private action runner that you deploy in your environment, either inside the Datadog Agent (recommended) or as a standalone runner. Datadog products that use private actions include Workflow Automation, App Builder, Datadog MCP, and Bits AI investigations.
 
 Private actions rely on two layers:
 
-- **The authorization layer** is managed in Datadog. It defines which users and products can run which
-  actions on which runners, and grants or denies each action before it reaches a runner. The actions a
-  runner is allowed to run are also restricted on the Agent side, by the actions allowlist in the Agent
-  configuration (`datadog.yaml`).
-- **Private action runner** executes the actions. It runs in your network, receives action tasks
-  from Datadog, runs each task against the target service, and returns the result to Datadog. 
-For how authorization works, see [How private actions are authorized](#how-private-actions-are-authorized).
+- [**Private action runner**](#private-action-runner) executes the actions. It runs in your network, receives action tasks from Datadog, runs each task against the target service, and returns the result to Datadog.
+- [**The authorization layer**](#authorization-models) is managed in Datadog. It defines which users and products can run which actions on which runners, and grants or denies each action before it reaches a runner. The actions a runner is allowed to run are also restricted on the Agent side, by the actions allowlist in the Agent configuration (`datadog.yaml`).
 
-## The private action runner
+## Private action runner
 
-The private action runner is the component you deploy in your environment to run private actions. It opens
-an outbound connection to Datadog, polls for action tasks, runs each task against the target service, and
-returns the result. 
+The private action runner is the component you deploy in your environment to run private actions. It opens an outbound connection to Datadog, polls for action tasks, runs each task against the target service, and returns the result.
 
-## Choose how to run the runner
-
-The private action runner is available in two forms: a standalone runner that you deploy and manage
-yourself, or a runner built into the Datadog Agent.
+The private action runner is available in two forms: a standalone runner that you deploy and manage yourself, or a runner built into the Datadog Agent.
 
 | | Runner in the Datadog Agent | Standalone runner |
 |---|---|---|
@@ -55,41 +38,33 @@ yourself, or a runner built into the Datadog Agent.
 | **Best when** | You already run the Datadog Agent and want to manage the runner through the Agent life cycle. | You need an integration that is not yet available in the Agent. |
 | **Status** | Recommended for new deployments. | Supported (maintenance mode). |
 
-For most users, running the private action runner in the Datadog Agent is the recommended path. For
-installation steps, see [Set up a private action runner in the Datadog Agent][1] or
-[Set up a standalone runner][7].
+<div class="alert alert-tip">Datadog recommends running the private action runner in the Datadog Agent</div>
 
-## How private actions are authorized
+For installation steps, see [Set up a private action runner in the Datadog Agent][1] or [Set up a standalone runner][2].
 
-Datadog offers two authorization models. The model a runner uses is set when the runner is enrolled, and
-it follows from the runner's ownership. For details, see [Enrollment and ownership][2].
+## Authorization models
 
-- **Execution Policies** apply to runners in the Datadog Agent and are built for managing access at scale.
-  Instead of creating a separate connection for each integration on each runner, you use Agent tags to
-  target one or more sets of runners. Execution Policies also give you fine-grained control: you can allow
-  or deny specific actions or sets of actions, and apply integration-specific scopes, such as the target
-  Kubernetes namespaces for a Kubernetes action.
-- **Connections** are available for both the runner in the Agent and the standalone runner. They can be
-  attached to at most a single runner. A connection can store credentials for a service.
+Datadog offers two authorization models. The model a runner uses is set when the runner is enrolled, and it follows from the runner's ownership. For more information, see [Enrollment and ownership][3].
 
-To compare the two models and decide which one applies to your runner, see [Authorize private actions][3].
+- **Execution Policies** apply to runners in the Datadog Agent and are built for managing access at scale. Instead of creating a separate connection for each integration on each runner, you use Agent tags to target one or more sets of runners. Execution Policies also give you fine-grained control: you can allow or deny specific actions or sets of actions, and apply integration-specific scopes, such as the target Kubernetes namespaces for a Kubernetes action.
+- **Connections** are available for both the runner in the Agent and the standalone runner. They can be attached to at most a single runner. A connection can store credentials for a service.
 
-## Choose your setup
+To compare the two models and decide which one applies to your runner, see [Authorize private actions][4].
 
-- To use the recommended, Agent-managed setup with fleet-wide access control, run the runner in the
-  Datadog Agent and authorize it with Execution Policies. Start with:
-    1. [Set up a private action runner][1]
-    2. then [Execution Policies][4].
-- Or use Connections with a runner in the Agent or a standalone runner. See [Connections][5].
+## Next steps
+
+- **New to private actions**: Follow [Getting started with private actions][7] to deploy a runner and run your first action.
+- **You have a runner in the Datadog Agent and want fleet-wide access control**: Authorize it with [Execution Policies][5].
+- **You have a runner in the Agent or a standalone runner and want to authorize a single runner**: Authorize it with [Connections][6].
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /actions/private_actions/set_up_agent_based/
-[2]: /actions/private_actions/enroll_runner/
-[3]: /actions/private_actions/authorize_private_actions/
-[4]: /actions/private_actions/execution_policies/
-[5]: /actions/connections/
-[7]: /actions/private_actions/set_up_standalone/
-[8]: /actions/private_actions/getting_started/
+[2]: /actions/private_actions/set_up_standalone/
+[3]: /actions/private_actions/enroll_runner/
+[4]: /actions/private_actions/authorize_private_actions/
+[5]: /actions/private_actions/execution_policies/
+[6]: /actions/connections/
+[7]: /actions/private_actions/getting_started/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Rewrites the Private Actions Overview page around the new **Execution Policies** authorization model (replacing Execution Groups). Reorders the "How private actions are authorized" and "Choose your setup" sections so Execution Policies is listed before Connections, per the docs' standing ordering convention (agent-based/ownerless first).

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code carried this page's content over from a pre-drafted, QA-verified draft, ran Vale, and applied a couple of small copy fixes.

### Additional notes