### PR TITLE
[DOCS-15453] Add description frontmatter to guide, monitoring, scaling, and search docs

### DIFF
--- a/hugo/content/en/observability_pipelines/_index.md
+++ b/hugo/content/en/observability_pipelines/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Observability Pipelines
+description: Learn how Observability Pipelines lets you collect, process, and route logs, metrics, and traces within your own infrastructure to destinations such as Datadog, Amazon S3, Splunk, and Microsoft Sentinel.
 disable_toc: false
 further_reading:
 - link: "/observability_pipelines/configuration/explore_templates/"

--- a/hugo/content/en/observability_pipelines/guide/_index.md
+++ b/hugo/content/en/observability_pipelines/guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Observability Pipelines Guides
+description: Find guides on reducing log volume, environment variables, upgrading the Worker, and working with Observability Pipelines processors.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/guide/environment_variables.md
+++ b/hugo/content/en/observability_pipelines/guide/environment_variables.md
@@ -1,5 +1,6 @@
 ---
 title: Environment Variables
+description: Find the environment variables available for Observability Pipelines sources, processors, and destinations.
 disable_toc: false
 aliases:
     - /observability_pipelines/environment_variables/

--- a/hugo/content/en/observability_pipelines/guide/get_started_with_the_custom_processor.md
+++ b/hugo/content/en/observability_pipelines/guide/get_started_with_the_custom_processor.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started with the Custom Processor
+description: Learn how to use Custom Processor functions, such as Base64 decoding and encoding, and see example scripts for common log transformation use cases.
 disable_toc: false
 further_reading:
 - link: "/observability_pipelines/processors/custom_processor/"

--- a/hugo/content/en/observability_pipelines/guide/remap_reserved_attributes.md
+++ b/hugo/content/en/observability_pipelines/guide/remap_reserved_attributes.md
@@ -1,5 +1,6 @@
 ---
 title: Remap Reserved Attributes
+description: Learn how to remap the value of reserved log attributes, such as host, source, and service, with the Edit Fields or Custom Processor in Observability Pipelines.
 disable_toc: false
 further_reading:
 - link: "/observability_pipelines/processors/edit_fields/"

--- a/hugo/content/en/observability_pipelines/guide/strategies_for_reducing_log_volume.md
+++ b/hugo/content/en/observability_pipelines/guide/strategies_for_reducing_log_volume.md
@@ -1,5 +1,6 @@
 ---
 title: Strategies for Reducing Log Volume
+description: Learn strategies, such as sampling and filtering logs, for reducing log volume with Observability Pipelines processors.
 disable_toc: false
 further_reading:
 - link: "/observability_pipelines/set_up_pipelines"

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/_index.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring and Troubleshooting
+description: Find links to Worker CLI commands, pipeline monitoring, usage metrics, and troubleshooting resources for Observability Pipelines.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/monitoring_pipelines.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/monitoring_pipelines.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring Pipelines
+description: Learn how to track the status of Observability Pipelines pipelines, Workers, and components with health graphs and out-of-the-box monitors.
 disable_toc: false
 aliases:
   - /observability_pipelines/monitoring/

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/monitoring_pipelines.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/monitoring_pipelines.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring Pipelines
-description: Learn how to track the status of Observability Pipelines pipelines, Workers, and components with health graphs and out-of-the-box monitors.
+description: Learn how to track the status of pipelines, Workers, and components with health graphs and out-of-the-box monitors.
 disable_toc: false
 aliases:
   - /observability_pipelines/monitoring/

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Pipelines Usage Metrics
+description: Find the metrics available from Observability Pipelines for building dashboards, notebooks, and monitors.
 disable_toc: false
 aliases:
   - /observability_pipelines/monitoring/metrics/

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Learn how to view Worker stats and logs, and use the tap and top commands to inspect events and diagnose Observability Pipelines setup issues.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/worker_cli_commands.md
+++ b/hugo/content/en/observability_pipelines/monitoring_and_troubleshooting/worker_cli_commands.md
@@ -1,5 +1,6 @@
 ---
 title: Worker CLI Commands
+description: Find the run, tap, and top commands and options for the Observability Pipelines Worker command-line interface.
 disable_toc: false
 aliases:
   - /observability_pipelines/install_the_worker/worker_commands/

--- a/hugo/content/en/observability_pipelines/scaling_and_performance/_index.md
+++ b/hugo/content/en/observability_pipelines/scaling_and_performance/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Scaling and Performance
+description: Find links on running multiple pipelines on a host, buffering and backpressure, and best practices for scaling Observability Pipelines Workers.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/scaling_and_performance/_index.md
+++ b/hugo/content/en/observability_pipelines/scaling_and_performance/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Scaling and Performance
-description: Find links on running multiple pipelines on a host, buffering and backpressure, and best practices for scaling Observability Pipelines Workers.
+description: Find documentation links to topics such as running multiple pipelines on a host, buffering and backpressure, and best practices for scaling Observability Pipelines Workers.
 disable_toc: false
 ---
 

--- a/hugo/content/en/observability_pipelines/scaling_and_performance/best_practices_for_scaling_observability_pipelines.md
+++ b/hugo/content/en/observability_pipelines/scaling_and_performance/best_practices_for_scaling_observability_pipelines.md
@@ -1,5 +1,6 @@
 ---
 title: Best Practices for Scaling Observability Pipelines
+description: Learn the recommended aggregator architecture, instance optimization, and capacity planning practices for scaling Observability Pipelines Workers in large deployments.
 aliases:
     - /observability_pipelines/best_practices_for_scaling_observability_pipelines/
 further_reading:

--- a/hugo/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
+++ b/hugo/content/en/observability_pipelines/scaling_and_performance/buffering_and_backpressure.md
@@ -1,5 +1,6 @@
 ---
 title: Buffering and Backpressure
+description: Learn how Observability Pipelines uses buffering and backpressure to handle destination outages, and how to configure destination buffer settings.
 disable_toc: false
 aliases:
   - /observability_pipelines/performance/

--- a/hugo/content/en/observability_pipelines/search_syntax/_index.md
+++ b/hugo/content/en/observability_pipelines/search_syntax/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Search Syntax
+description: Learn the search syntax for filtering data with Observability Pipelines processors.
 type: multi-code-lang
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15453

Adds a `description` field to the frontmatter of Observability Pipelines guide, monitoring and troubleshooting, scaling and performance, and search syntax docs that were missing one.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Descriptions were drafted with Claude Code based on each page's existing content, then reviewed.

### Additional notes