### PR TITLE
Rename 'Kafka Monitoring' to 'Kafka Console' in public-facing docs

### DIFF
--- a/hugo/content/en/data_streams/kafka/_index.md
+++ b/hugo/content/en/data_streams/kafka/_index.md
@@ -7,7 +7,7 @@ aliases:
   - /data_streams/kafka/messages
 ---
 
-With Kafka Console, a Datadog Agent check connects to your Kafka cluster and starts collecting health and performance metrics. Kafka Console allows you to:
+With Data Streams Monitoring's Kafka Console, a Datadog Agent check connects to your Kafka cluster and starts collecting health and performance metrics. Kafka Console allows you to:
 
 - **Monitor Kafka health**: See cluster, broker, topic, and partition health with throughput, lag, and replication metrics
 - **Pinpoint root cause**: Correlate configuration and schema changes with lag, throughput, and errors, and trace issues to the exact topic, schema version, or configuration change

--- a/hugo/content/en/data_streams/kafka/_index.md
+++ b/hugo/content/en/data_streams/kafka/_index.md
@@ -1,13 +1,13 @@
 ---
-title: Kafka Monitoring
-description: Monitor Kafka cluster health, connect services to topics, and inspect schemas and messages with Data Streams Monitoring's Kafka Monitoring.
+title: Kafka Console
+description: Monitor Kafka cluster health, connect services to topics, and inspect schemas and messages with Kafka Console.
 aliases:
   - /data_streams/live_messages
   - /data_streams/messages
   - /data_streams/kafka/messages
 ---
 
-With Data Streams Monitoring's Kafka Monitoring, a Datadog Agent check connects to your Kafka cluster and starts collecting health and performance metrics. Kafka Monitoring allows you to:
+With Kafka Console, a Datadog Agent check connects to your Kafka cluster and starts collecting health and performance metrics. Kafka Console allows you to:
 
 - **Monitor Kafka health**: See cluster, broker, topic, and partition health with throughput, lag, and replication metrics
 - **Pinpoint root cause**: Correlate configuration and schema changes with lag, throughput, and errors, and trace issues to the exact topic, schema version, or configuration change
@@ -15,7 +15,7 @@ With Data Streams Monitoring's Kafka Monitoring, a Datadog Agent check connects 
 - **Inspect topic schemas and messages**: View schemas, compare versions, and access messages to debug poison payloads or explore the topic
 - **Alert and automate responses**: Use [recommended monitor templates][4] and trigger Workflow Automation or webhooks when a Kafka condition fires
 
-To get started, see [Kafka Monitoring Setup][2].
+To get started, see [Kafka Console Setup][2].
 
 ## Workflows
 
@@ -23,7 +23,7 @@ To get started, see [Kafka Monitoring Setup][2].
 
 The {{< ui >}}Clusters{{< /ui >}}, {{< ui >}}Topics{{< /ui >}}, and {{< ui >}}Brokers{{< /ui >}} tabs display health status across your entire Kafka infrastructure. For each topic, you can see partition count, under-replicated and offline partitions, message throughput, and consumer lag.
 
-{{< img src="data_streams/kafka_clusters_overview-2.png" alt="The Kafka Monitoring clusters view showing cluster list with broker counts, topic names, replication status, and messages-in rate" >}}
+{{< img src="data_streams/kafka_clusters_overview-2.png" alt="The Kafka Console clusters view showing cluster list with broker counts, topic names, replication status, and messages-in rate" >}}
 
 Click into any topic to see a detailed summary, including incoming message rate, maximum lag across all partitions, and whether current lag is approaching the retention limit.
 

--- a/hugo/content/en/data_streams/kafka/data_collection.md
+++ b/hugo/content/en/data_streams/kafka/data_collection.md
@@ -1,13 +1,13 @@
 ---
 title: Data Collection
-description: Metrics, configurations, and capabilities collected by Data Streams Monitoring's Kafka Monitoring when cluster monitoring is enabled.
+description: Metrics, configurations, and capabilities collected by Kafka Console when cluster monitoring is enabled.
 ---
 
-Data Streams Monitoring (DSM)'s [Kafka Monitoring][6] uses the [Kafka Consumer integration][1] to collect cluster health data. In addition to the integration's default collection, enabling cluster monitoring collects extra data and unlocks the actions described on this page.
+[Kafka Console][6] uses the [Kafka Consumer integration][1] to collect cluster health data. In addition to the integration's default collection, enabling cluster monitoring collects extra data and unlocks the actions described on this page.
 
 ## Metrics
 
-To collect the **DSM-only** [Kafka Consumer integration metrics][5], set `enable_cluster_monitoring: true`. See [Kafka Monitoring Setup][4] for how to configure the check.
+To collect the **DSM-only** [Kafka Consumer integration metrics][5], set `enable_cluster_monitoring: true`. See [Kafka Console Setup][4] for how to configure the check.
 
 ## Configurations and schemas
 

--- a/hugo/content/en/data_streams/kafka/monitors_and_automation.md
+++ b/hugo/content/en/data_streams/kafka/monitors_and_automation.md
@@ -16,10 +16,10 @@ further_reading:
   text: "Metric monitors"
 - link: "/data_streams/kafka/setup/"
   tag: "Documentation"
-  text: "Kafka Monitoring setup"
+  text: "Kafka Console setup"
 ---
 
-After your Kafka clusters are connected to Data Streams Monitoring (see [Kafka Monitoring Setup][1]), the next step is to alert on the conditions that put your pipelines at risk and, where possible, automate the response.
+After your Kafka clusters are connected to Data Streams Monitoring (see [Kafka Console Setup][1]), the next step is to alert on the conditions that put your pipelines at risk and, where possible, automate the response.
 
 This page covers:
 

--- a/hugo/content/en/data_streams/kafka/setup.md
+++ b/hugo/content/en/data_streams/kafka/setup.md
@@ -1,9 +1,9 @@
 ---
-title: Kafka Monitoring Setup
-description: Set up Data Streams Monitoring's Kafka Monitoring, including prerequisites, Agent configuration, and the additional steps required to inspect Kafka messages.
+title: Kafka Console Setup
+description: Set up Kafka Console, including prerequisites, Agent configuration, and the additional steps required to inspect Kafka messages.
 ---
 
-This page covers the prerequisites and setup steps for Data Streams Monitoring's Kafka Monitoring.
+This page covers the prerequisites and setup steps for Kafka Console.
 
 ## Prerequisites
 
@@ -25,9 +25,9 @@ If your Kafka cluster uses ACLs, the Datadog Agent user requires the following m
 
 ## Setup
 
-Go to the [Kafka Monitoring setup page][1] and click {{< ui >}}Get Started{{< / ui >}}. Then choose your environment and follow the instructions. To request assistance, choose {{< ui >}}Request a pairing session{{< /ui >}}.
+Go to the [Kafka Console setup page][1] and click {{< ui >}}Get Started{{< / ui >}}. Then choose your environment and follow the instructions. To request assistance, choose {{< ui >}}Request a pairing session{{< /ui >}}.
 
-{{< img src="data_streams/kafka_setup-2.png" alt="The Kafka Monitoring setup dialog showing environment selection, security protocol, schema registry options, and Kubernetes configuration instructions" >}}
+{{< img src="data_streams/kafka_setup-2.png" alt="The Kafka Console setup dialog showing environment selection, security protocol, schema registry options, and Kubernetes configuration instructions" >}}
 
 The setup page provides environment-specific configuration instructions. You can copy the instructions directly to an AI agent with {{< ui >}}Copy for AI{{< /ui >}}.
 

--- a/hugo/content/en/tracing/guide/monitor-kafka-queues.md
+++ b/hugo/content/en/tracing/guide/monitor-kafka-queues.md
@@ -17,7 +17,7 @@ further_reading:
 <div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
   <p style="margin:0;line-height:1.5;">
     <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
-    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka/?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try Kafka Monitoring &rarr;</a>
+    <strong>Kafka Console</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="/data_streams/kafka/?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-TracingGuide">Try Kafka Console &rarr;</a>
   </p>
 </div>
 

--- a/hugo/content/en/universal_service_monitoring/setup.md
+++ b/hugo/content/en/universal_service_monitoring/setup.md
@@ -1026,10 +1026,10 @@ agents:
 {{< /tabs >}}
 {{< /collapse-content >}}
 
-{{< collapse-content title="Kafka Monitoring (Preview)" level="h4" >}}
+{{< collapse-content title="Kafka Console (Preview)" level="h4" >}}
 
 <div class="alert alert-info">
-Kafka Monitoring is available in <strong>Preview</strong>.
+Kafka Console is available in <strong>Preview</strong>.
 </div>
 
 <strong>Note</strong>:


### PR DESCRIPTION
## Summary

Renames the internal product name "Kafka Monitoring" to the official product name **Kafka Console** in all public-facing documentation.

## Context

Per [this Slack thread](https://dd.slack.com/archives/C02TRJWDHQS/p1786470112140809), the Kafka monitoring product is officially called **Kafka Console**. Previous PR #36702 introduced the old "Kafka Monitoring" name in a callout; this PR updates that and all other references across the docs.

## Files changed

| File | Changes |
|------|---------|
| `data_streams/kafka/_index.md` | Page title, description, prose, alt text (8 instances) |
| `data_streams/kafka/setup.md` | Page title, description, prose, alt text (4 instances) |
| `data_streams/kafka/data_collection.md` | Description, prose (3 instances) |
| `data_streams/kafka/monitors_and_automation.md` | Further reading link text, prose (2 instances) |
| `universal_service_monitoring/setup.md` | Collapsible section title and preview note (2 instances) |
| `tracing/guide/monitor-kafka-queues.md` | Callout text (2 instances) |

## Intentionally not changed

- `data_streams/setup/technologies/kafka.md` page title (still "Data Streams Monitoring for Kafka") — this is the DSM instrumentation setup guide, distinct from the Kafka Console feature page
- UTM campaign parameters containing `DSMKafka` — tracking identifiers, not product names
- `Data Streams Monitoring Capture Messages` permission name — internal Datadog permission name

## Related PRs

- integrations-core: https://github.com/DataDog/integrations-core/pull/24845
- corp-hugo: pending (repo not cloned locally)