### PR TITLE
Add BYOC Logs 0.1.33 release notes

### DIFF
--- a/hugo/content/en/byoc-logs/release_notes.md
+++ b/hugo/content/en/byoc-logs/release_notes.md
@@ -52,7 +52,7 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs](/byoc-logs/
 
 #### Helm chart changes
 - **Breaking**: Removes the `medium` pod size. `indexer.podSize` and `searcher.podSize` accept `large`, `xlarge`, `2xlarge`, `4xlarge`, `6xlarge`, and `8xlarge`.
-- Adjusts pod-size CPU and memory requests and limits to account for node reservations and add-ons, and rescales caches, ingest queues, and concurrent split searches accordingly.
+- Adjusts pod-size CPU and memory requests and limits to account for node reservations and add-ons. This rescales caches, ingest queues, and concurrent split searches accordingly.
 - Enables document clustering by default with `config.docs_clustering`.
 - Sets indexer and standalone-compactor decommission timeouts to 90% of each workload's `terminationGracePeriodSeconds`.
 - Adds a default metastore `PodDisruptionBudget` and global DNS `ndots: 1` setting.

--- a/hugo/content/en/byoc-logs/release_notes.md
+++ b/hugo/content/en/byoc-logs/release_notes.md
@@ -40,6 +40,24 @@ Binary upgrades ship through the Helm chart. See [Install BYOC Logs](/byoc-logs/
 
 ## Releases
 
+### v0.1.33 — 2026-08-18
+
+*Bundled in chart: `0.5.2`.*
+*Validated with Observability Pipelines Worker: `2.20.x`.*
+
+#### Changed
+- Adds document clustering to group similar logs together and reduce storage footprint by 10% to 20%. To disable document clustering, set `QW_DISABLE_DOCS_CLUSTERING=true`.
+- Adds support for flat attribute group-by queries.
+- Adds operational metrics for system resource usage, decommissioning, S3 PUT failures, WAL usage, metastore capacity, and split-search outcomes.
+
+#### Helm chart changes
+- **Breaking**: Removes the `medium` pod size. `indexer.podSize` and `searcher.podSize` accept `large`, `xlarge`, `2xlarge`, `4xlarge`, `6xlarge`, and `8xlarge`.
+- Adjusts pod-size CPU and memory requests and limits to account for node reservations and add-ons, and rescales caches, ingest queues, and concurrent split searches accordingly.
+- Enables document clustering by default with `config.docs_clustering`.
+- Sets indexer and standalone-compactor decommission timeouts to 90% of each workload's `terminationGracePeriodSeconds`.
+- Adds a default metastore `PodDisruptionBudget` and global DNS `ndots: 1` setting.
+- Lowers the indexer HPA CPU target to 70% and removes the scale-up stabilization window so indexers scale out under load.
+
 ### v0.1.32 — 2026-07-21
 
 *Bundled in chart: `0.4.6`.*


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the BYOC Logs 0.1.33 release note, including the CloudPrem Helm chart 0.5.2 binding and Observability Pipelines Worker 2.20.x compatibility.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
