### PR TITLE
Fix preview-link generator appending /index to API doc links

### DIFF
--- a/hugo/local/bin/py/preview_links.py
+++ b/hugo/local/bin/py/preview_links.py
@@ -16,6 +16,7 @@ comment_template = Template(filename='hugo/local/bin/py/preview-links-template.m
 
 pattern1 = re.compile('hugo/content/en/(.*?).md')
 pattern2 = re.compile('hugo/content/en/glossary/terms/(.*?).md')
+pattern3 = re.compile('hugo/content/en/api/latest/(.*?).md')
 
 # Grab YAML frontmatter from markdown file
 def grab_glossary_title(filename):
@@ -30,10 +31,11 @@ def compile_filename(filename):
         return grab_glossary_title(filename)
     elif pattern1.match(filename):
         filename = filename.split('content/en/', 1)[-1]
-        filename = filename.replace(
-            '_index', ''
-            ).replace('.mdoc', ''
-            ).replace('.md', '')
+        filename = filename.replace('_index', '').replace('.mdoc', '').replace('.md', '')
+        # API docs use bare `index.md` leaf bundles (no underscore), which the
+        # replace above doesn't strip, leaving a trailing /index in the URL.
+        if pattern3.match(f'hugo/content/en/{filename}.md'):
+            filename = re.sub(r'(^|/)index$', '', filename)
         return filename
 
 def sort_files(file_string):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The "Post preview link" GitHub Action comment was appending `/index` to preview links for new/renamed API doc pages (see #39166's bot comment for an example). API doc pages use bare `index.md` leaf bundles, but `preview_links.py`'s filename cleanup only stripped Hugo's `_index.md` (section page) convention, not `index.md`, leaving the trailing `/index` segment in the URL.

### Merge readiness

- [x] Ready for merge