### PR TITLE
[DOCS-XXXXX] Add Private Actions Reference

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -3161,6 +3161,11 @@ menu:
       parent: private_actions
       identifier: run_script
       weight: 7
+    - name: Reference
+      url: actions/private_actions/reference/
+      parent: private_actions
+      identifier: private_actions_reference
+      weight: 8
     - name: Cloudcraft
       url: datadog_cloudcraft/
       pre: cloudcraft

--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -3161,7 +3161,7 @@ menu:
       parent: private_actions
       identifier: run_script
       weight: 7
-    - name: Reference
+    - name: Runner Reference
       url: actions/private_actions/reference/
       parent: private_actions
       identifier: private_actions_reference

--- a/hugo/content/en/actions/private_actions/reference.md
+++ b/hugo/content/en/actions/private_actions/reference.md
@@ -43,7 +43,7 @@ This matrix shows, for each integration, its availability in each runner type an
 | Integration | Runner in the Agent | Authorizable through<br>Execution Policies | Standalone runner |
 |---|:---:|:---:|:---:|
 | Kubernetes | {{< X >}} | {{< X >}} | {{< X >}} |
-| Remote Action (rshell + network path) | {{< X >}} | {{< X >}} | {{< X >}} |
+| Remote Action (for example, rshell) | {{< X >}} | {{< X >}} | {{< X >}} |
 | Script | {{< X >}} | {{< X >}} | {{< X >}} |
 | HTTP | {{< X >}} |  | {{< X >}} |
 | GitLab | {{< X >}} |  | {{< X >}} |
@@ -52,7 +52,7 @@ This matrix shows, for each integration, its availability in each runner type an
 | PostgreSQL |  |  | {{< X >}} |
 | Temporal | {{< X >}} |  | {{< X >}} |
 
-- **Remote Action** is the integration family under the `com.datadoghq.remoteaction` prefix. It includes network path actions and the rshell bundle, whose `runCommand` action runs shell commands through a restricted shell.
+- **Remote Action** is the integration family under the `com.datadoghq.remoteaction` prefix. It includes the rshell bundle, whose `runCommand` action runs shell commands through a restricted shell. See [Agent Restricted Shell (rshell)][8]
 - **Script** actions are limited to *predefined* scripts declared in the runner's `script-config.yaml`. To configure script actions (`runPredefinedScript` for Linux or `runPredefinedPowershellScript` for Windows), see [Run a script with a private action runner][5].
 
 {{% collapse-content title="Available actions by runner type" level="h3" %}}
@@ -78,3 +78,4 @@ For the full set of credential file formats and examples, see [Handling private 
 [5]: /actions/private_actions/run_script/
 [6]: /actions/connections/
 [7]: /actions/connections/private_action_credentials/
+[8]: /agent/guide/rshell/

--- a/hugo/content/en/actions/private_actions/reference.md
+++ b/hugo/content/en/actions/private_actions/reference.md
@@ -1,7 +1,6 @@
 ---
-title: Private Actions Reference
-description: Reference tables for private action runners, including runner configuration settings, the field-name crosswalk across host, Helm, and Operator installs, the supported actions and integrations matrix, and credential file formats.
-disable_toc: false
+title: Private Action Runner Reference
+description: Reference tables for private action runner configuration settings, supported actions and integrations, and credential file formats.
 further_reading:
 - link: "actions/private_actions/"
   tag: "Documentation"
@@ -17,20 +16,17 @@ further_reading:
   text: "Handling private action credentials"
 ---
 
-This page is the single-source lookup for private action runners: the configuration settings you can set, the
-actions and integrations each runner supports, and where to find credential file formats. For concepts and setup,
-start with the [Private Actions Overview][1] and [Set up a private action runner][2].
+## Overview
+
+This page is the reference for private action runners and covers the configuration settings, the actions and integrations each runner supports, and credential file formats. To learn more about Private Actions concepts and setup, see [Private Actions Overview][1].
 
 ## Runner configuration
 
-The runner reads its settings from the `private_action_runner` section of its [configuration][8].
-For how the enrollment settings (`self_enroll` and `api_key_only_enrollment`) fit into runner enrollment, see [Enrollment and ownership][7].
+The runner reads its settings from the `private_action_runner` section of its [configuration][2].
 
-### Field-name crosswalk
+For how the enrollment settings (`self_enroll` and `api_key_only_enrollment`) fit into runner enrollment, see [Enrollment and ownership][3].
 
-The same setting is named differently depending on how you install the runner. Host installs use environment variables,
-Helm uses camelCase keys under `privateActionRunner`, and the Datadog Operator uses snake_case keys under
-`private_action_runner`. Use this table to translate the common settings across install methods.
+The same setting is named differently depending on how you install the runner. Host installs use environment variables, Helm uses camelCase keys under `privateActionRunner`, and the Datadog Operator uses snake_case keys under `private_action_runner`. Use this table to translate the common settings across install methods.
 
 | Setting | Host (environment variable) | Helm (`privateActionRunner.*`) | Operator (`private_action_runner.*`) |
 |---|---|---|---|
@@ -40,62 +36,45 @@ Helm uses camelCase keys under `privateActionRunner`, and the Datadog Operator u
 
 ## Supported actions and integrations
 
-The following matrix shows, for each integration, whether it is available in the runner in the Datadog Agent, available
-in the standalone runner, and authorizable through [Execution Policies][3].
+This matrix shows, for each integration, its availability in each runner type and whether it is authorizable through [Execution Policies][4].
 
-| Integration | Runner in the Agent | Authorizable through Execution Policies | Standalone runner |
+<div class="alert alert-info">Availability in the Agent and authorization through Execution Policies are independent. An integration can run in the Agent without being authorizable through an Execution Policy.</div>
+
+| Integration | Runner in the Agent | Authorizable through<br>Execution Policies | Standalone runner |
 |---|:---:|:---:|:---:|
-| Kubernetes | Yes | Yes | Yes |
-| Remote Action (rshell + network path) | Yes | Yes | Yes |
-| Script | Yes | Yes | Yes |
-| HTTP | Yes | No | Yes |
-| GitLab | Yes | No | Yes |
-| Jenkins | Yes | No | Yes |
-| MongoDB | Yes | No | Yes |
-| PostgreSQL | No | No | Yes |
-| Temporal | Yes | No | Yes |
+| Kubernetes | {{< X >}} | {{< X >}} | {{< X >}} |
+| Remote Action (rshell + network path) | {{< X >}} | {{< X >}} | {{< X >}} |
+| Script | {{< X >}} | {{< X >}} | {{< X >}} |
+| HTTP | {{< X >}} |  | {{< X >}} |
+| GitLab | {{< X >}} |  | {{< X >}} |
+| Jenkins | {{< X >}} |  | {{< X >}} |
+| MongoDB | {{< X >}} |  | {{< X >}} |
+| PostgreSQL |  |  | {{< X >}} |
+| Temporal | {{< X >}} |  | {{< X >}} |
 
-**"Available in the Agent" and "authorizable through Execution Policies" are different things.** The first column tells you
-whether the integration can run in the runner in the Agent at all. The second column tells you whether that integration
-can be authorized through an Execution Policy. An integration can be available in the Agent while not being authorizable
-through Execution Policies today. Integrations that are authorizable through Execution Policies are **Kubernetes** and
-**Remote Action** (the rshell `runCommand` action and network path actions).
+- **Remote Action** is the integration family under the `com.datadoghq.remoteaction` prefix. It includes network path actions and the rshell bundle, whose `runCommand` action runs shell commands through a restricted shell.
+- **Script** actions are limited to *predefined* scripts declared in the runner's `script-config.yaml`. To configure script actions (`runPredefinedScript` for Linux or `runPredefinedPowershellScript` for Windows), see [Run a script with a private action runner][5].
 
-Notes:
-
-- **Remote Action** is the integration family under the `com.datadoghq.remoteaction` prefix. It includes the rshell
-  bundle, whose `runCommand` action runs shell commands through the restricted shell (rshell), and network path actions.
-- **Script** actions are limited to *predefined* scripts declared in the runner's
-  `script-config.yaml`. See [Run a script with a private action runner][4].
-
-### Available actions by runner type
-
-{{% collapse-content title="Available actions by runner type" level="p" %}}
+{{% collapse-content title="Available actions by runner type" level="h3" %}}
 
 {{< partial name="actions/private_actions_allowlist.html" >}}
 
 {{% /collapse-content %}}
 
-**Note:** to configure script actions (`runPredefinedScript` for Linux or
-`runPredefinedPowershellScript` for Windows), see [Run a script with a private action runner][4].
-
 ## Credential file formats
 
-Some integrations, such as HTTP, Jenkins, PostgreSQL, MongoDB, and Temporal, require credentials to run. Credentials are
-supplied to the runner as JSON files that you reference from a connection. Each integration has its own credential file
-structure and supported authentication methods.
+Some integrations, such as HTTP, Jenkins, PostgreSQL, MongoDB, and Temporal, require credentials to run. Credentials are supplied to the runner as JSON files that you reference from a [connection][6]. Each integration has its own credential file structure and supported authentication methods.
 
-For the full set of credential file formats and examples, see [Handling private action credentials][5].
+For the full set of credential file formats and examples, see [Handling private action credentials][7].
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /actions/private_actions/
-[2]: /actions/private_actions/set_up_agent_based/
-[3]: /actions/private_actions/execution_policies/
-[4]: /actions/private_actions/run_script/
-[5]: /actions/connections/private_action_credentials/
+[2]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/schema/yaml/private_action_runner.yaml
+[3]: /actions/private_actions/enroll_runner/
+[4]: /actions/private_actions/execution_policies/
+[5]: /actions/private_actions/run_script/
 [6]: /actions/connections/
-[7]: /actions/private_actions/enroll_runner/
-[8]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/schema/yaml/private_action_runner.yaml
+[7]: /actions/connections/private_action_credentials/

--- a/hugo/content/en/actions/private_actions/reference.md
+++ b/hugo/content/en/actions/private_actions/reference.md
@@ -1,0 +1,101 @@
+---
+title: Private Actions Reference
+description: Reference tables for private action runners, including runner configuration settings, the field-name crosswalk across host, Helm, and Operator installs, the supported actions and integrations matrix, and credential file formats.
+disable_toc: false
+further_reading:
+- link: "actions/private_actions/"
+  tag: "Documentation"
+  text: "Private Actions Overview"
+- link: "actions/private_actions/set_up_agent_based/"
+  tag: "Documentation"
+  text: "Set up a private action runner"
+- link: "actions/private_actions/execution_policies/"
+  tag: "Documentation"
+  text: "Execution Policies"
+- link: "actions/connections/private_action_credentials/"
+  tag: "Documentation"
+  text: "Handling private action credentials"
+---
+
+This page is the single-source lookup for private action runners: the configuration settings you can set, the
+actions and integrations each runner supports, and where to find credential file formats. For concepts and setup,
+start with the [Private Actions Overview][1] and [Set up a private action runner][2].
+
+## Runner configuration
+
+The runner reads its settings from the `private_action_runner` section of its [configuration][8].
+For how the enrollment settings (`self_enroll` and `api_key_only_enrollment`) fit into runner enrollment, see [Enrollment and ownership][7].
+
+### Field-name crosswalk
+
+The same setting is named differently depending on how you install the runner. Host installs use environment variables,
+Helm uses camelCase keys under `privateActionRunner`, and the Datadog Operator uses snake_case keys under
+`private_action_runner`. Use this table to translate the common settings across install methods.
+
+| Setting | Host (environment variable) | Helm (`privateActionRunner.*`) | Operator (`private_action_runner.*`) |
+|---|---|---|---|
+| Enable | `DD_PRIVATE_ACTION_RUNNER_ENABLED` | `enabled` | `enabled` |
+| Self-enroll | `DD_PRIVATE_ACTION_RUNNER_SELF_ENROLL` | `selfEnroll` | `self_enroll` |
+| Actions allowlist | `DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST` (comma-separated) | `actionsAllowlist` (list) | `actions_allowlist` (list) |
+
+## Supported actions and integrations
+
+The following matrix shows, for each integration, whether it is available in the runner in the Datadog Agent, available
+in the standalone runner, and authorizable through [Execution Policies][3].
+
+| Integration | Runner in the Agent | Authorizable through Execution Policies | Standalone runner |
+|---|:---:|:---:|:---:|
+| Kubernetes | Yes | Yes | Yes |
+| Remote Action (rshell + network path) | Yes | Yes | Yes |
+| Script | Yes | Yes | Yes |
+| HTTP | Yes | No | Yes |
+| GitLab | Yes | No | Yes |
+| Jenkins | Yes | No | Yes |
+| MongoDB | Yes | No | Yes |
+| PostgreSQL | No | No | Yes |
+| Temporal | Yes | No | Yes |
+
+**"Available in the Agent" and "authorizable through Execution Policies" are different things.** The first column tells you
+whether the integration can run in the runner in the Agent at all. The second column tells you whether that integration
+can be authorized through an Execution Policy. An integration can be available in the Agent while not being authorizable
+through Execution Policies today. Integrations that are authorizable through Execution Policies are **Kubernetes** and
+**Remote Action** (the rshell `runCommand` action and network path actions).
+
+Notes:
+
+- **Remote Action** is the integration family under the `com.datadoghq.remoteaction` prefix. It includes the rshell
+  bundle, whose `runCommand` action runs shell commands through the restricted shell (rshell), and network path actions.
+- **Script** actions are limited to *predefined* scripts declared in the runner's
+  `script-config.yaml`. See [Run a script with a private action runner][4].
+
+### Available actions by runner type
+
+{{% collapse-content title="Available actions by runner type" level="p" %}}
+
+{{< partial name="actions/private_actions_allowlist.html" >}}
+
+{{% /collapse-content %}}
+
+**Note:** to configure script actions (`runPredefinedScript` for Linux or
+`runPredefinedPowershellScript` for Windows), see [Run a script with a private action runner][4].
+
+## Credential file formats
+
+Some integrations, such as HTTP, Jenkins, PostgreSQL, MongoDB, and Temporal, require credentials to run. Credentials are
+supplied to the runner as JSON files that you reference from a connection. Each integration has its own credential file
+structure and supported authentication methods.
+
+For the full set of credential file formats and examples, see [Handling private action credentials][5].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /actions/private_actions/
+[2]: /actions/private_actions/set_up_agent_based/
+[3]: /actions/private_actions/execution_policies/
+[4]: /actions/private_actions/run_script/
+[5]: /actions/connections/private_action_credentials/
+[6]: /actions/connections/
+[7]: /actions/private_actions/enroll_runner/
+[8]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/schema/yaml/private_action_runner.yaml

--- a/hugo/layouts/partials/actions/private_actions_allowlist.html
+++ b/hugo/layouts/partials/actions/private_actions_allowlist.html
@@ -1,8 +1,8 @@
 {{ $workflow_bundles := site.Data.workflow_bundles | default slice }}
 {{ $runner_flavors := slice
-    (dict "key" "standalone" "title" "Standalone private action runners")
     (dict "key" "agent" "title" "Datadog Agent private action runners")
     (dict "key" "cluster_agent" "title" "Datadog Cluster Agent private action runners")
+    (dict "key" "standalone" "title" "Standalone private action runners")
 }}
 {{ $runner_flavor_keys := slice "standalone" "agent" "cluster_agent" }}
 {{ $allowlists_by_runner := dict "standalone" (dict) "agent" (dict) "cluster_agent" (dict) }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

Adds a new "Private Actions Reference" page: runner configuration and field-name crosswalk across host/Helm/Operator installs, the supported actions/integrations matrix, and credential file formats. Also fixes the runner-type ordering in the shared `private_actions_allowlist` partial to put Agent-based runners before Standalone, per the docs' standing ordering convention.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code carried this page's content over from a pre-drafted, QA-verified draft, ran Vale, fixed a stale link to a page moved earlier in this stack, and reworded one column header ("via" → "through") to satisfy the style guide.

### Additional notes

Open item carried from planning: whether the `supportsExecutionGroups` manifest-schema field reaches the build-time `workflow_bundles.json` data used elsewhere on this page couldn't be verified in this environment (that data is fetched externally at build time).