### PR TITLE
[CCC-2415] Document Azure EA to MCA export migration

### DIFF
--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -210,7 +210,7 @@ Navigate to [Setup & Configuration][3] and follow the steps.
 
 Azure exports cost data starting from the month you created the export. Datadog automatically ingests up to 15 months of available historical cost data from these exports. You can manually backfill up to 12 months of Azure cost data using the Azure Cost Exports UI.
 
-If you migrated from an EA to an MCA, follow the [migration instructions][18] before running a historical export. Run the export from the agreement scope that covered the requested dates.
+If you migrated from an EA to an MCA, follow the [migration instructions][18] before running a historical export.
 
 1. Complete the instructions in the **Setup** and **Configure Cloud Cost in Datadog** sections above.
 1. Wait up to 24 hours for cost data to appear in Datadog to ensure the integration is working end-to-end before beginning the backfill process. **Note:** If you have already completed setup, and cost data is appearing in Datadog, you can proceed directly to the backfill steps below.
@@ -244,8 +244,10 @@ This migration process preserves historical EA data for Datadog configurations t
    * Storage container
    * Storage directory and export prefix
    * Dataset version, format, and compression type
-2. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
-3. After the MCA becomes active, follow the [cost export instructions][17] to recreate the actual and amortized exports at the corresponding MCA scope. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
+1. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
+1. After the MCA becomes active, recreate the actual and amortized exports at the corresponding MCA scope using Terraform or the Azure portal. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
+   * For Terraform, follow the [Terraform export instructions][19].
+   * For the Azure portal, follow the [manual cost export instructions][17].
 
 Datadog continues to read the historical EA files from the existing destination and adds MCA data to the same cost history.
 
@@ -259,7 +261,7 @@ To backfill data after an EA-to-MCA migration, use the agreement that covered th
 * For dates before the MCA effective date, run the one-time actual and amortized exports from the previous EA scope.
 * For dates on or after the MCA effective date, run the one-time actual and amortized exports from the MCA scope.
 
-If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16] before creating more exports.
+If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16]. Do not create additional one-time or scheduled exports until Support reviews the configuration.
 
 ### Cost types
 
@@ -362,5 +364,6 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config
 [15]: https://learn.microsoft.com/en-us/azure/cost-management-billing/microsoft-customer-agreement/onboard-microsoft-customer-agreement
 [16]: /help/
-[17]: #generate-cost-exports
+[17]: ?tab=manual#generate-cost-exports
 [18]: #migrate-exports-after-changing-billing-agreements
+[19]: ?tab=terraform#select-the-resources-to-create

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -210,6 +210,8 @@ Navigate to [Setup & Configuration][3] and follow the steps.
 
 Azure exports cost data starting from the month you created the export. Datadog automatically ingests up to 15 months of available historical cost data from these exports. You can manually backfill up to 12 months of Azure cost data using the Azure Cost Exports UI.
 
+If you migrated from an EA to an MCA, follow the migration instructions below before running a historical export. Run the export from the agreement scope that covered the requested dates.
+
 1. Complete the instructions in the **Setup** and **Configure Cloud Cost in Datadog** sections above.
 1. Wait up to 24 hours for cost data to appear in Datadog to ensure the integration is working end-to-end before beginning the backfill process. **Note:** If you have already completed setup, and cost data is appearing in Datadog, you can proceed directly to the backfill steps below.
 1. Manually export an **actual** and **amortized** report for each calendar month. For example, for June 2025:
@@ -227,6 +229,37 @@ Azure exports cost data starting from the month you created the export. Datadog 
 Datadog automatically discovers and ingests this data, and it should appear in Datadog within 24 hours.
 
 You can also create historical data in your storage account using the [Microsoft API][6] or by creating a [support ticket with Microsoft][7]. Ensure the file structure and partitioning follows the format of scheduled exports.
+
+### Migrate exports after changing billing agreements
+
+Azure does not automatically migrate cost export definitions from an Enterprise Agreement (EA) to a Microsoft Customer Agreement (MCA). For more information, see Microsoft's [MCA onboarding documentation][15].
+
+This migration process preserves historical EA data for Datadog configurations that use a billing account, subscription, or resource group scope.
+
+**Note**: For a billing account scope, Datadog retains the EA billing account ID in the configuration.
+
+1. Record the following settings for both the actual and amortized EA exports:
+   * Export name, including capitalization
+   * Storage account
+   * Storage container
+   * Storage directory and export prefix
+   * Dataset version, format, and compression type
+2. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
+3. After the MCA becomes active, follow the [cost export instructions](#generate-cost-exports) to recreate the actual and amortized exports at the corresponding MCA scope. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
+
+Datadog continues to read the historical EA files from the existing destination and adds MCA data to the same cost history.
+
+<div class="alert alert-warning">
+<strong>Do not backfill EA dates from an MCA scope</strong>
+<p>An MCA export does not include costs from the previous EA. Running a one-time MCA export for an EA date range can write a newer empty manifest to the shared destination. Datadog reads the latest export for each month, so the empty manifest can make previously available EA data unavailable.</p>
+</div>
+
+To backfill data after an EA-to-MCA migration, use the agreement that covered the requested dates:
+
+* For dates before the MCA effective date, run the one-time actual and amortized exports from the previous EA scope.
+* For dates on or after the MCA effective date, run the one-time actual and amortized exports from the MCA scope.
+
+If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16] before creating more exports.
 
 ### Cost types
 
@@ -327,3 +360,5 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [12]: /cloud_cost_management/tags
 [13]: /api/latest/cloud-cost-management/#create-cloud-cost-management-azure-configs
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config
+[15]: https://learn.microsoft.com/en-us/azure/cost-management-billing/microsoft-customer-agreement/onboard-microsoft-customer-agreement
+[16]: /help/

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -251,7 +251,7 @@ Datadog continues to read the historical EA files from the existing destination 
 
 <div class="alert alert-warning">
 <strong>Do not backfill EA dates from an MCA scope</strong>
-<p>An MCA export does not include costs from the previous EA. Running a one-time MCA export for an EA date range can write a newer empty manifest to the shared destination. Datadog reads the latest export for each month, so the empty manifest can make previously available EA data unavailable.</p>
+<p>An MCA export does not include costs from the previous EA. Running a one-time MCA export for an EA date range can write a newer empty manifest to the shared destination. Datadog reads the latest export for each month, so the empty manifest can zero out EA data that was previously ingested.</p>
 </div>
 
 To backfill data after an EA-to-MCA migration, use the agreement that covered the requested dates:

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -210,7 +210,7 @@ Navigate to [Setup & Configuration][3] and follow the steps.
 
 Azure exports cost data starting from the month you created the export. Datadog automatically ingests up to 15 months of available historical cost data from these exports. You can manually backfill up to 12 months of Azure cost data using the Azure Cost Exports UI.
 
-If you migrated from an EA to an MCA, follow the migration instructions below before running a historical export. Run the export from the agreement scope that covered the requested dates.
+If you migrated from an EA to an MCA, follow the [migration instructions][18] before running a historical export. Run the export from the agreement scope that covered the requested dates.
 
 1. Complete the instructions in the **Setup** and **Configure Cloud Cost in Datadog** sections above.
 1. Wait up to 24 hours for cost data to appear in Datadog to ensure the integration is working end-to-end before beginning the backfill process. **Note:** If you have already completed setup, and cost data is appearing in Datadog, you can proceed directly to the backfill steps below.
@@ -245,7 +245,7 @@ This migration process preserves historical EA data for Datadog configurations t
    * Storage directory and export prefix
    * Dataset version, format, and compression type
 2. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
-3. After the MCA becomes active, follow the [cost export instructions](#generate-cost-exports) to recreate the actual and amortized exports at the corresponding MCA scope. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
+3. After the MCA becomes active, follow the [cost export instructions][17] to recreate the actual and amortized exports at the corresponding MCA scope. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
 
 Datadog continues to read the historical EA files from the existing destination and adds MCA data to the same cost history.
 
@@ -362,3 +362,5 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [14]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/azure_uc_config
 [15]: https://learn.microsoft.com/en-us/azure/cost-management-billing/microsoft-customer-agreement/onboard-microsoft-customer-agreement
 [16]: /help/
+[17]: #generate-cost-exports
+[18]: #migrate-exports-after-changing-billing-agreements

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -206,21 +206,20 @@ To resolve this, add Datadog's webhook IPs to your network allowlist by visiting
 ### Configure Cloud Cost in Datadog
 Navigate to [Setup & Configuration][3] and follow the steps.
 
-### Migrate exports after changing billing agreements
+### Migrate exports from an EA to an MCA
 
 Azure does not automatically migrate cost export definitions from an Enterprise Agreement (EA) to a Microsoft Customer Agreement (MCA). For more information, see Microsoft's [MCA onboarding documentation][15].
 
-This migration process preserves historical EA data for Datadog configurations that use a billing account, subscription, or resource group scope.
+The following process preserves historical EA data for Datadog configurations that use a billing account, subscription, or resource group scope.
 
-**Note**: For a billing account scope, Datadog retains the EA billing account ID in the configuration.
-
-1. Record the following settings for both the actual and amortized EA exports:
+1. Record the following settings for both the actual and the amortized EA exports:
    * Export name, including capitalization
    * Storage account
    * Storage container
    * Storage directory and export prefix
    * Dataset version, format, and compression type
-1. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
+1. After the final EA-period exports run, disable the scheduled EA exports, but keep their definitions. Do not allow the EA and MCA scheduled exports to write to the same destination at the same time.
+1. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged. For a billing account scope, Datadog retains the EA ID.
 1. After the MCA becomes active, recreate the actual and amortized exports at the corresponding MCA scope using Terraform or the Azure portal. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
    * For Terraform, follow the [Terraform setup flow][19] through the Azure resource HCL steps. Do not apply new Datadog HCL or replace the existing Cloud Cost Management configuration.
    * For the Azure portal, follow the [manual cost export instructions][17].
@@ -365,5 +364,5 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [15]: https://learn.microsoft.com/en-us/azure/cost-management-billing/microsoft-customer-agreement/onboard-microsoft-customer-agreement
 [16]: /help/
 [17]: ?tab=manual#generate-cost-exports
-[18]: #migrate-exports-after-changing-billing-agreements
+[18]: #migrate-exports-from-an-ea-to-an-mca
 [19]: ?tab=terraform

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -237,13 +237,13 @@ To backfill data after an EA-to-MCA migration, use the agreement that covered th
 * For dates before the MCA effective date, run the one-time actual and amortized exports from the previous EA scope.
 * For dates on or after the MCA effective date, run the one-time actual and amortized exports from the MCA scope.
 
-If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16]. Do not create additional one-time or scheduled exports until Support reviews the configuration.
+If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16]. Do not create additional one-time or scheduled exports until Datadog Support reviews the configuration.
 
 ### Getting historical data
 
 Azure exports cost data starting from the month you created the export. Datadog automatically ingests up to 15 months of available historical cost data from these exports. You can manually backfill up to 12 months of Azure cost data using the Azure Cost Exports UI.
 
-If you migrated from an EA to an MCA, follow the [migration instructions][18] before running a historical export.
+**Note**: If you migrated from an EA to an MCA, follow the [migration instructions][18] before running a historical export.
 
 1. Complete the instructions in the **Setup** and **Configure Cloud Cost in Datadog** sections above.
 1. Wait up to 24 hours for cost data to appear in Datadog to ensure the integration is working end-to-end before beginning the backfill process. **Note:** If you have already completed setup, and cost data is appearing in Datadog, you can proceed directly to the backfill steps below.

--- a/hugo/content/en/cloud_cost_management/setup/azure.md
+++ b/hugo/content/en/cloud_cost_management/setup/azure.md
@@ -206,6 +206,39 @@ To resolve this, add Datadog's webhook IPs to your network allowlist by visiting
 ### Configure Cloud Cost in Datadog
 Navigate to [Setup & Configuration][3] and follow the steps.
 
+### Migrate exports after changing billing agreements
+
+Azure does not automatically migrate cost export definitions from an Enterprise Agreement (EA) to a Microsoft Customer Agreement (MCA). For more information, see Microsoft's [MCA onboarding documentation][15].
+
+This migration process preserves historical EA data for Datadog configurations that use a billing account, subscription, or resource group scope.
+
+**Note**: For a billing account scope, Datadog retains the EA billing account ID in the configuration.
+
+1. Record the following settings for both the actual and amortized EA exports:
+   * Export name, including capitalization
+   * Storage account
+   * Storage container
+   * Storage directory and export prefix
+   * Dataset version, format, and compression type
+1. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
+1. After the MCA becomes active, recreate the actual and amortized exports at the corresponding MCA scope using Terraform or the Azure portal. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
+   * For Terraform, follow the [Terraform setup flow][19] through the Azure resource HCL steps. Do not apply new Datadog HCL or replace the existing Cloud Cost Management configuration.
+   * For the Azure portal, follow the [manual cost export instructions][17].
+
+Datadog continues to read the historical EA files from the existing destination and adds MCA data to the same cost history.
+
+<div class="alert alert-warning">
+<strong>Do not backfill EA dates from an MCA scope</strong>
+<p>An MCA export does not include costs from the previous EA. Running a one-time MCA export for an EA date range can write a newer empty manifest to the shared destination. Datadog reads the latest export for each month, so the empty manifest can zero out EA data that was previously ingested.</p>
+</div>
+
+To backfill data after an EA-to-MCA migration, use the agreement that covered the requested dates:
+
+* For dates before the MCA effective date, run the one-time actual and amortized exports from the previous EA scope.
+* For dates on or after the MCA effective date, run the one-time actual and amortized exports from the MCA scope.
+
+If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16]. Do not create additional one-time or scheduled exports until Support reviews the configuration.
+
 ### Getting historical data
 
 Azure exports cost data starting from the month you created the export. Datadog automatically ingests up to 15 months of available historical cost data from these exports. You can manually backfill up to 12 months of Azure cost data using the Azure Cost Exports UI.
@@ -229,39 +262,6 @@ If you migrated from an EA to an MCA, follow the [migration instructions][18] be
 Datadog automatically discovers and ingests this data, and it should appear in Datadog within 24 hours.
 
 You can also create historical data in your storage account using the [Microsoft API][6] or by creating a [support ticket with Microsoft][7]. Ensure the file structure and partitioning follows the format of scheduled exports.
-
-### Migrate exports after changing billing agreements
-
-Azure does not automatically migrate cost export definitions from an Enterprise Agreement (EA) to a Microsoft Customer Agreement (MCA). For more information, see Microsoft's [MCA onboarding documentation][15].
-
-This migration process preserves historical EA data for Datadog configurations that use a billing account, subscription, or resource group scope.
-
-**Note**: For a billing account scope, Datadog retains the EA billing account ID in the configuration.
-
-1. Record the following settings for both the actual and amortized EA exports:
-   * Export name, including capitalization
-   * Storage account
-   * Storage container
-   * Storage directory and export prefix
-   * Dataset version, format, and compression type
-1. Leave the Azure Cloud Cost Management configuration in Datadog enabled and unchanged.
-1. After the MCA becomes active, recreate the actual and amortized exports at the corresponding MCA scope using Terraform or the Azure portal. Use the export names, storage account, container, directory, and prefix recorded from the EA exports.
-   * For Terraform, follow the [Terraform export instructions][19].
-   * For the Azure portal, follow the [manual cost export instructions][17].
-
-Datadog continues to read the historical EA files from the existing destination and adds MCA data to the same cost history.
-
-<div class="alert alert-warning">
-<strong>Do not backfill EA dates from an MCA scope</strong>
-<p>An MCA export does not include costs from the previous EA. Running a one-time MCA export for an EA date range can write a newer empty manifest to the shared destination. Datadog reads the latest export for each month, so the empty manifest can zero out EA data that was previously ingested.</p>
-</div>
-
-To backfill data after an EA-to-MCA migration, use the agreement that covered the requested dates:
-
-* For dates before the MCA effective date, run the one-time actual and amortized exports from the previous EA scope.
-* For dates on or after the MCA effective date, run the one-time actual and amortized exports from the MCA scope.
-
-If the previous EA scope is unavailable, contact Microsoft Support to request the historical exports. If you changed an export name or destination, or deleted and recreated the Datadog configuration, contact [Datadog Support][16]. Do not create additional one-time or scheduled exports until Support reviews the configuration.
 
 ### Cost types
 
@@ -366,4 +366,4 @@ For example, to view cost and utilization for each Azure VM, you can make a tabl
 [16]: /help/
 [17]: ?tab=manual#generate-cost-exports
 [18]: #migrate-exports-after-changing-billing-agreements
-[19]: ?tab=terraform#select-the-resources-to-create
+[19]: ?tab=terraform


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes CCC-2415.

Documents the Azure EA-to-MCA export migration path so customers can preserve historical cost data.

- Explains how to reuse export names and storage destinations.
- Warns against using MCA exports to backfill EA dates.
- Clarifies which agreement scope to use for historical exports.
- Documents billing-account ID behavior during migration.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used AI-assisted research and drafting; the content was reviewed and refined manually.

### Additional notes

- `git diff --check` passes.
- Vale reports no errors or new warnings.
- The updated Azure page renders with the migration section and warning.
