### PR TITLE
Clarify Exposure SQL Model use cases

### DIFF
--- a/hugo/content/en/experiments/concepts/exposure_sql.md
+++ b/hugo/content/en/experiments/concepts/exposure_sql.md
@@ -18,14 +18,14 @@ further_reading:
 
 ## Overview
 
-Datadog Experiments analyzes experiments run with [Datadog Feature Flags][1] or an independent randomization system. If you randomize subjects outside of Datadog Feature Flags, create **Exposure SQL Models** to tell Datadog who was exposed to your experiment and when, by reading exposure records from your warehouse.
+Datadog Experiments analyzes experiments run with [Datadog Feature Flags][1] or an independent randomization system. **Exposure SQL Models** tell Datadog who was exposed to your experiment and when, by reading exposure records from your warehouse. If you randomize subjects outside of Datadog Feature Flags, create an Exposure SQL Model for bring-your-own randomization. For a Datadog Feature Flag experiment whose decision metrics use warehouse data, an Exposure SQL Model can supply exposure records as an alternative to Datadog's default exported exposure logs.
 
 
 Similar to [Metric SQL Models][2], Exposure SQL Models are SQL queries that describe exposure data in your warehouse. Exposure SQL Models return the following columns:
 
 | Column | Required | Description |
 |--------|----------|-------------|
-| Subject Key | Yes | A unique identifier for the subject randomized into the experiment. This is typically a `user_id`. |
+| Subject Key | Yes | A unique identifier for the subject randomized into the experiment. The model must map the experiment's subject type and every subject type required by the analysis so Datadog can join exposures to metric data. |
 | Timestamp | Yes | The timestamp when the user was exposed to the experiment. |
 | Experiment ID | Yes | The experiment that the user was exposed to. One Exposure SQL Model can track many experiments; this column filters records to a specific experiment. |
 | Variant ID | Yes | The variant the user was assigned to (for example, `treatment` or `control`). |


### PR DESCRIPTION
<!-- dd-meta {"pullId":"21fefeea-8c05-40d1-aa00-9713c6d3f3cb","source":"chat","resourceId":"13c46fcb-a477-4426-9e83-49597fdc4f6f","workflowId":"94add999-0607-4877-8c96-80dd5aebb5e4","codeChangeId":"94add999-0607-4877-8c96-80dd5aebb5e4","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Motivation: Source product changes support using Exposure SQL Models to supply exposure records for Datadog Feature Flag experiments when decision metrics use warehouse data.

Source PRs:
https://github.com/ddoghq/dd-source/pull/49220
https://github.com/DataDog/web-ui/pull/340582

Changes:
- Updated hugo/content/en/experiments/concepts/exposure_sql.md to explain that Exposure SQL Models support bring-your-own randomization and Datadog Feature Flag experiments with warehouse decision metrics.
- Documented that the model must map the experiment subject type and every subject type required by the analysis so exposures can be joined to metric data.

### Testing

- Ran git diff --check.
- Attempted vale hugo/content/en/experiments/concepts/exposure_sql.md, but vale is not installed in this sandbox.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to draft and apply the documentation edit; manually reviewed the diff.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/13c46fcb-a477-4426-9e83-49597fdc4f6f)

Comment @datadog to request changes