### PR TITLE
Add OpenAI Codex to Cloud Cost Management docs

### DIFF
--- a/hugo/content/en/cloud_cost_management/ai_costs.md
+++ b/hugo/content/en/cloud_cost_management/ai_costs.md
@@ -34,7 +34,7 @@ further_reading:
 
 ## Overview
 
-AI Costs in Cloud Cost Management gives FinOps and engineering teams a unified destination for analyzing AI spend across providers, including Amazon Bedrock, Anthropic, Google Gemini, OpenAI, Vertex AI, GitHub Copilot, and Cursor. View total AI spend alongside your existing cloud infrastructure costs, analyze it with normalized tags, track cost anomalies, identify optimization opportunities, and attribute usage to the specific users and API keys driving it.
+AI Costs in Cloud Cost Management gives FinOps and engineering teams a unified destination for analyzing AI spend across providers, including Amazon Bedrock, Anthropic, Google Gemini, OpenAI, OpenAI Codex, Vertex AI, GitHub Copilot, and Cursor. View total AI spend alongside your existing cloud infrastructure costs, analyze it with normalized tags, track cost anomalies, identify optimization opportunities, and attribute usage to the specific users and API keys driving it.
 
 ## Prerequisites
 
@@ -48,6 +48,7 @@ To use AI Costs, you must have at least one of the following supported providers
 | Azure Foundry Models   | [Azure integration][18] |
 | Google Gemini  | [Google Cloud integration][4] |
 | OpenAI     | [SaaS integration][5] |
+| OpenAI Codex | [OpenAI Codex][19] |
 | Vertex AI  | [Google Cloud integration][4] |
 | GitHub Copilot | [GitHub Copilot][15] |
 | Cursor | [Cursor][16] |
@@ -84,7 +85,7 @@ The following tags are available for all supported AI providers:
 
 ## Attribute AI spend to sources
 
-[Out-of-the-box (OOTB) allocation rules][12] use Datadog observability data to attribute AI costs to the users, API keys, and other sources that generated them. OOTB allocation rules require no configuration and are available for Anthropic and OpenAI. User-level allocation is also supported for Cursor.
+[Out-of-the-box (OOTB) allocation rules][12] use Datadog observability data to attribute AI costs to the users, API keys, and other sources that generated them. OOTB allocation rules require no configuration and are available for Anthropic, OpenAI, and OpenAI Codex. User-level allocation is also supported for Cursor.
 
 
 The following tags are available through OOTB allocation rules:
@@ -122,6 +123,14 @@ The following tags are available through OOTB allocation rules:
 - `user_id`
 
 {{% /tab %}}
+{{% tab "OpenAI Codex" %}}
+
+- `model`
+- `model_speed`
+- `user_email`
+- `workspace_id`
+
+{{% /tab %}}
 {{< /tabs >}}
 
 Configure [Tag Pipelines][13] to map OOTB tags (such as `user_email`) to teams, services, or business units for aggregate reporting:
@@ -154,3 +163,4 @@ After mapping, attributed spend appears in provider-specific dashboards and [Cos
 [16]: /cloud_cost_management/setup/saas_costs/?tab=cursor#configure-your-saas-accounts
 [17]: /cloud_cost_management/recommendations
 [18]: /cloud_cost_management/setup/azure/?tab=terraform
+[19]: /cloud_cost_management/setup/saas_costs/?tab=openaicodex#configure-your-saas-accounts

--- a/hugo/content/en/cloud_cost_management/setup/saas_costs.md
+++ b/hugo/content/en/cloud_cost_management/setup/saas_costs.md
@@ -158,6 +158,18 @@ Your OpenAI cost data for the past 15 months can be accessed in Cloud Cost Manag
 
 {{% /tab %}}
 
+{{% tab "OpenAI Codex" %}}
+
+1. Set up the [OpenAI Codex integration][101] in Datadog, entering your Codex API credential and workspace ID.
+2. Under the {{< ui >}}Resources{{< /ui >}} section, click the toggle for each account to enable `OpenAI Codex in Cloud Cost Management`.
+3. Click {{< ui >}}Save{{< /ui >}}.
+
+Datadog collects daily Codex spend, which becomes available in Cloud Cost Management after 24 hours. To access the available data collected by each SaaS Cost Integration, see the [Data Collected section](#data-collected).
+
+[101]: /integrations/openai_codex/
+
+{{% /tab %}}
+
 {{% tab "Anthropic" %}}
 
 ### 1. Generate an Admin API key
@@ -584,6 +596,19 @@ The following table contains a non-exhaustive list of out-of-the-box tags associ
 | `organization_name` | The name of the organization. |
 | `project_id` | The unique identifier of the project. |
 | `project_name` | The name of the project. |
+
+{{% /tab %}}
+
+{{% tab "OpenAI Codex" %}}
+
+**Note**: Datadog uses the provider's cost total when available and otherwise estimates Codex spend from token usage and public list prices. The `model` and `model_speed` tags are unavailable when the provider reports a single total that covers multiple models.
+
+| Tag Name | Tag Description |
+|---|---|
+| `workspace_id` | The identifier of the OpenAI Codex workspace. |
+| `user_email` | The email address of the user who incurred the cost. |
+| `model` | The Codex model used to generate the cost. |
+| `model_speed` | The speed tier of the Codex model. |
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"76630d65-4661-4112-a717-9b94c687e9af","source":"chat","resourceId":"66e9e7d4-ac36-411f-bf00-55814b38e67e","workflowId":"a63b18c7-e961-4653-b8f9-e543f3a1c64c","codeChangeId":"a63b18c7-e961-4653-b8f9-e543f3a1c64c","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds OpenAI Codex as a supported AI cost source in Cloud Cost Management. Two pages are updated:

- **SaaS and AI Costs** (`saas_costs.md`): adds a setup tab for OpenAI Codex (directing customers to configure the integration with their Codex API credential and workspace ID) and a Data Collected tab documenting the available dimensions (`workspace_id`, `user_email`, `model`, `model_speed`) along with a note on model-level attribution and how Codex spend is estimated.
- **AI Costs** (`ai_costs.md`): lists OpenAI Codex separately from OpenAI in the Prerequisites table, adds it to the provider list in the overview, updates the OOTB allocation rules description, and adds an OpenAI Codex attribution tab with the available dimensions.

Source PR: https://github.com/ddoghq/dd-source/pull/47725

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code (Bits Code) to draft and apply the documentation changes.

### Additional notes

OpenAI Codex is a distinct AI product from OpenAI's API platform; the two are kept clearly separated throughout both pages. The integration page linked from the setup tab (`/integrations/openai_codex/`) is generated from the integration tile configuration.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/66e9e7d4-ac36-411f-bf00-55814b38e67e)

Comment @datadog-staging to request changes