### PR TITLE
[DOCS-13132] Add data collection paths shortcode for Google Cloud

### DIFF
--- a/hugo/content/en/getting_started/integrations/google_cloud.md
+++ b/hugo/content/en/getting_started/integrations/google_cloud.md
@@ -38,6 +38,10 @@ further_reading:
 
 Use this guide to get started with monitoring your Google Cloud environment. This approach simplifies the setup for Google Cloud environments with multiple projects, allowing you to maximize your monitoring coverage.
 
+## How Google Cloud data reaches Datadog
+
+{{% google-cloud-data-collection-paths %}}
+
 ## Setup
 
 ### Prerequisites

--- a/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
+++ b/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
@@ -1,0 +1,14 @@
+The Google Cloud integration provides three independent collection paths. Each is configured separately. Set up the ones you need.
+
+**Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][1]. Custom and log-based metrics are not collected automatically. Start with [Metric collection][2].
+
+**Logs**: Cloud Logging sends logs through Cloud Pub/Sub and Cloud Dataflow to Datadog Log Management. Log collection runs as a separate pipeline from metrics. Start with the [Google Cloud log forwarding guide][3]. For details on the log forwarding architecture, see [Stream cloud logs to Datadog][4] in the Google Cloud Architecture Center.
+
+**Log-based metrics**: The integration does not automatically import [Google Cloud log-based metrics][5]. To get metric-style data from log content, forward the logs to Datadog and define a [Datadog log-based metric][6].
+
+[1]: https://cloud.google.com/monitoring/api/metrics_gcp
+[2]: #metric-collection
+[3]: /logs/guide/google-cloud-log-forwarding/
+[4]: https://docs.cloud.google.com/architecture/partners/stream-cloud-logs-to-datadog
+[5]: https://cloud.google.com/logging/docs/logs-based-metrics
+[6]: /logs/log_configuration/logs_to_metrics/

--- a/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
+++ b/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
@@ -1,6 +1,6 @@
 The Google Cloud integration provides three independent collection paths. Each is configured separately. Set up the ones you need.
 
-**Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][1]. Custom and log-based metrics are not collected automatically. Start with [Metric collection][2].
+**Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][1]. Start with [Metric collection][2].
 
 **Logs**: Cloud Logging sends logs through Cloud Pub/Sub and Cloud Dataflow to Datadog Log Management. Log collection runs as a separate pipeline from metrics. Start with the [Google Cloud log forwarding guide][3]. For details on the log forwarding architecture, see [Stream cloud logs to Datadog][4] in the Google Cloud Architecture Center.
 

--- a/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
+++ b/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
@@ -1,10 +1,10 @@
 The Google Cloud integration provides two independent collection paths. Each is configured separately. Set up the ones you need.
 
-**Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][1]. Start with [Metric collection][2].
+**Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][101]. Start with [Metric collection][102].
 
-**Logs**: Cloud Logging sends logs through Cloud Pub/Sub and Cloud Dataflow to Datadog Log Management. Log collection runs as a separate pipeline from metrics. Start with the [Google Cloud log forwarding guide][3]. For details on the log forwarding architecture, see [Stream cloud logs to Datadog][4] in the Google Cloud Architecture Center.
+**Logs**: Cloud Logging sends logs through Cloud Pub/Sub and Cloud Dataflow to Datadog Log Management. Log collection runs as a separate pipeline from metrics. Start with the [Google Cloud log forwarding guide][103]. For details on the log forwarding architecture, see [Stream cloud logs to Datadog][104] in the Google Cloud Architecture Center.
 
-[1]: https://cloud.google.com/monitoring/api/metrics_gcp
-[2]: #metric-collection
-[3]: /logs/guide/google-cloud-log-forwarding/
-[4]: https://docs.cloud.google.com/architecture/partners/stream-cloud-logs-to-datadog
+[101]: https://cloud.google.com/monitoring/api/metrics_gcp
+[102]: #metric-collection
+[103]: /logs/guide/google-cloud-log-forwarding/
+[104]: https://docs.cloud.google.com/architecture/partners/stream-cloud-logs-to-datadog

--- a/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
+++ b/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
@@ -1,4 +1,4 @@
-The Google Cloud integration provides three independent collection paths. Each is configured separately. Set up the ones you need.
+The Google Cloud integration provides two independent collection paths. Each is configured separately. Set up the ones you need.
 
 **Metrics**: Datadog pulls metrics from the Google Cloud Monitoring API after the integration is configured. The integration ingests metrics from the [Google Cloud metric catalog][1]. Start with [Metric collection][2].
 

--- a/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
+++ b/hugo/layouts/shortcodes/google-cloud-data-collection-paths.md
@@ -4,11 +4,7 @@ The Google Cloud integration provides three independent collection paths. Each i
 
 **Logs**: Cloud Logging sends logs through Cloud Pub/Sub and Cloud Dataflow to Datadog Log Management. Log collection runs as a separate pipeline from metrics. Start with the [Google Cloud log forwarding guide][3]. For details on the log forwarding architecture, see [Stream cloud logs to Datadog][4] in the Google Cloud Architecture Center.
 
-**Log-based metrics**: The integration does not automatically import [Google Cloud log-based metrics][5]. To get metric-style data from log content, forward the logs to Datadog and define a [Datadog log-based metric][6].
-
 [1]: https://cloud.google.com/monitoring/api/metrics_gcp
 [2]: #metric-collection
 [3]: /logs/guide/google-cloud-log-forwarding/
 [4]: https://docs.cloud.google.com/architecture/partners/stream-cloud-logs-to-datadog
-[5]: https://cloud.google.com/logging/docs/logs-based-metrics
-[6]: /logs/log_configuration/logs_to_metrics/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-13132

Adds a reusable `google-cloud-data-collection-paths` shortcode that disambiguates the two independent collection paths the Google Cloud integration provides (metrics through the Google Cloud Monitoring API, and logs through Cloud Pub/Sub plus Dataflow).

References the new shortcode from `getting_started/integrations/google_cloud.md` so the section renders as a `## How Google Cloud data reaches Datadog` block between Overview and Setup, and defers the log forwarding architecture diagram to the existing [Google Cloud Architecture Center page](https://docs.cloud.google.com/architecture/partners/stream-cloud-logs-to-datadog) rather than redrawing it.

Supersedes #36311, which was opened before the repo reorganization moved this content under `hugo/`. Same change, recreated at the new file locations. See #36311 for eng approval.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to rebase the change from #36311 onto the reorganized repo structure (paths moved under `hugo/`).

### Additional notes