### PR TITLE
Clarify options field merge behavior on tag indexing rule update

### DIFF
--- a/hugo/data/api/v2/full_spec.yaml
+++ b/hugo/data/api/v2/full_spec.yaml
@@ -169096,9 +169096,12 @@ paths:
         If you have any feedback, contact [Datadog support](https://docs.datadoghq.com/help/).
     put:
       description: |-
-        Partially update a tag indexing rule. Fields omitted from the request body are left unchanged.
-        Setting `rule_order` to a value already used by another rule returns 409; use the
-        reorder endpoint for atomic re-sequencing. Requires the `Manage Tags for Metrics` permission.
+        Partially update a tag indexing rule. Fields omitted from the request body are left unchanged,
+        except for fields inside the `options` object. When a request includes `options`, any field left
+        out of `options.data` resets instead of keeping its current value, so include the full
+        `options.data` object on any update that touches it. Setting `rule_order` to a value already used
+        by another rule returns 409; use the reorder endpoint for atomic re-sequencing. Requires the
+        `Manage Tags for Metrics` permission and the `metric_tags_write` permission.
       operationId: UpdateTagIndexingRule
       parameters:
         - $ref: "#/components/parameters/TagIndexingRuleId"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies the `Update a Tag Indexing Rule` API description: the "fields omitted are left unchanged" partial-update behavior does not extend into the `options` object. When a request includes `options`, any field left out of `options.data` resets to its default instead of being preserved, so callers need to send the full `options.data` object on any update that touches it. Also adds the `metric_tags_write` permission to the description, alongside the existing `Manage Tags for Metrics` permission mention.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the options-field partial-update behavior (verified via live API testing) and draft/apply this description update.

### Additional notes