### PR TITLE
Fix JSON filter example in parsing.md (external contribution, #35904)

### DIFF
--- a/hugo/content/en/logs/log_configuration/parsing.md
+++ b/hugo/content/en/logs/log_configuration/parsing.md
@@ -531,7 +531,12 @@ parsing_rule %{date("MMM dd HH:mm:ss"):timestamp} %{word:vm} %{word:app}\[%{numb
   "app": "program",
   "logger": {
     "thread_id": 123
-  }
+  },
+  "server": "server.1",
+  "method": "GET",
+  "status_code": 200,
+  "url": "https://app.datadoghq.com/logs/pipelines",
+  "duration": 123456
 }
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Mirrors the change from #35904 (opened from a fork by @julienbraure) onto an internal branch so it can run through required CI checks, which don't trigger on fork-originated PRs.

Fixes a JSON parsing filter example in the logs parsing documentation.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify why #35904's required CI checks weren't running (fork PRs don't trigger the GitLab pipeline) and to mirror the commit onto this internal branch via cherry-pick.

### Additional notes

Original contribution and authorship credit: @julienbraure in #35904. Closing that PR once this merges.