### PR TITLE
[CRED-2815] Document PAT/SAT scope, TTL, and app-key restrictions

### DIFF
--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -74,7 +74,7 @@ To limit how a PAT can escalate its own access, Datadog restricts what an API ca
 - **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.
 - **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that outlives itself.
 
-These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+A call that violates one of these restrictions returns a `403 Forbidden` response.
 
 ## Manage Personal Access Tokens
 

--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -66,7 +66,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 
 **Note:** When a valid PAT is provided in the `dd-application-key` header, Datadog authenticates with the PAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
-## Restrictions
+## Restrictions on PAT-authenticated API calls
 
 To limit how a PAT can escalate its own access, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
 

--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -72,7 +72,7 @@ To limit how a PAT can escalate its own access, Datadog restricts what an API ca
 
 - **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
 - **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.
-- **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that outlives itself.
+- **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that extends beyond its own expiration.
 
 A call that violates one of these restrictions returns a `403 Forbidden` response.
 

--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -68,7 +68,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 
 ## Restrictions on PAT-authenticated API calls
 
-To limit how a PAT can escalate its own access, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
+To prevent privilege escalation, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
 
 - **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
 - **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.

--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -66,6 +66,16 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 
 **Note:** When a valid PAT is provided in the `dd-application-key` header, Datadog authenticates with the PAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
+## Restrictions
+
+To limit how a PAT can escalate its own access, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
+
+- **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.
+- **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that outlives itself.
+
+These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+
 ## Manage Personal Access Tokens
 
 ### View your tokens

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -99,7 +99,7 @@ To limit how a SAT can escalate its own access, Datadog restricts what an API ca
 - **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.
 - **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that outlives itself.
 
-These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+A call that violates one of these restrictions returns a `403 Forbidden` response.
 
 ## Manage Service Access Tokens
 

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -93,7 +93,7 @@ with the SAT only. The `dd-api-key` header is optional and its value is not eval
 
 ## Restrictions on SAT-authenticated API calls
 
-To limit how a SAT can escalate its own access, Datadog restricts what an API call authenticated with a SAT can do. These restrictions apply regardless of the API client making the call:
+To prevent privilege escalation, Datadog restricts what an API call authenticated with a SAT can do. These restrictions apply regardless of the API client making the call:
 
 - **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
 - **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -97,7 +97,7 @@ To limit how a SAT can escalate its own access, Datadog restricts what an API ca
 
 - **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
 - **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.
-- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that outlives itself.
+- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that extends beyond its own expiration.
 
 A call that violates one of these restrictions returns a `403 Forbidden` response.
 

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -91,7 +91,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 **Note:** When a valid SAT is provided in the `dd-application-key` header, Datadog authenticates
 with the SAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
-## Restrictions
+## Restrictions on SAT-authenticated API calls
 
 To limit how a SAT can escalate its own access, Datadog restricts what an API call authenticated with a SAT can do. These restrictions apply regardless of the API client making the call:
 

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -91,6 +91,16 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 **Note:** When a valid SAT is provided in the `dd-application-key` header, Datadog authenticates
 with the SAT only. The `dd-api-key` header is optional and its value is not evaluated.
 
+## Restrictions
+
+To limit how a SAT can escalate its own access, Datadog restricts what an API call authenticated with a SAT can do. These restrictions apply regardless of the API client making the call:
+
+- **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.
+- **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that outlives itself.
+
+These restrictions apply only to API calls authenticated with a PAT or SAT. A call that violates one of these restrictions returns a `403 Forbidden` response.
+
 ## Manage Service Access Tokens
 
 ### View tokens


### PR DESCRIPTION
## What changed

Adds a Restrictions section to the Personal Access Tokens and Service Access Tokens documentation.

The new sections document containment rules for API calls authenticated with a PAT or SAT:

- Cannot create or update application keys. Revocation is still allowed.
- Cannot create or update another token with scopes broader than its own.
- Cannot create a token with a TTL that outlives itself.

Calls that violate these restrictions return a `403 Forbidden` response.

## Why

This redoes the changes from #38945 on a fresh branch after the docs repo reorg. The content now targets the current `hugo/content/...` paths.

## Validation

- `git diff --check`
- `vale hugo/content/en/account_management/personal-access-tokens.md hugo/content/en/account_management/service-access-tokens.md`

Vale reports no errors. Remaining warnings/suggestions are pre-existing lines in these files.