### PR TITLE
Drop confusing 'still' from PAT/SAT application key restriction

### DIFF
--- a/hugo/content/en/account_management/personal-access-tokens.md
+++ b/hugo/content/en/account_management/personal-access-tokens.md
@@ -70,7 +70,7 @@ curl -X GET "https://api.datadoghq.com/api/v2/users" \
 
 To prevent privilege escalation, Datadog restricts what an API call authenticated with a PAT can do. These restrictions apply regardless of the API client making the call:
 
-- **Application keys**: A PAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Application keys**: A PAT cannot create or update application keys. Revoking application keys is allowed.
 - **Scopes on new tokens**: A PAT can create or update a PAT or a SAT only if the new token's scopes are a subset of its own scopes.
 - **Time-to-live (TTL) on new tokens**: A PAT cannot create a PAT or a SAT with a TTL that extends beyond its own expiration.
 

--- a/hugo/content/en/account_management/service-access-tokens.md
+++ b/hugo/content/en/account_management/service-access-tokens.md
@@ -95,7 +95,7 @@ with the SAT only. The `dd-api-key` header is optional and its value is not eval
 
 To prevent privilege escalation, Datadog restricts what an API call authenticated with a SAT can do. These restrictions apply regardless of the API client making the call:
 
-- **Application keys**: A SAT cannot create or update application keys. Revoking application keys is still allowed.
+- **Application keys**: A SAT cannot create or update application keys. Revoking application keys is allowed.
 - **Scopes on new tokens**: A SAT can create or update another SAT only if the new token's scopes are a subset of its own scopes.
 - **Time-to-live (TTL) on new tokens**: A SAT cannot create a SAT with a TTL that extends beyond its own expiration.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Follow-up to #39105, addressing [this review comment](https://github.com/DataDog/documentation/pull/39105#discussion_r3768491601) that arrived after the other suggestions had already been committed.

"Revoking application keys is **still** allowed" implies the other two restrictions in the list were previously permitted and have now changed. The real contrast is with the sibling bullets, not with past behavior, so "still" reads as a change note that isn't one. This drops the word from both pages.

The comment was left on the PAT page, but the same sentence appears on the SAT page, so both are updated:

- `personal-access-tokens.md:73`
- `service-access-tokens.md:98`

No other changes.

### Merge readiness

- [x] Ready for merge

### AI assistance

Claude Code made the edit and confirmed Vale reports nothing on the changed lines.

### Additional notes
