### PR TITLE
docs(llm_obs): note Strands Agents support is via OpenTelemetry

### DIFF
--- a/hugo/content/en/llm_observability/instrumentation/auto_instrumentation.md
+++ b/hugo/content/en/llm_observability/instrumentation/auto_instrumentation.md
@@ -44,7 +44,7 @@ Agent Observability can automatically trace and annotate calls to supported LLM 
 | [OpenAI](#openai), [Azure OpenAI](#openai)      | >= 1.0.0           | >= 2.9.0       |
 | [OpenAI Agents](#openai-agents)                 | >= 0.0.2           | >= 3.5.0       |
 | [Pydantic AI](#pydantic-ai)                     | >= 0.3.0           | >= 3.11.0      |
-| [Strands Agents](#strands-agents)               | >= 1.11.0          | Any            |
+| [Strands Agents](#strands-agents) (via OpenTelemetry) | >= 1.11.0     | Any            |
 | [Vertex AI](#vertex-ai)                         | >= 1.71.1          | >= 2.18.0      |
 | [vLLM](#vllm)                                   | >= 0.10.2          | >= 4.2.0       |
 

--- a/hugo/content/en/llm_observability/instrumentation/auto_instrumentation.md
+++ b/hugo/content/en/llm_observability/instrumentation/auto_instrumentation.md
@@ -44,7 +44,7 @@ Agent Observability can automatically trace and annotate calls to supported LLM 
 | [OpenAI](#openai), [Azure OpenAI](#openai)      | >= 1.0.0           | >= 2.9.0       |
 | [OpenAI Agents](#openai-agents)                 | >= 0.0.2           | >= 3.5.0       |
 | [Pydantic AI](#pydantic-ai)                     | >= 0.3.0           | >= 3.11.0      |
-| [Strands Agents](#strands-agents) (via OpenTelemetry) | >= 1.11.0     | Any            |
+| [Strands Agents](#strands-agents) (through OpenTelemetry) | >= 1.11.0     | Any            |
 | [Vertex AI](#vertex-ai)                         | >= 1.71.1          | >= 2.18.0      |
 | [vLLM](#vllm)                                   | >= 0.10.2          | >= 4.2.0       |
 


### PR DESCRIPTION
### What does this PR do?

Labels the **Strands Agents** row in the Agent Observability auto-instrumentation table (Python tab) as `(via OpenTelemetry)`.

### Motivation

The table's `Tracer Version: Any` value for Strands Agents reads as "any ddtrace version auto-instruments this." There is no ddtrace integration for Strands, v1.11.0+ natively emits OTel GenAI semconv 1.37 spans that Agent Observability ingests without the Datadog SDK, which the collapsed `Strands Agents` section further down the page already states. This has caused confusion for sales/customers. The parenthetical makes the table match the prose and nudges readers to the OTel setup (which requires `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`).

Claude session: `c27f303a-474e-45a2-87d9-b243528d5674`
Resume: `claude --resume c27f303a-474e-45a2-87d9-b243528d5674`

🤖 Generated with [Claude Code](https://claude.com/claude-code)