### PR TITLE
Add orange intake PrivateLink endpoints for US1 and AP2

### DIFF
--- a/hugo/content/en/agent/guide/private-link.md
+++ b/hugo/content/en/agent/guide/private-link.md
@@ -400,6 +400,7 @@ Use the following table to identify which VPC endpoints to set up for the Datado
 | `data-obs-intake.datadoghq.com` | `lime.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-0ee865cd1c0a7ba32` |
 | `trace.agent.datadoghq.com` | `lime.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-0ee865cd1c0a7ba32` |
 | `network-devices.datadoghq.com` | `olive.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-05e3bfec4501e714d` |
+| `*.datadoghq.com` | `orange.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-0b67fd56f90bd3c41` |
 | `*.api.datadoghq.com` | `orchid.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-07895350fd0109264` |
 | `*.synthetics.datadoghq.com` | `orchid.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-07895350fd0109264` |
 | `api.datadoghq.com` | `orchid.intake.datadoghq.com` | `com.amazonaws.vpce.us-east-1.vpce-svc-07895350fd0109264` |
@@ -473,6 +474,7 @@ Use the following table to identify which VPC endpoints to set up for the Datado
 | `data-obs-intake.ap2.datadoghq.com` | `lime.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-0f3e01f4180b2ae09` |
 | `trace.agent.ap2.datadoghq.com` | `lime.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-0f3e01f4180b2ae09` |
 | `orchestrator.ap2.datadoghq.com` | `linen.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-031da3ffac78ef902` |
+| `*.ap2.datadoghq.com` | `orange.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-01911394f8bac8056` |
 | `*.synthetics.ap2.datadoghq.com` | `orchid.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-06ec78b291ce8020a` |
 | `api.ap2.datadoghq.com` | `orchid.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-06ec78b291ce8020a` |
 | `quota.browser-intake-ap2-datadoghq.com` | `orchid.intake.ap2.datadoghq.com` | `com.amazonaws.vpce.ap-southeast-2.vpce-svc-06ec78b291ce8020a` |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds `orange.intake.datadoghq.com` (US1) and `orange.intake.ap2.datadoghq.com` (AP2) to the AWS PrivateLink VPC Endpoint Service IDs tables, matching the existing pattern for UK1.

- US1: `*.datadoghq.com` → `orange.intake.datadoghq.com` (`com.amazonaws.vpce.us-east-1.vpce-svc-0b67fd56f90bd3c41`)
- AP2: `*.ap2.datadoghq.com` → `orange.intake.ap2.datadoghq.com` (`com.amazonaws.vpce.ap-southeast-2.vpce-svc-01911394f8bac8056`)

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Changes identified via DDSQL query against prod AWS account resources; endpoint service IDs sourced directly from `aws.ec2_vpcendpoint_service` table.

### Additional notes

---
*Co-authored with [Pi](https://pi.dev) (Claude Sonnet 4.6)*