### PR TITLE
Removing reference to Llama LLM

### DIFF
--- a/hugo/content/en/logs/explorer/search.md
+++ b/hugo/content/en/logs/explorer/search.md
@@ -26,9 +26,6 @@ The [Log Explorer][1] lets you search and view individual logs as a list. Howeve
 Natural Language Queries is not available in the <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).
 </div>
 {{% /site-region %}}
-
-<div class="alert alert-info">Natural Language Queries (NLQ) for Logs is <strong>built with Llama</strong>.</div>
-
 Use Natural Language Queries (NLQ) to describe what you're looking for in plain English. Datadog automatically translates your request into a structured log query, making it easier to explore logs without needing to write complex syntax. To access this feature, click {{< ui >}}Ask{{< /ui >}} in the search field.
 
 {{< img src="/logs/explorer/search/log_explorer_nlq.mp4" alt="Natural language query in Log Explorer showing how to search for logs using plain English phrases" video=true >}}


### PR DESCRIPTION
Datadog no longer uses Llama LLM to power Natural Language Queries (NLQ) for logs so I am removing it.  Legal had previously required Datadog to call out Llama in the documentation because the Llama license required it.  Now that NLQ has switched to using Microsoft Phi-4 we can remove the reference to Llama and there is no legal obligation to publicize it is powered by Microsoft Phi-4.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
