### PR TITLE
Add python pub/sub docs

### DIFF
--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
@@ -118,7 +118,7 @@ gcloud eventarc triggers create order-processor-trigger \
   --destination-run-service=order-processor \
   --destination-run-region=us-central1 \
   --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --event-filters="topic=projects/my-project/topics/orders" \
+  --transport-topic=projects/my-project/topics/orders \
   --location=us-central1
 {{< /code-block >}}
 

--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
@@ -83,67 +83,7 @@ logger.info('Hello world!');
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create proper span links.
-
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][4] and [Payload unwrapping][5] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -156,6 +96,4 @@ gcloud pubsub subscriptions update \
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
 [3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs#code-examples-5
-[4]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[5]: https://cloud.google.com/pubsub/docs/payload-unwrapping
 [6]: /profiler/

--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -94,6 +94,72 @@ logger.info("Hello world!")
 
 {{% svl-tracing-env %}}
 
+## Distributed tracing with Pub/Sub
+
+To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true`. This creates an inferred `gcp.pubsub.receive` span for the push request.
+
+Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
+
+For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+
+### Configure push subscriptions for full trace visibility
+
+**Create a new push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions create order-processor-sub \
+  --topic=orders \
+  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+**Update an existing push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update order-processor-sub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+### Configure Eventarc Pub/Sub triggers
+
+Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
+
+1. **Create the Eventarc trigger:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud eventarc triggers create order-processor-trigger \
+  --destination-run-service=order-processor \
+  --destination-run-region=us-central1 \
+  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
+  --transport-topic=projects/my-project/topics/orders \
+  --location=us-central1
+{{< /code-block >}}
+
+2. **Find the auto-created subscription:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions list \
+  --filter="topic:projects/my-project/topics/orders" \
+  --format="table(name,pushConfig.pushEndpoint)"
+{{< /code-block >}}
+
+   Example output:
+   ```
+   NAME                                                          PUSH_ENDPOINT
+   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
+   ```
+
+3. **Update the subscription for trace propagation:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update \
+  eventarc-us-central1-order-processor-trigger-abc-sub-def \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
 ## Troubleshooting
 
 {{% serverless-init-troubleshooting productNames="Cloud Run services" in_container="true" %}}
@@ -108,3 +174,5 @@ logger.info("Hello world!")
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
+[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
+[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -100,7 +100,7 @@ To get end-to-end distributed traces between Pub/Sub producers and Cloud Run ser
 
 Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
 
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
 
 ### Configure push subscriptions for full trace visibility
 

--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -96,69 +96,9 @@ logger.info("Hello world!")
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true`. This creates an inferred `gcp.pubsub.receive` span for the push request.
+Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true`. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
-Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
-
-For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -174,5 +114,3 @@ gcloud pubsub subscriptions update \
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
-[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -98,6 +98,8 @@ logger.info("Hello world!")
 
 Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true`. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
+Google Cloud Pub/Sub push subscription tracing requires `ddtrace` version 4.8.0 or later.
+
 {{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
@@ -135,7 +135,7 @@ gcloud eventarc triggers create order-processor-trigger \
   --destination-run-service=order-processor \
   --destination-run-region=us-central1 \
   --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --event-filters="topic=projects/my-project/topics/orders" \
+  --transport-topic=projects/my-project/topics/orders \
   --location=us-central1
 {{< /code-block >}}
 

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
@@ -100,67 +100,7 @@ logger.info('Hello world!');
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create proper span links.
-
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][4] and [Payload unwrapping][5] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -173,6 +113,4 @@ gcloud pubsub subscriptions update \
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
 [3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs#code-examples-5
-[4]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[5]: https://cloud.google.com/pubsub/docs/payload-unwrapping
 [6]: /profiler/

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -109,6 +109,72 @@ logger.info('Hello world!')
 
 {{% svl-tracing-env %}}
 
+## Distributed tracing with Pub/Sub
+
+To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
+
+Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
+
+For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+
+### Configure push subscriptions for full trace visibility
+
+**Create a new push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions create order-processor-sub \
+  --topic=orders \
+  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+**Update an existing push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update order-processor-sub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+### Configure Eventarc Pub/Sub triggers
+
+Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
+
+1. **Create the Eventarc trigger:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud eventarc triggers create order-processor-trigger \
+  --destination-run-service=order-processor \
+  --destination-run-region=us-central1 \
+  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
+  --transport-topic=projects/my-project/topics/orders \
+  --location=us-central1
+{{< /code-block >}}
+
+2. **Find the auto-created subscription:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions list \
+  --filter="topic:projects/my-project/topics/orders" \
+  --format="table(name,pushConfig.pushEndpoint)"
+{{< /code-block >}}
+
+   Example output:
+   ```
+   NAME                                                          PUSH_ENDPOINT
+   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
+   ```
+
+3. **Update the subscription for trace propagation:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update \
+  eventarc-us-central1-order-processor-trigger-abc-sub-def \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
 ## Troubleshooting
 
 {{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
@@ -123,3 +189,5 @@ logger.info('Hello world!')
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
+[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
+[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -113,6 +113,8 @@ logger.info('Hello world!')
 
 Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
+Google Cloud Pub/Sub push subscription tracing requires `ddtrace` version 4.8.0 or later.
+
 {{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -111,69 +111,9 @@ logger.info('Hello world!')
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run services, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
+Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
-Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
-
-For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -189,5 +129,3 @@ gcloud pubsub subscriptions update \
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
-[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -115,7 +115,7 @@ To get end-to-end distributed traces between Pub/Sub producers and Cloud Run ser
 
 Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
 
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
 
 ### Configure push subscriptions for full trace visibility
 

--- a/hugo/content/en/serverless/google_cloud_run/functions/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/nodejs.md
@@ -129,7 +129,7 @@ gcloud eventarc triggers create order-processor-trigger \
   --destination-run-service=order-processor \
   --destination-run-region=us-central1 \
   --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --event-filters="topic=projects/my-project/topics/orders" \
+  --transport-topic=projects/my-project/topics/orders \
   --location=us-central1
 {{< /code-block >}}
 

--- a/hugo/content/en/serverless/google_cloud_run/functions/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/nodejs.md
@@ -94,67 +94,7 @@ logger.info('Hello world!');
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run functions, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create proper span links.
-
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][4] and [Payload unwrapping][5] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -167,7 +107,4 @@ gcloud pubsub subscriptions update \
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
 [3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs#code-examples-5
-[4]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[5]: https://cloud.google.com/pubsub/docs/payload-unwrapping
 [6]: /profiler/
-

--- a/hugo/content/en/serverless/google_cloud_run/functions/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/python.md
@@ -99,6 +99,72 @@ import ddtrace.auto
 
 {{% svl-tracing-env %}}
 
+## Distributed tracing with Pub/Sub
+
+To get end-to-end distributed traces between Pub/Sub producers and Cloud Run functions, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
+
+Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
+
+For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+
+### Configure push subscriptions for full trace visibility
+
+**Create a new push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions create order-processor-sub \
+  --topic=orders \
+  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+**Update an existing push subscription:**
+
+{{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update order-processor-sub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
+### Configure Eventarc Pub/Sub triggers
+
+Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
+
+1. **Create the Eventarc trigger:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud eventarc triggers create order-processor-trigger \
+  --destination-run-service=order-processor \
+  --destination-run-region=us-central1 \
+  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
+  --transport-topic=projects/my-project/topics/orders \
+  --location=us-central1
+{{< /code-block >}}
+
+2. **Find the auto-created subscription:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions list \
+  --filter="topic:projects/my-project/topics/orders" \
+  --format="table(name,pushConfig.pushEndpoint)"
+{{< /code-block >}}
+
+   Example output:
+   ```
+   NAME                                                          PUSH_ENDPOINT
+   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
+   ```
+
+3. **Update the subscription for trace propagation:**
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+gcloud pubsub subscriptions update \
+  eventarc-us-central1-order-processor-trigger-abc-sub-def \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+{{< /code-block >}}
+
 ## Troubleshooting
 
 {{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
@@ -113,3 +179,5 @@ import ddtrace.auto
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
+[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
+[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/functions/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/python.md
@@ -103,6 +103,8 @@ import ddtrace.auto
 
 Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
+Google Cloud Pub/Sub push subscription tracing requires `ddtrace` version 4.8.0 or later.
+
 {{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting

--- a/hugo/content/en/serverless/google_cloud_run/functions/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/python.md
@@ -105,7 +105,7 @@ To get end-to-end distributed traces between Pub/Sub producers and Cloud Run fun
 
 Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
 
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] and [Payload unwrapping][8] in the Google Cloud documentation.
+For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
 
 ### Configure push subscriptions for full trace visibility
 

--- a/hugo/content/en/serverless/google_cloud_run/functions/python.md
+++ b/hugo/content/en/serverless/google_cloud_run/functions/python.md
@@ -101,69 +101,9 @@ import ddtrace.auto
 
 ## Distributed tracing with Pub/Sub
 
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run functions, set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
+Set `DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED=true` in the application container. This creates an inferred `gcp.pubsub.receive` span for the push request.
 
-Configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract the producer trace context.
-
-For more information, see the [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][7] blog and [Payload unwrapping][8] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --transport-topic=projects/my-project/topics/orders \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
+{{% gcr-pubsub-push-tracing %}}
 
 ## Troubleshooting
 
@@ -179,5 +119,3 @@ gcloud pubsub subscriptions update \
 [4]: /extend/dogstatsd/?tab=python#install-the-dogstatsd-client
 [5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples-5
 [6]: /profiler/
-[7]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[8]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/content/en/serverless/google_cloud_run/jobs/nodejs.md
+++ b/hugo/content/en/serverless/google_cloud_run/jobs/nodejs.md
@@ -88,70 +88,6 @@ logger.info('Hello world!');
 
 {{% svl-tracing-env %}}
 
-## Distributed tracing with Pub/Sub
-
-To get end-to-end distributed traces between Pub/Sub producers and Cloud Run jobs, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create proper span links.
-
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][5] and [Payload unwrapping][6] in the Google Cloud documentation.
-
-### Configure push subscriptions for full trace visibility
-
-**Create a new push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions create order-processor-sub \
-  --topic=orders \
-  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-**Update an existing push subscription:**
-
-{{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update order-processor-sub \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
-### Configure Eventarc Pub/Sub triggers
-
-Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
-
-1. **Create the Eventarc trigger:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud eventarc triggers create order-processor-trigger \
-  --destination-run-service=order-processor \
-  --destination-run-region=us-central1 \
-  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
-  --event-filters="topic=projects/my-project/topics/orders" \
-  --location=us-central1
-{{< /code-block >}}
-
-2. **Find the auto-created subscription:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions list \
-  --filter="topic:projects/my-project/topics/orders" \
-  --format="table(name,pushConfig.pushEndpoint)"
-{{< /code-block >}}
-
-   Example output:
-   ```
-   NAME                                                          PUSH_ENDPOINT
-   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
-   ```
-
-3. **Update the subscription for trace propagation:**
-
-   {{< code-block lang="shell" disable_copy="false" >}}
-gcloud pubsub subscriptions update \
-  eventarc-us-central1-order-processor-trigger-abc-sub-def \
-  --push-no-wrapper \
-  --push-no-wrapper-write-metadata
-{{< /code-block >}}
-
 ## Troubleshooting
 
 {{% serverless-init-troubleshooting productNames="Cloud Run services" %}}
@@ -164,6 +100,4 @@ gcloud pubsub subscriptions update \
 [2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
 [3]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
 [4]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs#code-examples-5
-[5]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
-[6]: https://cloud.google.com/pubsub/docs/payload-unwrapping
 [7]: /profiler/

--- a/hugo/layouts/shortcodes/gcr-pubsub-push-tracing.en.md
+++ b/hugo/layouts/shortcodes/gcr-pubsub-push-tracing.en.md
@@ -1,6 +1,6 @@
 To get end-to-end distributed traces between Pub/Sub producers and Cloud Run, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create span links.
 
-For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run](https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/) and [Payload unwrapping](https://cloud.google.com/pubsub/docs/payload-unwrapping) in the Google Cloud documentation.
+For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run][101] and [Payload unwrapping][102] in the Google Cloud documentation.
 
 ### Configure push subscriptions for full trace visibility
 
@@ -60,3 +60,6 @@ Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mech
      --push-no-wrapper \
      --push-no-wrapper-write-metadata
    ```
+
+[101]: https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/
+[102]: https://cloud.google.com/pubsub/docs/payload-unwrapping

--- a/hugo/layouts/shortcodes/gcr-pubsub-push-tracing.en.md
+++ b/hugo/layouts/shortcodes/gcr-pubsub-push-tracing.en.md
@@ -1,0 +1,62 @@
+To get end-to-end distributed traces between Pub/Sub producers and Cloud Run, configure your push subscriptions with the `--push-no-wrapper` and `--push-no-wrapper-write-metadata` flags. This moves message attributes from the JSON body to HTTP headers, allowing Datadog to extract producer trace context and create span links.
+
+For more information, see [Producer-aware tracing for Google Cloud Pub/Sub and Cloud Run](https://www.datadoghq.com/blog/pubsub-cloud-run-tracing/) and [Payload unwrapping](https://cloud.google.com/pubsub/docs/payload-unwrapping) in the Google Cloud documentation.
+
+### Configure push subscriptions for full trace visibility
+
+**Create a new push subscription:**
+
+```shell
+gcloud pubsub subscriptions create order-processor-sub \
+  --topic=orders \
+  --push-endpoint=https://order-processor-xyz.run.app/pubsub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+```
+
+**Update an existing push subscription:**
+
+```shell
+gcloud pubsub subscriptions update order-processor-sub \
+  --push-no-wrapper \
+  --push-no-wrapper-write-metadata
+```
+
+### Configure Eventarc Pub/Sub triggers
+
+Eventarc Pub/Sub triggers use push subscriptions as the underlying delivery mechanism. When you create an Eventarc trigger, GCP automatically creates a managed push subscription. However, Eventarc does not expose `--push-no-wrapper-write-metadata` as a trigger creation parameter, so you must manually update the auto-created subscription.
+
+1. **Create the Eventarc trigger:**
+
+   ```shell
+   gcloud eventarc triggers create order-processor-trigger \
+     --destination-run-service=order-processor \
+     --destination-run-region=us-central1 \
+     --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
+     --transport-topic=projects/my-project/topics/orders \
+     --location=us-central1
+   ```
+
+2. **Find the auto-created subscription:**
+
+   ```shell
+   gcloud pubsub subscriptions list \
+     --filter="topic:projects/my-project/topics/orders" \
+     --format="table(name,pushConfig.pushEndpoint)"
+   ```
+
+   Example output:
+
+   ```text
+   NAME                                                          PUSH_ENDPOINT
+   eventarc-us-central1-order-processor-trigger-abc-sub-def      https://order-processor-xyz.run.app
+   ```
+
+3. **Update the subscription for trace propagation:**
+
+   ```shell
+   gcloud pubsub subscriptions update \
+     eventarc-us-central1-order-processor-trigger-abc-sub-def \
+     --push-no-wrapper \
+     --push-no-wrapper-write-metadata
+   ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Add python pub/sub docs by extracting the content to a shortcode. Also, fix 2 issues (changing it in the shortcode, and therefore in the preexisting node docs):

### 1. Use --transport-topic for existing Pub/Sub topics

  The previous Eventarc examples used:

  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
  --event-filters="topic=projects/my-project/topics/orders"

  They now use:

  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished" \
  --transport-topic=projects/my-project/topics/orders

  The distinction is important:

  - --transport-topic selects the Pub/Sub topic that transports messagePublished events.
  - Google documents that if --transport-topic is omitted, Eventarc creates a transport topic. Therefore, using topic as an event filter does not bind the trigger to the existing orders topic.
  - Google’s official Cloud Run example uses the same type event filter followed by --transport-topic=projects/PROJECT_ID/topics/TOPIC_ID.

  Sources:

  - Google Cloud CLI reference for gcloud eventarc triggers create (https://docs.cloud.google.com/sdk/gcloud/reference/eventarc/triggers/create)
  - Google Cloud Pub/Sub triggers for Cloud Run (https://docs.cloud.google.com/run/docs/triggering/pubsub-triggers

### 2. Remove “Distributed tracing with Pub/Sub” from Cloud Run Jobs

  Both parts of the section assumed a request-serving Cloud Run resource:

  1. The direct subscription example configured an HTTP endpoint:

     --push-endpoint=https://order-processor-xyz.run.app/pubsub

  2. The Eventarc Standard example configured:

     --destination-run-service=order-processor

  Neither applies to a Cloud Run Job:

  - Google explicitly states that a Cloud Run Job runs its tasks and exits; it does not listen for or serve requests. Consequently, it cannot receive Pub/Sub push deliveries at a run.app request endpoint. Cloud Run Jobs documentation (https://docs.cloud.google.com/run/docs/create-jobs)
  - The Eventarc Standard CLI defines --destination-run-service as the name of a Cloud Run fully managed service. It is not a Cloud Run Job destination. Eventarc trigger CLI reference (https://docs.cloud.google.com/sdk/gcloud/reference/eventarc/triggers/create)
  - Eventarc can execute Cloud Run Jobs through Eventarc Advanced, but that is a different integration. It requires a message bus, pipeline, enrollment, and a Cloud Run Admin API job-execution URI. It does not use the Standard --destination-run-service trigger shown in the removed section. Eventarc Advanced Cloud
    Run Jobs guide (https://docs.cloud.google.com/eventarc/advanced/docs/quickstarts/publish-events-cloud-run-job)

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
