### PR TITLE
(maint) Make web-ops the owner of astro for now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ hugo/i18n/                             @DataDog/corpweb
 hugo/archetypes/                       @DataDog/corpweb
 
 # Websites Platform
+astro/                                                       @DataDog/WebOps-Platform   
 hugo/babel.config.js                                         @DataDog/WebOps-Platform
 hugo/data/reference/                                         @DataDog/WebOps-Platform
 datadog-ci.preview.json                                 @DataDog/WebOps-Platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,8 +138,8 @@ hugo/content/en/logs/error_tracking/browser_and_mobile.md            @Datadog/ru
 hugo/content/en/real_user_monitoring/error_tracking/browser.md       @Datadog/rum-browser @DataDog/documentation
 
 # Threat Intel
-hugo/content/en/security/threat_intelligence.md  @DataDog/documentation @datamarmot
-hugo/content/en/security/application_security/threats/threat_intelligence.md  @DataDog/documentation @datamarmot
+hugo/content/en/security/threat_intelligence.md  @DataDog/documentation
+hugo/content/en/security/application_security/threats/threat_intelligence.md  @DataDog/documentation
 
 # Observability Pipelines
 hugo/static/resources/yaml/observability_pipelines/                  @DataDog/observability-pipelines-worker-admin  @DataDog/documentation


### PR DESCRIPTION
To prevent a bunch of on call noise, I'm adding webops as the owner of the entire astro directory. When we start putting reviewable docs etc in there, we'll figure out how to divide ownership.

Unrelated: Removed user `@datamarmot` cos it's causing errors in the diff.