### PR TITLE
Fix find-int repo paths after hugo/ reorg

### DIFF
--- a/hugo/local/bin/py/integration-finder.py
+++ b/hugo/local/bin/py/integration-finder.py
@@ -28,7 +28,7 @@ integrations_repos = {
 def update_repos(integrations_repos):
     for repo, cfg in integrations_repos.items():
         branch = cfg['branch']
-        local_repo_path = os.path.join('..', repo)
+        local_repo_path = os.path.join('..', '..', repo)
         if isdir(local_repo_path):
             try:
                 print(f'Updating {repo}')
@@ -58,7 +58,7 @@ def find_integration(integrations_repos, integration_name):
     for repo, cfg in integrations_repos.items():
         branch = cfg['branch']
         is_github = cfg['github']
-        location = os.path.join('..', repo)
+        location = os.path.join('..', '..', repo)
         if not os.path.isdir(location):
             continue
         dirs = [f.name for f in os.scandir(location) if f.is_dir()]


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The repo reorg moved everything one directory down (under `hugo`), including the `make find-int` script. The script looks for integration repos to live one directory up (parallel to the documentation repo), so after the reorg, it was trying to clone the integration repos _inside_ the docs repo.

I added an extra `../`, which should fix it, but let me know if there's a better solution.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Claude Code made the edit and ran the local verification.

### Additional notes

