### PR TITLE
Point Kubernetes Explorer OpenTelemetry setup at reference configurations

### DIFF
--- a/hugo/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/hugo/content/en/containers/monitoring/kubernetes_explorer.md
@@ -92,206 +92,49 @@ Recommendations:
 1. Use Kubernetes 1.33 or later, which includes [streaming list improvements][106] that reduce API server impact.
 2. Start with smaller clusters. Limit the number of objects per resource type to fewer than 5,000 as a starting point, and scale up gradually while monitoring cluster health.
 
-The following steps walk through the required components for Kubernetes Explorer. For a complete reference example that also collects Kubernetes infrastructure metrics, see [Kubernetes Metrics][111].
+#### Set up Kubernetes Explorer
 
-#### 1. Create a Datadog API key secret
+Follow the [Kubernetes Metrics setup guide][111] to install `kube-state-metrics` and the OpenTelemetry Collectors. The guide provides complete, maintained [`cluster-collector.yaml`][110] and [`daemonset-collector.yaml`][109] reference configurations.
 
-Create a Kubernetes secret to store your Datadog API key:
+The Cluster Collector populates Kubernetes Explorer and collects cluster-wide metrics. The Node Collector collects node-level metrics and enriches application telemetry with the Kubernetes metadata used for correlation.
 
-```sh
-export DD_API_KEY="<YOUR_DATADOG_API_KEY>"
-kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
-```
+The Cluster Collector configuration:
 
-#### 2. Configure the cluster collector
+- Enables the `kubernetesObjects` [Helm preset][107], including the required service account and RBAC permissions.
+- Sets the `k8sobjects` collection interval to `3m`, as required by Kubernetes Explorer.
+- Detects the cluster name and UID with the [`resourcedetection`][105] processor.
+- Enables Kubernetes Explorer in the Datadog Exporter.
 
-This setup deploys the OTel Collector as a Kubernetes Deployment. Create a `deployment-collector.yaml` file with the following configuration blocks, or merge them into your existing OpenTelemetry Collector values file.
+The reference setup also collects Kubernetes infrastructure metrics. To understand or customize individual components, use the comments in the reference configuration files.
 
-##### Collector image and mode
-
-Set the Collector to run as a single-replica Deployment or as a DaemonSet using the Contrib distribution:
-
-```yaml
-mode: deployment
-replicaCount: 1
-
-image:
-  repository: otel/opentelemetry-collector-contrib
-  tag: 0.153.0
-  pullPolicy: IfNotPresent
-
-extraEnvs:
-  - name: DD_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: datadog-secret
-        key: api-key
-```
-
-To run as a DaemonSet, set `mode: daemonset` and remove `replicaCount`.
-
-##### Kubernetes objects collection
-
-The `kubernetesObjects` [preset][107] automatically provisions the service account, RBAC permissions, and `k8sobjects` receiver defaults required to populate Kubernetes Explorer. Override the receiver `interval` to `3m`, which is required for Kubernetes Explorer:
-
-```yaml
-presets:
-  kubernetesObjects:
-    enabled: true
-    watch: true
-
-config:
-  receivers:
-    k8sobjects:
-      interval: 3m
-```
-
-##### Datadog exporter
-
-Enable the `orchestrator_explorer` option in the Datadog Exporter. This is the setting that sends Kubernetes object data to the Explorer. Replace `<YOUR_DATADOG_SITE>` with your [Datadog site][104]:
-
-```yaml
-config:
-  exporters:
-    datadog:
-      api:
-        site: <YOUR_DATADOG_SITE>
-        key: ${env:DD_API_KEY}
-      orchestrator_explorer:
-        enabled: true
-```
-
-##### Processors and pipeline
-
-Add a [`resourcedetection`][105] processor to detect the cluster UID and name.
-
-- The `k8s_api` detector is required to detect the cluster UID (`k8s.cluster.uid`).
-- Cluster name detection depends on your cloud provider. Check the [`resourcedetection` processor documentation][105] for supported providers (EKS, AKS, GCP) and required permissions.
-- If your provider is not supported, use a `resource/add-cluster-name` processor to set the cluster name manually. Replace `<YOUR_CLUSTER_NAME>` with your cluster name.
-
-Then connect the components in a `logs` pipeline.
-
-The following examples show two approaches. Use the cloud provider example if you run on EKS, AKS, or GCP. Use the manual fallback if your provider is not supported.
-
-**Cloud provider detection (EKS example):**
-
-```yaml
-  processors:
-    resourcedetection:
-      detectors: [k8s_api, eks]
-      override: false
-      eks:
-        resource_attributes:
-          k8s.cluster.name:
-            enabled: true
-
-  service:
-    pipelines:
-      logs:
-        receivers: [k8sobjects]
-        processors: [resourcedetection]
-        exporters: [datadog]
-```
-
-Replace `eks` with your provider's detector (`aks`, `gcp`). See the [`resourcedetection` processor documentation][105] for provider-specific configuration.
-
-**Manual fallback:**
-
-If the `resourcedetection` processor does not support your cloud provider, set the cluster name manually. Replace `<YOUR_CLUSTER_NAME>` with your cluster name:
-
-```yaml
-  processors:
-    resourcedetection:
-      detectors: [k8s_api]
-      override: false
-    resource/add-cluster-name:
-      attributes:
-        - key: k8s.cluster.name
-          value: <YOUR_CLUSTER_NAME>
-          action: upsert
-
-  service:
-    pipelines:
-      logs:
-        receivers: [k8sobjects]
-        processors: [resourcedetection, resource/add-cluster-name]
-        exporters: [datadog]
-```
-
-#### 3. Deploy with Helm
-
-Install the OpenTelemetry Collector using your configuration file:
-
-```sh
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-helm repo update
-
-helm install deployment-collector open-telemetry/opentelemetry-collector \
-  --values ./deployment-collector.yaml
-```
-
-#### 4. Verify the installation
+#### Verify the installation
 
 Open the [Kubernetes Explorer][1] and filter by your OpenTelemetry cluster name. All core Kubernetes resource sections should populate, along with **Custom Resources > CRD**. The **Custom Resources > Resources** section is not supported with this setup.
 
-#### 5. Correlate logs, metrics, and traces with Kubernetes Explorer (optional)
+#### Correlate logs, metrics, and traces with Kubernetes Explorer
 
-To navigate between Kubernetes resources and their related logs, metrics, and traces, add the [`k8sattributes`][108] and [`resourcedetection`][105] processors to your existing collector pipelines. For `resourcedetection` configuration, see [Processors and pipeline](#processors-and-pipeline) above.
+The reference configurations use the [`k8sattributes`][108] and [`resourcedetection`][105] processors to enrich telemetry with the Kubernetes and cluster metadata used for correlation. They define the Kubernetes Attributes processor explicitly to customize metadata extraction and pod association for each Collector.
+
+If your custom Collector configuration does not require these overrides, enable the `kubernetesAttributes` [Helm preset][107] on the Collector that receives your application telemetry. The preset adds the required RBAC permissions and applies the `k8sattributes` processor defaults to the enabled logs, metrics, and traces pipelines:
 
 ```yaml
-processors:
-  k8sattributes:
-    auth_type: "serviceAccount"
-    extract:
-      metadata:
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.deployment.name
-        - k8s.namespace.name
-        - k8s.node.name
-        - k8s.replicaset.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.container.name
-    pod_association:
-      - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-      - sources:
-          - from: resource_attribute
-            name: k8s.pod.ip
-      - sources:
-          - from: resource_attribute
-            name: k8s.pod.name
-          - from: resource_attribute
-            name: k8s.namespace.name
-      - sources:
-          - from: connection
-
-service:
-  pipelines:
-    logs:
-      processors: [k8sattributes, resourcedetection, ...]
-    metrics:
-      processors: [k8sattributes, resourcedetection, ...]
-    traces:
-      processors: [k8sattributes, resourcedetection, ...]
+presets:
+  kubernetesAttributes:
+    enabled: true
 ```
 
-For a complete reference example, see the [DaemonSet collector configuration][109].
+Configure the `resourcedetection` processor for your cloud provider or set `k8s.cluster.name` manually. See the reference configurations for both approaches.
 
 [1]: https://app.datadoghq.com/orchestration/overview
 [100]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 [101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [102]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0
-[104]: /getting_started/site/
 [105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 [106]: https://kubernetes.io/blog/2025/05/09/kubernetes-v1-33-streaming-list-responses/
 [107]: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/opentelemetry-collector-0.156.2/charts/opentelemetry-collector
 [108]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
 [109]: https://github.com/DataDog/opentelemetry-examples/blob/main/guides/kubernetes/configuration/daemonset-collector.yaml
+[110]: https://github.com/DataDog/opentelemetry-examples/blob/main/guides/kubernetes/configuration/cluster-collector.yaml
 [111]: /opentelemetry/integrations/kubernetes_metrics/#setup
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

**This one needs input from the feature owners before it goes anywhere — it changes how the setup is documented, not just how it reads.**

The OpenTelemetry tab of the Kubernetes Explorer page currently walks through several configuration fragments, then a Helm install step, then another fragment that requires editing the values file and redeploying, and finally links to a complete reference configuration. Readers end up with two competing paths to follow.

This PR replaces the fragments with a pointer to the [Kubernetes Metrics setup guide](https://docs.datadoghq.com/opentelemetry/integrations/kubernetes_metrics/#setup) and its maintained `cluster-collector.yaml` and `daemonset-collector.yaml` reference configurations, keeping a summary of what the Cluster Collector configuration does for Kubernetes Explorer: the `kubernetesObjects` preset, the `3m` `k8sobjects` interval, `resourcedetection`, and `orchestrator_explorer`.

It also recommends the `kubernetesAttributes` Helm preset for custom Collector configurations that don't need custom metadata extraction or pod association, rather than copying a long processor block.

Open questions for reviewers:

- The tab no longer contains a copy-pasteable Collector configuration. Is delegating to the reference configs the right call for a setup that just went GA?
- The Kubernetes Metrics path installs `kube-state-metrics` and two Collectors. Kubernetes Explorer alone only needs the Cluster Collector, so readers who want just the Explorer follow a heavier setup than they strictly need.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Codex, then reviewed with Claude Code. Claude verified each claim about the reference configurations and Helm presets against the upstream `DataDog/opentelemetry-examples` files and the pinned `opentelemetry-collector` chart templates.

### Additional notes

The reference configurations in `DataDog/opentelemetry-examples` still define the Kubernetes Attributes processor explicitly rather than using the `kubernetesAttributes` preset. That looks intentional (they customize metadata extraction and pod association), but simplifying them is a possible follow-up in that repo.

Note that DOCS-15427 asks for a site-availability header on this same tab, since the feature isn't available on US1-FED or US2-FED. That change would touch the section this PR restructures.
