### PR TITLE
Code Coverage: require committing the config file, and document --ignored-source-paths

### DIFF
--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -20,6 +20,8 @@ further_reading:
 
 You can configure Code Coverage behavior by creating a configuration file named `code-coverage.datadog.yml` or `code-coverage.datadog.yaml` in the root of your repository.
 
+<div class="alert alert-warning">Commit the configuration file and push it to your repository. Datadog reads the file from your repository, so a file that is uncommitted or that exists only on an unpushed commit has no effect. See <a href="#commit-the-configuration-file">Commit the configuration file</a>.</div>
+
 Example configuration file:
 
 ```yaml
@@ -46,6 +48,19 @@ gates:
 comments:
   enabled: true
 ```
+
+## Commit the configuration file
+
+Datadog reads `code-coverage.datadog.yml` from your repository, at the commit that your coverage reports are attached to. Coverage uploads do not contain the contents of the file. They report the file path and the Git hash of its contents, and Datadog reads the file from your repository.
+
+The configuration applies only when both of the following are true:
+
+- **The file is committed.** A file that is uncommitted, staged but not committed, or excluded by `.gitignore` is not part of the commit reported with your coverage data. Datadog finds no configuration and applies default behavior.
+- **The commit that contains the file is pushed.** Datadog cannot read a commit that exists only on a local machine or on a CI runner.
+
+The same requirement applies to every later change. Editing a gate threshold or an `ignore` pattern takes effect for a commit only after that edit is committed and pushed.
+
+If your configuration appears to have no effect, check that `git status` reports no uncommitted changes to the file. Then confirm that the commit that adds or modifies it is present on your remote.
 
 ## Services configuration
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -260,11 +260,11 @@ Your operating system caps how much can be passed in a command-line argument or 
 
 On Linux, exceeding the limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
 
-<div class="alert alert-warning">On Windows, an oversized value can fail silently. <code>cmd.exe</code> drops an inherited environment variable that exceeds its 8,191-character limit. <code>datadog-ci</code> then receives nothing and behaves as though the option was never set. The <code>ignore</code> field of <code>code-coverage.datadog.yml</code> applies instead, and your coverage is computed against that list. No error appears.</div>
+<div class="alert alert-warning">On Windows, confirm that a large list reached the CLI. A value that exceeds a command-line or environment limit may not arrive, and <code>datadog-ci</code> then behaves as though the option was never set. The <code>ignore</code> field of <code>code-coverage.datadog.yml</code> applies instead, and no error appears. After your first upload, check in Datadog that the files you meant to exclude are absent from the coverage data.</div>
 
 For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. That is the only option with no size ceiling.
 
-The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable is not a way around these limits. On Linux the same per-value ceiling applies to environment variables, however your CI provider sets them. On Windows, a `set` command in `cmd.exe` counts against the command-line cap, and an oversized inherited value is dropped. Use the environment variable for convenience, such as newline-separated formatting, rather than for size.
+The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable is not a way around these limits. On Linux the same per-value ceiling applies to environment variables, however your CI provider sets them. On Windows, a `set` command in `cmd.exe` counts against the command-line cap. Use the environment variable for convenience, such as newline-separated formatting, rather than for size.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -250,7 +250,7 @@ The per-pattern limit matches the one Datadog applies. An over-long pattern is r
 
 #### Operating system limits
 
-Your operating system caps how much can be passed in a command-line argument or an environment variable. These ceilings are reached before the 256 KB limit of the option itself, and they differ by platform:
+Your operating system caps how much can be passed in a command-line argument or an environment variable. On Linux and Windows, that cap is reached before the 256 KB limit of the option itself. The ceilings differ by platform:
 
 | Platform | Limit |
 |---|---|

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -153,6 +153,8 @@ ignore:
 
 **Important**: Negative patterns take precedence over positive patterns. If any negative pattern matches a file path, that path is _not_ ignored.
 
+<div class="alert alert-warning">A <code>!</code> pattern is an exception to the positive patterns beside it, not a standalone rule. A list containing only <code>!</code> patterns ignores everything those patterns do not match. For example, an ignore list containing only <code>!src/keep/</code> ignores your entire repository apart from <code>src/keep/</code>. Pair every <code>!</code> pattern with the positive pattern it excepts.</div>
+
 ### Examples
 
 {{% collapse-content title="Exclude test files and generated code" level="h4" %}}
@@ -197,7 +199,11 @@ The option accepts the same [pattern syntax](#pattern-syntax) and the same `!` [
 
 <div class="alert alert-warning">The option <strong>replaces</strong> the <code>ignore</code> field instead of adding to it. When an upload supplies <code>--ignored-source-paths</code>, Datadog applies only those patterns to that upload and disregards the <code>ignore</code> field of <code>code-coverage.datadog.yml</code>. The two lists are not merged, so the option value needs to contain every pattern you want applied.</div>
 
+A supplied list replaces the `ignore` field even when none of its patterns compile. Nothing is excluded in that case, rather than the `ignore` field taking effect again.
+
 The list is scoped to the reports uploaded by that single command. Other uploads for the same commit keep their own lists, or fall back to the `ignore` field when they do not set the option.
+
+Datadog merges every upload for the same commit and flag. A file excluded by one upload still appears in that commit's coverage if another upload includes it. To exclude a file from every upload, use the `ignore` field of `code-coverage.datadog.yml`.
 
 An empty or whitespace-only value is treated as though the option was not passed, and the `ignore` field applies as usual. This keeps an unset CI variable from silently disabling the ignore list of a repository.
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -260,7 +260,7 @@ Your operating system caps how much can be passed in a command-line argument or 
 
 On Linux, exceeding the limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
 
-<div class="alert alert-warning">On Windows, confirm that a large list reached the CLI. A value that exceeds a command-line or environment limit may not arrive, and <code>datadog-ci</code> then behaves as though the option was never set. The <code>ignore</code> field of <code>code-coverage.datadog.yml</code> applies instead, and no error appears. After your first upload, check in Datadog that the files you meant to exclude are absent from the coverage data.</div>
+<div class="alert alert-warning">On Windows, an oversized value can fail silently. <code>cmd.exe</code> ignores an inherited environment variable longer than its 8,191-character limit. <code>datadog-ci</code> then receives nothing and behaves as though the option was never set. The <code>ignore</code> field of <code>code-coverage.datadog.yml</code> applies instead, and no error appears. After your first upload, check in Datadog that the files you meant to exclude are absent from the coverage data.</div>
 
 For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. That is the only option with no size ceiling.
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -232,9 +232,18 @@ Surrounding whitespace is removed from each pattern, and empty entries are dropp
 
 Use `--ignored-source-paths` to keep generated or vendored source code out of your coverage percentage. Use `--ignored-paths` to stop the CLI from picking up a coverage report file that you do not want to send.
 
+#### Limits
+
+A single `--ignored-source-paths` value accepts up to 2,000 patterns and 256 KB. Larger values fail with an error. Above 1,000 patterns or 100 KB, the CLI uploads the list and logs a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
+
 #### Long lists on Windows
 
-`cmd.exe` caps a whole command line at about 8191 characters, and the npm `.cmd` wrapper for `datadog-ci` runs through `cmd.exe`. A long list of patterns can exceed that cap. On Windows, supply long lists through the `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable or the `ignore` field of `code-coverage.datadog.yml` instead.
+`cmd.exe` caps a whole command line at about 8191 characters, and the npm `.cmd` wrapper for `datadog-ci` runs through `cmd.exe`. A long list of patterns can exceed that cap, which is far lower than the 256 KB the option itself accepts.
+
+Two alternatives keep the list off the command line:
+
+- The `ignore` field of `code-coverage.datadog.yml`.
+- The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable, when your CI provider sets it directly in the job environment. Setting it with a `set` command in `cmd.exe` is subject to the same cap.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -238,7 +238,11 @@ Use `--ignored-source-paths` to keep generated or vendored source code out of yo
 
 #### Limits
 
-A single `--ignored-source-paths` value accepts up to 2,000 patterns and up to 256 KB. Exceeding either limit fails the command, and nothing is uploaded. Above 1,000 patterns or 100 KB, the CLI uploads the list and logs a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
+A single `--ignored-source-paths` value accepts up to 2,000 patterns, up to 1,000 characters per pattern, and up to 256 KB in total. Exceeding any of the three fails the command, and nothing is uploaded. The error names the limit that was exceeded.
+
+Above 1,000 patterns or 100 KB, the upload still happens and the command prints a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
+
+The per-pattern limit matches the one Datadog applies. An over-long pattern is rejected up front rather than discarded later. A pattern discarded later could leave the list empty, which would silently bring back the `ignore` field of `code-coverage.datadog.yml`.
 
 #### Long lists on Windows
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -60,6 +60,8 @@ The configuration applies only when both of the following are true:
 
 The same requirement applies to every later change. Editing a gate threshold or an `ignore` pattern takes effect for a commit only after that edit is committed and pushed.
 
+Configuration is not applied retroactively. A file added or changed in a later commit does not affect coverage already reported at an earlier commit. The configuration that applies to a report is the one present at the commit the report was attached to.
+
 If your configuration appears to have no effect, check that `git status` reports no uncommitted changes to the file. Then confirm that the commit that adds or modifies it is present on your remote.
 
 ## Services configuration

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -484,6 +484,8 @@ Simple path prefixes without special characters are treated as prefix matches:
 - `"third_party/"` - Matches third-party code
 - `"generated/"` - Matches generated code
 
+**Note**: A prefix matches complete path segments, not any leading substring. `src/module` matches `src/module/foo.js`, but `src/mod` matches nothing under `src/module/`. A partial segment name matches no files and reports no error. To match part of a directory name, use a glob such as `src/mod*/**/*`.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -211,7 +211,7 @@ datadog-ci coverage upload --ignored-source-paths "**/*.{js,ts},vendor/" .
 
 This example supplies two patterns: `**/*.{js,ts}` and `vendor/`. The same applies to regex quantifiers such as `.{2,4}`.
 
-Newlines separate patterns as well, which is convenient for long lists supplied through the `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable:
+Newlines separate patterns as well, which is convenient for multi-line lists supplied through the `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable:
 
 {{< code-block lang="shell" >}}
 export DD_COVERAGE_IGNORED_SOURCE_PATHS="test/**/*
@@ -223,7 +223,7 @@ datadog-ci coverage upload .
 
 Surrounding whitespace is removed from each pattern, and empty entries are dropped.
 
-Because commas are separators, a pattern cannot contain a literal comma outside a brace group. Use the `ignore` field of `code-coverage.datadog.yml` for such a pattern.
+Because commas are separators, a pattern cannot contain a literal comma outside a brace group. A regex character class is a common case: `^src/[a,b]/.*$` splits into two patterns. Write it as `^src/[ab]/.*$`, or keep the pattern in the `ignore` field of `code-coverage.datadog.yml`.
 
 #### Difference from `--ignored-paths`
 
@@ -260,7 +260,9 @@ Your operating system caps how much can be passed in a command-line argument or 
 
 Exceeding an operating system limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
 
-For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable helps only in part. On Linux it faces the same per-value ceiling, and a `set` command in `cmd.exe` counts against the command-line cap. It avoids the cap only when your CI provider adds the variable to the job environment.
+For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. That is the only option with no size ceiling.
+
+The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable is not a way around these limits. On Linux the same per-value ceiling applies to environment variables, however your CI provider sets them. On Windows, a `set` command in `cmd.exe` counts against the command-line cap. Use the environment variable for convenience, such as newline-separated formatting, rather than for size.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -221,6 +221,8 @@ datadog-ci coverage upload .
 
 Surrounding whitespace is removed from each pattern, and empty entries are dropped.
 
+Because commas are separators, a pattern cannot contain a literal comma outside a brace group. Use the `ignore` field of `code-coverage.datadog.yml` for such a pattern.
+
 #### Difference from `--ignored-paths`
 
 `datadog-ci coverage upload` accepts two options with similar names that do different things:
@@ -228,13 +230,13 @@ Surrounding whitespace is removed from each pattern, and empty entries are dropp
 | Option | What it excludes | Where it applies |
 |---|---|---|
 | `--ignored-source-paths` | **Source files**, from the coverage computation. Replaces the `ignore` field. | In Datadog, after the upload |
-| `--ignored-paths` | **Coverage report files**, from the search for reports to upload. | In the CLI, before the upload |
+| `--ignored-paths` | **Coverage report files**, while the directories you pass are searched for reports. It does not apply to report files you pass explicitly. | In the CLI, before the upload |
 
-Use `--ignored-source-paths` to keep generated or vendored source code out of your coverage percentage. Use `--ignored-paths` to stop the CLI from picking up a coverage report file that you do not want to send.
+Use `--ignored-source-paths` to keep generated or vendored source code out of your coverage percentage. Use `--ignored-paths` to stop the CLI from picking up an unwanted coverage report file while it searches a directory.
 
 #### Limits
 
-A single `--ignored-source-paths` value accepts up to 2,000 patterns and 256 KB. Larger values fail with an error. Above 1,000 patterns or 100 KB, the CLI uploads the list and logs a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
+A single `--ignored-source-paths` value accepts up to 2,000 patterns and up to 256 KB. Exceeding either limit fails the command, and nothing is uploaded. Above 1,000 patterns or 100 KB, the CLI uploads the list and logs a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
 
 #### Long lists on Windows
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -137,6 +137,8 @@ ignore:
   - "vendor/"             # Exclude vendor directory
 ```
 
+You can also supply this list at upload time with the `--ignored-source-paths` option of `datadog-ci coverage upload`. See [Override the ignore list from the CLI](#override-the-ignore-list-from-the-cli).
+
 ### Exceptions
 
 Add `!` before a pattern to create an exception to your ignore rules. This lets you include specific files or folders that would otherwise be excluded.
@@ -180,6 +182,59 @@ ignore:
   - ".*\\.pb\\.go$"       # Regex: exclude protobuf files
 ```
 {{% /collapse-content %}}
+
+### Override the ignore list from the CLI
+
+Instead of committing the list to `code-coverage.datadog.yml`, you can supply it when uploading. Pass `--ignored-source-paths` to `datadog-ci coverage upload` with a comma-separated list of patterns:
+
+{{< code-block lang="shell" >}}
+datadog-ci coverage upload --ignored-source-paths "test/**/*,**/*.pb.go,vendor/" .
+{{< /code-block >}}
+
+The option accepts the same [pattern syntax](#pattern-syntax) and the same `!` [exceptions](#exceptions) as the `ignore` field. Datadog excludes the matching source files from the coverage computation in the same way.
+
+<div class="alert alert-warning">The option <strong>replaces</strong> the <code>ignore</code> field instead of adding to it. When an upload supplies <code>--ignored-source-paths</code>, Datadog applies only those patterns to that upload and disregards the <code>ignore</code> field of <code>code-coverage.datadog.yml</code>. The two lists are not merged, so the option value needs to contain every pattern you want applied.</div>
+
+The list is scoped to the reports uploaded by that single command. Other uploads for the same commit keep their own lists, or fall back to the `ignore` field when they do not set the option.
+
+An empty or whitespace-only value is treated as though the option was not passed, and the `ignore` field applies as usual. This keeps an unset CI variable from silently disabling the ignore list of a repository.
+
+#### Separating patterns
+
+Patterns are separated by commas. A comma inside a brace group is part of the pattern, so `**/*.{js,ts}` stays a single pattern:
+
+{{< code-block lang="shell" >}}
+datadog-ci coverage upload --ignored-source-paths "**/*.{js,ts},vendor/" .
+{{< /code-block >}}
+
+This example supplies two patterns: `**/*.{js,ts}` and `vendor/`. The same applies to regex quantifiers such as `.{2,4}`.
+
+Newlines separate patterns as well, which is convenient for long lists supplied through the `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable:
+
+{{< code-block lang="shell" >}}
+export DD_COVERAGE_IGNORED_SOURCE_PATHS="test/**/*
+**/*.pb.go
+vendor/"
+
+datadog-ci coverage upload .
+{{< /code-block >}}
+
+Surrounding whitespace is removed from each pattern, and empty entries are dropped.
+
+#### Difference from `--ignored-paths`
+
+`datadog-ci coverage upload` accepts two options with similar names that do different things:
+
+| Option | What it excludes | Where it applies |
+|---|---|---|
+| `--ignored-source-paths` | **Source files**, from the coverage computation. Replaces the `ignore` field. | In Datadog, after the upload |
+| `--ignored-paths` | **Coverage report files**, from the search for reports to upload. | In the CLI, before the upload |
+
+Use `--ignored-source-paths` to keep generated or vendored source code out of your coverage percentage. Use `--ignored-paths` to stop the CLI from picking up a coverage report file that you do not want to send.
+
+#### Long lists on Windows
+
+`cmd.exe` caps a whole command line at about 8191 characters, and the npm `.cmd` wrapper for `datadog-ci` runs through `cmd.exe`. A long list of patterns can exceed that cap. On Windows, supply long lists through the `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable or the `ignore` field of `code-coverage.datadog.yml` instead.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -258,11 +258,13 @@ Your operating system caps how much can be passed in a command-line argument or 
 | macOS | No per-value limit, but a single combined limit covers all arguments and the entire environment, so a large CI environment reduces the room available. |
 | Windows | 32,767 characters for the whole command line, and 8,191 through `cmd.exe`. The npm and Yarn `.cmd` wrappers run through `cmd.exe`. |
 
-Exceeding an operating system limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
+On Linux, exceeding the limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
+
+<div class="alert alert-warning">On Windows, an oversized value can fail silently. <code>cmd.exe</code> drops an inherited environment variable that exceeds its 8,191-character limit. <code>datadog-ci</code> then receives nothing and behaves as though the option was never set. The <code>ignore</code> field of <code>code-coverage.datadog.yml</code> applies instead, and your coverage is computed against that list. No error appears.</div>
 
 For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. That is the only option with no size ceiling.
 
-The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable is not a way around these limits. On Linux the same per-value ceiling applies to environment variables, however your CI provider sets them. On Windows, a `set` command in `cmd.exe` counts against the command-line cap. Use the environment variable for convenience, such as newline-separated formatting, rather than for size.
+The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable is not a way around these limits. On Linux the same per-value ceiling applies to environment variables, however your CI provider sets them. On Windows, a `set` command in `cmd.exe` counts against the command-line cap, and an oversized inherited value is dropped. Use the environment variable for convenience, such as newline-separated formatting, rather than for size.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -238,20 +238,29 @@ Use `--ignored-source-paths` to keep generated or vendored source code out of yo
 
 #### Limits
 
-A single `--ignored-source-paths` value accepts up to 2,000 patterns, up to 1,000 characters per pattern, and up to 256 KB in total. Exceeding any of the three fails the command, and nothing is uploaded. The error names the limit that was exceeded.
+A realistic list stays well clear of every limit below. 500 patterns of 80 characters is roughly 40 KB, which every platform accepts.
+
+The CLI accepts up to 2,000 patterns, and up to 1,000 characters per pattern. Exceeding either fails the command, and nothing is uploaded. The error names the limit that was exceeded.
+
+A serialized total above 256 KB fails the same way. Treat that ceiling as a backstop rather than a limit you meet. On most systems, the operating system rejects a value that large before `datadog-ci` starts. See [Operating system limits](#operating-system-limits).
 
 Above 1,000 patterns or 100 KB, the upload still happens and the command prints a warning. A list that large is usually better kept in `code-coverage.datadog.yml`.
 
 The per-pattern limit matches the one Datadog applies. An over-long pattern is rejected up front rather than discarded later. A pattern discarded later could leave the list empty, which would silently bring back the `ignore` field of `code-coverage.datadog.yml`.
 
-#### Long lists on Windows
+#### Operating system limits
 
-`cmd.exe` caps a whole command line at about 8191 characters, and the npm `.cmd` wrapper for `datadog-ci` runs through `cmd.exe`. A long list of patterns can exceed that cap, which is far lower than the 256 KB the option itself accepts.
+Your operating system caps how much can be passed in a command-line argument or an environment variable. These ceilings are reached before the 256 KB limit of the option itself, and they differ by platform:
 
-Two alternatives keep the list off the command line:
+| Platform | Limit |
+|---|---|
+| Linux | About 128 KB (131,072 bytes) for any single argument or environment variable. For an environment variable, the `NAME=` prefix counts toward it. |
+| macOS | No per-value limit, but a single combined limit covers all arguments and the entire environment, so a large CI environment reduces the room available. |
+| Windows | 32,767 characters for the whole command line, and 8,191 through `cmd.exe`. The npm and Yarn `.cmd` wrappers run through `cmd.exe`. |
 
-- The `ignore` field of `code-coverage.datadog.yml`.
-- The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable, when your CI provider sets it directly in the job environment. Setting it with a `set` command in `cmd.exe` is subject to the same cap.
+Exceeding an operating system limit produces an error from the shell, such as `Argument list too long`, rather than a message from `datadog-ci`.
+
+For a list large enough to approach these ceilings, use the `ignore` field of `code-coverage.datadog.yml`. The `DD_COVERAGE_IGNORED_SOURCE_PATHS` environment variable helps only in part. On Linux it faces the same per-value ceiling, and a `set` command in `cmd.exe` counts against the command-line cap. It avoids the cap only when your CI provider adds the variable to the job environment.
 
 ## PR Gates
 

--- a/hugo/content/en/code_coverage/setup.md
+++ b/hugo/content/en/code_coverage/setup.md
@@ -446,6 +446,8 @@ test:
 The command recursively searches the specified directories for supported coverage report files, so specifying the current directory (`.`) is usually sufficient.
 See the [`datadog-ci` documentation][14] for more details on the `datadog-ci coverage upload` command.
 
+To exclude source files such as generated or vendored code from the coverage computation, use the `--ignored-source-paths` option or the `ignore` field of `code-coverage.datadog.yml`. See [Ignoring paths][21].
+
 Shortly after the code coverage report upload is finished, Datadog adds a PR comment with code coverage percentage values.
 You can also view your coverage data aggregated by pull request in the [Code Coverage page][15] in Datadog, with the ability to examine individual files and lines of code.
 
@@ -555,3 +557,4 @@ For a description of how reports are merged and how each line status is counted,
 [18]: /code_coverage/setup/#integrate-with-source-code-provider
 [19]: https://app.datadoghq.com/organization-settings/data-access-controls
 [20]: /code_coverage/coverage_calculation
+[21]: /code_coverage/configuration#ignoring-paths


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Two related changes to the Code Coverage docs, kept as separate commits so either set can be dropped or split out.

**Commits form two independent sets:**

| Commits | Content | Mergeable |
|---|---|---|
| 1 and 5 | `code-coverage.datadog.yml` must be committed and pushed | **Now.** Documents behavior that is already live. |
| 14, and part of 13 | Corrections to existing `ignore` and pattern-matching documentation | **Now.** These describe behavior that is live today, independent of the new option. |
| 2, 3, 4, 6, 7, 8, 9, 10, 11 and 12, and part of 13 | The `--ignored-source-paths` option | Gated on the `datadog-ci` release that ships the option. |

Commits are separate rather than squashed because this repository forbids force-pushing.

**Commit 13 spans two sets, and that is worth a reviewer's attention.** It documents two pre-existing behaviours that the page previously implied the opposite of. The `!`-pattern warning sits in `Exceptions` and describes the `ignore` field as it behaves today, so it belongs with the first set and is safe to merge now. The per-upload merge caveat sits in the CLI section and belongs with the second. If review wants the sets kept strictly separate, that commit is the one to split.

**Two corrections to pre-existing content (commits 13 and 14).** Both describe behavior that is live today and that the page implied the opposite of, and both produce silent wrong results rather than errors.

The second is prefix matching. `Prefix patterns` said only "prefix matches", which reads as a leading substring. Prefixes are matched against complete path segments, so `src/mod` matches nothing at all under `src/module/` — no error, no match, the files stay in coverage. Every existing example ends in `/` and is therefore segment-aligned, which hid the distinction. Verified in the reducer: prefix patterns go through `java.nio.file.Path.startsWith`, which compares whole name elements.

The first, and more severe: The `Exceptions` section said only that negative patterns take precedence. It did not say that a list of *only* `!` patterns ignores everything those patterns fail to match — so an `ignore` list containing only `!src/keep/` wipes coverage for the whole repository apart from that path, which is the opposite of what the page led a reader to expect. This is existing `ignore` field behaviour, not new. Verified in the reducer: a file survives only when the matcher returns false, and with no positive patterns and no negative match it returns true.

**Commit 1 — `code-coverage.datadog.yml` must be committed and pushed.**

The configuration page never said this, and users are hitting it. Datadog reads the configuration file from the repository at the commit the coverage reports are attached to; coverage uploads report only the file's path and the Git hash of its contents, never the contents themselves. A file that is uncommitted, or committed but not pushed, therefore has no effect at all — with no error to indicate why. Adds a warning to the overview and a `Commit the configuration file` section covering the requirement and how to check it.

**Commit 2 — document the new `--ignored-source-paths` upload option.**

Documents the new `datadog-ci coverage upload --ignored-source-paths` option in the `Ignoring paths` section of the configuration page, next to the `ignore` field it overrides:

- It excludes **source files** from the coverage computation.
- It **replaces** the `ignore` field rather than merging with it.
- Separator rules: comma-separated, with commas inside brace groups (`**/*.{js,ts}`) treated as part of the pattern rather than as separators; newlines also separate patterns, which suits multi-line lists passed through `DD_COVERAGE_IGNORED_SOURCE_PATHS`.
- The literal-comma limitation, including the regex character class case users are most likely to hit (`^src/[a,b]/.*$` splits; `^src/[ab]/.*$` does not).
- That a supplied list replaces `ignore` even when none of its patterns compile, which excludes nothing rather than reinstating the field.
- That per-upload scoping does not remove a file from the commit: uploads for the same commit and flag are merged, so a file excluded by one upload still appears if another includes it.
- An empty or whitespace-only value behaves as though the option was not passed, so `ignore` still applies.
- A table contrasting it with the pre-existing and similarly named `--ignored-paths`, which filters **coverage report files** during report discovery. These two are easy to confuse and the consequences differ.
- The limits: 2,000 patterns and 1,000 characters per pattern, either of which fails the command without uploading, plus the softer 1,000 pattern / 100 KB warning threshold where the upload still proceeds.
- Why the 256 KB total is a backstop rather than a limit users meet, and a per-platform table of the operating system ceilings that are reached first (Linux ~128 KB per argument or environment variable, macOS a combined argument-plus-environment limit, Windows 32,767 characters and 8,191 through `cmd.exe`).
- The `cmd.exe` command-line length cap on Windows, and the environment variable and configuration file as the alternatives.

Commits 3 and 4 are follow-ups to commit 2 rather than separate changes: commit 3 adds the limits and the Windows detail, and commit 4 sharpens three accuracy points after reconciling the page against the shipped CLI behavior. Commit 6 adds the per-pattern length limit once it landed in the CLI. Commit 7 corrects the 256 KB cap, which the page had presented as a limit users would encounter when in practice the operating system rejects a value that large first. Commit 8 corrects the environment variable guidance: it is not a size escape hatch, because on Linux the same per-value ceiling applies to environment variables however they are set. Commit 9 scopes the operating-system-limit claim to Linux and Windows, since on current macOS the combined budget exceeds 256 KB and the option's own limit is the one that applies. Commits 10 to 12 add a Windows warning. `cmd.exe` ignores an inherited environment variable longer than its 8,191-character limit, so an oversized value never reaches the CLI, the option behaves as unset, and the configured `ignore` list applies with no error. Microsoft scopes the 8,191 limit to the command line, to individual environment variables inherited by other processes, and to environment variable expansions. The callout also asks readers to confirm after the first upload that the intended files were excluded. Commit 5 belongs to the first set, and states that configuration is not applied retroactively — the configuration that applies to a report is the one present at the commit the report was attached to.

Also adds a pointer from the upload section of the setup page.

### Merge readiness

- [ ] Ready for merge

**Please hold commit 2 until the `datadog-ci` release containing `--ignored-source-paths` is out.** Commit 1 documents behavior that is already live and is safe to merge at any time. Two open questions I could not resolve from the docs repo alone:

1. **Availability note pending — expected v5.22.0.** The `flags` page carries `available in datadog-ci vX.Y.Z and later` notes for `--flags`, and a matching note belongs on this option. It is deliberately omitted for now: the release containing `--ignored-source-paths` has not been cut, so the version is a projection rather than a fact. The note will be added as a final commit once the release version is confirmed, before this PR leaves draft.
2. Whether a `DOCS-` ticket should be created and linked in the title.

### On the failing `build_preview` check

`build_preview` fails on this branch. It is not a required check, and the evidence says the cause is not this change:

- **The same failure is hitting unrelated PRs.** Six open PRs from six different authors, with entirely unrelated content, show an identical signature: `detect_hugo_site_dir` success, `build_preview` failure. Roughly a quarter of open PRs are affected at the time of writing. This looks repo-wide rather than specific to these pages.
- **The content-side job passes.** `detect_hugo_site_dir` succeeds here; the failures are all in the preview build and publish steps.
- **The failures are far too quick to match a completed build.** A preview build that runs to completion in this repo takes roughly 35 minutes, whether it ends in success or in a genuine build failure. The four failures on this branch took 4 seconds, 2m15s, 4m44s and 7m50s. That fits a pipeline failing during setup rather than while processing content — though a build that died early would also be quick, so this narrows the cause rather than settling it.
- **Nothing exotic was added.** Every shortcode added by this PR is a balanced, standard `code-block` pair. There are no front-matter changes at all: no `aliases`, no redirects, no `title` or `weight` edits.

**Rendering was verified locally instead.** Both changed pages were built with Hugo extended v0.148.0 — the version pinned in `hugo/package.json` — which completed with no errors or warnings. The rendered HTML confirms:

- Heading hierarchy nests correctly: `Ignoring paths` (h2) → `Override the ignore list from the CLI` (h3) → the four h4 subsections.
- Every in-page anchor resolves to a real rendered `id`, including the new `#commit-the-configuration-file` and `#override-the-ignore-list-from-the-cli`.
- The pointer added to `setup.md` resolves to `/code_coverage/configuration#ignoring-paths`, and that `id` exists on the rendered page.
- The `--ignored-source-paths` / `--ignored-paths` comparison renders as a real table.
- The brace glob `**/*.{js,ts},vendor/` survives Goldmark byte-for-byte, which was the main rendering risk on this page.

**What that local build does not cover:** shortcodes were stubbed and the production theme was not loaded, so this verifies markup and document structure, not styling or final layout. A reviewer with a working preview should give the two pages a visual pass.

### What was checked, and how

This PR makes several claims about behavior, so it is worth being precise about the basis for each:

- **Read in the implementation, not observed at runtime.** The commit-and-push requirement (the upload resolves the config file with `git rev-parse <reported-commit>:<path>` and sends only its path and content hash), the `!`-only ignore semantics, and prefix matching on whole path segments.
- **Confirmed with the engineers who implemented them.** The option's separator rules, its limits, and the replace-not-merge relationship with `ignore`.
- **Verified by building the pages.** Rendering, using the Hugo version pinned in `hugo/package.json`. Details in the section above.
- **Not yet exercised end to end.** The new option's behavior has not been observed in a live pipeline. That is part of why its commits are held until the release ships.

The already-live content — the config-file requirement, and the corrections to the existing `ignore` and pattern-matching documentation — does not depend on the new option and can be reviewed and merged on its own.

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Written by Claude Code. The claim in commit 1 was verified against the `datadog-ci` source rather than taken on trust: the coverage upload command resolves the configuration file with `git rev-parse <reported-commit>:<path>` and puts only `config.path` and `config.sha` on the wire, so the file contents are never uploaded. The described option behavior was cross-checked with the engineer implementing it. Vale 3.9.1 was run locally against the `datadog-vale` styles; the changed lines produce no errors, warnings, or suggestions.

### Additional notes

While verifying the `--ignored-paths` behavior for the comparison table, I found that the `coverage upload` help text and plugin README describe `--ignored-paths` as `only applicable when --auto-discovery is set`. There is no `--auto-discovery` option on `coverage upload` — it exists only on `junit upload`, and the sentence appears to be copied from there. The docs in this PR describe the actual behavior and omit that precondition. The fix belongs in the `datadog-ci` repo and has been raised with its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
