### PR TITLE
[DOCS-15330] Remove links to deleted Agent config_template.yaml

### DIFF
--- a/hugo/content/en/account_management/billing/aws.md
+++ b/hugo/content/en/account_management/billing/aws.md
@@ -77,7 +77,7 @@ For technical questions, contact [Datadog support][6].
 For billing questions, contact your [Customer Success][7] Manager.
 
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-[2]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[2]: /agent/configuration/agent-configuration-files/
 [3]: https://app.datadoghq.com/integrations/amazon-web-services
 [4]: /api/latest/aws-integration/#set-an-aws-tag-filter
 [5]: /infrastructure/

--- a/hugo/content/en/administrators_guide/getting_started.md
+++ b/hugo/content/en/administrators_guide/getting_started.md
@@ -94,7 +94,6 @@ The [Datadog Agent][2] is open-source and published in GitHub. The Agent GitHub 
 
 Here are a few examples:
 
-* [Agent Config Template][3]   
 * [Integration Config Specs][4]   
 * [Fleet Automation][5]
 
@@ -109,7 +108,6 @@ To successfully create a new Datadog installation, review the [plan][11] page. Y
 
 [1]: https://learn.datadoghq.com/
 [2]: https://github.com/DataDog/datadog-agent
-[3]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
 [4]: https://github.com/DataDog/integrations-core
 [5]: https://app.datadoghq.com/fleet
 [6]: /getting_started/tagging/unified_service_tagging/

--- a/hugo/content/en/agent/configuration/agent-configuration-files.md
+++ b/hugo/content/en/agent/configuration/agent-configuration-files.md
@@ -23,8 +23,6 @@ The location of the Agent configuration file differs depending on the operating 
 | macOS                                | `/opt/datadog-agent/etc/datadog.yaml`      |
 | Windows                              | `%ProgramData%\Datadog\datadog.yaml` |
 
-See the [sample `config_template.yaml` file][1] for all available configuration options.
-
 ## Agent configuration directory
 
 Configuration files for Agent checks and integrations are stored in the `conf.d` directory. The location of the directory differs depending on the operating system.
@@ -71,5 +69,4 @@ For log collection, the Agent does not accept multiple YAML files that point to 
 
 JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is a list of all the beans that the Datadog Agent collects by default. This way, you do not need to list all of the beans manually when you configure a check through [Docker labels or k8s annotations][2].
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [2]: /agent/kubernetes/integrations/#configuration

--- a/hugo/content/en/agent/configuration/dual-shipping.md
+++ b/hugo/content/en/agent/configuration/dual-shipping.md
@@ -424,7 +424,6 @@ and add the relevant settings to `customAgentConfig`.
 
   # agents.customAgentConfig -- Specify custom contents for the datadog agent config (datadog.yaml)
   ## ref: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/?tab=agentv6
-  ## ref: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
   ## Note the `agents.useConfigMap` needs to be set to `true` for this parameter to be taken into account.
   customAgentConfig:
     additional_endpoints:

--- a/hugo/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/hugo/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -70,7 +70,7 @@ When upgrading from Agent v5 to Agent v6, there might be a difference in the hos
 
 `sub.domain.tld` --> `sub`
 
-**Note**: Starting from Agent v6.3, the `hostname_fqdn` configuration option was introduced that allows Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3+. See the [example datadog.yaml][1] for enabling this option.
+**Note**: Starting from Agent v6.3, the `hostname_fqdn` configuration option was introduced that allows Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3+. See the [Agent's main configuration][2] file for enabling this option.
 
 #### Determine if you're affected
 
@@ -115,7 +115,6 @@ By default, Agent v6 uses the instance's hostname provided by GCE. This matches 
 
 If you're upgrading from Agent v5 with `gce_updated_hostname` unset or set to false, and the hostname of the Agent is not hardcoded in `datadog.conf`/`datadog.yaml`, the reported hostname on Datadog changes from the GCE instance `name` to the full GCE instance `hostname` (which includes the GCE project id).
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [2]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Agent v5" %}}

--- a/hugo/content/en/agent/guide/agent-5-configuration-files.md
+++ b/hugo/content/en/agent/guide/agent-5-configuration-files.md
@@ -17,7 +17,7 @@ This page covers Agent 5 configuration files. Datadog recommends installing or u
 | Windows Server 2008, Vista and newer | `%ProgramData%\Datadog\datadog.conf`                                       |
 | Windows Server 2003, XP or older     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` |
 
-See the [sample `config_template.yaml` file][3] for all available configuration options.
+See the [sample `datadog.conf.example` file][3] for all available configuration options.
 
 ## Agent configuration directory
 

--- a/hugo/content/en/agent/guide/agent-6-configuration-files.md
+++ b/hugo/content/en/agent/guide/agent-6-configuration-files.md
@@ -19,8 +19,6 @@ The location of the `conf.d` directory differs depending on the operating system
 | macOS                                | `~/.datadog-agent/datadog.yaml`      |
 | Windows                              | `%ProgramData%\Datadog\datadog.yaml` |
 
-See the [sample `config_template.yaml` file][1] for all available configuration options.
-
 ## Agent configuration directory
 
 Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in the `conf.d` directory. The location of the directory differs depending on the operating system.
@@ -67,5 +65,4 @@ To preserve backwards compatibility, the Agent still picks up configuration file
 
 JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is a list of all the beans that the Datadog Agent collects by default. This way, you do not need to list all of the beans manually when you configure a check through [Docker labels or k8s annotations][2].
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [2]: /agent/kubernetes/integrations/#configuration

--- a/hugo/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/hugo/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -115,8 +115,6 @@ The log page displays the Agent logs being output to `agent.log`. Logs can be so
 
 The settings page displays the contents of the Agent's main configuration file `datadog.yaml`. You can edit this file directly from the Datadog Agent Manager. After making a change, click {{< ui >}}Save{{< /ui >}} in the upper right then [restart the Agent](#restart-agent).
 
-See the [sample config_template.yaml][2] for all available configuration options.
-
 ### Checks
 
 #### Manage checks
@@ -142,7 +140,6 @@ Clicking {{< ui >}}Restart Agent{{< /ui >}} from the left navigation bar restart
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/basic_agent_usage/windows/#installation
-[2]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [3]: /integrations/
 [4]: /help/
 [5]: /agent/troubleshooting/send_a_flare/

--- a/hugo/content/en/agent/logs/_index.md
+++ b/hugo/content/en/agent/logs/_index.md
@@ -39,8 +39,6 @@ logs_config:
     force_use_http: true
 {{< /code-block >}}
 
-See the [sample config_template.yaml file][6] for all available configuration options.
-
 <div class="alert alert-info">Starting with Agent v6.19+/v7.19+, HTTPS transport is the default transport used. For more details, see <a href="/agent/logs/log_transport/">Agent transport</a>.</div>
 
 To send logs with **environment variables**, configure the following:
@@ -257,7 +255,6 @@ For both file and journald tailer types, if an `end` or `beginning` position is 
 [3]: /containers/kubernetes/log/
 [4]: /containers/docker/log/
 [5]: /agent/configuration/agent-configuration-files/
-[6]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [7]: /agent/logs/log_transport/
 [8]: /agent/configuration/agent-commands/#restart-the-agent
 [9]: /agent/configuration/agent-commands/#agent-status-and-information

--- a/hugo/content/en/agent/supported_platforms/linux.md
+++ b/hugo/content/en/agent/supported_platforms/linux.md
@@ -58,7 +58,7 @@ The Datadog Agent configuration file is located in `/etc/datadog-agent/datadog.y
 - `proxy`: HTTP/HTTPS proxy endpoints for outbound traffic (see [Datadog Agent Proxy Configuration][8])
 - Default tags, log level, and Datadog configurations
 
-A fully commented reference file, located in `/etc/datadog-agent/datadog.yaml.example`, lists every available option for comparison or to copy and paste. Alternatively, see the sample `config_template.yaml` file for all available configuration options.
+A fully commented reference file, located in `/etc/datadog-agent/datadog.yaml.example`, lists every available option for comparison or to copy and paste.
 
 ### Integration files
 Configuration files for integrations live in `/etc/datadog-agent/conf.d/`. Each integration has its own sub-directory, `<INTEGRATION>.d/`, that contains:

--- a/hugo/content/en/agent/supported_platforms/osx.md
+++ b/hugo/content/en/agent/supported_platforms/osx.md
@@ -65,7 +65,7 @@ The [Datadog Agent configuration file][7] is located in `/opt/datadog-agent`. Th
 - `proxy`: HTTP/HTTPS proxy endpoints for outbound traffic (see [Datadog Agent Proxy Configuration][9])
 - Default tags, log levels, and Datadog configurations.
 
-A fully commented reference file, located in `/opt/datadog-agent/etc/datadog.yaml.example`, lists every available option for comparison or copy-paste. Alternatively, see the [sample config_template.yaml file][10] for all available configuration options.
+A fully commented reference file, located in `/opt/datadog-agent/etc/datadog.yaml.example`, lists every available option for comparison or copy-paste.
 
 ### Integration files
 Configuration files for integrations are found in `/opt/datadog-agent/etc/conf.d/`. Each integration has its own sub-directory, `<INTEGRATION>.d/`, which contains:
@@ -105,5 +105,4 @@ See the instructions on how to [add packages to the embedded Agent][3] for more 
 [7]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [8]: https://app.datadoghq.com/organization-settings/api-keys
 [9]: /agent/configuration/proxy/
-[10]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [11]: https://install.datadoghq.com/scripts/uninstall_mac_os.sh

--- a/hugo/content/en/agent/supported_platforms/sccm.md
+++ b/hugo/content/en/agent/supported_platforms/sccm.md
@@ -61,7 +61,7 @@ Microsoft SCCM (Systems Center Configuration Manager) is a configuration managem
 
 SCCM packages allow you to deploy configuration files to your Datadog Agents, overwriting their default settings. An Agent configuration consists of a `datadog.yaml` configuration file and optional `conf.yaml` files for each integration. You must create a package for each configuration file you want to deploy.
 
-1. Collect your `datadog.yaml` and `conf.yaml` files in a local SCCM machine folder. See the [sample `config_template.yaml` file][4] for all available configuration options.
+1. Collect your `datadog.yaml` and `conf.yaml` files in a local SCCM machine folder.
 1. Create an SCCM Package and select {{< ui >}}Standard program{{< /ui >}}.
 1. Select the location that contains the configuration file that you want to deploy to your Agents.
 1. Select a [Device collection][5] to deploy the changes to.
@@ -83,6 +83,5 @@ Restart the Agent service to observe your configuration changes:
 [1]: https://learn.microsoft.com/en-us/mem/configmgr/core/servers/deploy/configure/manage-content-and-content-infrastructure
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [3]: /agent/basic_agent_usage/windows/?tab=commandline#configuration
-[4]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [5]: https://learn.microsoft.com/en-us/mem/configmgr/core/clients/manage/collections/create-collections#bkmk_create
 [6]: /agent/basic_agent_usage/windows/#agent-commands

--- a/hugo/content/en/containers/docker/apm.md
+++ b/hugo/content/en/containers/docker/apm.md
@@ -75,7 +75,7 @@ Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (d
 
 ## Docker APM Agent environment variables
 
-Use the following environment variables to configure tracing for the Docker Agent. See the [sample `config_template.yaml` file][8] for more details.
+Use the following environment variables to configure tracing for the Docker Agent.
 
 `DD_API_KEY`                      
 : required - _string_
@@ -395,4 +395,3 @@ Refer to the [language-specific APM instrumentation docs][3] for tracer settings
 [5]: /tracing/guide/ignoring_apm_resources/
 [6]: /tracing/troubleshooting/agent_rate_limits
 [7]: /getting_started/site/
-[8]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml

--- a/hugo/content/en/continuous_integration/pipelines/github.md
+++ b/hugo/content/en/continuous_integration/pipelines/github.md
@@ -110,7 +110,7 @@ Logs are billed separately from CI Visibility. Log retention, exclusion, and ind
 
 The GitHub Actions CI Visibility integration allows for correlation between infrastructure and jobs. To achieve this, ensure the [Datadog Agent][20] is running on the host where the jobs are executed. Depending on the configuration, additional steps might be required:
 
-- For [Actions Runner Controller][21]: No additional setup required. Due to limitations in the Datadog Agent, jobs shorter than the minimum collection interval of the Datadog Agent might not always display infrastructure correlation metrics. To adjust this value, see [Datadog Agent configuration template][22] and change `min_collection_interval` to be less than 15 seconds.
+- For [Actions Runner Controller][21]: No additional setup required. Due to limitations in the Datadog Agent, jobs shorter than the minimum collection interval of the Datadog Agent might not always display infrastructure correlation metrics. To adjust this value, set `min_collection_interval` to less than 15 seconds in your [Agent configuration file][22].
 
 - For other configurations: To correlate jobs with the hosts running them, ensure the GitHub runner name matches the machine's hostname.
 
@@ -155,7 +155,7 @@ The {{< ui >}}CI Pipeline List{{< /ui >}} page shows data for only the default b
 [19]: /continuous_integration/search/#search-for-pipelines
 [20]: /agent
 [21]: https://github.com/actions/actions-runner-controller
-[22]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[22]: /agent/configuration/agent-configuration-files/
 [23]: /continuous_integration/guides/use_ci_jobs_failure_analysis/
 [24]: /continuous_integration/guides/identify_highest_impact_jobs_with_critical_path/
 [25]: /glossary/#pipeline-execution-time

--- a/hugo/content/en/continuous_integration/pipelines/gitlab.md
+++ b/hugo/content/en/continuous_integration/pipelines/gitlab.md
@@ -300,10 +300,10 @@ CI Visibility supports Infrastructure metrics for "Instance" executors through l
 {{% tab "Kubernetes" %}}
 CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][1] to install the Datadog Agent in a Kubernetes cluster.
 
-Due to limitations in the Datadog Agent, jobs shorter than the minimum collection interval of the Datadog Agent might not always display infrastructure correlation metrics. To adjust this value, see [Datadog Agent configuration template][2] and adjust the variable `min_collection_interval` to be less than 15 seconds.
+Due to limitations in the Datadog Agent, jobs shorter than the minimum collection interval of the Datadog Agent might not always display infrastructure correlation metrics. To adjust this value, set `min_collection_interval` to less than 15 seconds in your [Agent configuration file][2].
 
 [1]: /containers/kubernetes/installation/?tab=datadogoperator
-[2]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[2]: /agent/configuration/agent-configuration-files/
 {{% /tab %}}
 
 {{% tab "Other executors" %}}

--- a/hugo/content/en/getting_started/agent/_index.md
+++ b/hugo/content/en/getting_started/agent/_index.md
@@ -46,7 +46,7 @@ The Agent's main configuration file is `datadog.yaml`. The required parameters a
 - Your [Datadog API key][16], which is used to associate the Agent's data with your organization. 
 - Your [Datadog site][41] ({{< region-param key="dd_site" code="true" >}}).
 
-See the [sample `config_template.yaml` file][23] for all available configuration options. You can adjust the Agent configuration files to take advantage of other Datadog features.
+You can adjust the Agent configuration files to take advantage of other Datadog features.
 
 
 ## Installation
@@ -282,7 +282,6 @@ For help troubleshooting the Agent:
 [20]: https://app.datadoghq.com/event/explorer
 [21]: /extend/service_checks/#visualize-your-service-check-in-datadog
 [22]: https://app.datadoghq.com/metric/summary
-[23]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [24]: /getting_started/tagging/
 [25]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [26]: /agent/configuration/agent-commands/#restart-the-agent

--- a/hugo/content/en/integrations/guide/aws-integration-troubleshooting.md
+++ b/hugo/content/en/integrations/guide/aws-integration-troubleshooting.md
@@ -198,7 +198,7 @@ By default, host-level tags remain permanently attached to AWS hosts. If you wan
 [3]: /agent/
 [4]: /help/
 [5]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[6]: /agent/configuration/agent-configuration-files/
 [7]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
 [8]: https://docs.aws.amazon.com/cli/latest/reference/ec2/modify-instance-metadata-options.html
 [9]: https://github.com/DataDog/helm-charts/blob/58bf52e4e342c79dbec95659458f7de8c5de7e6c/charts/datadog/values.yaml#L1683-L1688

--- a/hugo/content/en/integrations/guide/azure-advanced-configuration.md
+++ b/hugo/content/en/integrations/guide/azure-advanced-configuration.md
@@ -133,7 +133,7 @@ The protected settings include:
 This example shows how to specify a configuration for the Datadog Agent to use.
 The Datadog Agent configuration URI must be an Azure blob storage URI.
 The Datadog Windows Agent Azure Extension checks that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
-The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder (see the [sample `config_template.yaml` file][101] for all available configuration options).
+The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder.
 
 <div class="alert alert-info">
 To reuse the configuration of an existing Agent:
@@ -169,7 +169,6 @@ Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "Datadog
 {{< /code-block >}}
 
 [100]: https://learn.microsoft.com/powershell/module/az.compute/set-azvmextension
-[101]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 {{% /tab %}}
 {{% tab "Linux" %}}
 
@@ -203,7 +202,7 @@ The protected settings include:
 This example shows how to specify a configuration for the Datadog Agent to use.
 - The Datadog Agent configuration URI must be an Azure blob storage URI.
 - The Datadog Linux Agent Azure Extension checks that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
-- The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder (see the [sample `config_template.yaml` file][201] for all available configuration options).
+- The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder.
 
 <div class="alert alert-info">
 To reuse the configuration of an existing Agent by saving its <code>/etc/datadog-agent</code> folder as a ZIP file:
@@ -227,7 +226,6 @@ az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --ver
 
 
 [200]: https://learn.microsoft.com/cli/azure/vm/extension
-[201]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/hugo/content/en/network_monitoring/devices/guide/cluster-agent.md
+++ b/hugo/content/en/network_monitoring/devices/guide/cluster-agent.md
@@ -209,7 +209,6 @@ clusterAgent:
   #
   datadog_cluster_yaml:
 
-    # See here for all `network_devices.autodiscovery` configs: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
     autodiscovery:
       workers: 2
       discovery_interval: 10

--- a/hugo/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/hugo/content/en/network_monitoring/devices/snmp_metrics.md
@@ -113,7 +113,7 @@ To use Autodiscovery with Network Device Monitoring:
 
 2. Edit the [`datadog.yaml`][8] Agent configuration file to include all the subnets for Datadog to scan. The following sample config provides required parameters, default values, and examples for Autodiscovery.
 
-3. Optionally, enable [de-duplication][11] of devices during Autodiscovery of the Agent. This feature is disabled by default and requires Agent version `7.67+`.
+3. Optionally, enable de-duplication of devices during Autodiscovery of the Agent. This feature is disabled by default and requires Agent version `7.67+`.
 
    ```yaml
    network_devices:
@@ -231,4 +231,3 @@ For all available `interface_configs` options, see the [sample snmp.d/conf.yaml]
 [8]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file
 [9]: https://github.com/DataDog/datadog-agent/blob/51dd4482466cc052d301666628b7c8f97a07662b/pkg/config/config_template.yaml#L855
 [10]: /agent/configuration/agent-commands/#agent-status-and-information
-[11]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L4036

--- a/hugo/content/en/observability_pipelines/sources/datadog_agent.md
+++ b/hugo/content/en/observability_pipelines/sources/datadog_agent.md
@@ -114,7 +114,7 @@ observability_pipelines_worker:
 
 After you [restart the Agent][2], your observability data should be going to the Worker, processed by the pipeline, and delivered to Datadog.
 
-[1]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[1]: /agent/configuration/agent-configuration-files/
 [2]: /agent/configuration/agent-commands/#restart-the-agent
 
 {{% /collapse-content %}}

--- a/hugo/content/en/opentelemetry/setup/ddot_collector/install/linux.md
+++ b/hugo/content/en/opentelemetry/setup/ddot_collector/install/linux.md
@@ -116,7 +116,7 @@ DDOT automatically binds the OpenTelemetry Collector to ports 4317 (grpc) and 43
 
 <div class="alert alert-warning">Enabling these features may incur additional charges. Review the <a href="https://www.datadoghq.com/pricing/">pricing page</a> and talk to your Customer Success Manager before proceeding.</div>
 
-For a complete list of available options, refer to the fully commented reference file at `/etc/datadog-agent/datadog.yaml.example` or the sample [`config_template.yaml`][12] file.
+For a complete list of available options, see the fully commented reference file at `/etc/datadog-agent/datadog.yaml.example`.
 
 When enabling additional Datadog features, always use the Datadog or OpenTelemetry Collector configuration files instead of relying on Datadog environment variables.
 
@@ -336,5 +336,4 @@ View metrics from the DDOT Collector to monitor the Collector health.
 [9]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/src/main/java/com/otel/service/CalendarService.java#L27-L48
 [10]: /opentelemetry/correlate/
 [11]: /opentelemetry/integrations/collector_health_metrics/
-[12]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
 [13]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/run-otel-local.sh

--- a/hugo/content/en/opentelemetry/setup/ddot_collector/install/windows.md
+++ b/hugo/content/en/opentelemetry/setup/ddot_collector/install/windows.md
@@ -118,7 +118,7 @@ DDOT automatically binds the OpenTelemetry Collector to ports 4317 (grpc) and 43
 
 <div class="alert alert-warning">Enabling these features may incur additional charges. Review the <a href="https://www.datadoghq.com/pricing/">pricing page</a> and talk to your Customer Success Manager before proceeding.</div>
 
-For a complete list of available options, refer to the fully commented reference file at `C:\ProgramData\Datadog\datadog.yaml.example` or the sample [`config_template.yaml`][12] file.
+For a complete list of available options, see the fully commented reference file at `C:\ProgramData\Datadog\datadog.yaml.example`.
 
 When enabling additional Datadog features, always use the Datadog or OpenTelemetry Collector configuration files instead of relying on Datadog environment variables.
 
@@ -338,6 +338,5 @@ View metrics from the DDOT Collector to monitor the Collector health.
 [9]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/src/main/java/com/otel/service/CalendarService.java#L27-L48
 [10]: /opentelemetry/correlate/
 [11]: /opentelemetry/integrations/collector_health_metrics/
-[12]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
 [13]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/run-otel-local.sh
 [14]: /agent/supported_platforms/windows/

--- a/hugo/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
+++ b/hugo/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
@@ -317,7 +317,7 @@ For more information, see [log collection with your DaemonSet][8].
 {{% /tab %}}
 {{< /tabs >}}
 
-There are many other environment variables and settings supported in the Datadog Agent. To get an overview of them all, see [the configuration template][6].
+There are many other environment variables and settings supported in the Datadog Agent. For an overview, see [Agent configuration files][6].
 
 ## Sending OpenTelemetry traces, metrics, and logs to Datadog Agent
 
@@ -390,5 +390,5 @@ env:
 [3]: https://opentelemetry.io/docs/concepts/instrumenting/
 [4]: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md
-[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[6]: /agent/configuration/agent-configuration-files/
 [10]: /opentelemetry/runtime_metrics/

--- a/hugo/content/en/serverless/guide/agent_configuration.md
+++ b/hugo/content/en/serverless/guide/agent_configuration.md
@@ -101,7 +101,7 @@ Send custom metrics with [the StatsD protocol][5]:
 | `DD_STATSD_FORWARD_PORT`                          | Port to forward StatsD packets to.                                                                                                                                                                                                                                                                                                                                                                                          |
 | `DD_STATSD_METRIC_NAMESPACE`                      | Set a namespace for all StatsD metrics coming from this host. Each metric received is prefixed with the namespace before it is sent to Datadog.                                                                                                                                                                                                                                                                                                          |
 
-[1]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[1]: /agent/configuration/agent-configuration-files/
 
 [2]: https://docs.datadoghq.com/agent/logs/advanced_log_collection/#global-processing-rules
 

--- a/hugo/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.en.md
+++ b/hugo/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.en.md
@@ -20,5 +20,5 @@ logs_config:
 
 After you [restart the Agent][1032], your observability data should be going to the Worker, processed by the pipeline, and delivered to Datadog.
 
-[1031]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[1031]: /agent/configuration/agent-configuration-files/
 [1032]: /agent/configuration/agent-commands/#restart-the-agent

--- a/hugo/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.es.md
+++ b/hugo/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.es.md
@@ -14,4 +14,4 @@ Para las instalaciones de Kubernetes, puedes utilizar el registro DNS interno de
 
 Después de reiniciar el Agent, tus datos de observabilidad deberían ir al worker, ser procesados por el pipeline y entregados a Datadog.
 
-[1031]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+[1031]: /agent/configuration/agent-configuration-files/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15330

[DataDog/datadog-agent#54160](https://github.com/DataDog/datadog-agent/pull/54160) deleted `pkg/config/config_template.yaml`. [#39006](https://github.com/DataDog/documentation/pull/39006) removed the build-time dependency on that file; this PR is the follow-up that clears the remaining prose links, which now 404.

Only `blob/main/…` and `blob/master/…` links are affected. Commit-pinned (`blob/<sha>/…`) and tag-pinned (`blob/7.53.0/…`) links still resolve, so those are left as-is.

Also corrects a pre-existing mismatch on the Agent 5 configuration files page, where the prose said "sample `config_template.yaml` file" but the link pointed at `dd-agent/datadog.conf.example`.

### Merge readiness

- [x] Ready for merge

### AI assistance

Claude Code was used to audit the repository for references.

### Additional notes

Agent-side follow-up: Maxime proposed committing a generated `pkg/config/schema/example/datadog.yaml` at each Agent release. That file does not exist yet. If it lands, the pages in this PR can be repointed at it.
