### PR TITLE
[MA-7886] Clarify monitor missing data behavior public docs

### DIFF
--- a/hugo/content/en/monitors/configuration/_index.md
+++ b/hugo/content/en/monitors/configuration/_index.md
@@ -220,10 +220,10 @@ The selected behavior is applied when a monitor's query does not return any data
 | {{< ui >}}Show NO DATA and notify{{< /ui >}} | Monitor status is set to `NO DATA` and a notification is sent out.        |
 | {{< ui >}}Show OK{{< /ui >}}                 | Monitor is resolved and status is set to `OK`.                            |
 
-The default and available missing-data behaviors depend on whether the query uses the `default_zero()` function:
+Using default_zero() in a query locks the missing-data behavior to that query type's default and disables the other options:
 
 - For queries with `default_zero()`, missing data is always evaluated as zero, and the other missing-data behaviors are unavailable.
-- For queries without `default_zero()`, `Count` queries default to {{< ui >}}Evaluate as zero{{< /ui >}}, while other query types default to {{< ui >}}Show last known status{{< /ui >}}. The other missing-data behaviors remain available.
+- For queries without `default_zero()`, `Count` queries default to {{< ui >}}Evaluate as zero{{< /ui >}}, while other query types default to {{< ui >}}Show last known status{{< /ui >}}. All missing-data behaviors remain available.
 
 #### Auto resolve
 

--- a/hugo/content/en/monitors/configuration/_index.md
+++ b/hugo/content/en/monitors/configuration/_index.md
@@ -220,10 +220,10 @@ The selected behavior is applied when a monitor's query does not return any data
 | {{< ui >}}Show NO DATA and notify{{< /ui >}} | Monitor status is set to `NO DATA` and a notification is sent out.        |
 | {{< ui >}}Show OK{{< /ui >}}                 | Monitor is resolved and status is set to `OK`.                            |
 
-The {{< ui >}}Evaluate as zero{{< /ui >}} and {{< ui >}}Show last known status{{< /ui >}} options are displayed based on the query type:
+The default and available missing-data behaviors depend on whether the query uses the `default_zero()` function:
 
-- {{< ui >}}Evaluate as zero{{< /ui >}}: This option is available for monitors using `Count` queries without the `default_zero()` function.
-- {{< ui >}}Show last known status{{< /ui >}}: This option is available for monitors using any other query type than `Count`, for example `Gauge`, `Rate`, and `Distribution`, as well as for `Count` queries with `default_zero()`.
+- For queries with `default_zero()`, missing data is always evaluated as zero, and the other missing-data behaviors are unavailable.
+- For queries without `default_zero()`, `Count` queries default to {{< ui >}}Evaluate as zero{{< /ui >}}, while other query types default to {{< ui >}}Show last known status{{< /ui >}}. The other missing-data behaviors remain available.
 
 #### Auto resolve
 


### PR DESCRIPTION
## What changed

- Clarify how `default_zero()` affects missing-data behavior.
- Distinguish the default behavior for Count and non-Count queries that do not use `default_zero()`.

## Why

MNTS-94024 identified a mismatch between the documented options and the monitor configuration UI. The previous text incorrectly stated that Count queries using `default_zero()` use the last known status. In practice, queries using `default_zero()` always evaluate missing data as zero and the other missing-data behaviors are unavailable.

[MA-7886](https://datadoghq.atlassian.net/browse/MA-7886)

## Impact

Users configuring monitor missing-data behavior can now understand which behavior is selected by default and when alternative behaviors remain available.





[MA-7886]: https://datadoghq.atlassian.net/browse/MA-7886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ