### PR TITLE
[DOCS-15453] Add description frontmatter to configuration docs

### DIFF
--- a/hugo/content/en/observability_pipelines/configuration/_index.md
+++ b/hugo/content/en/observability_pipelines/configuration/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: Learn about the source, processor, and destination components that make up an Observability Pipelines pipeline, and the methods available for building and deploying them.
 disable_toc: false
 further_reading:
 - link: "observability_pipelines/configuration/set_up_pipelines/"

--- a/hugo/content/en/observability_pipelines/configuration/_index.md
+++ b/hugo/content/en/observability_pipelines/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Learn about the source, processor, and destination components that make up an Observability Pipelines pipeline, and the methods available for building and deploying them.
+description: Learn about the source, processor, and destination components that make up a pipeline, and how to build and deploy them.
 disable_toc: false
 further_reading:
 - link: "observability_pipelines/configuration/set_up_pipelines/"

--- a/hugo/content/en/observability_pipelines/configuration/access_control.md
+++ b/hugo/content/en/observability_pipelines/configuration/access_control.md
@@ -1,5 +1,6 @@
 ---
 title: Access Control
+description: Learn how to use role-based and granular access control to restrict who can view, edit, deploy, or delete Observability Pipelines configurations and Live Capture.
 disable_toc: false
 aliases:
     - /observability_pipelines/access_control/

--- a/hugo/content/en/observability_pipelines/configuration/explore_templates.md
+++ b/hugo/content/en/observability_pipelines/configuration/explore_templates.md
@@ -1,5 +1,6 @@
 ---
 title: Explore Templates
+description: Learn about the out-of-the-box logs, metrics, and traces templates available for building and deploying pipelines in the Observability Pipelines UI.
 disable_toc: false
 further_reading:
 - link: "observability_pipelines/set_up_pipelines#set-up-a-pipeline"

--- a/hugo/content/en/observability_pipelines/configuration/explore_templates.md
+++ b/hugo/content/en/observability_pipelines/configuration/explore_templates.md
@@ -1,6 +1,6 @@
 ---
 title: Explore Templates
-description: Learn about the preconfigured logs, metrics, and traces templates available for building and deploying pipelines in the Observability Pipelines UI.
+description: Learn about the out-of-the-box logs, metrics, and traces templates available for building and deploying pipelines in the Observability Pipelines UI.
 disable_toc: false
 further_reading:
 - link: "observability_pipelines/set_up_pipelines#set-up-a-pipeline"

--- a/hugo/content/en/observability_pipelines/configuration/explore_templates.md
+++ b/hugo/content/en/observability_pipelines/configuration/explore_templates.md
@@ -1,6 +1,6 @@
 ---
 title: Explore Templates
-description: Learn about the out-of-the-box logs, metrics, and traces templates available for building and deploying pipelines in the Observability Pipelines UI.
+description: Learn about the preconfigured logs, metrics, and traces templates available for building and deploying pipelines in the Observability Pipelines UI.
 disable_toc: false
 further_reading:
 - link: "observability_pipelines/set_up_pipelines#set-up-a-pipeline"

--- a/hugo/content/en/observability_pipelines/configuration/export_and_import_pipeline_configurations.md
+++ b/hugo/content/en/observability_pipelines/configuration/export_and_import_pipeline_configurations.md
@@ -1,5 +1,6 @@
 ---
 title: Export and Import a Pipeline Configuration
+description: Learn how to export a draft or deployed pipeline's configuration to JSON or Terraform, and import a JSON configuration into the Observability Pipelines UI.
 aliases:
   - /observability_pipelines/configuration/export_pipeline_configuration/
 disable_toc: false

--- a/hugo/content/en/observability_pipelines/configuration/install_the_worker/_index.mdoc.md
+++ b/hugo/content/en/observability_pipelines/configuration/install_the_worker/_index.mdoc.md
@@ -1,5 +1,6 @@
 ---
 title: Install the Worker
+description: Install and set up the Observability Pipelines Worker on your platform.
 disable_toc: false
 aliases:
     - /observability_pipelines/install_the_worker/

--- a/hugo/content/en/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations.md
+++ b/hugo/content/en/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Worker Configurations
+description: Learn about Worker bootstrap options, other configuration options, and how to enable the health check endpoint and liveness and readiness probes for the Observability Pipelines Worker.
 disable_toc: false
 aliases:
   - /observability_pipelines/setup_opw/

--- a/hugo/content/en/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations.md
+++ b/hugo/content/en/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Worker Configurations
-description: Learn about Worker bootstrap options, other configuration options, and how to enable the health check endpoint and liveness and readiness probes for the Observability Pipelines Worker.
+description: Learn about Worker bootstrap options and other configuration options.
 disable_toc: false
 aliases:
   - /observability_pipelines/setup_opw/

--- a/hugo/content/en/observability_pipelines/configuration/install_the_worker/run_multiple_pipelines_on_a_host.md
+++ b/hugo/content/en/observability_pipelines/configuration/install_the_worker/run_multiple_pipelines_on_a_host.md
@@ -1,5 +1,6 @@
 ---
 title: Run Multiple Pipelines on a Host
+description: Learn which Worker files to add and modify to run multiple Observability Pipelines Workers for different pipelines on a single host.
 disable_toc: false
 aliases:
     - /observability_pipelines/set_up_pipelines/run_multiple_pipelines_on_a_host/

--- a/hugo/content/en/observability_pipelines/configuration/live_capture.md
+++ b/hugo/content/en/observability_pipelines/configuration/live_capture.md
@@ -1,5 +1,6 @@
 ---
 title: Live Capture
+description: Learn how to use Live Capture to see the data a source receives and a processor sends through an Observability Pipelines pipeline, and who can set up captures.
 disable_toc: false
 aliases:
   - /observability_pipelines/live_capture/

--- a/hugo/content/en/observability_pipelines/configuration/live_capture.md
+++ b/hugo/content/en/observability_pipelines/configuration/live_capture.md
@@ -1,6 +1,6 @@
 ---
 title: Live Capture
-description: Learn how to use Live Capture to see the data a source receives and a processor sends through an Observability Pipelines pipeline, and who can set up captures.
+description: Learn how to use Live Capture to see the data a source receives and the data a processor sends through an Observability Pipelines pipeline.
 disable_toc: false
 aliases:
   - /observability_pipelines/live_capture/

--- a/hugo/content/en/observability_pipelines/configuration/set_up_pipelines.md
+++ b/hugo/content/en/observability_pipelines/configuration/set_up_pipelines.md
@@ -1,5 +1,6 @@
 ---
 title: Set Up Pipelines
+description: Learn how to set up an Observability Pipelines pipeline's source, processors, and destinations with the Pipeline UI, API, or Terraform.
 disable_toc: false
 aliases:
   - /observability_pipelines/set_up_pipelines/

--- a/hugo/content/en/observability_pipelines/configuration/set_up_pipelines.md
+++ b/hugo/content/en/observability_pipelines/configuration/set_up_pipelines.md
@@ -1,6 +1,6 @@
 ---
 title: Set Up Pipelines
-description: Learn how to set up an Observability Pipelines pipeline's source, processors, and destinations with the Pipeline UI, API, or Terraform.
+description: Learn how to set up an Observability Pipelines pipeline's source, processors, and destinations.
 disable_toc: false
 aliases:
   - /observability_pipelines/set_up_pipelines/

--- a/hugo/content/en/observability_pipelines/configuration/update_existing_pipelines.md
+++ b/hugo/content/en/observability_pipelines/configuration/update_existing_pipelines.md
@@ -1,5 +1,6 @@
 ---
 title: Update Existing Pipelines
+description: Learn how to update and deploy changes to an existing Observability Pipelines pipeline's source, destination, and processor settings, including environment variables.
 disable_toc: false
 aliases:
   - /observability_pipelines/update_existing_pipelines/

--- a/hugo/content/en/observability_pipelines/configuration/update_existing_pipelines.md
+++ b/hugo/content/en/observability_pipelines/configuration/update_existing_pipelines.md
@@ -1,6 +1,6 @@
 ---
 title: Update Existing Pipelines
-description: Learn how to update and deploy changes to an existing Observability Pipelines pipeline's source, destination, and processor settings, including environment variables.
+description: Learn how to update and deploy changes to an existing Observability Pipelines pipeline's source, destination, and processor settings.
 disable_toc: false
 aliases:
   - /observability_pipelines/update_existing_pipelines/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15453

Adds a `description` field to the frontmatter of Observability Pipelines configuration docs that were missing one.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Descriptions were drafted with Claude Code based on each page's existing content, then reviewed.

### Additional notes