### PR TITLE
Align IaC Security docs with Rule Type terminology

### DIFF
--- a/hugo/content/en/security/code_security/iac_security/configuration.md
+++ b/hugo/content/en/security/code_security/iac_security/configuration.md
@@ -18,7 +18,7 @@ further_reading:
     text: "IaC Security Rules"
 ---
 
-Infrastructure as Code (IaC) Security detects IaC misconfigurations. By default, IaC Security scans repositories with [all supported rules][3]. You can customize which rules run and on which paths, as well as their severities and categories. Configure these settings under the `iac` key in the Code Security configuration, either in Datadog or in a `code-security.datadog.yaml` file.
+Infrastructure as Code (IaC) Security detects IaC misconfigurations. By default, IaC Security scans repositories with [all supported rules][3]. You can customize which rules run and on which paths, as well as their severities and rule types. Configure these settings under the `iac` key in the Code Security configuration, either in Datadog or in a `code-security.datadog.yaml` file.
 
 For information on configuration locations, precedence, and merging, see [Code Security Configuration Reference][1].
 
@@ -26,7 +26,7 @@ For information on configuration locations, precedence, and merging, see [Code S
 
 You can configure IaC Security using:
 
-- Datadog or a `code-security.datadog.yaml` file for repository-wide rule, severity, category, and path settings. Use this method when you want the same configuration to apply across a repository or organization.
+- Datadog or a `code-security.datadog.yaml` file for repository-wide rule, severity, rule type, and path settings. Use this method when you want the same configuration to apply across a repository or organization.
 - Inline comments for local, file-specific exclusions that should stay with the IaC file. Use this method when an exception applies to a specific line, block, or file.
 
 ## Configuration format
@@ -64,10 +64,10 @@ iac:
     only-severities:
       - high
       - critical
-    # Do not report findings in these categories.
+    # Do not report findings with these rule types.
     ignore-categories:
       - "Best Practices"
-    # Report only findings in these categories.
+    # Report only findings with these rule types.
     only-categories:
       - "Encryption"
     # Do not run rules from these platforms.
@@ -136,8 +136,8 @@ The `global-config` object controls repository-wide settings:
 | `ignore-paths` | Array | File paths or glob patterns to exclude. Matching files are not analyzed. |
 | `only-severities` | Array | Severity levels to report. Findings with other severities are not reported. |
 | `ignore-severities` | Array | Severity levels to ignore. |
-| `only-categories` | Array | Categories to report. Findings in other categories are not reported. |
-| `ignore-categories` | Array | Categories to ignore. |
+| `only-categories` | Array | Rule types to report. Findings with other rule types are not reported. |
+| `ignore-categories` | Array | Rule types to ignore. |
 | `ignore-platforms` | Array | Platforms to skip. Rules from these platforms are not applied. |
 | `only-platforms` | Array | Platforms to scan. Rules from other platforms are not applied. |
 
@@ -175,9 +175,9 @@ iac:
       - "**/config.file"
 {{< /code-block >}}
 
-### Categories
+### Rule types
 
-Use `ignore-categories` to ignore findings in specific categories. Use `only-categories` to report only specific categories.
+Use `ignore-categories` to ignore findings with specific rule types. Use `only-categories` to report only specific rule types.
 
 **Possible values:**
 

--- a/hugo/layouts/iac_security/list.html
+++ b/hugo/layouts/iac_security/list.html
@@ -85,7 +85,7 @@
             *   }
             *   show ruleEl if condition met (aws OR azure) AND (terraform OR kubernetes) AND security AND warning
             *
-            *   Filter info structure: [cloud_provider, category, severity, platform]
+            *   Filter info structure: [cloud_provider, rule_type, severity, platform]
             *   Map each filter type to its specific index position
             */
 
@@ -372,11 +372,12 @@
         {{/*  NAV - Keep here. scratch pad for filters need to form first */}}
         <nav id="multifilter-search-nav" class="container px-0">
             {{ $filter_types := (slice "Providers" "Platforms" "Categories" "Severities") }}
+            {{ $filter_type_labels := dict "Categories" "Rule Types" }}
             <div class="filters__multifilter row">
                 {{ range $filter_types }}
                 {{ $filter_type := . | lower}}
                 <div class='filter-type flex-column col-12 col-md-6' data-id="{{$filter_type}}" >
-                    <p class="filter-type-name fw-semibold">{{ . }}</p>
+                    <p class="filter-type-name fw-semibold">{{ index $filter_type_labels . | default . }}</p>
                     <div class="filter-component position-relative">
                         {{/*  FILTER TOGGLER  */}}
                         <button


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Aligns IaC Security public documentation with the product UI, which uses **Rule Type** (not "category") for IaC rule classification.

## Changes

- **`iac_security/configuration.md`**: Update user-facing prose and the section heading from "Categories" to "Rule types". YAML keys (`ignore-categories`, `only-categories`) are unchanged, as this is how they are programmatically defined to be handled by the scanner, it would be a breaking change.
- **`layouts/iac_security/list.html`**: Rename the public IaC Rules browser filter label from "Categories" to "Rule Types".

## Merge readiness

- [x] Ready for merge