### PR TITLE
[RUM] Fix broken "force collection" link in retention filters docs

### DIFF
--- a/hugo/content/en/real_user_monitoring/rum_without_limits/retention_filters.md
+++ b/hugo/content/en/real_user_monitoring/rum_without_limits/retention_filters.md
@@ -192,7 +192,7 @@ Analyze performance with [metrics][8].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /synthetics/
-[2]: /session_replay/browser/#force-session-replay
+[2]: /session_replay/setup_and_configuration/?platform=browser&tab=npm#start-or-stop-the-recording-manually
 [3]: https://app.datadoghq.com/rum/list
 [4]: /real_user_monitoring/explorer/
 [5]: /real_user_monitoring/guide/retention_filter_best_practices


### PR DESCRIPTION
### What does this PR do?

Fixes the "force collection" link in the [Permanent retention filters](https://docs.datadoghq.com/real_user_monitoring/rum_without_limits/retention_filters#permanent-retention-filters) section.

### Motivation

The link pointed at `/session_replay/browser/#force-session-replay`. That page exists, but it has no `force-session-replay` anchor — there's no heading containing "force" on it at all — so the link silently landed readers at the top of the Browser Session Replay page instead of at the relevant instructions.

It now points to the section that actually documents forcing replay collection:

`/session_replay/setup_and_configuration/?platform=browser&tab=npm#start-or-stop-the-recording-manually`

That section covers `startSessionReplayRecordingManually`, `startSessionReplayRecording()` and `stopSessionReplayRecording()`, which is what a reader following "force collection" is looking for.

The query parameters are needed rather than optional: the browser variant of that content is gated behind `{% if equals($platform, "browser") %}` and lives in the NPM tab, so without `?platform=browser&tab=npm` the anchor isn't rendered. This matches existing usage elsewhere in the docs, for example the four `?platform=` links in `error_tracking/frontend/replay_errors.md`.

### Review checklist

- [x] Single-line change to a link reference definition
- [x] Verified the old anchor does not exist on the target page
- [x] Verified the new anchor exists (`hugo/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/setup_and_configuration.mdoc.md`)
- [x] Reference `[2]` is used in only one place in the file; the other references are untouched
