### PR TITLE
Add AI Agent setup path to AWS CCM docs

### DIFF
--- a/hugo/content/en/cloud_cost_management/setup/aws.md
+++ b/hugo/content/en/cloud_cost_management/setup/aws.md
@@ -28,7 +28,7 @@ To set up Cloud Cost Management in Datadog, you need:
 
 ## Setup
 
-You can setup using the [API][21], [Terraform][22], the **Set up with AI Agent** guided flow, or directly in Datadog by following the instructions below.
+You can set up using the [API][21], [Terraform][22], the **Set up with AI Agent** guided flow, or directly in Datadog by following the instructions below.
 
 ### Configure the AWS integration
 
@@ -230,7 +230,23 @@ Attach the new S3 policy to the Datadog integration role.
 
 {{% tab "AI Agent" %}}
 
-The **Set up with AI Agent** flow guides you through creating or importing a Cost and Usage Report and generates Terraform for you to review before applying. The AWS account must already be connected to Datadog through a role-based integration.
+The **Set up with AI Agent** flow guides you through creating or importing a Cost and Usage Report and generates Terraform for you to review before applying. Datadog gives you a setup prompt to run in your own coding agent, such as Claude Code or Cursor, and the agent walks you through the rest.
+
+Before you begin:
+- The AWS account must already be connected to Datadog through a role-based integration. Accounts that authenticate with an access key pair are not supported, because the Cost and Usage Report read policy must be attached to an IAM role.
+- You need the {{< ui >}}AWS Configurations Manage{{< /ui >}} permission.
+- You need a coding agent installed locally. Datadog provides instructions for Claude Code and Cursor.
+
+### Start the flow in Datadog
+
+1. Navigate to [Setup & Configuration][300], find {{< ui >}}Amazon Web Services{{< /ui >}}, and click {{< ui >}}Add Account{{< /ui >}}.
+2. Select {{< ui >}}Set up with AI agent{{< /ui >}}. Datadog generates a Datadog-managed API key and application key for the session.
+3. Start your agent:
+    - **Claude Code**: Copy the generated command and run it in your terminal.
+    - **Cursor**: Click {{< ui >}}Open in Cursor{{< /ui >}} to download your credentials and open Cursor with the prompt prefilled.
+4. Leave the Datadog setup page open. It waits for the agent and shows {{< ui >}}Setup complete{{< /ui >}} when it detects your new configuration.
+
+### Complete the setup with the agent
 
 1. Choose a Cost and Usage Report format:
     - **CUR 2.0**: Recommended and selected by default for new reports.
@@ -239,6 +255,8 @@ The **Set up with AI Agent** flow guides you through creating or importing a Cos
     - Create a Cost and Usage Report and its S3 bucket
     - Use an existing report and S3 bucket
 3. Review the generated Terraform configuration, then apply it to finish setting up the account.
+
+[300]: https://app.datadoghq.com/cost/setup
 
 {{% /tab %}}
 

--- a/hugo/content/en/cloud_cost_management/setup/aws.md
+++ b/hugo/content/en/cloud_cost_management/setup/aws.md
@@ -230,21 +230,22 @@ Attach the new S3 policy to the Datadog integration role.
 
 {{% tab "AI Agent" %}}
 
-The **Set up with AI Agent** flow guides you through creating or importing a Cost and Usage Report and generates Terraform for you to review before applying. Datadog gives you a setup prompt to run in your own coding agent, such as Claude Code or Cursor, and the agent walks you through the rest.
+The **Set up with AI Agent** flow creates or imports a Cost and Usage Report and generates Terraform for you to review before applying. Datadog provides a setup prompt that you run in your own coding agent, such as Claude Code or Cursor.
 
-Before you begin:
-- The AWS account must already be connected to Datadog through a role-based integration. Accounts that authenticate with an access key pair are not supported, because the Cost and Usage Report read policy must be attached to an IAM role.
-- You need the {{< ui >}}AWS Configurations Manage{{< /ui >}} permission.
-- You need a coding agent installed locally. Datadog provides instructions for Claude Code and Cursor.
+### Prerequisites
+
+- An AWS account already connected to Datadog through a role-based integration. Accounts that authenticate with an access key pair are not supported, because the report read policy must attach to an IAM role.
+- The **AWS Configurations Manage** permission.
+- A coding agent installed locally. Datadog provides instructions for Claude Code and Cursor.
 
 ### Start the flow in Datadog
 
 1. Navigate to [Setup & Configuration][300], find {{< ui >}}Amazon Web Services{{< /ui >}}, and click {{< ui >}}Add Account{{< /ui >}}.
-2. Select {{< ui >}}Set up with AI agent{{< /ui >}}. Datadog generates a Datadog-managed API key and application key for the session.
+2. Select {{< ui >}}Set up with AI agent{{< /ui >}}. Datadog generates a managed API key and application key for the session.
 3. Start your agent:
     - **Claude Code**: Copy the generated command and run it in your terminal.
     - **Cursor**: Click {{< ui >}}Open in Cursor{{< /ui >}} to download your credentials and open Cursor with the prompt prefilled.
-4. Leave the Datadog setup page open. It waits for the agent and shows {{< ui >}}Setup complete{{< /ui >}} when it detects your new configuration.
+4. Leave the Datadog setup page open while the agent works. After Datadog detects your new configuration, the {{< ui >}}Waiting for agent{{< /ui >}} button changes to {{< ui >}}Setup complete{{< /ui >}}. Click it to finish.
 
 ### Complete the setup with the agent
 

--- a/hugo/content/en/cloud_cost_management/setup/aws.md
+++ b/hugo/content/en/cloud_cost_management/setup/aws.md
@@ -28,7 +28,7 @@ To set up Cloud Cost Management in Datadog, you need:
 
 ## Setup
 
-You can setup using the [API][21], [Terraform][22], or directly in Datadog by following the instructions below.
+You can setup using the [API][21], [Terraform][22], the **Set up with AI Agent** guided flow, or directly in Datadog by following the instructions below.
 
 ### Configure the AWS integration
 
@@ -225,6 +225,30 @@ Attach the new S3 policy to the Datadog integration role.
 [204]: https://docs.aws.amazon.com/cur/latest/userguide/dataexports-view.html
 [205]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html
 [210]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
+
+{{% /tab %}}
+
+{{% tab "AI Agent" %}}
+
+The **Set up with AI Agent** flow guides you through creating or importing a Cost and Usage Report and generates Terraform for you to review before applying. The AWS account must already be connected to Datadog through a role-based integration.
+
+### Choose a Cost and Usage Report format
+
+The flow asks you to choose a report format:
+
+* **CUR 2.0**: Recommended and selected by default for new reports.
+* **Legacy CUR**: Available for an existing legacy report or as a fallback.
+
+### Select the resources to create
+
+The flow checks for an existing Cost and Usage Report before creating a new one. You can:
+
+* Create a Cost and Usage Report and its S3 bucket
+* Use an existing report and S3 bucket
+
+### Review and apply the generated Terraform
+
+The flow generates Terraform for the format you selected. Review the configuration, then apply it to finish setting up the account.
 
 {{% /tab %}}
 

--- a/hugo/content/en/cloud_cost_management/setup/aws.md
+++ b/hugo/content/en/cloud_cost_management/setup/aws.md
@@ -232,23 +232,13 @@ Attach the new S3 policy to the Datadog integration role.
 
 The **Set up with AI Agent** flow guides you through creating or importing a Cost and Usage Report and generates Terraform for you to review before applying. The AWS account must already be connected to Datadog through a role-based integration.
 
-### Choose a Cost and Usage Report format
-
-The flow asks you to choose a report format:
-
-* **CUR 2.0**: Recommended and selected by default for new reports.
-* **Legacy CUR**: Available for an existing legacy report or as a fallback.
-
-### Select the resources to create
-
-The flow checks for an existing Cost and Usage Report before creating a new one. You can:
-
-* Create a Cost and Usage Report and its S3 bucket
-* Use an existing report and S3 bucket
-
-### Review and apply the generated Terraform
-
-The flow generates Terraform for the format you selected. Review the configuration, then apply it to finish setting up the account.
+1. Choose a Cost and Usage Report format:
+    - **CUR 2.0**: Recommended and selected by default for new reports.
+    - **Legacy CUR**: Available for an existing legacy report or as a fallback.
+2. Select the resources to create. The flow checks for an existing Cost and Usage Report before creating a new one. You can:
+    - Create a Cost and Usage Report and its S3 bucket
+    - Use an existing report and S3 bucket
+3. Review the generated Terraform configuration, then apply it to finish setting up the account.
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bfa9c016-0680-4948-8ade-8ca10265665f","source":"chat","resourceId":"d9674d88-44f2-4401-94af-62b58a031952","workflowId":"fa18a63d-5706-4201-819e-385ff53c68bd","codeChangeId":"fa18a63d-5706-4201-819e-385ff53c68bd","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the customer-facing **Set up with AI Agent** path in the `## Setup` section of the AWS Cloud Cost Management setup page, so customers can discover and use the guided flow alongside the existing CloudFormation, Terraform, and Manual methods. This accompanies the product change in https://github.com/ddoghq/dd-source/pull/46702.

**Changes**
- Add an **AI Agent** tab to the setup-method tabs in `hugo/content/en/cloud_cost_management/setup/aws.md`, and add the flow to the opening setup-method list.
- Explain that the guided flow lets customers choose between CUR 2.0 (recommended and selected by default for new reports) and Legacy CUR (for an existing legacy report or as a fallback), and generates Terraform for the selected format to review before applying.
- Surface the customer-facing prerequisites and decisions: the AWS account must already use a role-based Datadog integration; the flow checks for an existing report before creating another; and customers can create a report and bucket or use existing resources.
- Leave the existing Manual tab's Legacy CUR instructions unchanged, since they still apply to that method.

**Testing**
- Confirmed the `{{< tabs >}}` shortcode remains balanced with four tabs (CloudFormation, Terraform, Manual, AI Agent) and that the Manual tab content is unchanged.
- Checked the new content against the repository style guide, matching the surrounding tab structure, voice, and terminology.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted and edited with Bits Code (powered by OpenCode); reviewed by a human before merge.

### Additional notes

<!-- Anything else we should know when reviewing?-->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d9674d88-44f2-4401-94af-62b58a031952)

Comment @datadog to request changes