### PR TITLE
Add Government site-support banner to billable hosts CSV section

### DIFF
--- a/hugo/content/en/account_management/plan_and_usage/bill_overview.md
+++ b/hugo/content/en/account_management/plan_and_usage/bill_overview.md
@@ -111,6 +111,10 @@ Click {{< ui >}}View Details{{< /ui >}} on a Trends card or click any row in the
 
 ### Download billable hosts as CSV
 
+{{< site-region region="gov,gov2" >}}
+<div class="alert alert-warning">Downloading billable hosts as a CSV is not yet available for this site.</div>
+{{< /site-region >}}
+
 Download a CSV of the individual hosts that make up your billable Infra Hosts total for a given month. Use it to reconcile the total shown on the Bill Overview page, find the hosts driving the largest share of your count, attribute usage to teams by tag, or compare months to spot unexpected changes.
 
 To export the list:


### PR DESCRIPTION
### What does this PR do?

Adds a Government site-support banner to the **Download billable hosts as CSV** section of the Bill Overview page. The billable hosts CSV export is not yet available on the US1-FED or US2-FED (Government) sites.

### Description of Requested Changes

Because the caveat applies to a single feature partway down the page (not the whole page), this uses a manually inserted mid-page `site-region` banner, per the [Documenting site support](https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/5201857960/Documenting+site+support) guide. The banner targets both Government sites with `region="gov,gov2"` and renders only for readers on those sites.

Banner placed directly under the section heading:

    {{< site-region region="gov,gov2" >}}
    <div class="alert alert-warning">Downloading billable hosts as a CSV is not yet available for this site.</div>
    {{< /site-region >}}

Renders on US1-FED and US2-FED as: "Downloading billable hosts as a CSV is not yet available for this site."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
