### PR TITLE
is_alert_recovery update

### DIFF
--- a/hugo/content/en/monitors/notify/variables.md
+++ b/hugo/content/en/monitors/notify/variables.md
@@ -46,7 +46,7 @@ The following conditional variables are available:
 | `{{^is_recovery}}`         | The monitor does not recover from `ALERT`, `WARNING`, `UNKNOWN`, or `NO DATA` |
 | `{{#is_warning_recovery}}` | The monitor recovers from `WARNING` to `OK`                        |
 | `{{^is_warning_recovery}}` | The monitor does not recover from `WARNING` to `OK`                |
-| `{{#is_alert_recovery}}`   | The monitor recovers from `ALERT` to `OK`<br> Note: For `ALERT` to `WARNING` transitions, `{{#is_alert_recovery}}` recipients are notified but the message body is not included. Use `{{#is_alert_to_warning}}` to include a message  |
+| `{{#is_alert_recovery}}`   | The monitor recovers from `ALERT` to `OK`<br> **Note**: For `ALERT` to `WARNING` transitions, `{{#is_alert_recovery}}` recipients receive notifications without message bodies. Use `{{#is_alert_to_warning}}` to include messages  |
 | `{{^is_alert_recovery}}`   | The monitor does not recover from an `ALERT` to `OK`               |
 | `{{#is_alert_to_warning}}` | The monitor transitions from `ALERT` to `WARNING`                  |
 | `{{^is_alert_to_warning}}` | The monitor does not transition from `ALERT` to `WARNING`          |

--- a/hugo/content/en/monitors/notify/variables.md
+++ b/hugo/content/en/monitors/notify/variables.md
@@ -46,8 +46,8 @@ The following conditional variables are available:
 | `{{^is_recovery}}`         | The monitor does not recover from `ALERT`, `WARNING`, `UNKNOWN`, or `NO DATA` |
 | `{{#is_warning_recovery}}` | The monitor recovers from `WARNING` to `OK`                        |
 | `{{^is_warning_recovery}}` | The monitor does not recover from `WARNING` to `OK`                |
-| `{{#is_alert_recovery}}`   | The monitor recovers from `ALERT` to `WARNING` or `OK`             |
-| `{{^is_alert_recovery}}`   | The monitor does not recover from an ALERT to OK                   |
+| `{{#is_alert_recovery}}`   | The monitor recovers from `ALERT` to `OK`<br> Note: For `ALERT` to `WARNING` transitions, `{{#is_alert_recovery}}` recipients are notified but the message body is not included. Use `{{#is_alert_to_warning}}` to include a message  |
+| `{{^is_alert_recovery}}`   | The monitor does not recover from an `ALERT` to `OK`               |
 | `{{#is_alert_to_warning}}` | The monitor transitions from `ALERT` to `WARNING`                  |
 | `{{^is_alert_to_warning}}` | The monitor does not transition from `ALERT` to `WARNING`          |
 | `{{#is_no_data_recovery}}` | The monitor recovers from `NO DATA`                                |


### PR DESCRIPTION
Improving accuracy of the {{#is_alert_recovery}} description. Also fixing formatting for the {{^is_alert_recovery}} description

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
The current version makes it sound like {{#is_alert_recovery}} blocks appear on transitions from ALERT to WARNING or OK but this is not accurate. The block only appears on ALERT to OK, but ALERT to WARNING also includes the {{#is_alert_recovery}} recipients. After talking with Alerting Product, we arrived a wording to make this more precise. Additionally, the statuses in the {{^is_alert_recovery}} description are lacking the formatting of the other entries

### Merge readiness

- [√] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
