### PR TITLE
Document Insight triage trackers

### DIFF
--- a/hugo/content/en/llm_observability/_index.md
+++ b/hugo/content/en/llm_observability/_index.md
@@ -113,6 +113,10 @@ Outlier detection is performed across key dimensions:
 
 These outliers are analyzed over the past week and automatically surfaced in the corresponding time window selected by the user. This enables teams to proactively detect regressions, performance drifts, or unexpected behavior in their LLM applications.
 
+In an Agent Insight's **Next Steps**, use the **Triage** area to track follow-up work in Jira or Linear. Create a Linear issue or Jira ticket, or link an existing one. After you create or link a work item, the link remains accessible from the Insight. Jira and Linear actions do not change the Insight's status or the other tracker.
+
+To create or link Linear issues or Jira tickets, configure Jira or Linear in [Case Management notifications and integrations][11]. Case Management read access is required to view linked work items. Case Management read and write access is required to create or link them.
+
 {{< img src="llm_observability/Overview_LLMO.png" alt="An 'Insights' banner across the top of the Agent Observability Monitor page. The banner displays 8 insights and has a View Insights button that leads to a side panel with further details." style="width:100%;" >}}
 
 ## Use integrations with Agent Observability
@@ -141,3 +145,4 @@ See the [Setup documentation][5] for instructions on instrumenting your LLM appl
 [8]: /llm_observability/setup/auto_instrumentation
 [9]: /llm_observability/evaluations/managed_evaluations
 [10]: /llm_observability/monitoring/patterns
+[11]: /incident_response/case_management/notifications_integrations


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e66d0e8c-1bc3-4ac1-895b-088624c5334f","source":"chat","resourceId":"49d36a29-16e4-4554-921a-872da1932d03","workflowId":"9ba52e1b-f93d-45b1-88d4-4d3aca465cb5","codeChangeId":"9ba52e1b-f93d-45b1-88d4-4d3aca465cb5","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

Documents the Agent Insight Triage workflow for tracking follow-up work in Jira and Linear.

Source PR: https://github.com/DataDog/web-ui/pull/339106

Changes:
- Adds the Triage workflow for creating or linking Linear issues and Jira tickets from Agent Insights.
- Documents tracker link behavior and Case Management access requirements.
- Adds the Case Management notifications and integrations prerequisite link.

### Testing/Validation

- Ran `git diff --check`.
- Attempted `vale hugo/content/en/llm_observability/_index.md`, but Vale is not installed in this environment.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code for the documentation edit and PR metadata.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/49d36a29-16e4-4554-921a-872da1932d03)

Comment @datadog to request changes