### PR TITLE
[DOCS-15331] Restore integration pages dropped in repo reorg

### DIFF
--- a/hugo/.gitignore
+++ b/hugo/.gitignore
@@ -84,6 +84,15 @@ content/en/integrations/guide/amazon_cloudformation.md
 !content/en/integrations/apigee.md
 !content/en/integrations/snyk.md
 !content/en/integrations/content_security_policy_logs.md
+!content/en/integrations/agentprofiling.md
+!content/en/integrations/amazon_guardduty.md
+!content/en/integrations/nxlog.md
+!content/en/integrations/rsyslog.md
+!content/en/integrations/sinatra.md
+!content/en/integrations/stunnel.md
+!content/en/integrations/syslog_ng.md
+!content/en/integrations/uwsgi.md
+!content/en/integrations/vmware_tanzu_application_service.md
 
 # Ignore the marketplace images that get pulled
 static/images/marketplace

--- a/hugo/content/en/integrations/agentprofiling.md
+++ b/hugo/content/en/integrations/agentprofiling.md
@@ -1,0 +1,65 @@
+---
+integration_title: Agent Profiling Check
+name: agentprofiling
+custom_kind: integration
+git_integration_title: agentprofiling
+updated_for_agent: 7.66
+description: 'Generates flare with profiles based on user-defined memory and CPU thresholds.'
+is_public: true
+public_title: Datadog-Agent Profiling
+short_description: 'Generates flare with profiles based on user-defined memory and CPU thresholds.'
+supported_os:
+    - linux
+    - mac_os
+    - windows
+integration_id: "agentprofiling"
+---
+
+## Overview
+
+This check should be used when troubleshooting a memory or CPU issue in the Agent. After a user-configured memory or CPU threshold is exceeded, a flare with profiles is automatically generated. This flare can be generated locally or sent directly to a Datadog Support case. A valid `ticket_id` and `user_email` must be provided in the `conf.yaml` for the flare to be sent directly to a Support case. It is otherwise generated locally.   
+
+## Setup
+
+### Installation
+
+The System check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
+
+### Configuration
+
+1. Edit the `agentprofiling.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample agentprofiling.d/conf.yaml][3] for all available configuration options. **Note**: At least one entry is required under `instances` to enable the check, for example:
+
+    ```yaml
+    init_config:
+    instances:
+        - memory_threshold: 1GB
+          cpu_threshold: 50
+          ticket_id: # Given by Support
+          user_email: # Email used in correspondence with Support
+    ```
+
+2. [Restart the Agent][4].
+
+### Validation
+
+[Run the Agent's status subcommand][1] and look for `agentprofiling` under the Checks section.
+
+## Data collected
+
+### Metrics
+
+The Agent Profiling check does not include any metrics.
+
+### Events
+
+The Agent Profiling check does not include any events.
+
+### Service checks
+
+The Agent Profiling check does not include any service checks.
+
+[1]: /agent/guide/agent-commands/#agent-status-and-information
+[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/agentprofiling.d/conf.yaml.example
+[4]: /agent/guide/agent-commands/#start-stop-restart-the-agent
+[5]: https://github.com/DataDog/integrations-core/blob/master/system_swap/datadog_checks/system_swap/data/conf.yaml.example

--- a/hugo/content/en/integrations/amazon_guardduty.md
+++ b/hugo/content/en/integrations/amazon_guardduty.md
@@ -1,0 +1,54 @@
+---
+categories:
+    - cloud
+    - aws
+    - log collection
+    - security
+description: Gather your Amazon GuardDuty logs.
+doc_link: /integrations/amazon_guardduty/
+has_logo: true
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/amazon_guardduty.md']
+integration_title: Amazon GuardDuty
+is_public: true
+custom_kind: integration
+name: amazon_guardduty
+public_title: Datadog-Amazon GuardDuty Integration
+short_description: Gather your Amazon GuardDuty logs.
+version: '1.0'
+integration_id: "amazon-guardduty"
+---
+
+## Overview
+
+Datadog integrates with Amazon GuardDuty through a Lambda function that ships GuardDuty findings to Datadog's Log Management solution.
+
+## Setup
+
+### Log collection
+
+#### Enable logging
+
+1. If you haven't already, set up the [Datadog Forwarder Lambda function][1].
+
+2. Create a new rule in [Amazon EventBridge][2]. Give the rule a name and select **Rule with an event pattern**. Click **Next**.
+
+3. Build the event pattern to match your GuardDuty Findings. In the **Event source** section, select `AWS events or EventBridge partner events`. In the **Event pattern** section, specify `AWS services` for the source, `GuardDuty` for the service, and `GuardDuty Finding` as the type. Click **Next**.
+
+4. Select the Datadog Forwarder as the target. Set `AWS service` as the target type, `Lambda function` as the target, and choose the Datadog forwarder from the dropdown `Function` menu. Click **Next**.
+
+5. Configure any desired tags, and click **Create rule**.
+
+#### Send your logs to Datadog
+
+1. In the AWS console, go to **Lambda**.
+
+2. Click **Functions** and select the Datadog forwarder.
+
+3. In the Function Overview section, click **Add Trigger**. Select **EventBridge (CloudWatch Events)** from the dropdown menu, and specify the rule created in the [enable logging section](#enable-logging).
+
+4. See any new GuardDuty Findings in the [Datadog Log Explorer][3].
+
+[1]: /logs/guide/forwarder/
+[2]: https://console.aws.amazon.com/events/home
+[3]: https://app.datadoghq.com/logs

--- a/hugo/content/en/integrations/nxlog.md
+++ b/hugo/content/en/integrations/nxlog.md
@@ -1,0 +1,99 @@
+---
+title: NXLog
+name: nxlog
+custom_kind: integration
+description: 'Configure NXLog to gather logs from your host, containers, & services.'
+short_description: 'Configure NXLog to gather logs from your host, containers, & services.'
+categories:
+    - log collection
+doc_link: /integrations/nxlog/
+aliases:
+    - /logs/log_collection/nxlog
+has_logo: true
+integration_title: NXLog
+is_public: true
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/nxlog.md']
+public_title: Datadog-NXlog Integration
+supported_os:
+    - windows
+integration_id: "nxlog"
+---
+
+## Overview
+
+Configure NXLog to gather logs from your host, containers, and services.
+
+## Setup
+
+The following outlines the setup for log collection through HTTP endpoints and [NXLog TLS encryption](#nxlog-tls-encryption). For more information on logging endpoints, see [Log Collection][1].
+
+### Log collection over HTTP
+
+```conf
+    ## Set the ROOT to the folder your nxlog was installed into,
+    ## otherwise it won't start.
+    #To change for your own system if necessary
+    define ROOT C:\Program Files\nxlog
+    #define ROOT_STRING C:\Program Files\nxlog
+    #define ROOT C:\Program Files (x86)\nxlog
+    Moduledir %ROOT%\modules
+    CacheDir %ROOT%\data
+    Pidfile %ROOT%\data\nxlog.pid
+    SpoolDir %ROOT%\data
+    LogFile %ROOT%\data\nxlog.log
+    ##Extension to format the message in JSON format
+    <Extension json>
+        Module xm_json
+    </Extension>
+    ##Extension to format the message in syslog format
+    <Extension syslog>
+    Module xm_syslog
+    </Extension>
+    ########## INPUTS ###########
+    ##Input for windows event logs
+    <Input syslogs>
+        Module      im_msvistalog
+    ##For windows 2003 and earlier use the following:
+    #    Module      im_mseventlog
+    </Input>
+    ############ OUTPUTS ##############
+    ##HTTP output module
+    <Output out>
+        Module      om_http
+        URL         {{< region-param key="http_endpoint" >}}
+        Port        {{< region-param key="http_port" >}}
+        Exec        to_syslog_ietf();
+        Exec        $raw_event="<DATADOG_API_KEY> "+$raw_event;
+    </Output>
+    ############ ROUTES TO CHOOSE #####
+    <Route 1>
+        Path        syslogs => out
+    </Route>
+```
+
+### NXLog TLS encryption
+
+1. Download the [CA certificate][2].
+
+2. Add the `om_ssl` module in your NXLog configuration to enable secure transfer over port 10516:
+
+    ```conf
+    <Output out>
+      Module  om_ssl
+      Host    {{< region-param key="web_integrations_endpoint" >}}
+      Port    {{< region-param key="tcp_endpoint_port" >}}
+      Exec    to_syslog_ietf();
+      Exec    $raw_event="my_api_key " + $raw_event;
+      CAFile  <CERT_DIR>/ca-certificates.crt
+      AllowUntrusted FALSE
+    </Output>
+    ```
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][3].
+
+[1]: /logs/log_collection/
+[2]: /resources/crt/ca-certificates.crt
+[3]: /help/

--- a/hugo/content/en/integrations/rsyslog.md
+++ b/hugo/content/en/integrations/rsyslog.md
@@ -1,0 +1,115 @@
+---
+title: Rsyslog
+name: rsyslog
+custom_kind: integration
+description: 'Configure Rsyslog to gather logs from your host, containers, & services.'
+short_description: 'Configure Rsyslog to gather logs from your host, containers, & services.'
+categories:
+    - log collection
+doc_link: /integrations/rsyslog/
+aliases:
+    - /logs/log_collection/rsyslog
+has_logo: true
+integration_title: rsyslog
+is_public: true
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/rsyslog.md']
+public_title: Datadog-Rsyslog Integration
+supported_os:
+    - linux
+integration_id: "rsyslog"
+further_reading:
+- link: "https://www.datadoghq.com/architecture/using-rsyslog-to-send-logs-to-datadog/"
+  tag: "Architecture Center"
+  text: "Using Rsyslog to send logs to Datadog"
+- link: "/logs/log_collection/?tab=host#logging-endpoints"
+  tag: "Documentation"
+  text: "Log Collection and Integrations"
+- link: "https://docs.datadoghq.com/data_security/logs/"
+  tag: "Documentation"
+  text: "Log Management Data Security"
+
+---
+
+## Overview
+
+Configure Rsyslog to gather logs from your host, containers, and services.
+
+## Setup
+
+### Log collection
+
+<div class="alert alert-info"> From <a href="https://www.rsyslog.com/doc/configuration/modules/imfile.html#mode">version 8.1.5</a> Rsyslog recommends <code>inotify</code> mode. Traditionally, <code>imfile</code> used polling mode, which is much more resource-intense (and slower) than <code>inotify</code> mode. </div>
+
+1. Activate the `imfile` module to monitor specific log files. To add the `imfile` module, add the following to your `rsyslog.conf`:
+
+    ```conf
+    module(load="imfile" PollingInterval="10") #needs to be done just once
+    ```
+
+2. Create an `/etc/rsyslog.d/datadog.conf` file.
+
+3. In `/etc/rsyslog.d/datadog.conf`, add the following configuration. Replace `<site_url>` with **{{< region-param key="dd_site" >}}** and `<API_KEY>` with your Datadog API key. You must include a separate `input` line for each log file you want to monitor:
+
+   ```conf
+   ## For each file to send
+   input(type="imfile" ruleset="infiles" Tag="<TAGS>" File="<PATH_TO_FILE1>")
+
+   ## Set the Datadog Format to send the logs
+   template(name="test_template" type="list") { constant(value="{") property(name="msg" outname="message" format="jsonfr") constant(value="}")}
+
+   # include the omhttp module
+   module(load="omhttp")
+
+   ruleset(name="infiles") {
+      action(type="omhttp" server="http-intake.logs.<site_url>" serverport="443" restpath="api/v2/logs" template="test_template" httpheaders=["DD-API-KEY: <API_KEY>", "Content-Type: application/json"])
+   }
+   ```
+
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+   ```shell
+   sudo systemctl restart rsyslog
+   ```
+
+5. Associate your logs with the host metrics and tags.
+
+   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
+   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
+   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
+
+6. To get the best use out of your logs in Datadog, set a source for the logs.
+   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
+   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`.
+
+     To set the source, use the following format (if you have several sources, change the name of the format in each file):
+
+     ```conf
+     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
+     ```
+
+     You can add custom tags with the `ddtags` attribute:
+
+     ```conf
+     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+     ```
+
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+
+   1. Add the following lines to your Rsyslog configuration file:
+
+      ```conf
+      $ModLoad immark
+      $MarkMessagePeriod 20
+      ```
+
+   2. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][1].
+
+[1]: /help/

--- a/hugo/content/en/integrations/sinatra.md
+++ b/hugo/content/en/integrations/sinatra.md
@@ -1,0 +1,98 @@
+---
+title: Sinatra
+name: Sinatra
+custom_kind: integration
+description: 'Gather Sinatra application logs.'
+short_description: 'Gather Sinatra application logs.'
+categories:
+    - log collection
+aliases:
+    - /logs/log_collection/nxlog
+has_logo: true
+integration_title: Sinatra
+is_public: true
+public_title: Datadog-Sinatra Integration
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/sinatra.md']
+supported_os:
+    - linux
+    - mac_os
+    - windows
+integration_id: "sinatra"
+---
+
+## Overview
+
+This integration enables you to get web access logging from your [Sinatra][1] applications in order to monitor:
+
+- Errors logs (4xx codes, 5xx codes)
+- Web pages response time
+- Number of requests
+- Number of bytes exchanged
+
+## Setup
+
+### Installation
+
+[Install the Agent][2] on the instance that runs your Sinatra application.
+
+### Configuration
+
+The default [Sinatra logging][3] feature logs to stdout. Datadog recommends that you use the [Rack][4] [Common Logger][5] in order to log to a file and in the console.
+
+Here is a configuration example that generate logs in a file and the console. This can be set in the Rack configuration file (`config.ru`) or the configuration block for your Sinatra application.
+
+```ruby
+require 'sinatra'
+
+configure do
+  # logging is enabled by default in classic style applications,
+  # so `enable :logging` is not needed
+  file = File.new("/var/log/sinatra/access.log", 'a+')
+  file.sync = true
+  use Rack::CommonLogger, file
+end
+
+get '/' do
+  'Hello World'
+end
+```
+
+This logger uses the common Apache Access format and generates logs in the following format:
+
+```text
+127.0.0.1 - - [15/Jul/2018:17:41:40 +0000] "GET /uptime_status HTTP/1.1" 200 34 0.0004
+127.0.0.1 - - [15/Jul/2018 23:40:31] "GET /uptime_status HTTP/1.1" 200 6997 1.8096
+```
+
+#### Log collection
+
+_Available for Agent versions >6.0_
+
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file with:
+
+    ```yaml
+    logs_enabled: true
+    ```
+
+2. Add this configuration block to your `sinatra.d/conf.yaml` file at the root of your [Agent's configuration directory][6] to start collecting your Sinatra application logs:
+
+    ```yaml
+    logs:
+      - type: file
+        path: /var/log/sinatra/access.log
+        source: sinatra
+        service: webapp
+    ```
+
+      Change the `path` and `service` parameter values and configure them for your environment.
+
+3. [Restart the Agent][7]
+
+[1]: http://sinatrarb.com
+[2]: https://app.datadoghq.com/account/settings/agent/latest
+[3]: http://sinatrarb.com/intro.html#Logging
+[4]: http://rack.github.io
+[5]: https://www.rubydoc.info/github/rack/rack/Rack/CommonLogger
+[6]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[7]: /agent/guide/agent-commands/#restart-the-agent

--- a/hugo/content/en/integrations/stunnel.md
+++ b/hugo/content/en/integrations/stunnel.md
@@ -1,0 +1,65 @@
+---
+categories:
+    - log collection
+description: Gather your logs from your Stunnel proxy and send them to Datadog.
+has_logo: true
+integration_title: Stunnel
+is_public: true
+custom_kind: integration
+name: Stunnel
+public_title: Datadog-Stunnel Integration
+short_description: Gather your logs from your Stunnel proxy and send them to Datadog.
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/stunnel.md']
+integration_id: "stunnel"
+---
+
+## Overview
+
+Stunnel is a proxy designed to add TLS encryption functionality to existing clients and servers without any changes in the programs' code.
+
+Use the Datadog - Stunnel proxy integration to monitor potential network issues or DDoS attacks.
+
+## Setup
+
+### Installation
+
+You must [install the Datadog Agent][1] on the server running Stunnel.
+
+### Configuration
+
+Create a `stunnel.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting your Stunnel Proxy logs.
+
+#### Log collection
+
+_Available for Agent versions >v6.0_
+
+1. Collecting logs is disabled by default in the Datadog Agent. You must enable it in the `datadog.yaml` file:
+
+    ```yaml
+    logs_enabled: true
+    ```
+
+2. Add this configuration block to your `stunnel.d/conf.yaml` file to start collecting Stunnel Logs:
+
+    ```yaml
+    logs:
+        - type: file
+          path: /var/log/stunnel.log
+          source: stunnel
+          service: '<MY_SERVICE>'
+          sourcecategory: proxy
+    ```
+
+     Change the `path` and `service` parameter values and configure them for your environment.
+
+3. [Restart the Agent][3]
+
+### Validation
+
+[Run the Agent's `status` subcommand][4] and look for `stunnel` under the Checks section.
+
+[1]: https://app.datadoghq.com/account/settings/agent/latest
+[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: /agent/guide/agent-commands/#start-stop-restart-the-agent
+[4]: /agent/guide/agent-commands/#agent-status-and-information

--- a/hugo/content/en/integrations/syslog_ng.md
+++ b/hugo/content/en/integrations/syslog_ng.md
@@ -1,0 +1,97 @@
+---
+title: Syslog-ng
+name: syslog_ng
+custom_kind: integration
+description: 'Configure Syslog-ng to gather logs from your host, containers, & services.'
+short_description: 'Configure Syslog-ng to gather logs from your host, containers, & services.'
+categories:
+    - log collection
+doc_link: /integrations/syslog_ng/
+aliases:
+    - /logs/log_collection/syslog_ng
+has_logo: true
+integration_title: syslog_ng
+is_public: true
+public_title: Datadog-Syslog-ng Integration
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/syslog_ng.md']
+supported_os:
+    - linux
+    - windows
+integration_id: "syslog_ng"
+---
+
+## Overview
+
+Configure Syslog-ng to gather logs from your host, containers, & services.
+
+## Setup
+
+### Log collection
+
+1. Collect system logs and log files in `/etc/syslog-ng/syslog-ng.conf` and make sure the source is correctly defined:
+
+    ```conf
+    source s_src {
+    system();
+    internal();
+
+    };
+    ```
+
+    If you want to monitor files, add the following source:
+
+    ```conf
+    #########################
+    # Sources
+    #########################
+
+    ...
+
+    source s_files {
+    file("path/to/your/file1.log",flags(no-parse),follow_freq(1),program_override("<program_name_file1>"));
+    file("path/to/your/file2.log",flags(no-parse),follow_freq(1),program_override("<program_name_file2>"));
+
+    };
+    ```
+
+2. Set the correct log format:
+
+    ```conf
+    #########################
+    # Destination
+    #########################
+
+    ...
+
+    # For Datadog platform:
+    destination d_datadog {
+      http(
+          url("https://http-intake.logs.{{< region-param key="dd_site" code="true" >}}/api/v2/logs?ddsource=<SOURCE>&ddtags=<TAG_1:VALUE_1,TAG_2:VALUE_2>")
+          method("POST")
+          headers("Content-Type: application/json", "Accept: application/json", "DD-API-KEY: <DATADOG_API_KEY>")
+          body("<${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} $MSG\n")
+      );
+    };
+    ```
+
+3. Define the output in the path section:
+
+    ```conf
+    #########################
+    # Log Path
+    #########################
+
+    ...
+
+    log { source(s_src); source(s_files); destination(d_datadog); };
+    ```
+
+4. Restart syslog-ng.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][2].
+
+[1]: https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html
+[2]: /help/

--- a/hugo/content/en/integrations/uwsgi.md
+++ b/hugo/content/en/integrations/uwsgi.md
@@ -1,0 +1,77 @@
+---
+title: uWSGI
+name: uwsgi
+custom_kind: integration
+description: 'Collect uWSGI logs in order to track requests per second, bytes served, request status, and more.'
+short_description: 'Collect logs to track requests per second, bytes served, request status, and more.'
+categories:
+  - log collection
+  - web
+doc_link: /integrations/uwsgi/
+dependencies: ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/uwsgi.md"]
+has_logo: true
+integration_title: uWSGI
+is_public: true
+public_title: Integration Datadog-uWSGI
+git_integration_title: uwsgi
+supported_os:
+- linux
+- mac_os
+- windows
+integration_id: "uwsgi"
+---
+
+## Overview
+
+Collect uWSGI logs in order to track requests per second, bytes served, request status (2xx, 3xx, 4xx, 5xx), service uptime, slowness, and more.
+
+## Setup
+
+### Installation
+
+[Install the agent][1] on the instance that runs the uWSGI server.
+
+### Configuration
+
+By default uWSGI server logs to stdout. Run the following command to start logging to a file or follow [uWSGI instructions to log to a file][2]:
+
+```text
+uwsgi --socket :3031 --logger file:logfile=/var/log/uwsgi/uwsgi.log,maxsize=2000000
+```
+
+Create the `uwsgi.d/conf.yaml` file in the root of your Agent's configuration directory.
+
+#### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file with:
+
+```yaml
+logs_enabled: true
+```
+
+Then add this configuration block to your `uwsgi.d/conf.yaml` file to start collecting your logs:
+
+```yaml
+logs:
+    - type: file
+      path: /var/log/uwsgi/uwsgi.log
+      service: '<MY_APPLICATION>'
+      source: uwsgi
+```
+
+Finally, [restart the agent][3].
+
+By default the Datadog-uWSGI integration supports the [default uWSGI log format][4] and the [Apache-like combined format][5].
+
+## Troubleshooting
+
+Need help? Contact [Datadog Support][6].
+
+[1]: https://app.datadoghq.com/account/settings/agent/latest
+[2]: https://uwsgi-docs.readthedocs.io/en/latest/Logging.html#logging-to-files
+[3]: /agent/guide/agent-commands/#start-stop-restart-the-agent
+[4]: https://uwsgi-docs.readthedocs.io/en/latest/LogFormat.html#uwsgi-default-logging
+[5]: https://uwsgi-docs.readthedocs.io/en/latest/LogFormat.html#apache-style-combined-request-logging
+[6]: /help/

--- a/hugo/content/en/integrations/vmware_tanzu_application_service.md
+++ b/hugo/content/en/integrations/vmware_tanzu_application_service.md
@@ -1,0 +1,175 @@
+---
+integration_title: VMware Tanzu Application Service
+name: vmware_tanzu_application_service
+custom_kind: integration
+aliases:
+    - /integrations/cloud_foundry/
+    - /integrations/pivotal_platform/
+newhlevel: true
+updated_for_agent: 6.0
+description: 'Track the health of your VMware Tanzu Application Service (formerly Pivotal Cloud Foundry) VMs and the jobs they run.'
+is_public: true
+public_title: Datadog-VMware Tanzu Application Service (Pivotal Cloud Foundry) Integration
+short_description: 'Track the health of VMware Tanzu Application Service VMs and the jobs they run.'
+categories:
+    - provisioning
+    - configuration & deployment
+    - log collection
+dependencies:
+    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/vmware_tanzu_application_service.md']
+doc_link: /integrations/vmware_tanzu_application_service/
+integration_id: "pivotal-platform"
+further_reading:
+- link: "https://www.datadoghq.com/blog/pcf-monitoring-with-datadog/"
+  tag: "Blog"
+  text: "Pivotal Platform Monitoring with Datadog"
+- link: "/integrations/guide/application-monitoring-vmware-tanzu/"
+  tag: "documentation"
+  text: "Datadog Application Monitoring for VMware Tanzu"
+- link: "/integrations/guide/cluster-monitoring-vmware-tanzu/"
+  tag: "documentation"
+  text: "Datadog Cluster Monitoring for VMware Tanzu"
+
+---
+
+## Overview
+
+Any VMware Tanzu Application Service (formerly known as Pivotal Cloud Foundry, see the [VMware announcement][1] for more information) deployment can send metrics and events to Datadog. You can track the health and availability of all nodes in the deployment, monitor the jobs they run, collect metrics from the Loggregator Firehose, and more.
+
+For the best experience, use this page to automatically set up monitoring through Tanzu Ops Manager for your application on VMware Tanzu Application Service and your VMware Tanzu Application Service cluster. For manual setup steps, see the [VMware Tanzu Application Service Manual Setup Guide][2].
+
+There are three main components for the VMware Tanzu Application Service integration with Datadog. First, the buildpack is used to collect custom metrics from your applications. Second, the BOSH Release collects metrics from the platform. Third, the Loggregator Firehose Nozzle collects all other metrics from your infrastructure. Read the [Datadog VMware Tanzu Application Service architecture][3] guide for more information.
+
+## Monitor your applications
+
+Use the [VMware Tanzu installation and configuration][4] guide to install the integration through the Tanzu Ops Manager. For manual setup steps, read the [Monitor your applications][5] section in the manual setup guide.
+
+### Configuration
+
+#### Metric collection
+
+Set an API Key in your environment to enable the buildpack:
+
+```shell
+# set the environment variable
+cf set-env <YOUR_APP> DD_API_KEY <DATADOG_API_KEY>
+# restage the application to make it pick up the new environment variable and use the buildpack
+cf restage <YOUR_APP>
+```
+
+#### Trace and profile collection
+
+The Datadog Trace Agent (APM) is enabled by default. Learn more about setup for your specific language in [APM setup][6] and [Profiling setup][7].
+
+#### Log collection
+
+{{% site-region region="us3" %}}
+
+Log collection is not supported for this site.
+
+{{% /site-region %}}
+
+{{% site-region region="us,us5,eu,gov,gov2,ap1,uk1" %}}
+
+##### Enable log collection
+
+To start collecting logs from your application in VMware Tanzu Application Service, the Agent contained in the buildpack needs to be activated and log collection enabled.
+
+```shell
+cf set-env <YOUR_APP_NAME> DD_LOGS_ENABLED true
+# Disable the Agent core checks to disable system metrics collection
+cf set-env <YOUR_APP_NAME> DD_ENABLE_CHECKS false
+# Redirect Container Stdout/Stderr to a local port so the Agent collects the logs
+cf set-env <YOUR_APP_NAME> STD_LOG_COLLECTION_PORT <PORT>
+# Configure the Agent to collect logs from the wanted port and set the value for source and service
+cf set-env <YOUR_APP_NAME> LOGS_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+# restage the application to make it pick up the new environment variable and use the buildpack
+cf restage <YOUR_APP_NAME>
+```
+
+##### Configure log collection
+
+The following table describes the parameters above, and how they can be used to configure log collection:
+
+| Parameter                 | Description                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DD_LOGS_ENABLED`         | Set to `true` to enable Datadog Agent log collection.                                                                                      |
+| `DD_ENABLE_CHECKS`        | Set to `false` to disable the Agent's system metrics collection through core checks.                                                       |
+| `STD_LOG_COLLECTION_PORT` | Must be used when collecting logs from `stdout` or `stderr`. It redirects the `stdout` or `stderr` stream to the corresponding local port value. |
+| `LOGS_CONFIG`             | Use this option to configure the Agent to listen to a local TCP port and set the value for the `service` and `source` parameters.          |
+
+**Example:**
+
+A Java application named `app01` is running in VMware Tanzu Application Service. The following configuration redirects the container `stdout`/`stderr` to the local port `10514`. It then configures the Agent to collect logs from that port while setting the proper value for `service` and `source`:
+
+```shell
+# Redirect Stdout/Stderr to port 10514
+cf set-env app01 STD_LOG_COLLECTION_PORT 10514
+# Configure the Agent to listen to port 10514
+cf set-env app01 LOGS_CONFIG '[{"type":"tcp","port":"10514","source":"java","service":"app01"}]'
+```
+
+##### Notification in case of misconfigured proxy
+
+For Agent version 6.12 or greater, when using a [proxy configuration][101] with the buildpack, a verification is made to check if the connection can be established. Log collection is started depending on the result of this test.
+
+If the connection fails to establish and log collection does not start, an event like this appears in the [Events Explorer][102]. Set up a monitor to track these events and be notified when a misconfigured Buildpack is deployed:
+
+{{< img src="integrations/cloud_foundry/logs_misconfigured_proxy.png" alt="An event in Datadog with the title Log endpoint cannot be reached - Log collection not started and a message stating that a TCP connection could not be established" >}}
+
+### Tags
+
+In order to add custom tags to your application, set the `DD_TAGS` environment variable through the `manifest.yml` file or the CF CLI command:
+
+```shell
+# set the environment variable
+cf set-env <YOUR_APP> DD_TAGS key1=value1,key2=value2
+# restage the application to make it pick up the new environment variable and use the new tags
+cf restage <YOUR_APP>
+```
+
+[101]: /agent/logs/proxy/
+[102]: /events/explorer/
+
+{{% /site-region %}}
+
+### DogStatsD
+
+You can use [DogStatsD][10] to send custom application metrics to Datadog. See [Metric Submission: DogStatsD][11] for more information. There is a list of [DogStatsD libraries][12] compatible with a wide range of applications.
+
+## Monitor your VMware Tanzu Application Service cluster
+
+Use the [VMware Tanzu installation and configuration][13] guide to install the integration through the Tanzu Ops Manager. For manual setup steps, read the [Monitor your VMware Tanzu Application Service cluster][14] section in the manual setup guide.
+
+## Data Collected
+
+### Metrics
+
+The following metrics are sent by the Datadog Firehose Nozzle and are prefixed with `cloudfoundry.nozzle`. The Datadog Agent sends metrics from any Agent checks you configure in the Director runtime configuration, and [system][15], [network][16], [disk][17], and [NTP][18] metrics by default.
+
+The Datadog Firehose Nozzle only collects CounterEvents (as metrics, not events), ValueMetrics, and ContainerMetrics; it ignores LogMessages and Errors.
+
+Your specific list of metrics may vary based on the PCF version and the deployment. Datadog collects counter and gauge metrics emitted from the [Loggregator v2 API][19]. See [Cloud Foundry Component Metrics][20] for a list of metrics emitted by default.
+
+{{< get-metrics-from-git "cloud-foundry">}}
+
+[1]: https://tanzu.vmware.com/pivotal#:~:text=Pivotal%20Cloud%20Foundry%20%28PCF%29%20is%20now%20VMware%20Tanzu%20Application%20Service
+[2]: /integrations/guide/pivotal-cloud-foundry-manual-setup
+[3]: /integrations/faq/pivotal_architecture
+[4]: /integrations/guide/application-monitoring-vmware-tanzu/
+[5]: /integrations/guide/pivotal-cloud-foundry-manual-setup#monitor-your-applications
+[6]: /tracing/setup/
+[7]: /profiler/enabling/
+[8]: /agent/logs/proxy/
+[9]: /events/explorer/
+[10]: /extend/dogstatsd/
+[11]: /metrics/custom_metrics/dogstatsd_metrics_submission/
+[12]: /libraries/
+[13]: /integrations/guide/cluster-monitoring-vmware-tanzu/#installation
+[14]: /integrations/guide/cloud-foundry-setup/#monitor-your-cloud-foundry-cluster
+[15]: /integrations/system/#metrics
+[16]: /integrations/network/#metrics
+[17]: /integrations/disk/#metrics
+[18]: /integrations/ntp/#metrics
+[19]: https://github.com/cloudfoundry/loggregator-api
+[20]: https://docs.cloudfoundry.org/running/all_metrics.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Addresses DOCS-15331

Restores 9 integration pages that were dropped during the Hugo folder reorg (#38835) and are currently 404 in production.

- Restore `rsyslog`, `syslog_ng`, `nxlog`, `amazon_guardduty`, `sinatra`, `stunnel`, `uwsgi`, `vmware_tanzu_application_service`, and `agentprofiling` to `hugo/content/en/integrations/`
- Add `.gitignore` allowlist entries for each page, without which the files do not stage

**Root cause**: `content/en/integrations/*.md` is gitignored, with an allowlist of `!` negations for the integration pages that live in this repo. `.gitignore` only applies to untracked files, so these pages had been tracked without ever being allowlisted. The reorg's `git rm` at the old path succeeded, and the corresponding `git add` at the new path was silently skipped because the files matched the ignore rule. That is why restoring the files alone is not sufficient — the allowlist entries are required for them to stage.

`rsyslog` is linked from the [Architecture Center](https://www.datadoghq.com/architecture/using-rsyslog-to-send-logs-to-datadog/) and from [Log Collection](https://docs.datadoghq.com/logs/log_collection/?tab=host). `agentprofiling` was broken the same way but had not been reported.

All 9 files are byte-identical to their pre-reorg versions, so the diff can be verified as a clean restore.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to diff the tree across the reorg commit, identify the dropped files, and confirm the `.gitignore` mechanism.

### Additional notes

This failure mode is not specific to integrations. Any tracked file covered by a gitignore pattern would have been dropped the same way during the reorg. Integrations is simply where it surfaced, because that is where a link check happened to run. Auditing the full reorg diff for other silently dropped files is out of scope here, but may be worth doing.
