### PR TITLE
Set the Datadog site in the Kubernetes Metrics setup secret

### DIFF
--- a/hugo/content/en/opentelemetry/integrations/kubernetes_metrics.md
+++ b/hugo/content/en/opentelemetry/integrations/kubernetes_metrics.md
@@ -48,13 +48,16 @@ helm repo update
 helm install kube-state-metrics prometheus-community/kube-state-metrics
 ```
 
-#### 2. Create a Datadog API key secret
+#### 2. Create a Datadog configuration secret
 
-Create a Kubernetes secret to store your Datadog API key:
+Create a Kubernetes secret to store your Datadog API key and [site][12]. Replace `<YOUR_DATADOG_SITE>` with your Datadog site, such as `datadoghq.com` or `datadoghq.eu`:
 
 ```sh
 export DD_API_KEY="<YOUR_DATADOG_API_KEY>"
-kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
+export DD_SITE="<YOUR_DATADOG_SITE>"
+kubectl create secret generic datadog-secret \
+  --from-literal api-key="$DD_API_KEY" \
+  --from-literal dd-site="$DD_SITE"
 ```
 
 #### 3. Install the OpenTelemetry Collectors
@@ -180,3 +183,4 @@ The [count connector][11] generates object-count metrics by counting the number 
 [9]: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/opentelemetry-collector-0.156.2/charts/opentelemetry-collector
 [10]: /containers/monitoring/kubernetes_explorer/
 [11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector
+[12]: /getting_started/site/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The reference Collector configurations in the Kubernetes Metrics setup read the Datadog site from a `dd-site` secret key that falls back to `datadoghq.com`:

```yaml
site: ${env:DD_SITE:-datadoghq.com}
```

The setup step created the secret with only an API key, so customers on any other site had no instruction to set it and their data would go to US1.

This PR adds the site to the secret creation step and links to the Datadog site reference.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Found and verified with Claude Code, which checked the secret key name and site value format against the reference configurations in `DataDog/opentelemetry-examples`.

### Additional notes

Independent of the other two Kubernetes Explorer PRs; this one is a standalone correctness fix.
