### PR TITLE
Fix the annotation key names listed in the AD Annotations v1 tab

### DIFF
--- a/hugo/content/en/getting_started/containers/autodiscovery.md
+++ b/hugo/content/en/getting_started/containers/autodiscovery.md
@@ -103,7 +103,7 @@ annotations:
 
 In the example above, the `tags.datadoghq.com` labels set the `env`, `service`, and even `version` as tags for all logs and metrics emitted for the pod's `redis` container. These standard labels are part of [Unified Service Tagging][1]. As a best practice, Datadog recommends using unified service tagging when configuring tags and environment variables.
 
-The check configuration annotation key follows the format `ad.datadoghq.com/<container-name>.checks`.
+The check configuration annotation keys follow the format `ad.datadoghq.com/<container-name>.check_names`, `ad.datadoghq.com/<container-name>.init_configs`, and `ad.datadoghq.com/<container-name>.instances`.
 
 `check_names` includes the names of the check to run, and `init_configs` contains some configuration parameters, such as minimum collection interval. Each item in `instances` represents the configuration to run for one instance of a check. **Note**: In this example, `%%host%%` is a template variable that is dynamically populated with your container's IP.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

In [Getting Started with Containers → Autodiscovery](https://docs.datadoghq.com/getting_started/containers/autodiscovery/?tab=adannotationsv1), the **AD Annotations v1** tab says the check configuration key is `ad.datadoghq.com/<container-name>.checks`. That is the v2 key — the sentence is duplicated from the v2 tab, where it is correct. The YAML example in the same tab correctly uses `check_names`, `init_configs`, and `instances`, so the tab contradicts itself.

This is worth more than a typo fix. Autodiscovery applies only one annotation format per container, preferring v2 over v1, so a reader who follows both the v1 example and its prose ends up setting v1 and v2 keys together — and the v1 configuration is the one that gets silently dropped.

### Merge readiness

- [x] Ready for merge

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
