### PR TITLE
[SEC-35986][k9] Rename STIX docs count

### DIFF
--- a/hugo/content/en/security/cloud_siem/guide/ingest-stix-threat-intelligence.md
+++ b/hugo/content/en/security/cloud_siem/guide/ingest-stix-threat-intelligence.md
@@ -134,7 +134,7 @@ A successful request returns `200 OK` and a summary of how Datadog processed the
     "type": "threat-intel-stix-ingest",
     "id": "acme",
     "attributes": {
-      "added": 3,
+      "accepted": 3,
       "unsupported": 1,
       "invalid": 0
     }
@@ -144,7 +144,7 @@ A successful request returns `200 OK` and a summary of how Datadog processed the
 
 | Attribute | Description |
 |---|---|
-| `added` | The number of indicator objects that Datadog ingested. One object can produce more than one indicator when its pattern uses `IN` or `OR`. |
+| `accepted` | The number of supported indicator objects that Datadog accepted for processing. This count includes new indicators, updates, and revocations. One object can produce more than one indicator when its pattern uses `IN` or `OR`. |
 | `unsupported` | The number of indicator objects that Datadog skipped because their type, pattern, or object-level STIX version is not supported. |
 | `invalid` | The number of indicator objects whose pattern Datadog could not parse. |
 


### PR DESCRIPTION
## Changes
Related to SEC-35986.

Renames the documented STIX ingestion response attribute from `added` to `accepted` and clarifies that the count includes new indicators, updates, and revocations. This PR is stacked on DataDog/documentation#38480 because that PR introduces the guide.