### PR TITLE
Update link to APM default settings in documentation

### DIFF
--- a/hugo/content/en/tracing/guide/setting_primary_tags_to_scope.md
+++ b/hugo/content/en/tracing/guide/setting_primary_tags_to_scope.md
@@ -177,7 +177,7 @@ Primary tags appear at the top of APM pages. Use these selectors to filter the d
 [3]: /getting_started/tagging/unified_service_tagging
 [4]: /getting_started/tagging/assigning_tags/#traces
 [5]: /tracing/metrics/metrics_namespace/
-[6]: https://app.datadoghq.com/apm/settings
+[6]: https://app.datadoghq.com/apm/settings/default-settings
 [7]: https://app.datadoghq.com/services
 [8]: /getting_started/tagging/assigning_tags
 [9]: /tracing/troubleshooting/#data-volume-guidelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Adding APM Primary Tags is now handled in https://app.datadoghq.com/apm/settings/default-settings.  Following the link from [here](https://docs.datadoghq.com/tracing/guide/setting_primary_tags_to_scope/) brings you to the Overview page instead, so this PR updates the link to bring you to the location where you can configure primary tags.


### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
