### PR TITLE
Document Allowed Resources setting for FDD deployment gate rules

### DIFF
--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -98,6 +98,7 @@ The analysis is automatically done for all APM-instrumented services, and no pri
 * **Operation Name**: Auto-populated from the service's [APM primary operation][3] settings.
 * **Duration**: Enter the period of time (in seconds) for which the analysis should be done. For optimal analysis confidence, this value should be at least 900 seconds (15 minutes) after a deployment starts.
 * **Excluded Resources**: Enter a comma-separated list of [APM resources][2] to ignore (such as low-volume or low-priority endpoints).
+* **Allowed Resources**: Enter a comma-separated list of [APM resources][2] to restrict the analysis to. Mutually exclusive with **Excluded Resources**.
 
 ##### Notes
 - The rule is evaluated for each [additional primary tag][4] value as well as an aggregate analysis. If you only want to consider a single primary tag, you can specify it when [requesting a gate evaluation](#evaluate-deployment-gates) (see below).


### PR DESCRIPTION
## Summary
- The Deployment Gates web UI already exposes an **Allowed Resources** field for `faulty_deployment_detection` rules (mutually exclusive with **Excluded Resources**), but the setup guide only documented **Excluded Resources**.
- Adds a corresponding bullet to the "APM Faulty Deployment Detection" configuration settings section.
- Related API spec change: DataDog/datadog-api-spec#6370

## Test plan
- [x] Reviewed rendered bullet text alongside the existing Excluded Resources entry for consistency