### PR TITLE
docs(databricks): require Databricks SQL Access and Workspace Access entitlements

### DIFF
--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -460,16 +460,18 @@ DD_LOGS_CONFIG_PROCESSING_RULES=[{\"type\": \"exclude_at_match\",\"name\": \"dro
 ```
 
 ### Permissions
-Grant {{< ui >}}Workspace Admin{{< /ui >}} privileges to the user or service principal that connects to your Databricks workspace. This allows Datadog to manage init script installations and updates automatically, reducing the risk of misconfiguration.
+The user or service principal that connects to your Databricks workspace must have the following workspace entitlements enabled, in addition to the permissions described below:
 
-<div class="alert alert-info">Regardless of whether you grant <strong>Workspace Admin</strong> privileges or the granular permissions below, the user or service principal must have the following workspace entitlements enabled:
-<ul>
-<li>{{< ui >}}Databricks SQL access{{< /ui >}}</li>
-<li>{{< ui >}}Workspace access{{< /ui >}}</li>
-</ul>
-</div>
+- {{< ui >}}Databricks SQL access{{< /ui >}}
+- {{< ui >}}Workspace access{{< /ui >}}
 
-If you need more granular control, grant these minimal permissions to the following [workspace level objects][19] to still be able to monitor all jobs, clusters, and queries within a workspace:
+#### Workspace Admin privileges
+
+Grant {{< ui >}}Workspace Admin{{< /ui >}} privileges to the user or service principal. This allows Datadog to manage init script installations and updates automatically, reducing the risk of misconfiguration.
+
+#### Granular permissions
+
+If you need more granular control instead of Workspace Admin privileges, grant these minimal permissions to the following [workspace level objects][19] to still be able to monitor all jobs, clusters, and queries within a workspace:
 
 | Object                 | Permission                                                                                                                                                      |
 |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -478,6 +480,8 @@ If you need more granular control, grant these minimal permissions to the follow
 | Lakeflow Declarative Pipelines   | [CAN VIEW][22]
 | Query                            | [CAN VIEW][23]
 | SQL warehouse                    | [CAN MONITOR][24]
+
+#### Cost data permissions
 
 Additionally, for Datadog to access your Databricks cost data in Data Observability: Jobs Monitoring or [Cloud Cost Management][26], the user or service principal used to query [system tables][27] must have the following permissions:
    - `CAN USE` permission on the SQL Warehouse.

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -462,8 +462,8 @@ DD_LOGS_CONFIG_PROCESSING_RULES=[{\"type\": \"exclude_at_match\",\"name\": \"dro
 ### Permissions
 The user or service principal that connects to your Databricks workspace must have the following workspace entitlements enabled, in addition to the permissions described below:
 
-- {{< ui >}}Databricks SQL access{{< /ui >}}
 - {{< ui >}}Workspace access{{< /ui >}}
+- {{< ui >}}Databricks SQL access{{< /ui >}}
 
 #### Workspace permissions
 
@@ -474,11 +474,11 @@ Choose one of the following approaches for the user or service principal:
 
   | Object                 | Permission                                                                                                                                                      |
   |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | Job                              | [CAN VIEW][20]
-  | Compute                          | [CAN ATTACH TO][21]
-  | Lakeflow Declarative Pipelines   | [CAN VIEW][22]
-  | Query                            | [CAN VIEW][23]
-  | SQL warehouse                    | [CAN MONITOR][24]
+  | [Job][20]                              | CAN VIEW
+  | [Compute][21]                          | CAN ATTACH TO
+  | [Lakeflow Declarative Pipelines][22]   | CAN VIEW
+  | [Query][23]                            | CAN VIEW
+  | [SQL warehouse][24]                    | CAN MONITOR
 
 #### Cost data permissions
 

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -465,21 +465,20 @@ The user or service principal that connects to your Databricks workspace must ha
 - {{< ui >}}Databricks SQL access{{< /ui >}}
 - {{< ui >}}Workspace access{{< /ui >}}
 
-#### Workspace Admin privileges
+#### Workspace permissions
 
-Grant {{< ui >}}Workspace Admin{{< /ui >}} privileges to the user or service principal. This allows Datadog to manage init script installations and updates automatically, reducing the risk of misconfiguration.
+Choose one of the following approaches for the user or service principal:
 
-#### Granular permissions
+- **Workspace Admin privileges** (recommended): Grant {{< ui >}}Workspace Admin{{< /ui >}} privileges. This allows Datadog to manage init script installations and updates automatically, reducing the risk of misconfiguration.
+- **Granular permissions**: If you need more granular control, grant these minimal permissions to the following [workspace level objects][19] to still be able to monitor all jobs, clusters, and queries within a workspace:
 
-If you need more granular control instead of Workspace Admin privileges, grant these minimal permissions to the following [workspace level objects][19] to still be able to monitor all jobs, clusters, and queries within a workspace:
-
-| Object                 | Permission                                                                                                                                                      |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Job                              | [CAN VIEW][20]
-| Compute                          | [CAN ATTACH TO][21]
-| Lakeflow Declarative Pipelines   | [CAN VIEW][22]
-| Query                            | [CAN VIEW][23]
-| SQL warehouse                    | [CAN MONITOR][24]
+  | Object                 | Permission                                                                                                                                                      |
+  |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | Job                              | [CAN VIEW][20]
+  | Compute                          | [CAN ATTACH TO][21]
+  | Lakeflow Declarative Pipelines   | [CAN VIEW][22]
+  | Query                            | [CAN VIEW][23]
+  | SQL warehouse                    | [CAN MONITOR][24]
 
 #### Cost data permissions
 

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -462,6 +462,13 @@ DD_LOGS_CONFIG_PROCESSING_RULES=[{\"type\": \"exclude_at_match\",\"name\": \"dro
 ### Permissions
 Grant {{< ui >}}Workspace Admin{{< /ui >}} privileges to the user or service principal that connects to your Databricks workspace. This allows Datadog to manage init script installations and updates automatically, reducing the risk of misconfiguration.
 
+<div class="alert alert-info">Regardless of whether you grant <strong>Workspace Admin</strong> privileges or the granular permissions below, the user or service principal must have the following workspace entitlements enabled:
+<ul>
+<li>{{< ui >}}Databricks SQL access{{< /ui >}}</li>
+<li>{{< ui >}}Workspace access{{< /ui >}}</li>
+</ul>
+</div>
+
 If you need more granular control, grant these minimal permissions to the following [workspace level objects][19] to still be able to monitor all jobs, clusters, and queries within a workspace:
 
 | Object                 | Permission                                                                                                                                                      |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a note to the **Permissions** section (Advanced Configuration) of the [Jobs Monitoring for Databricks](https://docs.datadoghq.com/data_observability/jobs_monitoring/databricks/?tab=useaserviceprincipalforoauth#permissions) page stating that the connecting user or service principal must have the **Databricks SQL Access** and **Workspace Access** workspace entitlements enabled, in addition to the other permissions already listed there.

This requirement applies regardless of whether **Workspace Admin** privileges or the granular workspace-level permissions are granted, so it is surfaced as an info callout at the top of the section.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI-assisted draft; content manually reviewed.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->