### PR TITLE
Clarify Okta SCIM role profile selection

### DIFF
--- a/hugo/content/en/account_management/scim/okta.md
+++ b/hugo/content/en/account_management/scim/okta.md
@@ -73,7 +73,7 @@ Datadog's SCIM role support follows the SCIM multi-valued attribute convention d
 }
 ```
 
-1. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the Okta user profile, then click {{< ui >}}Add Attribute{{< /ui >}} to create a `roles` attribute:
+1. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the user profile for the application configured for Datadog SCIM—not the default Okta user profile—then click {{< ui >}}Add Attribute{{< /ui >}} to create a `roles` attribute:
     - {{< ui >}}Data type{{< /ui >}}: **string**
     - {{< ui >}}Display name{{< /ui >}}: **Roles**
     - {{< ui >}}Variable name{{< /ui >}}: **roles**

--- a/hugo/content/en/account_management/scim/okta.md
+++ b/hugo/content/en/account_management/scim/okta.md
@@ -73,7 +73,7 @@ Datadog's SCIM role support follows the SCIM multi-valued attribute convention d
 }
 ```
 
-1. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the user profile for the application configured for Datadog SCIM—not the default Okta user profile—then click {{< ui >}}Add Attribute{{< /ui >}} to create a `roles` attribute:
+1. In {{< ui >}}Directory{{< /ui >}} > {{< ui >}}Profile Editor{{< /ui >}}, select the user profile for the application configured for Datadog SCIM, then click {{< ui >}}Add Attribute{{< /ui >}} to create a `roles` attribute:
     - {{< ui >}}Data type{{< /ui >}}: **string**
     - {{< ui >}}Display name{{< /ui >}}: **Roles**
     - {{< ui >}}Variable name{{< /ui >}}: **roles**


### PR DESCRIPTION
## What changed

- Clarified that Okta administrators must select the user profile for the application configured for Datadog SCIM before adding the `roles` attribute.
- Distinguished that profile from the default Okta user profile.

## Why

The default Okta user profile does not expose the app-specific external name and namespace fields used by the SCIM role mapping.

## Impact

Okta administrators can find the documented fields without changing product behavior.

## Validation

- Vale 3.9.1: 0 errors and no alerts on the changed line
- `git diff --check`
