### PR TITLE
[DOCS-15336] Use the API host for the SCIM Base URL and Tenant URL

### DIFF
--- a/hugo/content/en/account_management/scim/entra.md
+++ b/hugo/content/en/account_management/scim/entra.md
@@ -51,8 +51,8 @@ When using SAML and SCIM together, Datadog strongly recommends disabling SAML ju
 2. In the {{< ui >}}Provisioning Mode{{< /ui >}} menu, select {{< ui >}}Automatic{{< /ui >}}
 3. Open {{< ui >}}Admin Credentials{{< /ui >}}
 4. Complete the {{< ui >}}Admin Credentials{{< /ui >}} section as follows:
-    - {{< ui >}}Tenant URL{{< /ui >}}: `https://{{< region-param key="dd_full_site" >}}/api/v2/scim?aadOptscim062020`
-        - **Note:** Use the appropriate subdomain for your site. To find your URL, see [Datadog sites][3].
+    - {{< ui >}}Tenant URL{{< /ui >}}: `{{< region-param key="dd_api" >}}/api/v2/scim?aadOptscim062020`
+        - **Note:** Use the API host for your site, not the app host. For the SCIM endpoints for each site, see the [SCIM API reference][3].
         - **Note:** The `?aadOptscim062020` part of the Tenant URL is specifically for Entra ID. This is a flag that tells Entra to correct its SCIM behavior as outlined in this [Microsoft Entra documentation][8]. If you are not using Entra ID, you should not include this suffix on the URL.
     - {{< ui >}}Secret Token{{< /ui >}}: Use a valid Datadog application key. You can create an application key on [your organization settings page][4]. To maintain continuous access to your data, use a [service account][5] application key.
 
@@ -94,7 +94,7 @@ Group mapping is not supported.
 
 [1]: /account_management/scim/
 [2]: /account_management/scim/#using-a-service-account-with-scim
-[3]: /getting_started/site
+[3]: /api/latest/scim/
 [4]: https://app.datadoghq.com/organization-settings/application-keys
 [5]: /account_management/org_settings/service_accounts
 [6]: https://entra.microsoft.com/

--- a/hugo/content/en/account_management/scim/okta.md
+++ b/hugo/content/en/account_management/scim/okta.md
@@ -46,7 +46,7 @@ When using SAML and SCIM together, Datadog strongly recommends disabling SAML ju
 2. Click {{< ui >}}Configure API integration{{< /ui >}}.
 3. Select {{< ui >}}Enable API integration{{< /ui >}}.
 4. Complete the {{< ui >}}Credentials{{< /ui >}} section as follows:
-    - {{< ui >}}Base URL{{< /ui >}}: `https://{{< region-param key="dd_full_site" >}}/api/v2/scim` **Note:** Use the appropriate subdomain for your site. To find your URL, see [Datadog sites][3].
+    - {{< ui >}}Base URL{{< /ui >}}: `{{< region-param key="dd_api" >}}/api/v2/scim` **Note:** Use the API host for your site, not the app host. For the SCIM endpoints for each site, see the [SCIM API reference][3].
     - {{< ui >}}API Token{{< /ui >}}: Use a valid Datadog application key. You can create an application key on [your organization settings page][4]. To maintain continuous access to your data, use a [service account][5] application key.
 
 {{< img src="/account_management/scim/okta-admin-credentials.png" alt="Okta Admin Credentials configuration screen">}}
@@ -154,7 +154,7 @@ This procedure allows you to manage team membership in Datadog instead of Okta a
 
 [1]: /account_management/scim/
 [2]: /account_management/scim/#using-a-service-account-with-scim
-[3]: /getting_started/site
+[3]: /api/latest/scim/
 [4]: https://app.datadoghq.com/organization-settings/application-keys
 [5]: /account_management/org_settings/service_accounts
 [6]: /account_management/teams/manage/#manage-teams-through-an-identity-provider


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15336

The SCIM setup pages told readers to build the Base URL (Okta) and Tenant URL (Entra) from the `dd_full_site` region param, which renders the **app** host (for example, `app.ddog-gov.com`). The SCIM API is served from the **API** host (`api.ddog-gov.com`), so following the pages as written produces a URL that fails the identity provider's credentials test.

Both pages now use the `dd_api` region param, which already includes the scheme, and the adjacent note points at the SCIM API reference (which lists the endpoint host for each site) instead of the app Site URL table.

- `account_management/scim/okta.md` — Base URL
- `account_management/scim/entra.md` — Tenant URL (the `?aadOptscim062020` Entra-only suffix and its note are unchanged)

Verified `dd_api` values in `hugo/assets/scripts/config/regions.config.js`, and confirmed against the [SCIM API reference](https://docs.datadoghq.com/api/latest/scim/?site=gov) that the documented endpoint host is `api.ddog-gov.com` for US1-FED.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code was used to verify the `dd_api` region-param values and the SCIM API endpoint hosts against the repo config and the published API reference, and to draft the edits.

### Additional notes

