### PR TITLE
Fix Viewer access to browser test recordings

### DIFF
--- a/hugo/content/en/synthetics/browser_tests/_index.md
+++ b/hugo/content/en/synthetics/browser_tests/_index.md
@@ -363,7 +363,7 @@ Use [granular access control][17] to limit who has access to your test based on 
 | Access level | View test configuration | Edit test configuration | View test results | Run test  | View recording | Edit recording |
 | ------------ | ----------------------- | ----------------------- | ------------------| --------- | -------------- | -------------- |
 | No access    |                         |                         |                   |           |                |                |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |                |                |
+| Viewer       | {{< X >}}               |                         | {{< X >}}         |           | {{< X >}}      |                |
 | Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} | {{< X >}}      | {{< X >}}      |
 
 ## Further Reading


### PR DESCRIPTION
## Motivation

The Viewer access level is view-only. It already grants **View test configuration** and **View test results**, so it should also grant **View recording** — a Viewer should be able to see the recording, not create or edit one. The missing checkmark made the table inconsistent with the Viewer/Editor pattern (Viewer views; Editor views + edits + runs).

## Changes

Add `{{< X >}}` to the Viewer × View recording cell in the Restrict Access table in `hugo/content/en/synthetics/browser_tests/_index.md`.

## Testing

- Verified rendered table alignment; single table-cell change, no prose edits.
- Translations (`ja`/`ko`/`es`/`fr`) left untouched.

<!-- Ready for merge: leave unchecked -->