### PR TITLE
[DBM] Clarify secret_refresh_interval default behavior on resolution failure

### DIFF
--- a/hugo/content/en/agent/configuration/secrets-management.md
+++ b/hugo/content/en/agent/configuration/secrets-management.md
@@ -1830,6 +1830,10 @@ Set a refresh interval:
 secret_refresh_interval: 3600  # refresh every hour
 ```
 
+<div class="alert alert-info">
+<code>secret_refresh_interval</code> defaults to <code>0</code>, which disables automatic refresh. If a secret fails to resolve at Agent startup—for example, because of a transient network or authentication error against your secrets backend, such as Azure Key Vault when using managed identity—it is not retried automatically and remains unresolved until the Agent is restarted. If calls to your secrets backend can be transiently unreliable, set <code>secret_refresh_interval</code> to a non-zero value (for example, <code>3600</code>) so failed resolutions are retried automatically.
+</div>
+
 Or, trigger a refresh manually:
 ```shell
 datadog-agent secret refresh


### PR DESCRIPTION
## What

Added a callout next to the `secret_refresh_interval` configuration option in the Agent secrets management page clarifying that its default value of `0` disables automatic refresh, so a secret that fails to resolve at Agent startup (for example, due to a transient network or auth error against a secrets backend like Azure Key Vault) is not retried automatically and stays unresolved until the Agent is restarted. The callout recommends setting a non-zero interval (for example, `3600`) if backend calls can be transiently unreliable.

## Why

With the default `secret_refresh_interval: 0`, a transient secret backend failure at Agent startup causes secrets resolved via that backend to fail silently and persistently until a manual restart, and this behavior wasn't called out in the secrets management docs.

## Docs preview

https://docs.datadoghq.com/agent/configuration/secrets-management/