### PR TITLE
Update LLM evaluation UI docs

### DIFF
--- a/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/custom_llm_as_a_judge_evaluations/_index.md
@@ -43,7 +43,7 @@ Learn more about the [compatibility requirements][6].
 
 1. In Datadog, navigate to the Agent Observability [Evaluations page][1]. Select {{< ui >}}Create Evaluation{{< /ui >}}, then select {{< ui >}}Create your own{{< /ui >}}.
    {{< img src="llm_observability/evaluations/EvalConfig_LLMO_1.png" alt="The Agent Observability Evaluations page after selecting Create Evaluation." style="width:100%;" >}}
-1. To enable tracing for evaluations, click the {{< ui >}}Tracing Disabled{{< /ui >}} button, then select the {{< ui >}}Trace Evaluations{{< /ui >}} toggle to enable tracing. When this evaluation runs, its traces appear under `datadog-evaluations`, giving you greater visibility into your evaluations. **Note**: Enabling tracing increases the number of billed spans sent to Datadog.
+1. To enable tracing for evaluations, click the {{< ui >}}Tracing Disabled{{< /ui >}} button, then select the {{< ui >}}Trace Evaluations{{< /ui >}} toggle to enable tracing. When this evaluation runs, its traces appear under `datadog-evaluations`, giving you greater visibility into your evaluations. The {{< ui >}}Evaluate Span{{< /ui >}} action is not available on these judge traces because they are already the output of a judge run and are not intended to be re-evaluated. **Note**: Enabling tracing increases the number of billed spans sent to Datadog.
     {{< img src="llm_observability/evaluations/evaluation_tracing_enabled.png" alt="Trace Evaluations enabled after the toggle to enable evaluation tracing has been selected." >}}
 1. Provide a clear, descriptive {{< ui >}}evaluation name{{< /ui >}} (for example, `factuality-check` or `tone-eval`). You can use this name when querying evaluation results. The name must be unique within your application.
 1. Configure the model:
@@ -537,6 +537,7 @@ You can:
 - Filter by pass/fail assessment status (example, `@evaluation.helpfulness-check.assessment:fail`)
 - Use evaluation results as [facets][3]
 - View aggregate results in the Agent Observability Overview page's Evaluation section
+- Monitor evaluator performance in {{< ui >}}Evaluation Health{{< /ui >}}; charts on the {{< ui >}}Health{{< /ui >}}, {{< ui >}}Errors{{< /ui >}}, {{< ui >}}Cost{{< /ui >}}, and {{< ui >}}Token Usage{{< /ui >}} tabs can be expanded with {{< ui >}}View full screen{{< /ui >}} and exported to a dashboard with {{< ui >}}Save to Dashboard{{< /ui >}} using the controls above each chart.
 - Create [monitors][4] to alert on performance changes or regression
 
 ## Using in experiments
@@ -610,4 +611,3 @@ You can use basic CRUD operations to manipulate managed evaluation configs, afte
 [16]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/trace_level_evaluations
 [17]: /llm_observability/evaluations/custom_llm_as_a_judge_evaluations/session_level_evaluations
 [18]: https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations
-


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4ebaa449-94dc-441f-8ff5-86e301c738ce","source":"chat","resourceId":"84fcee2d-40d2-44a5-8fba-f03787833257","workflowId":"eef15e85-c873-4639-aea3-452907dc9853","codeChangeId":"eef15e85-c873-4639-aea3-452907dc9853","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

Motivation (WHY): Reflect recent LLM Observability evaluation UI changes from:
- https://github.com/DataDog/web-ui/pull/337941
- https://github.com/DataDog/web-ui/pull/337086

Changes (WHAT):
- Document that {{< ui >}}Evaluate Span{{< /ui >}} is not available on judge traces produced by evaluation tracing.
- Document that {{< ui >}}Evaluation Health{{< /ui >}} charts can be expanded full screen and saved to dashboards.

Testing (HOW verified):
- Ran `git diff --check`.
- Reviewed the markdown diff for concise placement and UI shortcode usage.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code for docs search, editing, and PR metadata preparation.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/84fcee2d-40d2-44a5-8fba-f03787833257)

Comment @datadog to request changes