### PR TITLE
Add Database Monitoring, Processes, and Hosts as DAC Preview telemetry types

### DIFF
--- a/hugo/content/en/account_management/rbac/data_access.md
+++ b/hugo/content/en/account_management/rbac/data_access.md
@@ -74,6 +74,9 @@ You may create a maximum of 100 Restricted Datasets under the Enterprise plan, a
 The following are available as a Preview upon request:
 - Custom metrics
     - **Note:** Standard and OpenTelemetry (OTel) metrics are not supported
+- Database Monitoring
+- Hosts
+- Processes
 
 ## Advanced configuration
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds Database Monitoring, Processes, and Hosts to the list of telemetry types available as a Preview upon request in the [Data Access Control docs](https://docs.datadoghq.com/account_management/rbac/data_access/#supported-telemetry).

These three products now support Restricted Datasets in Preview, but the public docs only list Custom metrics under the Preview list.

Verified in preview link: https://docs-staging.datadoghq.com/amy.li/dac-preview-telemetry-types/account_management/rbac/data_access/#supported-telemetry

### Additional notes

Docs-only change to a single list in `hugo/content/en/account_management/rbac/data_access.md`. Translated copies (`content/es/...`) are managed externally and were not edited.
