### PR TITLE
[DOCS-15415] Document metric streams health metric

### DIFF
--- a/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -158,6 +158,18 @@ If you set streaming up through the [AWS Console](?tab=awsconsole#installation):
 
 Once the resources are deleted, wait for five minutes for Datadog to recognize the change. To validate completion, go to the **Metric Collection** tab in Datadog's [AWS integration page][5] and verify that the disabled regions are not displayed under **CloudWatch Metric Streams** for the specified AWS account.
 
+### Monitor stream health
+
+Datadog submits the `datadog.aws_metric_streams.data_received` metric each time it receives a payload from a CloudWatch metric stream. Use this metric to confirm that AWS is sending metrics and that Datadog is receiving them.
+
+`datadog.aws_metric_streams.data_received`
+: **Type**: Gauge<br>
+A value of `1` for each payload Datadog receives from a CloudWatch metric stream. Tagged with `stream_arn`, `stream_name`, `aws_account`, and `region`.
+
+To check whether a stream is delivering data, query this metric in the [Metrics Explorer][8] and group by `stream_name` or `stream_arn`.
+
+To be notified when a stream stops delivering data, create a [metric monitor][9] on `datadog.aws_metric_streams.data_received`. Group the monitor by `stream_arn` and configure it to notify on missing data.
+
 ## Troubleshooting
 
 To resolve any issues encountered while setting up Metric Streams or the associated resources, see [AWS Troubleshooting][6].
@@ -172,3 +184,5 @@ To resolve any issues encountered while setting up Metric Streams or the associa
 [5]: https://app.datadoghq.com/integrations/amazon-web-services
 [6]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-troubleshoot.html
 [7]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html
+[8]: /metrics/explorer/
+[9]: /monitors/types/metric/

--- a/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -160,15 +160,17 @@ Once the resources are deleted, wait for five minutes for Datadog to recognize t
 
 ### Monitor stream health
 
-Datadog submits the `datadog.aws_metric_streams.data_received` metric each time it receives a payload from a CloudWatch metric stream. Use this metric to confirm that AWS is sending metrics and that Datadog is receiving them.
+Datadog submits the `datadog.aws_metric_streams.data_received` metric when it receives data from a CloudWatch metric stream. Use this metric to confirm that AWS is sending metrics and that Datadog is receiving them.
 
 `datadog.aws_metric_streams.data_received`
 : **Type**: Gauge<br>
-A value of `1` for each payload Datadog receives from a CloudWatch metric stream. Tagged with `stream_arn`, `stream_name`, `aws_account`, and `region`.
+Reports a value of `1` when Datadog receives data from a CloudWatch metric stream, and does not report when Datadog receives no data. Tagged with `stream_arn`, `stream_name`, `aws_account`, and `region`. How often the metric reports depends on your data volume and the buffering configuration of your Firehose delivery stream.
+
+For a cross-account stream, the metric stream and the Firehose delivery stream are in the monitoring account. The `aws_account` tag identifies the monitoring account, not the source accounts that the metrics come from.
 
 To check whether a stream is delivering data, query this metric in the [Metrics Explorer][8] and group by `stream_name` or `stream_arn`.
 
-To be notified when a stream stops delivering data, create a [metric monitor][9] on `datadog.aws_metric_streams.data_received`. Group the monitor by `stream_arn` and configure it to notify on missing data.
+Because the metric does not report when a stream stops delivering data, monitor it for the transition from reporting to no data. Create a [metric monitor][9] on `datadog.aws_metric_streams.data_received`, group it by `stream_arn`, and enable missing data notifications. For the configuration steps, see [Set up an alert for when a specific tag stops reporting][10].
 
 ## Troubleshooting
 
@@ -186,3 +188,4 @@ To resolve any issues encountered while setting up Metric Streams or the associa
 [7]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html
 [8]: /metrics/explorer/
 [9]: /monitors/types/metric/
+[10]: /monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting/

--- a/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/hugo/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -186,6 +186,6 @@ To resolve any issues encountered while setting up Metric Streams or the associa
 [5]: https://app.datadoghq.com/integrations/amazon-web-services
 [6]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-troubleshoot.html
 [7]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html
-[8]: /metrics/explorer/
+[8]: https://app.datadoghq.com/metric/explorer
 [9]: /monitors/types/metric/
 [10]: /monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15415

Adds a **Monitor stream health** section to the AWS CloudWatch Metric Streams with Amazon Data Firehose guide, documenting the new `datadog.aws_metric_streams.data_received` metric. The metric gives customers a single signal that a metric stream and its Firehose delivery stream are delivering data to Datadog.

The section covers:

- The metric name, type, tags, and reporting behavior.
- How to check whether a stream is delivering data in the Metrics Explorer.
- How to alert when a stream stops delivering data. Because the metric reports only when data arrives and does not report otherwise, the section points to [Set up an alert for when a specific tag stops reporting](https://docs.datadoghq.com/monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting/) for the monitor configuration.
- Cross-account tag behavior: `aws_account` identifies the monitoring account that owns the stream, not the source accounts.

The guide previously had no guidance on monitoring the ongoing health of a stream. Its only validation step was a setup-time check that the region appears in the **Metric Collection** tab.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code was used to draft the section and to check it against the existing conventions for documenting `datadog.*` metrics. All content was reviewed and edited by the author.

### Additional notes

Metric details were provided by the metric owner. Two items to confirm before merge:

1. Deployment to government sites has not yet been confirmed. The section currently carries no availability caveat.
2. The reporting-frequency wording is deliberately general ("depends on your data volume and the buffering configuration of your Firehose delivery stream") rather than naming a fixed interval.
