### PR TITLE
Fix broken tables of contents from headings without an id

### DIFF
--- a/hugo/layouts/partials/table-of-contents/scraped-toc.html
+++ b/hugo/layouts/partials/table-of-contents/scraped-toc.html
@@ -4,7 +4,7 @@
 */}}
 <nav id="TableOfContents">
     <ul>
-    {{ $headers_html := (findRE `<h([2-3]).*?>.*<\/h[2-3]>` .Content) }}
+    {{ $headers_html := (findRE `<h([2-3])[^>]*?id="[^"]*"[^>]*?>.*?<\/h[2-3]>` .Content) }}
     {{ $prev_h_level := 3 }}
     {{ $level_nested := 0 }}
     {{ range $i, $header := $headers_html }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes broken tables of contents on 21 pages.

`scraped-toc.html` is the fallback table of contents used for pages whose raw content contains `site-region`, `include-markdown`, or `registry-config-list`. It builds the ToC by running a regex over the rendered HTML, matching every `<h2>` and `<h3>`. The `collapse-content` shortcode emits a heading tag with no `id`, so when a collapsible's `level` is `h2` or `h3` the scraper matches it, fails to extract an anchor or title, and emits an empty `<a href="#"></a>` entry. The same failure also puts a non-numeric value into the heading-level variable that drives nesting, so the surrounding `<ul>`/`</li>` tags close in the wrong places and the rest of the ToC renders mis-indented.

This surfaced when #38862 normalized `collapse-content` `level` values, moving a number of collapsibles from `h4` (outside the scrape range) to `h3` (inside it). The template bug itself predates that PR — five of the affected pages were already broken.

This change requires an `id` attribute in the scrape pattern, so only real anchorable markdown headings enter the ToC. That matches how Hugo's native `.TableOfContents` behaves on every other page: shortcode-generated headings are not included there either.

Sample pages to check on the preview:

- `/actions/app_builder/expressions/`
- `/integrations/guide/azure-advanced-configuration/`
- `/security/application_security/setup/ruby/aws-fargate/`

### Merge readiness

- [ ] Ready for merge

### AI assistance

Claude Code was used to trace the root cause, apply the one-line template change, and run the before/after build comparison described above.

### Additional notes
n/a
