### PR TITLE
Document Python agent versioning in SDK reference

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/sdk.md
+++ b/hugo/content/en/llm_observability/instrumentation/sdk.md
@@ -848,6 +848,10 @@ To trace an agent execution, use the function decorator `ddtrace.llmobs.decorato
 : optional - _string_
 <br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
+`version`
+: optional - _string_
+<br/>Identifies the version of the agent. Recorded as the `agent_version` tag on the agent span only, not on its child spans.
+
 `session_id`
 : optional - _string_
 <br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
@@ -862,10 +866,19 @@ To trace an agent execution, use the function decorator `ddtrace.llmobs.decorato
 {{< code-block lang="python" >}}
 from ddtrace.llmobs.decorators import agent
 
-@agent
+@agent(version="v3")
 def react_agent():
     ... # user application logic
     return
+{{< /code-block >}}
+
+Or use a context manager to trace an agent execution inline:
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+
+with LLMObs.agent(name="weather-agent", version="v3"):
+    ... # user application logic
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -1380,6 +1393,10 @@ The `LLMObs.annotate()` method accepts the following arguments:
 `tool_definitions`
 : optional - _list of dictionaries_
 <br />List of tool definition dictionaries for function calling scenarios. Each tool definition should have a required `"name": "..."` key and optional `"description": "..."` and `"schema": {...}` keys.
+
+`agent`
+: optional - _dictionary_
+<br />A dictionary with the format `{"version": "..."}` that sets the version of an agent span. You can also import the `Agent` typed dictionary from `ddtrace.llmobs` and pass it in as the `agent` argument. This applies only when annotating an agent span, where the version is recorded as the `agent_version` tag.
 
 `metadata`
 : optional - _dictionary_
@@ -1907,6 +1924,10 @@ The `LLMObs.annotation_context()` method accepts the following arguments:
 : optional - _dictionary_
 <br />A dictionary that represents the prompt used for an LLM call. See the [Prompt object](#prompt-tracking-arguments) documentation for the complete schema and supported keys. You can also import the `Prompt` object from `ddtrace.llmobs.utils` and pass it in as the `prompt` argument. **Note**: This argument only applies to LLM spans.
 
+`agent`
+: optional - _dictionary_
+<br />A dictionary with the format `{"version": "..."}` that sets the agent version. You can also import the `Agent` typed dictionary from `ddtrace.llmobs` and pass it in as the `agent` argument. **Note**: This argument only applies to agent spans, where the version is recorded as the `agent_version` tag.
+
 `tags`
 : optional - _dictionary_
 <br />A dictionary of JSON serializable key-value pairs that users can add as tags on the span. Example keys: `session`, `env`, `system`, and `version`. For more information about tags, see [Getting Started with Tags](/getting_started/tagging/).
@@ -1945,6 +1966,15 @@ def rag_workflow(user_question):
         completion = openai_client.chat.completions.create(...)
     return completion.choices[0].message.content
 
+{{< /code-block >}}
+
+To set the version on auto-instrumented agent spans, pass the `agent` argument. Only agent spans started within the context are tagged with the version. Other span kinds are unaffected.
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+
+with LLMObs.annotation_context(agent={"version": "v3"}):
+    result = agent_executor.invoke("What's the weather?")  # auto-instrumented framework call
 {{< /code-block >}}
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"04a80686-054e-4253-9ab1-e1d110081d10","source":"chat","resourceId":"d37f20e3-c7cb-4576-8e2b-ab3d7312d56e","workflowId":"bd04174f-c1d7-481c-b27e-6696dccc5805","codeChangeId":"bd04174f-c1d7-481c-b27e-6696dccc5805","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents how to set an agent version when manually instrumenting agents with the Python SDK, so you can identify which version of an agent produced a span in the Agent Observability trace view. This documents the SDK support added in https://github.com/DataDog/dd-trace-py/pull/19490.

All edits are in `hugo/content/en/llm_observability/instrumentation/sdk.md`, within the existing Python tabs:

- **Agents**: adds the optional `version` argument to the agent decorator's arguments, updates the example to `@agent(version="v3")`, and adds a context-manager example using `LLMObs.agent(name="weather-agent", version="v3")`.
- **Enriching spans**: adds the optional `agent` argument (shape `{"version": "..."}`, also accepted through the `ddtrace.llmobs.Agent` typed dictionary) to the `LLMObs.annotate()` arguments, applied when annotating an agent span.
- **Annotating auto-instrumented spans**: adds the same optional `agent` argument to the `LLMObs.annotation_context()` arguments and adds an example that versions auto-instrumented agent spans.

### How was this tested?

- Reviewed the rendered additions in context to confirm each one matches the surrounding argument lists and example blocks.
- Checked the new copy against the Datadog Vale substitution rules by hand (the Vale binary is not available in this environment).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Written with Bits Code (Claude Code): it made the documentation edits and drafted this PR description. The content was reviewed for accuracy.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d37f20e3-c7cb-4576-8e2b-ab3d7312d56e)

Comment @datadog to request changes