### PR TITLE
[DOCS-10516] Link the Application keys intro to Actions API access

### DIFF
--- a/hugo/content/en/account_management/api-app-keys.md
+++ b/hugo/content/en/account_management/api-app-keys.md
@@ -15,7 +15,7 @@ API keys are unique to your organization. An [API key][1] is required by the Dat
 
 ## Application keys
 
-[Application keys][2], in conjunction with your organization's API key, give users access to Datadog's programmatic API. Application keys are associated with the user account that created them and by default have the permissions of the user who created them.
+[Application keys][2], in conjunction with your organization's API key, give users access to Datadog's programmatic API. Application keys are associated with the user account that created them and by default have the permissions of the user who created them. Some APIs require additional access on the application key before you can use it. See [Actions API access](#actions-api-access).
 
 ### One-Time Read mode
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-10516

The Application keys intro states that application keys "have the permissions of the user who created them," with no pointer to the exception. The Actions API access requirement (App Builder, Actions Connections, and Workflow Automation keys must have Actions API access enabled) is documented about 40 lines further down the same page, so a reader who stops at the intro can conclude an inherited-permissions key is enough for those APIs.

This adds one sentence linking the intro to the existing "Actions API access" section, matching the in-page cross-reference style already used elsewhere on the page.

### Merge readiness

- [x] Ready for merge

### AI assistance

Claude Code was used to check the ticket's premise against the OpenAPI spec and the current page content, and to draft the edit.

### Additional notes

