### PR TITLE
[SEC-35757] Document OCSF/alert enrichment and Always-On Content Packs

### DIFF
--- a/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
+++ b/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
@@ -45,12 +45,16 @@ further_reading:
 - [Investigator][3], an interactive graphical interface for investigating suspicious activity by a user or resource
 - [Workflow Automation][4], to automate actions and accelerate investigation and remediation of issues
 - Configuration guides
+- OCSF pipelines that normalize the integration's logs to the [Open Cybersecurity Schema Framework (OCSF)][5] common data model
+- Mapping of the integration's native alerts to Cloud SIEM security signals
 
 You can filter Content Packs by the following types:
 - **Content Packs**: Integrations bundled with security-relevant content such as detection rules, SOAR (Security Orchestration, Automation, and Response) workflows, and custom tooling
 - **Enrichment Packs**: Content to add valuable context to SIEM analysis, such as vulnerabilities or third-party insights, to improve investigations
 - **Integration Packs**: Content curated from Datadog's catalog to be relevant for use with Cloud SIEM
 - **Entity Packs**: Integrations and bundled content that power UEBA (User and Entity Behavior Analytics) by modeling normal activity for users and entities and surfacing risky anomalies in Cloud SIEM
+
+In addition to the Content Packs listed on this page, Cloud SIEM includes **Always-On Content Packs**: threat intelligence enrichments that Datadog automatically applies to your logs and security signals, with no installation or configuration required. [Bring Your Own Threat Intelligence][6] extends these enrichments with your own threat intelligence sources.
 
 {{% cloud-siem-content-packs %}}
 
@@ -62,3 +66,5 @@ You can filter Content Packs by the following types:
 [2]: /security/detection_rules/
 [3]: /security/cloud_siem/triage_and_investigate/investigator
 [4]: /actions/workflows/
+[5]: /security/cloud_siem/ingest_and_enrich/open_cybersecurity_schema_framework/
+[6]: /security/cloud_siem/ingest_and_enrich/threat_intelligence/

--- a/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
+++ b/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
@@ -67,4 +67,3 @@ In addition to the Content Packs listed on this page, Cloud SIEM includes **Alwa
 [3]: /security/cloud_siem/triage_and_investigate/investigator
 [4]: /actions/workflows/
 [5]: /security/cloud_siem/ingest_and_enrich/open_cybersecurity_schema_framework/
-[6]: /security/cloud_siem/ingest_and_enrich/threat_intelligence/

--- a/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
+++ b/hugo/content/en/security/cloud_siem/ingest_and_enrich/content_packs.md
@@ -45,8 +45,8 @@ further_reading:
 - [Investigator][3], an interactive graphical interface for investigating suspicious activity by a user or resource
 - [Workflow Automation][4], to automate actions and accelerate investigation and remediation of issues
 - Configuration guides
-- OCSF pipelines that normalize the integration's logs to the [Open Cybersecurity Schema Framework (OCSF)][5] common data model
-- Mapping of the integration's native alerts to Cloud SIEM security signals
+- [OCSF pipelines][5] to normalize the integration's logs to the Open Cybersecurity Schema Framework common data model
+- Third-party alerts from the integration, mapped to Cloud SIEM security signals
 
 You can filter Content Packs by the following types:
 - **Content Packs**: Integrations bundled with security-relevant content such as detection rules, SOAR (Security Orchestration, Automation, and Response) workflows, and custom tooling
@@ -54,7 +54,7 @@ You can filter Content Packs by the following types:
 - **Integration Packs**: Content curated from Datadog's catalog to be relevant for use with Cloud SIEM
 - **Entity Packs**: Integrations and bundled content that power UEBA (User and Entity Behavior Analytics) by modeling normal activity for users and entities and surfacing risky anomalies in Cloud SIEM
 
-In addition to the Content Packs listed on this page, Cloud SIEM includes **Always-On Content Packs**: threat intelligence enrichments that Datadog automatically applies to your logs and security signals, with no installation or configuration required. [Bring Your Own Threat Intelligence][6] extends these enrichments with your own threat intelligence sources.
+In addition to the Content Packs listed on this page, Cloud SIEM includes **Always-On Content Packs**: threat intelligence enrichments that Datadog automatically applies to your logs and security signals, with no installation or configuration required.
 
 {{% cloud-siem-content-packs %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

- https://datadoghq.atlassian.net/browse/SEC-35757

Updates the Cloud SIEM Content Packs overview page:
- Mentions OCSF pipeline normalization and native-alert-to-signal mapping as content a Content Pack can include.
- Adds a new "Always-On Content Packs" callout describing Datadog-curated threat intelligence enrichments that are automatically applied to logs and signals.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code based on discussion in SEC-35757.

### Additional notes