### PR TITLE
[DOCS-15453] Add description frontmatter to source docs

### DIFF
--- a/hugo/content/en/observability_pipelines/sources/_index.md
+++ b/hugo/content/en/observability_pipelines/sources/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Sources
+description: Learn about the sources available for the Observability Pipelines Worker.
 disable_toc: false
 further_reading:
 - link: "/observability_pipelines/configuration/set_up_pipelines/"

--- a/hugo/content/en/observability_pipelines/sources/amazon_data_firehose.md
+++ b/hugo/content/en/observability_pipelines/sources/amazon_data_firehose.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Data Firehose Source
+description: Learn how to collect logs from Amazon Data Firehose using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/amazon_s3.md
+++ b/hugo/content/en/observability_pipelines/sources/amazon_s3.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon S3 Source
+description: Learn how to collect logs from Amazon S3 using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/azure_event_hubs.md
+++ b/hugo/content/en/observability_pipelines/sources/azure_event_hubs.md
@@ -1,5 +1,6 @@
 ---
 title: Send Azure Event Hubs Logs to Observability Pipelines
+description: Learn how to send Azure Event Hubs logs to Observability Pipelines using the Kafka source.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/sources/datadog_agent.md
+++ b/hugo/content/en/observability_pipelines/sources/datadog_agent.md
@@ -1,5 +1,6 @@
 ---
 title: Datadog Agent Source
+description: Learn how to collect logs, metrics, or traces from the Datadog Agent using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/filebeat.md
+++ b/hugo/content/en/observability_pipelines/sources/filebeat.md
@@ -1,5 +1,6 @@
 ---
 title: Send Logs to Observability Pipelines with Filebeat
+description: Learn how to send logs to Observability Pipelines with Filebeat through the Logstash source.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/sources/fluent.md
+++ b/hugo/content/en/observability_pipelines/sources/fluent.md
@@ -1,5 +1,6 @@
 ---
 title: Fluentd and Fluent Bit Sources
+description: Learn how to collect logs from a Fluentd or Fluent Bit agent using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/google_pubsub.md
+++ b/hugo/content/en/observability_pipelines/sources/google_pubsub.md
@@ -1,5 +1,6 @@
 ---
 title: Google Pub/Sub Source
+description: Learn how to pull logs from Google Cloud Pub/Sub using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/http_client.md
+++ b/hugo/content/en/observability_pipelines/sources/http_client.md
@@ -1,5 +1,6 @@
 ---
 title: HTTP/S Client Source
+description: Learn how to pull logs from an upstream HTTP/S server using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/http_server.md
+++ b/hugo/content/en/observability_pipelines/sources/http_server.md
@@ -1,5 +1,6 @@
 ---
 title: HTTP/S Server Source
+description: Learn how to collect HTTP client logs using the Observability Pipelines Worker's HTTP/S Server source.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/kafka.md
+++ b/hugo/content/en/observability_pipelines/sources/kafka.md
@@ -1,5 +1,6 @@
 ---
 title: Kafka Source
+description: Learn how to collect logs from Kafka topics using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/lambda_forwarder.md
+++ b/hugo/content/en/observability_pipelines/sources/lambda_forwarder.md
@@ -1,5 +1,6 @@
 ---
 title: Send Datadog Lambda Forwarder Logs to Observability Pipelines
+description: Learn how to send AWS vended logs to Observability Pipelines using the Datadog Lambda Forwarder.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/sources/logstash.md
+++ b/hugo/content/en/observability_pipelines/sources/logstash.md
@@ -1,5 +1,6 @@
 ---
 title: Logstash Source
+description: Learn how to collect logs from a Logstash agent using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/opentelemetry.md
+++ b/hugo/content/en/observability_pipelines/sources/opentelemetry.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Source
+description: Learn how to collect logs, metrics, or traces from an OpenTelemetry Collector using the Observability Pipelines Worker.
 disable_toc: false
 further_reading:
   - link: https://www.datadoghq.com/blog/manage-metrics-cost-control-with-observability-pipelines

--- a/hugo/content/en/observability_pipelines/sources/prometheus.md
+++ b/hugo/content/en/observability_pipelines/sources/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus Source
+description: Learn how to collect metrics pushed by Prometheus clients using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Metrics

--- a/hugo/content/en/observability_pipelines/sources/socket.md
+++ b/hugo/content/en/observability_pipelines/sources/socket.md
@@ -1,5 +1,6 @@
 ---
 title: Socket Source
+description: Learn how to collect logs sent over a TCP or UDP socket connection using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/splunk_hec.md
+++ b/hugo/content/en/observability_pipelines/sources/splunk_hec.md
@@ -1,5 +1,6 @@
 ---
 title: Splunk HTTP Event Collector (HEC) Source
+description: Learn how to collect logs from a Splunk HTTP Event Collector (HEC) using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/splunk_tcp.md
+++ b/hugo/content/en/observability_pipelines/sources/splunk_tcp.md
@@ -1,5 +1,6 @@
 ---
 title: Splunk Heavy or Universal Forwarders (TCP) Source
+description: Learn how to collect logs from Splunk Heavy or Universal Forwarders over TCP using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/sumo_logic.md
+++ b/hugo/content/en/observability_pipelines/sources/sumo_logic.md
@@ -1,5 +1,6 @@
 ---
 title: Sumo Logic Hosted Collector
+description: Learn how to collect logs sent to a Sumo Logic Hosted Collector using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs

--- a/hugo/content/en/observability_pipelines/sources/syslog.md
+++ b/hugo/content/en/observability_pipelines/sources/syslog.md
@@ -1,5 +1,6 @@
 ---
 title: Syslog Source
+description: Learn how to collect logs sent to rsyslog or syslog-ng using the Observability Pipelines Worker.
 disable_toc: false
 products:
 - name: Logs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15453

Adds a `description` field to the frontmatter of Observability Pipelines source docs that were missing one.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Descriptions were drafted with Claude Code based on each page's existing content, then reviewed.

### Additional notes