### PR TITLE
removes `datadog-lambda-extensions` repo sourcing and processing

### DIFF
--- a/hugo/local/bin/py/build/configurations/pull_config.yaml
+++ b/hugo/local/bin/py/build/configurations/pull_config.yaml
@@ -256,21 +256,6 @@
               dependencies: ["https://github.com/DataDog/datadog-cdk-constructs/blob/main/README.md"]
               title: Datadog CDK Construct
 
-      - repo_name: datadog-lambda-extension
-        contents:
-        - action: pull-and-push-file
-          branch: main
-          globs:
-          - 'README.md'
-          options:
-            dest_path: '/serverless/libraries_integrations/'
-            file_name: 'extension.md'
-            front_matters:
-              dependencies: ["https://github.com/DataDog/datadog-lambda-extension/blob/main/README.md"]
-              title: Datadog Lambda Extension
-              aliases:
-                - /serverless/datadog_lambda_library/extension
-
       - repo_name: datadog-ci-azure-devops
         contents:
         - action: pull-and-push-file

--- a/hugo/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/hugo/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -283,23 +283,6 @@
               dependencies: ["https://github.com/DataDog/datadog-cdk-constructs/blob/main/README.md"]
               title: Datadog CDK Construct
 
-      - repo_name: datadog-lambda-extension
-        contents:
-        - action: pull-and-push-file
-          branch: main
-          globs:
-          - 'README.md'
-          options:
-            dest_path: '/serverless/libraries_integrations/'
-            file_name: 'extension.md'
-            front_matters:
-              dependencies: ["https://github.com/DataDog/datadog-lambda-extension/blob/main/README.md"]
-              title: Datadog Lambda Extension
-              algolia:
-                tags: ['datadog lambda extension']
-              aliases:
-                - /serverless/datadog_lambda_library/extension
-
       - repo_name: datadog-ci-azure-devops
         contents:
         - action: pull-and-push-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Removes `datadog-lambda-extensions` from the pull configs. This content is processed and loaded in via websites-sources: https://github.com/ddoghq/websites-sources/pull/683

**motivation**: https://datadoghq.atlassian.net/browse/WEB-9673

**preview (no cache)**: https://docs-staging.datadoghq.com/stefon.simmons/no-cache-web-9673/serverless/libraries_integrations/extension



### Merge readiness


- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
