### PR TITLE
[DBM] Document the Unmonitored status for Azure SQL databases

### DIFF
--- a/hugo/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/hugo/content/en/database_monitoring/setup_sql_server/azure.md
@@ -491,6 +491,20 @@ To avoid exposing the `datadog` user's password in plain text, use the Agent's [
 ## Example Agent Configurations
 {{% dbm-sqlserver-agent-config-examples %}}
 
+## Troubleshooting
+
+### Database shows as "Unmonitored"
+
+If an Azure SQL Database, Managed Instance, or Elastic Pool node appears under the **Unmonitored** tab in Database Monitoring even though the Agent can connect to it, this usually means the Agent's connection is working but a required setup step was not completed. Check the following:
+
+- Verify the Agent's SQL Server integration is enabled and configured correctly for your Azure deployment type.
+- Confirm that `dbm: true` is set in the `sqlserver.d/conf.yaml` instance configuration—without it, the check reports basic metrics only and the database is not classified as monitored by DBM.
+- Confirm the `datadog` login has the permissions required for your Azure SQL deployment type, as described in [Grant the Agent access](#grant-the-agent-access). A login that is missing a required grant (for example, `VIEW SERVER STATE` or `VIEW ANY DEFINITION` on Managed Instance) can connect successfully but be unable to collect the data DBM needs.
+- [Run the Agent's status subcommand](/agent/configuration/agent-commands/#agent-status-and-information) and confirm `sqlserver` appears under the **Checks** section without errors.
+- Check the Agent logs for connection or permission errors, which often point to a missing grant or an incorrect `azure` configuration block.
+
+See [Troubleshoot Common Issues](/database_monitoring/troubleshooting/?tab=sqlserver) for more general DBM troubleshooting steps.
+
 ## Install the Azure integration
 
 To collect more comprehensive database metrics and logs from Azure, install the [Azure integration][1].


### PR DESCRIPTION
## What

Added a short Troubleshooting section to the Azure SQL Server Database Monitoring setup page explaining what it means when an Azure SQL Database, Managed Instance, or Elastic Pool node shows up under the DBM "Unmonitored" tab, and listing the most common causes and fixes: verifying the SQL Server integration is enabled and configured correctly, confirming `dbm: true` is set, confirming the `datadog` login has the permissions required for the Azure SQL deployment type, checking the Agent's status output for the `sqlserver` check, and checking Agent logs for connection or permission errors.

## Why

Azure SQL nodes can appear correctly configured yet remain stuck under the DBM "Unmonitored" tab, and the Azure SQL Server setup page never explained what causes or resolves that state, leaving readers without guidance to self-serve the fix.

## Docs preview

https://docs.datadoghq.com/database_monitoring/setup_sql_server/azure/