### PR TITLE
gpu: document 7.79.0 system-probe workaround

### DIFF
--- a/hugo/content/en/gpu_monitoring/setup.md
+++ b/hugo/content/en/gpu_monitoring/setup.md
@@ -28,6 +28,7 @@ To begin using Datadog's GPU Monitoring, your environment must meet the followin
 
 - **Datadog Agent**: v7.80
   - (Preferred version: 7.81.3). Datadog advises against using v7.82.0 to avoid a bug that causes unexpected kernel panics. 
+  - On v7.79.0, set `gpu_monitoring.system_probe_deprecated: true` in `system-probe.yaml` to avoid a known issue affecting GPU Monitoring.
 - **Operating system**: Linux
 - **Linux kernel**: 5.8 and above
 - **NVIDIA driver**: version 450.51


### PR DESCRIPTION
Documents the Agent v7.79.0 workaround for GPU Monitoring: set `gpu_monitoring.system_probe_deprecated: true` in `system-probe.yaml`.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a sub-bullet under **Minimum version requirements** on the GPU Monitoring setup page covering an Agent v7.79.0 edge case that requires a system-probe config change.

This sits alongside the existing v7.82.0 kernel-panic clause rather than replacing it — the two are separate issues.

**Paired with:** [web-ui#340804](https://github.com/DataDog/web-ui/pull/340804) — the in-product banner asserting the same claim, behind `gpu-monitoring-agent-version-779-deprecation`. Both were produced by the `gpu-monitoring-public-doc-changes` skill ([web-ui#340806](https://github.com/DataDog/web-ui/pull/340806)).

### Merge readiness

- [ ] Ready for merge

> **Not ready to merge.** The symptom wording ("a known issue affecting GPU Monitoring") is a placeholder pending a precise description of the failure mode. Do not merge until that is replaced.

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code, which located the target section, checked the wording against the repo style guide, and prepared the paired in-product change. Reviewed by a human before submission.

### Additional notes

The value is `true` (enabling a `system_probe_deprecated` flag), not `false` — worth a second look from someone who knows the Agent-side semantics.
