### PR TITLE
feat(api): add date-based operation versioning

### DIFF
--- a/hugo/assets/scripts/build-api-pages.js
+++ b/hugo/assets/scripts/build-api-pages.js
@@ -245,6 +245,10 @@ const writeEndpointPage = (entry) => {
  */
 const createResources = (apiYaml, deref, apiVersion) => {
 
+  // Versioned oneOf variants are paired positionally with these dates,
+  // oldest to newest, so each schema can be diffed against its predecessor.
+  const versionDates = Object.keys((deref["x-datadog-api-versioning"] || {}).versions || {}).sort();
+
   apiYaml.tags.forEach((tag) => {
     const jsonData = {};
     const newDirName = getTagSlug(tag.name);
@@ -266,8 +270,16 @@ const createResources = (apiYaml, deref, apiVersion) => {
           const requestSchema = getSchema(action.requestBody.content);
           const requestJson = filterExampleJson("request", requestSchema);
           const requestCurlJson = filterExampleJson("curl", requestSchema);
-          const requestHtml = schemaTable("request", requestSchema);
+          const requestHtml = schemaTable("request", (requestSchema && requestSchema["x-datadog-api-versioned"])
+            ? pruneLargeOneOf(requestSchema)
+            : requestSchema);
           request = {"json_curl": requestCurlJson, "json": requestJson, "html": requestHtml};
+          if (requestSchema && requestSchema["x-datadog-api-versioned"] && Array.isArray(requestSchema.oneOf)) {
+            const pruned = requestSchema.oneOf.map((variant) => pruneLargeOneOf(variant));
+            assertVersionAlignment(action.operationId, "request", pruned.length, versionDates);
+            request.versionedHtml = pruned.map((variant, index) => schemaTable("request", variant, false, pruned[index - 1], versionDates[index]));
+            request.versionedJson = pruned.map((variant) => variant.example || filterExampleJson("request", variant));
+          }
           console.log(`successfully wrote ${pageDir}${action.operationId} html`);
         }
 
@@ -277,8 +289,19 @@ const createResources = (apiYaml, deref, apiVersion) => {
             if(response.content) {
               const responseSchema = getSchema(response.content);
               const responseJson = filterExampleJson("response", responseSchema);
-              const responseHtml = schemaTable("response", responseSchema);
-              responses[responseCode] = {"json": responseJson, "html": responseHtml};
+              const responseHtml = schemaTable("response", (responseSchema && responseSchema["x-datadog-api-versioned"])
+                ? pruneLargeOneOf(responseSchema)
+                : responseSchema);
+              const responseEntry = {"json": responseJson, "html": responseHtml};
+              // Date-based API versioning: render each schema variant separately so
+              // Hugo can switch the model and example panes with the version dropdown.
+              if (responseSchema && responseSchema["x-datadog-api-versioned"] && Array.isArray(responseSchema.oneOf)) {
+                const pruned = responseSchema.oneOf.map((variant) => pruneLargeOneOf(variant));
+                assertVersionAlignment(action.operationId, `response ${responseCode}`, pruned.length, versionDates);
+                responseEntry.versionedHtml = pruned.map((variant, index) => schemaTable("response", variant, false, pruned[index - 1], versionDates[index]));
+                responseEntry.versionedJson = pruned.map((variant) => variant.example || filterExampleJson("response", variant));
+              }
+              responses[responseCode] = responseEntry;
               console.log(`successfully wrote ${pageDir}${action.operationId}_response_${responseCode} html`);
             }
         });
@@ -707,6 +730,7 @@ const filterExampleJson = (actionType, data) => {
   const requiredKeys = getInitialRequiredData(data);
 
   // just return the example in additionalProperties cases with example
+  // just return the example in additionalProperties cases with example
   // just return the example if theres a top-level example and its response
   if(data.additionalProperties && data.example || data.example && actionType === 'response') {
     return data.example;
@@ -754,7 +778,7 @@ const isReadOnlyRow = (value) => {
  * @param {string} parentKey - optional key of the parent object
  * returns html column
  */
-const fieldColumn = (key, value, toggleMarkup, requiredMarkup, parentKey = '') => {
+const fieldColumn = (key, value, toggleMarkup, requiredMarkup, parentKey = '', markerMarkup = '') => {
   let field = '';
   if(['type'].includes(key) && (typeof value !== 'object') && (key !== "&lt;any-key&gt;")) {
     field = '';
@@ -763,7 +787,7 @@ const fieldColumn = (key, value, toggleMarkup, requiredMarkup, parentKey = '') =
   }
   return `
     <div class="col-4 column">
-      <p class="key table-cell">${toggleMarkup}${field}${requiredMarkup}</p>
+      <p class="key table-cell">${toggleMarkup}${field}${requiredMarkup}${markerMarkup}</p>
     </div>
   `.trim();
 };
@@ -949,6 +973,41 @@ const getOneOfChildData = (items) => {
 
 
 /**
+ * Given a field's schema `value`, resolves the nested properties dict rowRecursive
+ * should recurse into (array items, object properties, additionalProperties, oneOf),
+ * or null if the field has no nested structure. Factored out of rowRecursive so the
+ * same resolution can be applied to a field's *previous*-version value when diffing
+ * for D5 New/Changed/Removed markers.
+ * @param {object} value - part of a schema object
+ * returns {object|null} childData
+ */
+const extractChildData = (value) => {
+  let childData = null;
+  if (!value || typeof value !== 'object') return null;
+  if (value.type === 'array') {
+    if (typeof value.items === 'object') {
+      if (value.items.properties) {
+        childData = value.items.properties;
+      }
+      if (value.items.oneOf && value.items.oneOf instanceof Array && value.items.oneOf.length < oneOfLimit) {
+        childData = getOneOfChildData(value.items.oneOf);
+      }
+    }
+  } else if ("properties" in value) {
+    childData = value.properties;
+  } else if ("additionalProperties" in value) {
+    if (Object.keys(value.additionalProperties).length !== 0) {
+      childData = {"&lt;any-key&gt;": value.additionalProperties};
+    }
+  } else if ("oneOf" in value) {
+    if (value.oneOf instanceof Array && value.oneOf.length < oneOfLimit) {
+      childData = getOneOfChildData(value.oneOf);
+    }
+  }
+  return childData;
+};
+
+/**
  * Takes a application/json schema for request or response and outputs a table
  * @param {string} tableType - string 'request' or 'response'
  * @param {object} data - schema object
@@ -957,9 +1016,15 @@ const getOneOfChildData = (items) => {
  * @param {number} level - how deep does the rabbit hole go?
  * @param {string} parentKey - parent key
  * @param {boolean} skipAnyKeys - whether to skip <any-key> rows
+ * @param {object|null} prevData - the same-shaped properties dict from the prior
+ *   date-versioned variant, used to mark rows New/Removed relative to it (D5).
+ *   Only diffed when the field exists (unchanged presence) in both — a field new
+ *   or removed at this level isn't diffed further down.
+ * @param {string} versionLabel - the date this variant belongs to, shown in
+ *   "Added in {versionLabel}" / "Removed in {versionLabel}" markers.
  * returns html row with nested rows
  */
-const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, parentKey = '', skipAnyKeys = false) => {
+const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, parentKey = '', skipAnyKeys = false, prevData = null, versionLabel = '') => {
   let html = '';
   let newRequiredFields;
 
@@ -976,57 +1041,33 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
   if(level > 10) return '';
 
     if (typeof data === 'object') {
-      Object.entries(data).forEach(([key, value]) => {
+      const prevObj = (prevData && typeof prevData === 'object') ? prevData : null;
+      const keys = Object.keys(data);
+      if (prevObj) {
+        Object.keys(prevObj).forEach((k) => { if (!keys.includes(k)) keys.push(k); });
+      }
+
+      keys.forEach((key) => {
+        const isRemoved = !(key in data);
+        const existedBefore = !!(prevObj && key in prevObj);
+        const isNew = !!(versionLabel && prevObj && !isRemoved && !existedBefore);
+        const value = isRemoved ? prevObj[key] : data[key];
 
         // calculate child data in advance
         // we do this here so that we can add classes to html with this knowledge
-        let childData = null;
         let newParentKey = key;
-        if(value.type === 'array') {
-          if(typeof value.items === 'object') {
-            if (value.items.properties) {
-              childData = value.items.properties;
-              newRequiredFields = (value.items.required) ? value.items.required : [];
-            }
-            // for items -> oneOf
-            if (value.items.oneOf && value.items.oneOf instanceof Array && value.items.oneOf.length < oneOfLimit) {
-              childData = getOneOfChildData(value.items.oneOf);
-            }
-          } else if(typeof value.items === 'string') {
-            if(value.items === '[Circular]') {
-              childData = null;
-            }
-          }
+        let childData = extractChildData(value);
+        if(value.type === 'array' && typeof value.items === 'object' && value.items.properties) {
+          newRequiredFields = (value.items.required) ? value.items.required : [];
         } else if(typeof value === 'object' && "properties" in value) {
-          childData = value.properties;
           newRequiredFields = (value.required) ? value.required : [];
-        } else if (typeof value === 'object' && "additionalProperties" in value) {
-          // check if `additionalProperties` is an empty object
-          if(Object.keys(value.additionalProperties).length !== 0){
-            childData = {"&lt;any-key&gt;": value.additionalProperties};
-            newParentKey = "additionalProperties";
-          }
-        } else if (typeof value === 'object' && "oneOf" in value) {
-          // for properties -> oneOf
-          if(value.oneOf instanceof Array && value.oneOf.length < oneOfLimit) {
-            childData = getOneOfChildData(value.oneOf);
-          }
+        } else if (typeof value === 'object' && "additionalProperties" in value && childData) {
+          newParentKey = "additionalProperties";
         }
-        // for widgets
-        /*
-        if(key === "definition" && value.discriminator) {
-          childData = Object.keys(value.discriminator.mapping)
-            .map((mapkey, indx) => { return {[mapkey]: value.oneOf[indx]} })
-            .reduce((obj, item) => ({...obj, ...item}), {});
-        }
-        */
-        // console.log(childData);
-        // if(childData && "definition" in childData) {
-        //   console.log("YES!!!!")
-        //   console.log(childData)
-        //   childData = value["oneOf"];
-        // }
-
+        // Only keep diffing into a field that exists on both sides — a field
+        // that itself just appeared/disappeared doesn't need its children
+        // individually marked, the parent row's marker already covers it.
+        const childPrevData = (!isRemoved && !isNew && existedBefore) ? extractChildData(prevObj[key]) : null;
 
         if (skipAnyKeys && childData) {
           Object.entries(childData).forEach(([ckey, cvalue]) => {
@@ -1040,9 +1081,15 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
         }
 
         const isReadOnly = isReadOnlyRow(value);
+        const changeMarkerClass = isRemoved ? "isRemoved" : (isNew ? "isNew" : "");
+        const changeMarkerLabel = isRemoved ? `Removed in ${versionLabel}` : (isNew ? `Added in ${versionLabel}` : '');
+        const changeMarkerMarkup = changeMarkerLabel
+          ? ` <span class="schema-change-marker ${isRemoved ? "schema-change-marker-removed" : "schema-change-marker-new"}">${changeMarkerLabel}</span>`
+          : '';
+        const changeMarkerClassSuffix = changeMarkerClass ? ` ${changeMarkerClass}` : '';
 
         // build up row classes
-        const outerRowClasses = `${(isNested) ? "isNested d-none" : ""} ${(childData) ? "hasChildData" : ""} ${(isReadOnly) ? "isReadOnly" : ""}`;
+        const outerRowClasses = `${(isNested) ? "isNested d-none" : ""} ${(childData) ? "hasChildData" : ""} ${(isReadOnly) ? "isReadOnly" : ""}${changeMarkerClassSuffix}`;
         const nestedRowClasses = `first-row ${(childData) ? "js-collapse-trigger collapse-trigger" : ""} ${(isReadOnly) ? "isReadOnly" : ""}`;
 
         // build markdown
@@ -1055,11 +1102,11 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
         <div class="row ${outerRowClasses}">
           <div class="col-12 first-column">
             <div ${parentKey ? `data-parent-field="${parentKey}"` : ""} class="row table-row ${nestedRowClasses}">
-              ${fieldColumn(key, value, toggleArrow, required, parentKey)}
+              ${fieldColumn(key, value, toggleArrow, required, parentKey, changeMarkerMarkup)}
               ${typeColumn(key, value, readOnlyField)}
               ${descColumn(key, value)}
             </div>
-            ${(childData) ? rowRecursive(tableType, childData, true, (newRequiredFields || []), (level + 1), newParentKey, skipAnyKeys) : ''}
+            ${(childData) ? rowRecursive(tableType, childData, true, (newRequiredFields || []), (level + 1), newParentKey, skipAnyKeys, childPrevData, versionLabel) : ''}
           </div>
         </div>
         `.trim();
@@ -1071,37 +1118,94 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
 };
 
 /**
+ * Warns at build time when a date-versioned schema does not enumerate exactly one
+ * oneOf variant per declared version. The variant <-> version pairing is positional
+ * (see createResources), so a mismatch silently mislabels or blanks version panes.
+ * @param {string} operationId
+ * @param {string} schemaKind - e.g. "request" or "response 200"
+ * @param {number} variantCount - number of oneOf variants
+ * @param {string[]} versionDates - sorted list of declared version dates
+ */
+const assertVersionAlignment = (operationId, schemaKind, variantCount, versionDates) => {
+  if (variantCount !== versionDates.length) {
+    console.warn(
+      `WARNING: date-versioned ${schemaKind} schema for ${operationId} has ${variantCount} ` +
+      `oneOf variant(s) but ${versionDates.length} declared version(s) ` +
+      `(${versionDates.join(", ")}). Variant<->version pairing is positional; ` +
+      `enumerate one oneOf variant per version, oldest -> newest, or panes will be mislabeled/blank.`
+    );
+  }
+};
+
+/**
+ * Deep-clone a schema while replacing any oneOf whose length exceeds a threshold
+ * with a single-line stub. Used when pre-rendering versioned schema variants to
+ * avoid re-expanding large shared subtrees (e.g. WidgetDefinition, ~40 variants)
+ * per version. The threshold is set above the size of any legitimate per-field
+ * union so real polymorphic fields still render in full — only the big shared
+ * component trees get stubbed. (Non-versioned tables expand unions up to
+ * oneOfLimit=50; this is deliberately lower to catch the shared trees.)
+ */
+const pruneLargeOneOf = (schema, threshold = 25, depth = 0) => {
+  if (depth > 20) return schema;
+  if (!schema || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map((s) => pruneLargeOneOf(s, threshold, depth + 1));
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length > threshold) {
+    return { type: schema.type || 'object', description: schema.description || '' };
+  }
+  const out = {};
+  for (const [k, v] of Object.entries(schema)) {
+    out[k] = pruneLargeOneOf(v, threshold, depth + 1);
+  }
+  return out;
+};
+
+/**
+ * Resolves the same "what does rowRecursive iterate over" logic schemaTable
+ * uses for `data`, applied to a schema object generically — used to derive
+ * `initialData` for both the current variant and (when diffing, D5) the
+ * prior date-versioned variant, which won't necessarily share the same shape
+ * (e.g. array vs plain object) but still needs the same extraction rules.
+ * @param {object|null} data - schema object, or null
+ * returns {object|null} initialData
+ */
+const resolveInitialData = (data) => {
+  if (!data || typeof data !== 'object') return null;
+  if (data.type === 'array') {
+    // A pruned oneOf stub or malformed variant can be type:'array' with no items;
+    // bail out rather than deref undefined (this runs for prevData too now).
+    if (!data.items || typeof data.items !== 'object') return null;
+    if (data.items.type === 'array') {
+      return data.items.items && data.items.items.properties;
+    } else if (data.items.properties) {
+      return data.items.properties;
+    }
+    return data.items;
+  } else if (data.additionalProperties) {
+    return {"&lt;any-key&gt;": data.additionalProperties};
+  } else if (data.oneOf && data.oneOf.length > 0) {
+    // we don't have access to oneOf names in json so lets set them as "Option n"
+    return data.oneOf
+      .map((object, index) => ({[`Option ${index + 1}`]: object}))
+      .reduce((output, item) => ({...output, ...item}), {});
+  }
+  return data.properties;
+};
+
+/**
  * Takes a application/json schema for request or response and outputs a table
  * @param {string} tableType - 'request' or 'response'
  * @param {object} data - schema object
  * @param {boolean} skipAnyKeys - whether to skip <any-key>
+ * @param {object|null} prevData - the same-shaped schema object from the prior
+ *   date-versioned variant, if any (D5 New/Changed/Removed field diffing).
+ * @param {string} versionLabel - the date this variant belongs to.
  * returns html table string
  */
-const schemaTable = (tableType, data, skipAnyKeys = false) => {
-  let extraClasses = '';
-  let initialData;
-  if(data.type === 'array') {
-    if(data.items.type === 'array') {
-      initialData = data.items.items.properties;
-    } else if(data.items.properties) {
-      initialData = data.items.properties;
-    } else {
-      initialData = data.items;
-      extraClasses = 'hide-table';
-    }
-  } else if(data.additionalProperties) {
-    initialData = {"&lt;any-key&gt;": data.additionalProperties};
-  } else if(data.oneOf && data.oneOf.length > 0) {
-    // we don't have access to oneOf names in json so lets set them as "Option n"
-    initialData = data.oneOf
-      .map((obj, indx) => {
-        return {[`Option ${indx + 1}`]: data.oneOf[indx]}
-      })
-      .reduce((obj, item) => ({...obj, ...item}), {});
-  } else {
-    initialData = data.properties;
-  }
-  extraClasses = (initialData) ? extraClasses : 'hide-table';
+const schemaTable = (tableType, data, skipAnyKeys = false, prevData = null, versionLabel = '') => {
+  const initialData = resolveInitialData(data);
+  const prevInitialData = resolveInitialData(prevData);
+  const extraClasses = (initialData) ? (data.type === 'array' && data.items && !data.items.properties && data.items.type !== 'array' ? 'hide-table' : '') : 'hide-table';
   const emptyRow = `
     <div class="row">
       <div class="col-12 first-column">
@@ -1110,7 +1214,7 @@ const schemaTable = (tableType, data, skipAnyKeys = false) => {
         </div>
       </div>
     </div>`.trim();
-  return `<div class="${extraClasses}">${(initialData) ? rowRecursive(tableType, initialData, false, data.required || [], 0, '', skipAnyKeys) : emptyRow}</div>`;
+  return `<div class="${extraClasses}">${(initialData) ? rowRecursive(tableType, initialData, false, data.required || [], 0, '', skipAnyKeys, prevInitialData, versionLabel) : emptyRow}</div>`;
 };
 
 /**

--- a/hugo/assets/scripts/build-api-pages.js
+++ b/hugo/assets/scripts/build-api-pages.js
@@ -730,7 +730,6 @@ const filterExampleJson = (actionType, data) => {
   const requiredKeys = getInitialRequiredData(data);
 
   // just return the example in additionalProperties cases with example
-  // just return the example in additionalProperties cases with example
   // just return the example if theres a top-level example and its response
   if(data.additionalProperties && data.example || data.example && actionType === 'response') {
     return data.example;

--- a/hugo/assets/scripts/components/api.js
+++ b/hugo/assets/scripts/components/api.js
@@ -295,51 +295,34 @@ function getVersionLifecycle(block, version) {
     const entry = meta[version] || {};
     const remaining = daysUntil(entry.eol);
     const eolPast = remaining !== null && remaining < 0;
-    const eolSoon = remaining !== null && remaining >= 0 && remaining <= 90;
     return {
         deprecated: !!entry.deprecated,
-        eol: entry.eol || '',
         eolPast,
-        urgent: eolPast || eolSoon,
     };
 }
 
 const apiVersionBlocks = document.querySelectorAll('.api-version-block');
 
 // Applies `version` to an operation and updates
-// every piece of UI that reflects it: the chip, dropdown selection, and the
+// every piece of UI that reflects it: the button, dropdown selection, and the
 // underlying versioned panes / curl header.
 function applyApiVersion(operationId, version) {
     const block = document.querySelector(`.api-version-block[data-operation-id="${operationId}"]`);
     if (!block) return;
-    const { latestVersion } = block.dataset;
-    const isLatest = version === latestVersion;
     const lifecycle = getVersionLifecycle(block, version);
 
     const label = block.querySelector('.js-api-version-label');
     if (label) label.textContent = version;
 
-    const dot = block.querySelector('.js-api-version-dot');
-    if (dot) {
-        dot.classList.toggle('api-version-dot-green', isLatest);
-        dot.classList.toggle('api-version-dot-amber', !isLatest);
-    }
-
-    const chipPill = block.querySelector('.js-api-version-chip-pill');
-    if (chipPill) {
-        chipPill.classList.toggle('d-none', !lifecycle.deprecated);
-        chipPill.classList.toggle('is-urgent', lifecycle.urgent);
-        chipPill.textContent = lifecycle.eolPast ? 'End of life' : 'Deprecated';
-    }
-
-    const toggle = block.querySelector('.js-api-version-toggle');
-    if (toggle) {
-        toggle.classList.toggle('is-deprecated', lifecycle.deprecated);
+    const lifecycleLabel = block.querySelector('.js-api-version-lifecycle');
+    if (lifecycleLabel) {
+        lifecycleLabel.classList.toggle('d-none', !lifecycle.deprecated);
+        lifecycleLabel.textContent = lifecycle.eolPast ? 'End of life' : 'Deprecated';
     }
 
     block.querySelectorAll('.js-api-version-item').forEach((item) => {
         const selected = item.dataset.apiDateVersion === version;
-        item.classList.toggle('active', selected);
+        item.setAttribute('aria-current', selected ? 'true' : 'false');
         const check = item.querySelector('.js-api-version-check');
         if (check) check.classList.toggle('d-none', !selected);
     });

--- a/hugo/assets/scripts/components/api.js
+++ b/hugo/assets/scripts/components/api.js
@@ -254,6 +254,132 @@ if (changelogRoot) {
     });
 }
 
+// Date-based per-operation API version control (x-datadog-api-versioning)
+const apiVersionQueryParameter = 'datadog-api-version';
+
+function getRequestedApiVersion(block) {
+    const { apiMajorVersion, versions } = block.dataset;
+    const requestedVersion = new URLSearchParams(window.location.search).get(apiVersionQueryParameter);
+    const prefix = `${apiMajorVersion}-`;
+
+    if (!requestedVersion || !apiMajorVersion || !requestedVersion.startsWith(prefix)) return null;
+
+    const dateVersion = requestedVersion.slice(prefix.length);
+    return versions.split(',').includes(dateVersion) ? dateVersion : null;
+}
+
+function setRequestedApiVersion(block, version) {
+    const { apiMajorVersion } = block.dataset;
+    if (!apiMajorVersion) return;
+
+    const url = new URL(window.location.href);
+    url.searchParams.set(apiVersionQueryParameter, `${apiMajorVersion}-${version}`);
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
+function daysUntil(dateStr) {
+    if (!dateStr) return null;
+    const msPerDay = 24 * 60 * 60 * 1000;
+    return Math.round((new Date(dateStr) - new Date()) / msPerDay);
+}
+
+// Reads a version's { deprecated, eol } off the block's data-version-meta
+// JSON blob and derives escalation state for the lifecycle pill.
+function getVersionLifecycle(block, version) {
+    let meta = {};
+    try {
+        meta = JSON.parse(block.dataset.versionMeta || '{}');
+    } catch (err) {
+        meta = {};
+    }
+    const entry = meta[version] || {};
+    const remaining = daysUntil(entry.eol);
+    const eolPast = remaining !== null && remaining < 0;
+    const eolSoon = remaining !== null && remaining >= 0 && remaining <= 90;
+    return {
+        deprecated: !!entry.deprecated,
+        eol: entry.eol || '',
+        eolPast,
+        urgent: eolPast || eolSoon,
+    };
+}
+
+const apiVersionBlocks = document.querySelectorAll('.api-version-block');
+
+// Applies `version` to an operation and updates
+// every piece of UI that reflects it: the chip, dropdown selection, and the
+// underlying versioned panes / curl header.
+function applyApiVersion(operationId, version) {
+    const block = document.querySelector(`.api-version-block[data-operation-id="${operationId}"]`);
+    if (!block) return;
+    const { latestVersion } = block.dataset;
+    const isLatest = version === latestVersion;
+    const lifecycle = getVersionLifecycle(block, version);
+
+    const label = block.querySelector('.js-api-version-label');
+    if (label) label.textContent = version;
+
+    const dot = block.querySelector('.js-api-version-dot');
+    if (dot) {
+        dot.classList.toggle('api-version-dot-green', isLatest);
+        dot.classList.toggle('api-version-dot-amber', !isLatest);
+    }
+
+    const chipPill = block.querySelector('.js-api-version-chip-pill');
+    if (chipPill) {
+        chipPill.classList.toggle('d-none', !lifecycle.deprecated);
+        chipPill.classList.toggle('is-urgent', lifecycle.urgent);
+        chipPill.textContent = lifecycle.eolPast ? 'End of life' : 'Deprecated';
+    }
+
+    const toggle = block.querySelector('.js-api-version-toggle');
+    if (toggle) {
+        toggle.classList.toggle('is-deprecated', lifecycle.deprecated);
+    }
+
+    block.querySelectorAll('.js-api-version-item').forEach((item) => {
+        const selected = item.dataset.apiDateVersion === version;
+        item.classList.toggle('active', selected);
+        const check = item.querySelector('.js-api-version-check');
+        if (check) check.classList.toggle('d-none', !selected);
+    });
+
+    document.querySelectorAll(`.api-versioned-pane[data-operation-id="${operationId}"]`).forEach((pane) => {
+        pane.classList.toggle('d-none', pane.dataset.apiDateVersion !== version);
+    });
+    document.querySelectorAll(`.api-version-header-value[data-operation-id="${operationId}"]`).forEach((el) => {
+        el.textContent = version;
+    });
+}
+
+if (apiVersionBlocks.length) {
+    apiVersionBlocks.forEach((block) => {
+        const { operationId } = block.dataset;
+        const requestedVersion = getRequestedApiVersion(block);
+        if (requestedVersion) applyApiVersion(operationId, requestedVersion);
+    });
+
+    // Dropdown open/close is handled by Bootstrap's own dropdown component
+    // (data-bs-toggle="dropdown"); only selection needs custom wiring.
+    document.addEventListener('click', (e) => {
+        const item = e.target.closest('.js-api-version-item');
+        if (!item) return;
+        e.preventDefault();
+        const { apiDateVersion: version } = item.dataset;
+        const selectedBlock = item.closest('.api-version-block');
+        setRequestedApiVersion(selectedBlock, version);
+
+        // A page-level version query can apply to more than one operation. Keep
+        // every compatible selector in sync so reloading a copied URL produces
+        // exactly the same view.
+        apiVersionBlocks.forEach((block) => {
+            const { operationId: blockOperationId, versions } = block.dataset;
+            if (versions.split(',').includes(version)) applyApiVersion(blockOperationId, version);
+        });
+    });
+}
+
+
 // Scroll the active top level nav item into view below Docs search input
 if (bodyClassContains('api')) {
     setSidenavMaxHeight();

--- a/hugo/assets/styles/pages/_api.scss
+++ b/hugo/assets/styles/pages/_api.scss
@@ -1,5 +1,511 @@
 // API
 $ddpurple: #632ca6;
+// Operation title actions: keep the version selector and copy-page control on
+// the same row as the title when space allows.
+.api-operation-header {
+    gap: 1rem;
+    margin-bottom: 0.75rem !important;
+    .api-copy-btn {
+        flex-shrink: 0;
+        margin-top: 0;
+    }
+}
+.api-operation-header-actions {
+    gap: 1rem;
+    margin-left: auto;
+}
+.api-operation-request-line {
+    gap: 1rem;
+    margin-top: 0.5rem;
+
+    .api-url-info {
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+
+    @include media-breakpoint-down(md) {
+        align-items: flex-start !important;
+
+        .api-version-block {
+            margin-top: 0.5rem;
+        }
+    }
+}
+// Date-based per-operation API version control (compact chip + dropdown).
+.api-version-block {
+    flex: 0 0 auto;
+}
+.api-version-selector-col {
+    position: relative;
+}
+// Same button+menu convention as the site's language/region picker.
+.api-version-chip {
+    height: 31px;
+    padding: 0 0.625rem;
+    font-size: 0.8125rem;
+    font-family: monospace;
+    color: $brand-primary;
+    background: $gray-lightest;
+    border: 1px solid $gray-light;
+    border-radius: 4px;
+    // The button's width hugs its content, so add an explicit chevron gap.
+    .chevron {
+        margin-left: 0.5rem;
+    }
+}
+.js-api-version-toggle {
+    cursor: pointer;
+    transition: border-color .12s ease, box-shadow .12s ease;
+    &.is-deprecated {
+        border-color: rgba($brand-warning, 0.6);
+        box-shadow: 0 0 0 2px rgba($brand-warning, 0.14);
+    }
+    &[aria-expanded="true"] {
+        border-color: $brand-info;
+        box-shadow: 0 0 0 3px rgba($brand-info, 0.2);
+    }
+}
+.api-version-chip-dot {
+    display: inline-block;
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+    &.api-version-dot-green {
+        background: $brand-success;
+    }
+    &.api-version-dot-amber {
+        background: $brand-warning;
+    }
+}
+.api-version-chip-date {
+    font-family: monospace;
+    font-size: 0.8125rem;
+    font-weight: 600;
+}
+// Shared pill geometry for the version chip/tag/marker pills below. Bootstrap's
+// .badge base class (padding/radius/line-height) isn't imported anywhere in this
+// codebase — only the .badge-white color modifier is (see whats-next/nextlink) —
+// so the pill shape is defined here once; each pill sets only its own margin and
+// semantic color.
+%api-pill-shape {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    vertical-align: middle;
+    border-radius: 50rem;
+}
+.api-version-chip-pill {
+    @extend %api-pill-shape;
+    margin-left: 0.5rem;
+    color: $brand-warning;
+    background: rgba($brand-warning, 0.14);
+    &.is-urgent {
+        color: $brand-danger;
+        background: rgba($brand-danger, 0.14);
+    }
+}
+.api-version-dropdown .dropdown-menu {
+    width: 306px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+    text-align: left;
+}
+.api-version-menu-header {
+    padding: 0.625rem 0.875rem 0.375rem;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: $gray;
+}
+.api-version-menu-list {
+    padding-bottom: 0.25rem;
+}
+.js-api-version-item {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8125rem;
+    color: #212529;
+    &:hover {
+        color: $brand-primary;
+        background: $gray-lighter;
+    }
+    &.active {
+        color: $brand-primary;
+        font-weight: 600;
+        background: $gray-lighter;
+        .api-version-menu-item-date {
+            font-weight: 700;
+        }
+    }
+}
+.api-version-menu-item-dot {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+    &.api-version-dot-green {
+        background: $brand-success;
+    }
+    &.api-version-dot-amber {
+        background: $brand-warning;
+    }
+}
+.api-version-menu-item-date {
+    flex: 0 0 auto;
+    font-family: monospace;
+}
+// Same pill shape as .api-version-chip-pill above, reused for dropdown-row tags
+// — only the semantic color is custom.
+.api-version-tag {
+    @extend %api-pill-shape;
+    margin-left: 0.5rem;
+    &.api-version-tag-latest {
+        color: $brand-success;
+        background: rgba($brand-success, 0.12);
+    }
+    &.api-version-tag-default {
+        color: $gray-dark;
+        background: $gray-lighter;
+    }
+    &.api-version-tag-deprecated {
+        color: $brand-warning;
+        background: rgba($brand-warning, 0.14);
+    }
+}
+.api-version-check {
+    margin-left: auto;
+    color: $brand-info;
+}
+.api-version-menu-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.625rem 0.875rem 0.75rem;
+    font-size: 0.75rem;
+    line-height: 1.35;
+    color: $gray-dark;
+    text-decoration: none;
+    &:hover {
+        color: $gray-dark;
+        background: $gray-lighter;
+        text-decoration: none;
+    }
+}
+.api-version-menu-notice-icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0.05rem;
+    border: 1px solid $gray-light;
+    border-radius: 50%;
+    color: $gray-dark;
+    font-family: serif;
+    font-size: 0.6875rem;
+    font-weight: 700;
+}
+.api-version-menu-notice-link {
+    display: inline-block;
+    margin-left: 0.2rem;
+    color: $brand-primary;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+// Date-versioned schema surfaces use a quiet toolbar to establish hierarchy:
+// the version is context, while Model and Example remain the controls.
+.api-schema-panel {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid $gray-light;
+    border-radius: 6px;
+    background: $white;
+}
+.api-schema-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.75rem;
+    min-height: 42px;
+    padding: 0.375rem 6.5rem 0.375rem 0.875rem;
+    background: $gray-lightest;
+    border-bottom: 1px solid $gray-light;
+}
+.api-schema-namespace {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    min-width: 0;
+    color: $gray-dark;
+
+    code {
+        padding: 0;
+        color: $gray-dark;
+        background: transparent;
+        font-size: 0.75rem;
+        white-space: nowrap;
+    }
+}
+.api-schema-namespace-label {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: $gray;
+}
+.api-schema-tabs {
+    flex: 0 0 auto;
+    gap: 0.25rem;
+    margin: 0 !important;
+    padding: 0 !important;
+
+    .nav-item {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    .nav-item .nav-link {
+        min-width: auto;
+        margin: 0 !important;
+        padding: 0.25rem 0.5rem !important;
+        border: 1px solid transparent !important;
+        border-radius: 3px;
+        color: $gray-dark !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        font-size: 0.75rem !important;
+        font-weight: 600;
+        line-height: 1.25;
+
+        &:hover {
+            color: $brand-primary !important;
+            background: $white !important;
+        }
+        &.active {
+            color: $brand-primary !important;
+            background: rgba($ddpurple, 0.08) !important;
+            border-color: rgba($ddpurple, 0.2) !important;
+        }
+    }
+}
+.api-schema-panel-body {
+    padding: 0.75rem;
+
+    .schema-table {
+        margin-top: 0;
+        margin-bottom: 0;
+
+        .expand-all {
+            top: -49px;
+            right: 0;
+            width: auto;
+            margin: 0;
+            padding: 0.25rem 0;
+            font-size: 0.75rem;
+            line-height: 1.25;
+            white-space: nowrap;
+        }
+    }
+    .code-snippet-wrapper {
+        margin-bottom: 0;
+    }
+}
+
+// Response codes, description, and schema form one continuous surface for
+// date-versioned operations instead of reading as three unrelated tab groups.
+.api-response-panel {
+    overflow: hidden;
+    border: 1px solid $gray-light;
+    border-radius: 6px;
+    background: $white;
+
+    .api-schema-panel {
+        border-top: 0;
+        border-right: 0;
+        border-bottom: 0;
+        border-left: 0;
+        border-radius: 0;
+    }
+}
+.api-response-status-tabs {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-height: 42px;
+    margin: 0 !important;
+    padding: 0.375rem 0.875rem !important;
+    background: $gray-lighter;
+    border-bottom: 1px solid $gray-light !important;
+
+    .api-response-status-label {
+        margin-right: 0.25rem;
+        color: $gray;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+    .nav-item {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    .nav-item .nav-link {
+        display: inline-flex;
+        align-items: center;
+        min-width: auto;
+        margin: 0 !important;
+        padding: 0.25rem 0.625rem !important;
+        border: 1px solid transparent !important;
+        border-radius: 3px;
+        color: $gray-dark !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        font-size: 0.75rem !important;
+        font-weight: 600;
+        line-height: 1.25;
+
+        &:hover {
+            color: $brand-primary !important;
+            background: $white !important;
+        }
+        &.active {
+            color: $brand-primary !important;
+            background: rgba($ddpurple, 0.08) !important;
+            border-color: rgba($ddpurple, 0.2) !important;
+        }
+    }
+}
+.api-response-status-description {
+    display: none;
+    margin-left: 0.375rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+.api-response-status-tabs .nav-link.active .api-response-status-description {
+    display: inline;
+}
+.api-response-tab-content {
+    margin-bottom: 0 !important;
+}
+
+// Date-versioned code samples follow the same two-tier surface as responses:
+// language selection is the header and the selected sample is its body.
+.api-code-panel {
+    overflow: hidden;
+    border: 1px solid $gray-light;
+    border-radius: 6px;
+    background: $white;
+}
+.api-code-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 42px;
+    padding: 0.375rem 0.875rem;
+    background: $gray-lighter;
+    border-bottom: 1px solid $gray-light;
+}
+.api-code-toolbar-label {
+    flex: 0 0 auto;
+    margin-right: 0.25rem;
+    color: $gray;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+.api-code-toolbar .code-lang-list-container {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: transparent !important;
+
+    .nav-item {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    .nav-link {
+        min-width: auto;
+        margin: 0 !important;
+        padding: 0.25rem 0.625rem !important;
+        border: 1px solid transparent !important;
+        border-radius: 3px;
+        color: $gray-dark !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        font-size: 0.75rem !important;
+        font-weight: 600;
+        line-height: 1.25;
+
+        &:hover {
+            color: $brand-primary !important;
+            background: $white !important;
+        }
+        &.active {
+            color: $brand-primary !important;
+            background: rgba($ddpurple, 0.08) !important;
+            border-color: rgba($ddpurple, 0.2) !important;
+        }
+    }
+}
+.api-code-panel-body {
+    padding: 0.75rem;
+
+    > .code-snippet-wrapper:last-of-type,
+    > .code-snippet-wrapper[style*="display: block"] {
+        margin-bottom: 0;
+    }
+}
+
+// Subtle dividers make the long operation page easier to scan without turning
+// every section into a separate card.
+.api-endpoint-date-versioned .endpoint-content > h3:not(:first-of-type) {
+    padding-top: 1.25rem;
+    margin-top: 1.5rem !important;
+    border-top: 1px solid $gray-light;
+}
+// Schema table row markers for fields added/removed between date-versioned
+// variants (see rowRecursive's prevData diffing in build-api-pages.js). Same
+// pill shape as .api-version-chip-pill; only margin and color are custom.
+.schema-change-marker {
+    @extend %api-pill-shape;
+    margin-left: 0.375rem;
+}
+.schema-change-marker-new {
+    color: $brand-success;
+    background: rgba($brand-success, 0.12);
+}
+.schema-change-marker-removed {
+    color: $gray;
+    background: $gray-lighter;
+}
+.row.isRemoved {
+    > .first-column > .table-row > .key,
+    .table-row .key {
+        text-decoration: line-through;
+        opacity: 0.7;
+    }
+}
+.row.isNew {
+    > .first-column > .table-row {
+        background: rgba($brand-success, 0.05);
+    }
+}
+
 
 // Both endpoint and category pages: flush right alongside the h1.
 .main-api .api-copy-btn,

--- a/hugo/assets/styles/pages/_api.scss
+++ b/hugo/assets/styles/pages/_api.scss
@@ -1,512 +1,81 @@
 // API
 $ddpurple: #632ca6;
-// Operation title actions: keep the version selector and copy-page control on
-// the same row as the title when space allows.
-.api-operation-header {
-    gap: 1rem;
-    margin-bottom: 0.75rem !important;
-    .api-copy-btn {
-        flex-shrink: 0;
-        margin-top: 0;
-    }
-}
-.api-operation-header-actions {
-    gap: 1rem;
-    margin-left: auto;
-}
+// Keep the per-operation selector aligned with the method and path it controls.
 .api-operation-request-line {
     gap: 1rem;
-    margin-top: 0.5rem;
 
     .api-url-info {
         min-width: 0;
         overflow-wrap: anywhere;
     }
-
-    @include media-breakpoint-down(md) {
-        align-items: flex-start !important;
-
-        .api-version-block {
-            margin-top: 0.5rem;
-        }
-    }
 }
-// Date-based per-operation API version control (compact chip + dropdown).
+
 .api-version-block {
     flex: 0 0 auto;
 }
-.api-version-selector-col {
-    position: relative;
-}
-// Same button+menu convention as the site's language/region picker.
-.api-version-chip {
-    height: 31px;
-    padding: 0 0.625rem;
-    font-size: 0.8125rem;
-    font-family: monospace;
-    color: $brand-primary;
-    background: $gray-lightest;
-    border: 1px solid $gray-light;
-    border-radius: 4px;
-    // The button's width hugs its content, so add an explicit chevron gap.
-    .chevron {
-        margin-left: 0.5rem;
+
+.api-version-selector {
+    .dropdown-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding-right: 10px;
+        font-weight: 400;
+        border-bottom: none !important;
     }
 }
-.js-api-version-toggle {
-    cursor: pointer;
-    transition: border-color .12s ease, box-shadow .12s ease;
-    &.is-deprecated {
-        border-color: rgba($brand-warning, 0.6);
-        box-shadow: 0 0 0 2px rgba($brand-warning, 0.14);
+
+.api-version-selector.language-region-select-container {
+    .btn {
+        width: auto;
+        min-width: 220px;
     }
-    &[aria-expanded="true"] {
-        border-color: $brand-info;
-        box-shadow: 0 0 0 3px rgba($brand-info, 0.2);
-    }
-}
-.api-version-chip-dot {
-    display: inline-block;
-    width: 0.625rem;
-    height: 0.625rem;
-    border-radius: 50%;
-    margin-right: 0.5rem;
-    &.api-version-dot-green {
-        background: $brand-success;
-    }
-    &.api-version-dot-amber {
-        background: $brand-warning;
+
+    .dropdown-menu {
+        width: max-content;
+        min-width: 260px;
     }
 }
-.api-version-chip-date {
-    font-family: monospace;
-    font-size: 0.8125rem;
-    font-weight: 600;
-}
-// Shared pill geometry for the version chip/tag/marker pills below. Bootstrap's
-// .badge base class (padding/radius/line-height) isn't imported anywhere in this
-// codebase — only the .badge-white color modifier is (see whats-next/nextlink) —
-// so the pill shape is defined here once; each pill sets only its own margin and
-// semantic color.
-%api-pill-shape {
-    display: inline-block;
-    padding: 0.15rem 0.5rem;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    line-height: 1;
-    white-space: nowrap;
-    vertical-align: middle;
-    border-radius: 50rem;
-}
-.api-version-chip-pill {
-    @extend %api-pill-shape;
-    margin-left: 0.5rem;
-    color: $brand-warning;
-    background: rgba($brand-warning, 0.14);
-    &.is-urgent {
-        color: $brand-danger;
-        background: rgba($brand-danger, 0.14);
-    }
-}
-.api-version-dropdown .dropdown-menu {
-    width: 306px;
-    padding: 0;
-    border: none;
-    border-radius: 6px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
-    text-align: left;
-}
-.api-version-menu-header {
-    padding: 0.625rem 0.875rem 0.375rem;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
+
+.api-version-item-meta {
     color: $gray;
+    font-size: 14px;
 }
-.api-version-menu-list {
-    padding-bottom: 0.25rem;
-}
-.js-api-version-item {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8125rem;
-    color: #212529;
-    &:hover {
-        color: $brand-primary;
-        background: $gray-lighter;
-    }
-    &.active {
-        color: $brand-primary;
-        font-weight: 600;
-        background: $gray-lighter;
-        .api-version-menu-item-date {
-            font-weight: 700;
-        }
-    }
-}
-.api-version-menu-item-dot {
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    margin-right: 0.5rem;
-    &.api-version-dot-green {
-        background: $brand-success;
-    }
-    &.api-version-dot-amber {
-        background: $brand-warning;
-    }
-}
-.api-version-menu-item-date {
-    flex: 0 0 auto;
-    font-family: monospace;
-}
-// Same pill shape as .api-version-chip-pill above, reused for dropdown-row tags
-// — only the semantic color is custom.
-.api-version-tag {
-    @extend %api-pill-shape;
-    margin-left: 0.5rem;
-    &.api-version-tag-latest {
-        color: $brand-success;
-        background: rgba($brand-success, 0.12);
-    }
-    &.api-version-tag-default {
-        color: $gray-dark;
-        background: $gray-lighter;
-    }
-    &.api-version-tag-deprecated {
-        color: $brand-warning;
-        background: rgba($brand-warning, 0.14);
-    }
-}
+
 .api-version-check {
     margin-left: auto;
-    color: $brand-info;
 }
+
+.api-version-lifecycle {
+    margin-left: 0.5rem;
+    font-size: 14px;
+}
+
 .api-version-menu-notice {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    padding: 0.625rem 0.875rem 0.75rem;
-    font-size: 0.75rem;
-    line-height: 1.35;
-    color: $gray-dark;
-    text-decoration: none;
-    &:hover {
-        color: $gray-dark;
-        background: $gray-lighter;
-        text-decoration: none;
-    }
+    max-width: 300px;
+    white-space: normal;
 }
-.api-version-menu-notice-icon {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1rem;
-    height: 1rem;
-    margin-top: 0.05rem;
-    border: 1px solid $gray-light;
-    border-radius: 50%;
-    color: $gray-dark;
-    font-family: serif;
-    font-size: 0.6875rem;
-    font-weight: 700;
-}
-.api-version-menu-notice-link {
-    display: inline-block;
-    margin-left: 0.2rem;
-    color: $brand-primary;
-    font-weight: 600;
-    white-space: nowrap;
-}
-
-// Date-versioned schema surfaces use a quiet toolbar to establish hierarchy:
-// the version is context, while Model and Example remain the controls.
-.api-schema-panel {
-    position: relative;
-    overflow: hidden;
-    border: 1px solid $gray-light;
-    border-radius: 6px;
-    background: $white;
-}
-.api-schema-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 0.75rem;
-    min-height: 42px;
-    padding: 0.375rem 6.5rem 0.375rem 0.875rem;
-    background: $gray-lightest;
-    border-bottom: 1px solid $gray-light;
-}
-.api-schema-namespace {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.5rem;
-    min-width: 0;
-    color: $gray-dark;
-
-    code {
-        padding: 0;
-        color: $gray-dark;
-        background: transparent;
-        font-size: 0.75rem;
-        white-space: nowrap;
-    }
-}
-.api-schema-namespace-label {
-    font-size: 0.6875rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: $gray;
-}
-.api-schema-tabs {
-    flex: 0 0 auto;
-    gap: 0.25rem;
-    margin: 0 !important;
-    padding: 0 !important;
-
-    .nav-item {
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-
-    .nav-item .nav-link {
-        min-width: auto;
-        margin: 0 !important;
-        padding: 0.25rem 0.5rem !important;
-        border: 1px solid transparent !important;
-        border-radius: 3px;
-        color: $gray-dark !important;
-        background: transparent !important;
-        box-shadow: none !important;
-        font-size: 0.75rem !important;
-        font-weight: 600;
-        line-height: 1.25;
-
-        &:hover {
-            color: $brand-primary !important;
-            background: $white !important;
-        }
-        &.active {
-            color: $brand-primary !important;
-            background: rgba($ddpurple, 0.08) !important;
-            border-color: rgba($ddpurple, 0.2) !important;
-        }
-    }
-}
-.api-schema-panel-body {
-    padding: 0.75rem;
-
-    .schema-table {
-        margin-top: 0;
-        margin-bottom: 0;
-
-        .expand-all {
-            top: -49px;
-            right: 0;
-            width: auto;
-            margin: 0;
-            padding: 0.25rem 0;
-            font-size: 0.75rem;
-            line-height: 1.25;
-            white-space: nowrap;
-        }
-    }
-    .code-snippet-wrapper {
-        margin-bottom: 0;
-    }
-}
-
-// Response codes, description, and schema form one continuous surface for
-// date-versioned operations instead of reading as three unrelated tab groups.
-.api-response-panel {
-    overflow: hidden;
-    border: 1px solid $gray-light;
-    border-radius: 6px;
-    background: $white;
-
-    .api-schema-panel {
-        border-top: 0;
-        border-right: 0;
-        border-bottom: 0;
-        border-left: 0;
-        border-radius: 0;
-    }
-}
-.api-response-status-tabs {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    min-height: 42px;
-    margin: 0 !important;
-    padding: 0.375rem 0.875rem !important;
-    background: $gray-lighter;
-    border-bottom: 1px solid $gray-light !important;
-
-    .api-response-status-label {
-        margin-right: 0.25rem;
-        color: $gray;
-        font-size: 0.6875rem;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-    }
-    .nav-item {
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-    .nav-item .nav-link {
-        display: inline-flex;
-        align-items: center;
-        min-width: auto;
-        margin: 0 !important;
-        padding: 0.25rem 0.625rem !important;
-        border: 1px solid transparent !important;
-        border-radius: 3px;
-        color: $gray-dark !important;
-        background: transparent !important;
-        box-shadow: none !important;
-        font-size: 0.75rem !important;
-        font-weight: 600;
-        line-height: 1.25;
-
-        &:hover {
-            color: $brand-primary !important;
-            background: $white !important;
-        }
-        &.active {
-            color: $brand-primary !important;
-            background: rgba($ddpurple, 0.08) !important;
-            border-color: rgba($ddpurple, 0.2) !important;
-        }
-    }
-}
-.api-response-status-description {
-    display: none;
-    margin-left: 0.375rem;
-    font-weight: 500;
-    white-space: nowrap;
-}
-.api-response-status-tabs .nav-link.active .api-response-status-description {
-    display: inline;
-}
-.api-response-tab-content {
-    margin-bottom: 0 !important;
-}
-
-// Date-versioned code samples follow the same two-tier surface as responses:
-// language selection is the header and the selected sample is its body.
-.api-code-panel {
-    overflow: hidden;
-    border: 1px solid $gray-light;
-    border-radius: 6px;
-    background: $white;
-}
-.api-code-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-height: 42px;
-    padding: 0.375rem 0.875rem;
-    background: $gray-lighter;
-    border-bottom: 1px solid $gray-light;
-}
-.api-code-toolbar-label {
-    flex: 0 0 auto;
-    margin-right: 0.25rem;
-    color: $gray;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-.api-code-toolbar .code-lang-list-container {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    margin: 0 !important;
-    padding: 0 !important;
-    background: transparent !important;
-
-    .nav-item {
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-    .nav-link {
-        min-width: auto;
-        margin: 0 !important;
-        padding: 0.25rem 0.625rem !important;
-        border: 1px solid transparent !important;
-        border-radius: 3px;
-        color: $gray-dark !important;
-        background: transparent !important;
-        box-shadow: none !important;
-        font-size: 0.75rem !important;
-        font-weight: 600;
-        line-height: 1.25;
-
-        &:hover {
-            color: $brand-primary !important;
-            background: $white !important;
-        }
-        &.active {
-            color: $brand-primary !important;
-            background: rgba($ddpurple, 0.08) !important;
-            border-color: rgba($ddpurple, 0.2) !important;
-        }
-    }
-}
-.api-code-panel-body {
-    padding: 0.75rem;
-
-    > .code-snippet-wrapper:last-of-type,
-    > .code-snippet-wrapper[style*="display: block"] {
-        margin-bottom: 0;
-    }
-}
-
-// Subtle dividers make the long operation page easier to scan without turning
-// every section into a separate card.
-.api-endpoint-date-versioned .endpoint-content > h3:not(:first-of-type) {
-    padding-top: 1.25rem;
-    margin-top: 1.5rem !important;
-    border-top: 1px solid $gray-light;
-}
-// Schema table row markers for fields added/removed between date-versioned
-// variants (see rowRecursive's prevData diffing in build-api-pages.js). Same
-// pill shape as .api-version-chip-pill; only margin and color are custom.
+// Schema field annotations communicate changes between adjacent API versions.
 .schema-change-marker {
-    @extend %api-pill-shape;
     margin-left: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
 }
+
 .schema-change-marker-new {
     color: $brand-success;
-    background: rgba($brand-success, 0.12);
 }
+
 .schema-change-marker-removed {
     color: $gray;
-    background: $gray-lighter;
 }
+
 .row.isRemoved {
     > .first-column > .table-row > .key,
     .table-row .key {
         text-decoration: line-through;
-        opacity: 0.7;
     }
 }
-.row.isNew {
-    > .first-column > .table-row {
-        background: rgba($brand-success, 0.05);
-    }
-}
-
-
 // Both endpoint and category pages: flush right alongside the h1.
 .main-api .api-copy-btn,
 .api-intro-header .api-copy-btn {

--- a/hugo/content/en/api/versions.md
+++ b/hugo/content/en/api/versions.md
@@ -1,0 +1,12 @@
+---
+title: API versioning
+description: Learn about versioning for Datadog API operations.
+type: documentation
+disable_toc: true
+---
+
+Datadog is introducing date-based versions for selected API operations. Date-based versioning lets Datadog evolve an operation while giving you control over when to adopt its changes.
+
+During the rollout, use the version selector on a supported operation to view its request and response schemas, examples, and required version header.
+
+More guidance about version availability, upgrades, and lifecycle policies is coming soon.

--- a/hugo/data/api/v1/full_spec.yaml
+++ b/hugo/data/api/v1/full_spec.yaml
@@ -1534,6 +1534,125 @@ components:
         - layout_type
         - widgets
       type: object
+    Dashboard_Version20260401:
+      $ref: "#/components/schemas/Dashboard_Version20260601"
+    Dashboard_Version20260601:
+      description: |-
+        Dashboard object for API version 2026-06-01 (default).
+        Widgets use the `layout` field with `x`, `y`, `width`, and `height` integer coordinates for grid positioning.
+      example:
+        id: "abc-123-def"
+        title: "Infrastructure Overview"
+        layout_type: "free"
+        url: "/dashboard/abc-123-def/infrastructure-overview"
+        widgets:
+          - id: 1001
+            definition:
+              type: "timeseries"
+              title: "CPU Usage"
+              requests:
+                - q: "avg:system.cpu.user{*}"
+            layout:
+              x: 0
+              "y": 0
+              width: 6
+              height: 4
+              is_column_break: false
+          - id: 1002
+            definition:
+              type: "query_value"
+              title: "Active Hosts"
+              requests:
+                - q: "sum:system.up{*}"
+            layout:
+              x: 6
+              "y": 0
+              width: 3
+              height: 2
+              is_column_break: false
+      properties:
+        id:
+          description: The ID of the dashboard.
+          example: "123-abc-456"
+          readOnly: true
+          type: string
+        layout_type:
+          $ref: "#/components/schemas/DashboardLayoutType"
+        title:
+          description: The title of the dashboard.
+          type: string
+        url:
+          description: The URL of the dashboard.
+          readOnly: true
+          type: string
+        widgets:
+          description: The list of widgets to display on the dashboard.
+          items:
+            $ref: "#/components/schemas/Widget_Version20260601"
+          type: array
+      required:
+        - title
+        - layout_type
+        - widgets
+      type: object
+    Dashboard_Version20260701:
+      description: |-
+        Dashboard object for API version 2026-07-01.
+        The widget `layout` field has been removed. Widgets now use the required `position` field
+        with `column`, `row`, `span_columns`, and `span_rows` for named grid-slot positioning.
+      example:
+        id: "abc-123-def"
+        title: "Infrastructure Overview"
+        layout_type: "free"
+        url: "/dashboard/abc-123-def/infrastructure-overview"
+        widgets:
+          - id: 1001
+            definition:
+              type: "timeseries"
+              title: "CPU Usage"
+              requests:
+                - q: "avg:system.cpu.user{*}"
+            position:
+              column: 0
+              row: 0
+              span_columns: 6
+              span_rows: 4
+          - id: 1002
+            definition:
+              type: "query_value"
+              title: "Active Hosts"
+              requests:
+                - q: "sum:system.up{*}"
+            position:
+              column: 6
+              row: 0
+              span_columns: 3
+              span_rows: 2
+      properties:
+        id:
+          description: The ID of the dashboard.
+          example: "123-abc-456"
+          readOnly: true
+          type: string
+        layout_type:
+          $ref: "#/components/schemas/DashboardLayoutType"
+        title:
+          description: The title of the dashboard.
+          type: string
+        url:
+          description: The URL of the dashboard.
+          readOnly: true
+          type: string
+        widgets:
+          description: The list of widgets to display on the dashboard.
+          items:
+            $ref: "#/components/schemas/Widget_Version20260701"
+          type: array
+      required:
+        - title
+        - layout_type
+        - widgets
+      type: object
     DashboardBulkActionData:
       description: Dashboard bulk action request data.
       example: {"id": "123-abc-456", "type": "dashboard"}
@@ -28088,6 +28207,102 @@ components:
       required:
         - definition
       type: object
+    Widget_Version20260601:
+      description: |-
+        Widget object for API version 2026-06-01 (default).
+        Position is specified using the `layout` object with `x`, `y`, `width`, and `height` integer coordinates.
+      properties:
+        definition:
+          $ref: "#/components/schemas/WidgetDefinition"
+        id:
+          description: The ID of the widget.
+          format: int64
+          type: integer
+        layout:
+          description: |-
+            The position and dimensions of the widget on the dashboard grid.
+            Required for dashboards with `free` layout type or fixed `reflow_type`.
+          properties:
+            height:
+              description: The height of the widget. Non-negative integer.
+              format: int64
+              minimum: 0
+              type: integer
+            is_column_break:
+              description: Whether the widget should be the first one on the second column in high density mode.
+              type: boolean
+            width:
+              description: The width of the widget. Non-negative integer.
+              format: int64
+              minimum: 0
+              type: integer
+            x:
+              description: The position on the x (horizontal) axis. Non-negative integer.
+              format: int64
+              minimum: 0
+              type: integer
+            y:
+              description: The position on the y (vertical) axis. Non-negative integer.
+              format: int64
+              minimum: 0
+              type: integer
+          required:
+            - x
+            - y
+            - width
+            - height
+          type: object
+      required:
+        - definition
+      type: object
+    Widget_Version20260701:
+      description: |-
+        Widget object for API version 2026-07-01.
+        The `layout` field is removed. Widgets now require the `position` field using named
+        grid-slot fields: `column`, `row`, `span_columns`, and `span_rows`.
+        Requests that include a `layout` field return a validation error.
+      properties:
+        definition:
+          $ref: "#/components/schemas/WidgetDefinition"
+        id:
+          description: The ID of the widget.
+          format: int64
+          type: integer
+        position:
+          description: |-
+            Named grid-slot position for the widget. Replaces the `layout` field from API version 2026-06-01.
+            Widgets are placed using zero-based column and row slot indices with optional span counts.
+          properties:
+            column:
+              description: The zero-based column slot index where the widget starts.
+              format: int64
+              minimum: 0
+              type: integer
+            row:
+              description: The zero-based row slot index where the widget starts.
+              format: int64
+              minimum: 0
+              type: integer
+            span_columns:
+              default: 1
+              description: The number of column slots the widget spans. Defaults to 1.
+              format: int64
+              minimum: 1
+              type: integer
+            span_rows:
+              default: 1
+              description: The number of row slots the widget spans. Defaults to 1.
+              format: int64
+              minimum: 1
+              type: integer
+          required:
+            - column
+            - row
+          type: object
+      required:
+        - definition
+        - position
+      type: object
     WidgetAggregator:
       description: Aggregator used for the request.
       enum:
@@ -30299,7 +30514,11 @@ paths:
                         title: CPU Usage
                         type: timeseries
             schema:
-              $ref: "#/components/schemas/Dashboard"
+              oneOf:
+                - $ref: "#/components/schemas/Dashboard_Version20260401"
+                - $ref: "#/components/schemas/Dashboard_Version20260601"
+                - $ref: "#/components/schemas/Dashboard_Version20260701"
+              x-datadog-api-versioned: true
         description: Create a dashboard request body.
         required: true
       responses:
@@ -30328,7 +30547,11 @@ paths:
                           type: timeseries
                         id: 123
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                oneOf:
+                  - $ref: "#/components/schemas/Dashboard_Version20260401"
+                  - $ref: "#/components/schemas/Dashboard_Version20260601"
+                  - $ref: "#/components/schemas/Dashboard_Version20260701"
+                x-datadog-api-versioned: true
           description: OK
         "400":
           content:
@@ -31251,7 +31474,11 @@ paths:
                           type: timeseries
                         id: 123
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                oneOf:
+                  - $ref: "#/components/schemas/Dashboard_Version20260401"
+                  - $ref: "#/components/schemas/Dashboard_Version20260601"
+                  - $ref: "#/components/schemas/Dashboard_Version20260701"
+                x-datadog-api-versioned: true
           description: OK
         "403":
           content:
@@ -31335,7 +31562,11 @@ paths:
                           type: timeseries
                         id: 123
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                oneOf:
+                  - $ref: "#/components/schemas/Dashboard_Version20260401"
+                  - $ref: "#/components/schemas/Dashboard_Version20260601"
+                  - $ref: "#/components/schemas/Dashboard_Version20260701"
+                x-datadog-api-versioned: true
           description: OK
         "400":
           content:
@@ -46392,3 +46623,28 @@ tags:
       url: https://docs.datadoghq.com/integrations/webhooks
     name: Webhooks Integration
 x-group-parameters: true
+
+x-datadog-api-versioning:
+  versions:
+    "2026-04-01":
+      deprecated: true
+      eol: "2026-08-15"
+    "2026-06-01":
+      base: true
+    "2026-07-01":
+      breaking_changes:
+        - tag: "Dashboards"
+          description: |
+            The `Widget` object's `layout` field — which contained `x`, `y`, `width`, and `height`
+            integer coordinate properties — has been removed and replaced with a required `position` object.
+
+            The new `position` object uses named grid-slot fields: `column`, `row`, `span_columns`, and `span_rows`.
+            Requests that include a `layout` field on widgets in this version return a validation error.
+            Update all widget definitions to use `position` before adopting this API version.
+      changes:
+        - operationId: "GetDashboard"
+          description: "Response schema updated to `Dashboard_Version20260701`. Widget objects now include a required `position` field instead of `layout`."
+        - operationId: "CreateDashboard"
+          description: "Response schema updated to `Dashboard_Version20260701`. Widget objects in the response now use `position` instead of `layout`."
+        - operationId: "UpdateDashboard"
+          description: "Response schema updated to `Dashboard_Version20260701`. Widget objects in the response now use `position` instead of `layout`."

--- a/hugo/data/api/v1/translate_actions.json
+++ b/hugo/data/api/v1/translate_actions.json
@@ -85,7 +85,7 @@
     "description": "Create a dashboard using the specified options. When defining queries in your widgets, take note of which queries should have the `as_count()` or `as_rate()` modifiers appended.\nRefer to the following [documentation](https://docs.datadoghq.com/developers/metrics/type_modifiers/?tab=count#in-application-modifiers) for more information on these modifiers.",
     "summary": "Create a new dashboard",
     "request_description": "Create a dashboard request body.",
-    "request_schema_description": "A dashboard is Datadog’s tool for visually tracking, analyzing, and displaying\nkey performance metrics, which enable you to monitor the health of your infrastructure."
+    "request_schema_description": ""
   },
   "ListDashboardLists": {
     "description": "Fetch all of your existing dashboard list definitions.",

--- a/hugo/layouts/api/baseof.html
+++ b/hugo/layouts/api/baseof.html
@@ -35,6 +35,13 @@ data-bs-spy="scroll" data-bs-target="#navbar-example2" data-bs-offset="5"
 
   {{ partial "header/header.html" . }}
 
+  {{ $dateVersioning := partial "api/detect-date-versioning.html" (dict "dot" .) }}
+  {{ .Scratch.Set "isDateVersioned" $dateVersioning.isDateVersioned }}
+  {{ .Scratch.Set "apiVersionsList" $dateVersioning.apiVersionsList }}
+  {{ .Scratch.Set "baseVersion" $dateVersioning.baseVersion }}
+  {{ .Scratch.Set "dateVersionOperationId" $dateVersioning.dateVersionOperationId }}
+  {{ .Scratch.Set "apiMajorVersion" $dateVersioning.apiMajorVersion }}
+
   <div class="container container__content">
     <div class="row">
       <div class="d-none d-lg-flex col-sm-3 side">

--- a/hugo/layouts/api/single.html
+++ b/hugo/layouts/api/single.html
@@ -49,18 +49,22 @@
     {{ $versionCount := (len $versions) }}
     {{ $anchorStr := .Title }}
 
-    <div class="row align-items-start mb-1">
-      <div class="col-11 col-xl-9">
-          <h1 class="api-task-description mb-0" id="{{ $anchorStr | anchorize }}">
-              {{- $anchorStr -}}
-          </h1>
-      </div>
-      <div class="col-1 col-xl-3 d-flex justify-content-end align-items-center">
+    {{/* Reuse the date-versioning metadata detected in baseof.html before the sidebar rendered. */}}
+    {{ $topIsDateVersioned := $.Scratch.Get "isDateVersioned" }}
+    {{ $topApiVersionsList := $.Scratch.Get "apiVersionsList" }}
+    {{ $topBaseVersion := $.Scratch.Get "baseVersion" }}
+    {{ $topApiMajorVersion := $.Scratch.Get "apiMajorVersion" }}
+
+    <div class="api-operation-header d-flex flex-wrap align-items-center justify-content-between mb-1">
+      <h1 class="api-task-description mb-0" id="{{ $anchorStr | anchorize }}">
+          {{- $anchorStr -}}
+      </h1>
+      <div class="api-operation-header-actions d-flex align-items-center">
           {{ partial "api/api-copy-btn.html" . }}
       </div>
     </div>
 
-    {{ if gt $versionCount 0 }}
+    {{ if and (not $topIsDateVersioned) (gt $versionCount 0) }}
     <ul class="nav nav-tabs border-none response-toggle px-0">
       {{ range $versionIndex, $versionNum := $versions }}
         {{ $adat := cond (eq $versionNum "v1") $d $d2 }}
@@ -87,7 +91,7 @@
         {{ $endpoint := partial "api/get-endpoint.html" (dict "lang" $.Page.Lang "operationids" $operationids "version" $versionNum "generalRegions" $generalRegions ) }}
         {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuEntry "endpoint" $endpoint) }}
 
-        <div data-title="{{ $versionNum }}" id="{{ (print $anchorStr "-" $versionNum) | anchorize }}" class="tab-pane {{ if $endpointVisibility.isVisibleVersion }} active{{ end }}" role="tabpanel">
+        <div data-title="{{ $versionNum }}" id="{{ (print $anchorStr "-" $versionNum) | anchorize }}" class="{{ if not $topIsDateVersioned }}tab-pane{{ end }} {{ if or $topIsDateVersioned $endpointVisibility.isVisibleVersion }} active{{ end }}" {{ if not $topIsDateVersioned }}role="tabpanel"{{ end }}>
 
         <!-- the version-specific resource page (provides examples.json) lives at /api/{v}/{tag}/ -->
         {{ $resourcePage := $dot.Site.GetPage (print "/api/" $versionNum "/" $tagSlug "") }}
@@ -107,7 +111,11 @@
                 "adat" $adat
                 "tag" $tag
                 "translate_action" $translate_action
-                "resourcePage" $resourcePage) }}
+                "resourcePage" $resourcePage
+                "isDateVersioned" $topIsDateVersioned
+                "apiVersionsList" $topApiVersionsList
+                "baseVersion" $topBaseVersion
+                "apiMajorVersion" $topApiMajorVersion) }}
           {{ else }}
             {{ warnf "endpoint not found in api single.html lang: %q, version: %q, tag: %q, operationids: %v" $dot.Lang $versionNum $tagName $operationids }}
           {{ end }}

--- a/hugo/layouts/api/single.html
+++ b/hugo/layouts/api/single.html
@@ -55,11 +55,13 @@
     {{ $topBaseVersion := $.Scratch.Get "baseVersion" }}
     {{ $topApiMajorVersion := $.Scratch.Get "apiMajorVersion" }}
 
-    <div class="api-operation-header d-flex flex-wrap align-items-center justify-content-between mb-1">
-      <h1 class="api-task-description mb-0" id="{{ $anchorStr | anchorize }}">
-          {{- $anchorStr -}}
-      </h1>
-      <div class="api-operation-header-actions d-flex align-items-center">
+    <div class="row align-items-start mb-1">
+      <div class="col-11 col-xl-9">
+          <h1 class="api-task-description mb-0" id="{{ $anchorStr | anchorize }}">
+              {{- $anchorStr -}}
+          </h1>
+      </div>
+      <div class="col-1 col-xl-3 d-flex justify-content-end align-items-center">
           {{ partial "api/api-copy-btn.html" . }}
       </div>
     </div>

--- a/hugo/layouts/partials/api/code-example.html
+++ b/hugo/layouts/partials/api/code-example.html
@@ -5,10 +5,13 @@
 {{ $endpoint := .endpoint }}
 {{ $version := .version }}
 {{ $securitySchemes := .securitySchemes }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $apiVersionsList := .apiVersionsList | default slice }}
+{{ $baseVersion := .baseVersion | default "" }}
 {{- $codeExampleLookup := (index (index $context.Site.Data.api $version) "CodeExamples") -}}
 
 <h3 class="mb-2">{{ i18n "code_example" }}</h3>
-<div class="programming-lang-wrapper js-code-snippet-wrapper" >
+<div class="programming-lang-wrapper js-code-snippet-wrapper {{ if $isDateVersioned }}api-code-panel{{ end }}" >
 
 {{ $codeLangs := slice "curl" }}
 
@@ -35,7 +38,15 @@
 {{ end }}
 {{ $codeLangs = $codeLangs | uniq }}
 
+{{ if $isDateVersioned }}
+<div class="api-code-toolbar">
+  <span class="api-code-toolbar-label">Language</span>
+{{ end }}
 {{ partial "code-lang-tabs" (dict "context" $context "codeLangs" $codeLangs ) }}
+{{ if $isDateVersioned }}
+</div>
+<div class="api-code-panel-body">
+{{ end }}
 
 {{ define "partials/code-example-instructions" }}
   {{ $context := .context }}
@@ -81,6 +92,9 @@
   {{ $body := .body }}
   {{ $lang := .lang }}
   {{ $version := .version }}
+  {{ $isDateVersioned := .isDateVersioned | default false }}
+  {{ $apiVersionsList := .apiVersionsList | default slice }}
+  {{ $baseVersion := .baseVersion | default "" }}
   <div class="card">
     <div class="card-header p-0">
       <h5 class="m-0">
@@ -91,7 +105,7 @@
     </div>
     <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">
       <div class="card-body p-0 append-copy-btn">
-        {{ highlight $body $lang.syntax "" }}
+        {{ partial "api/render-versioned-code.html" (dict "body" $body "lang" $lang "operationId" $operationid "apiMajorVersion" $version "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
       </div>
     </div>
   </div>
@@ -157,15 +171,15 @@
                                                   {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                                               {{- end -}}
                                             {{- end -}}
-                                            {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                            {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                           {{- end -}}
                                       {{- else -}}
-                                        {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                        {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                       {{- end -}}
                                   {{- end -}}
                               {{- end -}}
                           {{- else -}}
-                            {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                            {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                           {{- end -}}
                           </code>
                         </pre>
@@ -214,15 +228,15 @@
                                             {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                                         {{- end -}}
                                       {{- end -}}
-                  {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                   {{- end -}}
                               {{- else -}}
-                  {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                               {{- end -}}
                           {{- end -}}
                       {{- end -}}
                   {{- else -}}
-                  {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                   {{- end -}}
                   </code>
                 </pre>
@@ -267,7 +281,7 @@
             {{ with $resourcePage.Resources.Match $fileStr }}
                 {{ range . }}
                   {{ if gt $numOfCodeExamples 1 }}
-                    {{ partial "accordion-card" (dict "count" $i "item" $item "body" .Content "lang" $lang "operationid" $operationid "version" $version ) }}
+                    {{ partial "accordion-card" (dict "count" $i "item" $item "body" .Content "lang" $lang "operationid" $operationid "version" $version "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
                   {{ else }}
                     <div class="card">
                       <div class="card-header p-0">
@@ -278,7 +292,7 @@
                         </h5>
                       </div>
                     </div>
-                    {{ highlight .Content $lang.syntax "" }}
+                    {{ partial "api/render-versioned-code.html" (dict "body" .Content "lang" $lang "operationId" $operationid "apiMajorVersion" $version "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
                   {{ end }}
                 {{ end }}
             {{ end }}
@@ -309,7 +323,7 @@
                   </h5>
                 </div>
               </div>
-              {{ highlight $file_content $lang.syntax "" }}
+              {{ partial "api/render-versioned-code.html" (dict "body" $file_content "lang" $lang "operationId" $operationid "apiMajorVersion" $version "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
             </div>
             {{ partial "code-example-instructions" (dict "context" $context "lang" $lang "endpoint" $endpoint "securitySchemes" $securitySchemes) }}
           </div>
@@ -317,5 +331,8 @@
     {{ end }}
   {{ end }}
 
+{{ end }}
+{{ if $isDateVersioned }}
+</div>
 {{ end }}
 </div>

--- a/hugo/layouts/partials/api/code-example.html
+++ b/hugo/layouts/partials/api/code-example.html
@@ -11,7 +11,7 @@
 {{- $codeExampleLookup := (index (index $context.Site.Data.api $version) "CodeExamples") -}}
 
 <h3 class="mb-2">{{ i18n "code_example" }}</h3>
-<div class="programming-lang-wrapper js-code-snippet-wrapper {{ if $isDateVersioned }}api-code-panel{{ end }}" >
+<div class="programming-lang-wrapper js-code-snippet-wrapper" >
 
 {{ $codeLangs := slice "curl" }}
 
@@ -38,15 +38,7 @@
 {{ end }}
 {{ $codeLangs = $codeLangs | uniq }}
 
-{{ if $isDateVersioned }}
-<div class="api-code-toolbar">
-  <span class="api-code-toolbar-label">Language</span>
-{{ end }}
 {{ partial "code-lang-tabs" (dict "context" $context "codeLangs" $codeLangs ) }}
-{{ if $isDateVersioned }}
-</div>
-<div class="api-code-panel-body">
-{{ end }}
 
 {{ define "partials/code-example-instructions" }}
   {{ $context := .context }}
@@ -331,8 +323,5 @@
     {{ end }}
   {{ end }}
 
-{{ end }}
-{{ if $isDateVersioned }}
-</div>
 {{ end }}
 </div>

--- a/hugo/layouts/partials/api/curl.html
+++ b/hugo/layouts/partials/api/curl.html
@@ -162,6 +162,11 @@
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
+{{- /* DD-API-VERSION header for date-versioned operations */ -}}
+{{- if .isDateVersioned -}}
+{{ " \\" }}
+<span class="o">-H</span> <span class="s1">"DD-API-VERSION: <span class="api-version-header-value" data-operation-id="{{ .operationId }}">{{ .baseVersion }}</span>"</span>
+{{- end -}}
 {{- /* Render binary data (usually compressed) */ -}}
 {{- if gt (len $contentEncoding) 0 -}}
 {{- if eq $contentEncoding "gzip" -}}

--- a/hugo/layouts/partials/api/date-version-selector.html
+++ b/hugo/layouts/partials/api/date-version-selector.html
@@ -1,0 +1,83 @@
+{{/*
+  Renders the per-operation date-version control for a date-versioned operation
+  (x-datadog-api-versioning): a compact chip (static if there's only one version
+  ever, a Bootstrap dropdown trigger otherwise), with a short link to the API
+  versioning overview in the dropdown itself.
+
+  Params:
+    operationId - string, the endpoint's operationId
+    versions    - slice of dicts: {date string, isBase bool}, sorted oldest -> newest
+    baseVersion - string, the date of the default selected version
+    apiMajorVersion - string, the endpoint's major version (for example, "v1")
+*/}}
+{{ $operationId := .operationId }}
+{{ $versions    := .versions }}
+{{ $baseVersion := .baseVersion }}
+{{ $apiMajorVersion := .apiMajorVersion | default "" }}
+{{ $count       := len $versions }}
+{{ $latest      := "" }}
+{{ range $versions }}{{ $latest = .date }}{{ end }}
+{{ $isLatest    := eq $baseVersion $latest }}
+{{ $versionsDesc := $versions | collections.Reverse }}
+{{ $dateCsv     := "" }}
+{{ range $i, $v := $versions }}{{ if $i }}{{ $dateCsv = print $dateCsv "," }}{{ end }}{{ $dateCsv = print $dateCsv $v.date }}{{ end }}
+{{ $versionMeta := dict }}
+{{ range $versions }}{{ $versionMeta = merge $versionMeta (dict .date (dict "deprecated" .deprecated "eol" .eol)) }}{{ end }}
+{{ $baseDeprecated := false }}
+{{ range $versions }}{{ if eq .date $baseVersion }}{{ $baseDeprecated = .deprecated }}{{ end }}{{ end }}
+
+<div class="api-version-block" data-operation-id="{{ $operationId }}" data-api-major-version="{{ $apiMajorVersion }}" data-base-version="{{ $baseVersion }}" data-latest-version="{{ $latest }}" data-versions="{{ $dateCsv }}" data-version-meta='{{ jsonify $versionMeta }}'>
+    {{ if le $count 1 }}
+      <div class="api-version-selector-col">
+        <span class="btn api-version-chip d-flex align-items-center">
+          <span class="api-version-chip-dot api-version-dot-green"></span>
+          <span class="api-version-chip-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ $baseVersion }}</span>
+        </span>
+      </div>
+    {{ else }}
+      <div class="api-version-selector-col">
+        <div class="dropdown bootstrap-dropdown-custom api-version-dropdown">
+          <button id="{{ $operationId }}-version" class="btn d-flex align-items-center justify-content-between api-version-chip js-api-version-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="api-version-chip-dot js-api-version-dot {{ if $isLatest }}api-version-dot-green{{ else }}api-version-dot-amber{{ end }}"></span>
+            <span class="api-version-chip-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}<span class="js-api-version-label">{{ $baseVersion }}</span></span>
+            <span class="api-version-chip-pill js-api-version-chip-pill {{ if not $baseDeprecated }}d-none{{ end }}">Deprecated</span>
+            <div class="chevron chevron-down"></div>
+            <div class="chevron chevron-up d-none"></div>
+          </button>
+          <div class="dropdown-menu dropdown-menu-end js-api-version-menu" aria-labelledby="{{ $operationId }}-version">
+            <div class="api-version-menu-header">Versions of this operation</div>
+            <div class="api-version-menu-list">
+              {{ range $versionsDesc }}
+                <a href="#"
+                        class="dropdown-item js-api-version-item {{ if eq .date $baseVersion }}active{{ end }}"
+                        data-api-date-version="{{ .date }}"
+                        data-operation-id="{{ $operationId }}">
+                  <span class="api-version-menu-item-dot {{ if eq .date $latest }}api-version-dot-green{{ else }}api-version-dot-amber{{ end }}"></span>
+                  <span class="api-version-menu-item-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ .date }}</span>
+                  {{ if eq .date $latest }}
+                    <span class="api-version-tag api-version-tag-latest">latest</span>
+                  {{ else if .isBase }}
+                    <span class="api-version-tag api-version-tag-default">default</span>
+                  {{ end }}
+                  {{ if .deprecated }}
+                    <span class="api-version-tag api-version-tag-deprecated">deprecated</span>
+                  {{ end }}
+                  <span class="api-version-check js-api-version-check {{ if ne .date $baseVersion }}d-none{{ end }}">
+                    <svg width="13" height="13" viewBox="0 0 14 14" fill="none"><path d="M2.5 7.5l3 3 6-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                  </span>
+                </a>
+              {{ end }}
+            </div>
+            <div class="dropdown-divider"></div>
+            <a href="{{ "/api/versions/" | relLangURL }}" class="api-version-menu-notice">
+              <span class="api-version-menu-notice-icon" aria-hidden="true">i</span>
+              <span>
+                Datadog is rolling out date-based API versions.
+                <span class="api-version-menu-notice-link">Learn more</span>
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    {{ end }}
+</div>

--- a/hugo/layouts/partials/api/date-version-selector.html
+++ b/hugo/layouts/partials/api/date-version-selector.html
@@ -1,8 +1,7 @@
 {{/*
   Renders the per-operation date-version control for a date-versioned operation
-  (x-datadog-api-versioning): a compact chip (static if there's only one version
-  ever, a Bootstrap dropdown trigger otherwise), with a short link to the API
-  versioning overview in the dropdown itself.
+  (x-datadog-api-versioning), using the same Bootstrap dropdown structure as the
+  site's language and region selectors.
 
   Params:
     operationId - string, the endpoint's operationId
@@ -17,7 +16,6 @@
 {{ $count       := len $versions }}
 {{ $latest      := "" }}
 {{ range $versions }}{{ $latest = .date }}{{ end }}
-{{ $isLatest    := eq $baseVersion $latest }}
 {{ $versionsDesc := $versions | collections.Reverse }}
 {{ $dateCsv     := "" }}
 {{ range $i, $v := $versions }}{{ if $i }}{{ $dateCsv = print $dateCsv "," }}{{ end }}{{ $dateCsv = print $dateCsv $v.date }}{{ end }}
@@ -26,55 +24,45 @@
 {{ $baseDeprecated := false }}
 {{ range $versions }}{{ if eq .date $baseVersion }}{{ $baseDeprecated = .deprecated }}{{ end }}{{ end }}
 
-<div class="api-version-block" data-operation-id="{{ $operationId }}" data-api-major-version="{{ $apiMajorVersion }}" data-base-version="{{ $baseVersion }}" data-latest-version="{{ $latest }}" data-versions="{{ $dateCsv }}" data-version-meta='{{ jsonify $versionMeta }}'>
+<div class="api-version-block language-region-select-container api-version-selector p-0" data-operation-id="{{ $operationId }}" data-api-major-version="{{ $apiMajorVersion }}" data-base-version="{{ $baseVersion }}" data-versions="{{ $dateCsv }}" data-version-meta='{{ jsonify $versionMeta }}'>
     {{ if le $count 1 }}
-      <div class="api-version-selector-col">
-        <span class="btn api-version-chip d-flex align-items-center">
-          <span class="api-version-chip-dot api-version-dot-green"></span>
-          <span class="api-version-chip-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ $baseVersion }}</span>
+      <div class="language-select-container">
+        <span class="btn d-flex align-items-center">
+          <span>{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ $baseVersion }}</span>
         </span>
       </div>
     {{ else }}
-      <div class="api-version-selector-col">
-        <div class="dropdown bootstrap-dropdown-custom api-version-dropdown">
-          <button id="{{ $operationId }}-version" class="btn d-flex align-items-center justify-content-between api-version-chip js-api-version-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="api-version-chip-dot js-api-version-dot {{ if $isLatest }}api-version-dot-green{{ else }}api-version-dot-amber{{ end }}"></span>
-            <span class="api-version-chip-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}<span class="js-api-version-label">{{ $baseVersion }}</span></span>
-            <span class="api-version-chip-pill js-api-version-chip-pill {{ if not $baseDeprecated }}d-none{{ end }}">Deprecated</span>
+      <div class="language-select-container">
+        <div class="dropdown bootstrap-dropdown-custom">
+          <button id="{{ $operationId }}-version" class="btn d-flex align-items-center justify-content-between js-api-version-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span>{{ with $apiMajorVersion }}{{ . }} - {{ end }}<span class="js-api-version-label">{{ $baseVersion }}</span></span>
+            <span class="api-version-lifecycle js-api-version-lifecycle {{ if not $baseDeprecated }}d-none{{ end }}">Deprecated</span>
             <div class="chevron chevron-down"></div>
             <div class="chevron chevron-up d-none"></div>
           </button>
           <div class="dropdown-menu dropdown-menu-end js-api-version-menu" aria-labelledby="{{ $operationId }}-version">
-            <div class="api-version-menu-header">Versions of this operation</div>
-            <div class="api-version-menu-list">
-              {{ range $versionsDesc }}
-                <a href="#"
-                        class="dropdown-item js-api-version-item {{ if eq .date $baseVersion }}active{{ end }}"
-                        data-api-date-version="{{ .date }}"
-                        data-operation-id="{{ $operationId }}">
-                  <span class="api-version-menu-item-dot {{ if eq .date $latest }}api-version-dot-green{{ else }}api-version-dot-amber{{ end }}"></span>
-                  <span class="api-version-menu-item-date">{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ .date }}</span>
-                  {{ if eq .date $latest }}
-                    <span class="api-version-tag api-version-tag-latest">latest</span>
-                  {{ else if .isBase }}
-                    <span class="api-version-tag api-version-tag-default">default</span>
-                  {{ end }}
-                  {{ if .deprecated }}
-                    <span class="api-version-tag api-version-tag-deprecated">deprecated</span>
-                  {{ end }}
-                  <span class="api-version-check js-api-version-check {{ if ne .date $baseVersion }}d-none{{ end }}">
-                    <svg width="13" height="13" viewBox="0 0 14 14" fill="none"><path d="M2.5 7.5l3 3 6-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path></svg>
-                  </span>
-                </a>
-              {{ end }}
-            </div>
-            <div class="dropdown-divider"></div>
-            <a href="{{ "/api/versions/" | relLangURL }}" class="api-version-menu-notice">
-              <span class="api-version-menu-notice-icon" aria-hidden="true">i</span>
-              <span>
-                Datadog is rolling out date-based API versions.
-                <span class="api-version-menu-notice-link">Learn more</span>
-              </span>
+            {{ range $versionsDesc }}
+              <a href="#"
+                      class="dropdown-item js-api-version-item"
+                      data-api-date-version="{{ .date }}"
+                      data-operation-id="{{ $operationId }}"
+                      aria-current="{{ if eq .date $baseVersion }}true{{ else }}false{{ end }}">
+                <span>{{ with $apiMajorVersion }}{{ . }} - {{ end }}{{ .date }}</span>
+                {{ if eq .date $latest }}
+                  <span class="api-version-item-meta">latest</span>
+                {{ else if .isBase }}
+                  <span class="api-version-item-meta">default</span>
+                {{ end }}
+                {{ if .deprecated }}
+                  <span class="api-version-item-meta">deprecated</span>
+                {{ end }}
+                <span class="api-version-check js-api-version-check {{ if ne .date $baseVersion }}d-none{{ end }}">
+                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none"><path d="M2.5 7.5l3 3 6-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                </span>
+              </a>
+            {{ end }}
+            <a href="{{ "/api/versions/" | relLangURL }}" class="dropdown-item api-version-menu-notice text-wrap">
+              Datadog is rolling out date-based API versions. Learn more
             </a>
           </div>
         </div>

--- a/hugo/layouts/partials/api/detect-date-versioning.html
+++ b/hugo/layouts/partials/api/detect-date-versioning.html
@@ -1,0 +1,116 @@
+{{/*
+  Detects whether the current API page is a single-operation page whose
+  request/response schemas use date-based versioning (x-datadog-api-versioning
+  / x-datadog-api-versioned), and if so, returns the version list needed to
+  render the per-operation control and its versioned content.
+
+  Runs against every api/* page (single, list, category) since it's called
+  once from baseof.html before the API page renders; on non-single-operation
+  pages it simply finds no matching menu entry and returns isDateVersioned=false.
+
+  Params:
+    dot - the current Page
+
+  Returns a dict:
+    isDateVersioned        - bool
+    apiVersionsList        - slice of {date string, isBase bool}, sorted oldest -> newest
+    baseVersion            - string
+    dateVersionOperationId - string
+    apiMajorVersion        - string (for example, "v1")
+*/}}
+{{ $dot := .dot }}
+
+{{ $relPath := strings.TrimSuffix "/" $dot.RelPermalink }}
+{{ $tagSlug := path.Base (path.Dir $relPath) }}
+{{ $endpointSlug := path.Base $relPath }}
+{{ $identifier := printf "%s-%s" $tagSlug $endpointSlug }}
+
+{{ $menuEntry := dict }}
+{{ $tagName := "" }}
+{{ with index $dot.Sites.Default.Menus "api" }}
+  {{ range . }}
+    {{ if eq .Identifier $tagSlug }}
+      {{ $tagName = .Name }}
+      {{/* The operation's menu entry (identifier "{tag}-{endpoint}") is always a
+           child of its own tag, so only walk this tag's children instead of every
+           tag's — on non-operation pages nothing matches and no children are walked. */}}
+      {{ range .Children }}
+        {{ if eq .Identifier $identifier }}
+          {{ $menuEntry = . }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $versions := $menuEntry.Params.versions | default (slice) | sort | collections.Reverse }}
+{{ $operationids := $menuEntry.Params.operationids | default (slice) }}
+
+{{ $dvScratch := newScratch }}
+{{ $dvScratch.Set "isDateVersioned" false }}
+{{ $dvScratch.Set "apiVersionsList" slice }}
+{{ $dvScratch.Set "baseVersion" "" }}
+{{ $dvScratch.Set "dateVersionOperationId" "" }}
+{{ $dvScratch.Set "apiMajorVersion" "" }}
+{{ range $versionNum := $versions }}
+  {{ $specData := partial "api/load-specs.html" (dict "version" $versionNum) }}
+  {{ if $specData }}
+    {{ $gr := partial "api/regions.html" (dict "servers" $specData.servers) }}
+    {{ $ep := partial "api/get-endpoint.html" (dict "lang" $dot.Lang "operationids" $operationids "version" $versionNum "generalRegions" $gr) }}
+    {{ if $ep }}
+      {{ range $respCode, $resp := $ep.action.responses }}
+        {{ range $mt, $content := $resp.content }}
+          {{ if index $content.schema "x-datadog-api-versioned" }}
+            {{ $dvScratch.Set "isDateVersioned" true }}
+            {{ $dvScratch.Set "dateVersionOperationId" $ep.action.operationId }}
+            {{ $dvScratch.Set "apiMajorVersion" $versionNum }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ with $ep.action.requestBody }}
+        {{ range $mt, $content := .content }}
+          {{ if index $content.schema "x-datadog-api-versioned" }}
+            {{ $dvScratch.Set "isDateVersioned" true }}
+            {{ $dvScratch.Set "dateVersionOperationId" $ep.action.operationId }}
+            {{ $dvScratch.Set "apiMajorVersion" $versionNum }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ if $dvScratch.Get "isDateVersioned" }}
+        {{ $apiVersioningData := index $specData "x-datadog-api-versioning" | default dict }}
+        {{ $versionMap := $apiVersioningData.versions | default dict }}
+        {{ $dateKeys := slice }}
+        {{ range $dk, $_ := $versionMap }}
+          {{ $dateKeys = append $dk $dateKeys }}
+        {{ end }}
+        {{ $dateKeys = sort $dateKeys }}
+        {{ $bvs := newScratch }}
+        {{ $bvs.Set "bv" "" }}
+        {{ range $dateKeys }}
+          {{ if (index $versionMap .).base }}
+            {{ $bvs.Set "bv" . }}
+          {{ end }}
+        {{ end }}
+        {{ $bv := $bvs.Get "bv" }}
+        {{ if and (eq $bv "") (gt (len $dateKeys) 0) }}
+          {{ $bv = index $dateKeys 0 }}
+        {{ end }}
+        {{ $dvScratch.Set "baseVersion" $bv }}
+        {{ $vList := slice }}
+        {{ range $dateKeys }}
+          {{ $vd := index $versionMap . }}
+          {{ $vList = append (dict "date" . "isBase" ($vd.base | default false) "deprecated" ($vd.deprecated | default false) "eol" ($vd.eol | default "")) $vList }}
+        {{ end }}
+        {{ $dvScratch.Set "apiVersionsList" $vList }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return dict
+  "isDateVersioned" ($dvScratch.Get "isDateVersioned")
+  "apiVersionsList" ($dvScratch.Get "apiVersionsList")
+  "baseVersion" ($dvScratch.Get "baseVersion")
+  "dateVersionOperationId" ($dvScratch.Get "dateVersionOperationId")
+  "apiMajorVersion" ($dvScratch.Get "apiMajorVersion")
+}}

--- a/hugo/layouts/partials/api/endpoint.html
+++ b/hugo/layouts/partials/api/endpoint.html
@@ -16,6 +16,10 @@ Required dict keys:
   tag                 — tag object (used for x-deprecated check)
   translate_action    — translated action dict (may be empty)
   resourcePage        — page object for the version-specific resource page
+  isDateVersioned     — bool, whether this operation is date-versioned
+  apiVersionsList     — slice of version metadata dicts
+  baseVersion         — default selected date version
+  apiMajorVersion     — endpoint major version (for example, "v1")
 */}}
 {{ $dot := .dot }}
 {{ $endpoint := .endpoint }}
@@ -28,8 +32,12 @@ Required dict keys:
 {{ $tag := .tag }}
 {{ $translate_action := .translate_action }}
 {{ $resourcePage := .resourcePage }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $apiVersionsList := .apiVersionsList | default slice }}
+{{ $baseVersion := .baseVersion | default "" }}
+{{ $apiMajorVersion := .apiMajorVersion | default $versionNum }}
 
-<div class="row endpoint">
+<div class="row endpoint {{ if $isDateVersioned }}api-endpoint-date-versioned{{ end }}">
     <div class="col-12">
         <div class="endpoint-content">
 
@@ -41,7 +49,7 @@ Required dict keys:
             {{ end }}
 
             <!-- if this is deprecated and we have a higher version link to that -->
-            {{ if (and $endpointVisibility.isVisibleVersion (eq $versionNum "v1") (gt $versionCount 1) (eq (index $tag "x-deprecated") true)) }}}}
+            {{ if (and $endpointVisibility.isVisibleVersion (eq $versionNum "v1") (gt $versionCount 1) (eq (index $tag "x-deprecated") true)) }}
               {{ $collapsedAnchorStr := (print $endpoint.action.summary " " (replace $versionNum "1" "2")) }}
               <div class="alert alert-warning">
                 <p class="alert-warning">This endpoint is deprecated use the latest endpoint here <a class="toggle-version-tab" href="#{{ $collapsedAnchorStr | anchorize }}">{{- $collapsedAnchorStr -}}.</a></p>
@@ -56,16 +64,21 @@ Required dict keys:
               </div>
             {{ end }}
 
-            <p class="mb-0 api-url-info"><span style="padding: 3px" class="font-semibold api-method text-api-method text-api-{{ $endpoint.actionType }} bg-bg-api-{{ $endpoint.actionType }}">{{ $endpoint.actionType | upper }}</span>&nbsp;
-              {{- range $region, $url := $endpoint.regions -}}
-                  <span class="api-url-pattern d-none" data-region="{{ $region }}">{{ $url }}{{ $endpoint.pathKey }}</span>
-              {{- end -}}
-              {{- range $region, $url := $generalRegions -}}
-                  {{- if not (index ($endpoint.regions) $region) -}}
-                      <span class="api-url-pattern d-none" data-region="{{ $region }}">Not supported in the {{ upper $region }} region</span>
-                  {{- end -}}
-              {{- end -}}
-            </p>
+            <div class="api-operation-request-line d-flex flex-wrap align-items-center justify-content-between">
+              <p class="mb-0 api-url-info"><span style="padding: 3px" class="font-semibold api-method text-api-method text-api-{{ $endpoint.actionType }} bg-bg-api-{{ $endpoint.actionType }}">{{ $endpoint.actionType | upper }}</span>&nbsp;
+                {{- range $region, $url := $endpoint.regions -}}
+                    <span class="api-url-pattern d-none" data-region="{{ $region }}">{{ $url }}{{ $endpoint.pathKey }}</span>
+                {{- end -}}
+                {{- range $region, $url := $generalRegions -}}
+                    {{- if not (index ($endpoint.regions) $region) -}}
+                        <span class="api-url-pattern d-none" data-region="{{ $region }}">Not supported in the {{ upper $region }} region</span>
+                    {{- end -}}
+                {{- end -}}
+              </p>
+              {{ if $isDateVersioned }}
+                {{ partial "api/date-version-selector.html" (dict "operationId" $endpoint.action.operationId "versions" $apiVersionsList "baseVersion" $baseVersion "apiMajorVersion" $apiMajorVersion) }}
+              {{ end }}
+            </div>
 
             <h3 class="mt-2">{{ i18n "overview" }}</h3>
             <p>
@@ -78,13 +91,13 @@ Required dict keys:
             {{ partial "api/arguments.html" (dict "context" $dot "endpoint" $endpoint) }}
 
             <!-- request body -->
-            {{ partial "api/request-body.html" (dict "context" $dot "body" $endpoint.action.requestBody "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum) }}
+            {{ partial "api/request-body.html" (dict "context" $dot "body" $endpoint.action.requestBody "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
 
             <!-- response -->
-            {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum) }}
+            {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
 
             <!-- code example -->
-            {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint "version" $versionNum) }}
+            {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint "version" $versionNum "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion) }}
         </div>
     </div>
 </div>

--- a/hugo/layouts/partials/api/endpoint.html
+++ b/hugo/layouts/partials/api/endpoint.html
@@ -37,7 +37,7 @@ Required dict keys:
 {{ $baseVersion := .baseVersion | default "" }}
 {{ $apiMajorVersion := .apiMajorVersion | default $versionNum }}
 
-<div class="row endpoint {{ if $isDateVersioned }}api-endpoint-date-versioned{{ end }}">
+<div class="row endpoint">
     <div class="col-12">
         <div class="endpoint-content">
 

--- a/hugo/layouts/partials/api/render-versioned-code.html
+++ b/hugo/layouts/partials/api/render-versioned-code.html
@@ -1,0 +1,21 @@
+{{/* Render an SDK example variant for every supported date-based API version. */}}
+{{ $body := .body }}
+{{ $lang := .lang }}
+{{ $operationId := .operationId }}
+{{ $apiMajorVersion := .apiMajorVersion }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $apiVersionsList := .apiVersionsList | default slice }}
+{{ $baseVersion := .baseVersion | default "" }}
+
+{{ if and $isDateVersioned (gt (len $apiVersionsList) 0) }}
+  {{ range $apiVersionsList }}
+    {{ $versionedBody := partial "api/version-code-namespace.html" (dict "body" $body "language" $lang.name "apiMajorVersion" $apiMajorVersion "date" .date) }}
+    <div class="api-versioned-pane api-versioned-code-pane {{ if ne .date $baseVersion }}d-none{{ end }}"
+         data-api-date-version="{{ .date }}"
+         data-operation-id="{{ $operationId }}">
+      {{ highlight $versionedBody $lang.syntax "" }}
+    </div>
+  {{ end }}
+{{ else }}
+  {{ highlight $body $lang.syntax "" }}
+{{ end }}

--- a/hugo/layouts/partials/api/request-body.html
+++ b/hugo/layouts/partials/api/request-body.html
@@ -5,6 +5,9 @@
 {{ $resourcePage := .resourcePage }}
 {{ $translate_action := .translate_action }}
 {{ $version := .version }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $apiVersionsList := .apiVersionsList | default slice }}
+{{ $baseVersion := .baseVersion | default "" }}
 {{ $codeExampleLookup := (index (index $context.Site.Data.api $version) "CodeExamples") }}
 {{ $s := newScratch }}
 
@@ -24,6 +27,8 @@
                       <!-- Get Json and HTML -->
                       {{ $s.Set "json" "" }}
                       {{ $s.Set "html" "" }}
+                      {{ $s.Set "versionedHtml" slice }}
+                      {{ $s.Set "versionedJson" slice }}
 
                       {{ if $resourcePage }}
                         {{ with $resourcePage.Resources.Match "examples.json" }}
@@ -41,6 +46,18 @@
                                           {{ $s.Set "json" (highlight ($jsonifiedData) "json" "") }}
                                           {{ $context.Scratch.Set "jsonRequestBody" $json_curl }}
                                           {{ $s.Set "html" (index $req "html") }}
+                                          {{ with (index $req "versionedHtml") }}
+                                              {{ $s.Set "versionedHtml" . }}
+                                          {{ end }}
+                                          {{ with (index $req "versionedJson") }}
+                                              {{ $highlightedList := slice }}
+                                              {{ range . }}
+                                                  {{ $jsonData := . | jsonify (dict "indent" "  ") }}
+                                                  {{ $jsonData = replace (replace $jsonData "\\u003c" "<") "\\u003e" ">" }}
+                                                  {{ $highlightedList = append (highlight $jsonData "json" "") $highlightedList }}
+                                              {{ end }}
+                                              {{ $s.Set "versionedJson" $highlightedList }}
+                                          {{ end }}
                                       {{ else }}
                                           {{ warnf "Could not load html/json request for %q" $operationid }}
                                       {{ end }}
@@ -59,8 +76,21 @@
 
                       {{ $json := ($s.Get "json") }}
                       {{ $html := ($s.Get "html") }}
+                      {{ $versionedHtml := ($s.Get "versionedHtml") }}
+                      {{ $versionedJson := ($s.Get "versionedJson") }}
+                      {{ $isVersionedSchema := index $schema "x-datadog-api-versioned" | default false }}
+                      {{ $renderVersioned := and $isVersionedSchema $isDateVersioned (gt (len $apiVersionsList) 0) (gt (len $versionedHtml) 0) }}
+                      {{ $showSchemaPanel := and $isDateVersioned (gt (len $apiVersionsList) 0) }}
 
-                      <ul class="nav nav-tabs border-none response-toggle">
+                      <div class="{{ if $showSchemaPanel }}api-schema-panel{{ end }}">
+                      {{ if $showSchemaPanel }}
+                      <div class="api-schema-toolbar">
+                          <div class="api-schema-namespace">
+                              <span class="api-schema-namespace-label">Schema</span>
+                              <code>{{ $version }} / <span class="api-version-header-value" data-operation-id="{{ $operationid }}">{{ $baseVersion }}</span></code>
+                          </div>
+                      {{ end }}
+                      <ul class="nav nav-tabs border-none response-toggle {{ if $showSchemaPanel }}api-schema-tabs{{ end }}">
                           <li class="nav-item">
                               <a class="nav-link me-1  js-model-link active" href="#" data-bs-toggle="tab">{{ i18n "model" }}</a>
                           </li>
@@ -68,11 +98,38 @@
                               <a class="nav-link me-1  js-example-link"  href="#" data-bs-toggle="tab">{{ i18n "example" }}</a>
                           </li>
                       </ul>
+                      {{ if $showSchemaPanel }}
+                      </div>
+                      {{ end }}
 
-                      <div class="tab-content">
+                      <div class="tab-content {{ if $showSchemaPanel }}api-schema-panel-body{{ end }}">
                           <div role="tabpanel" class="tab-pane active js-tab-model" id="{{ $operationid | lower }}-request-model" data-title="{{ i18n "model" }}">
 
-                              {{ if in $html "schema-table" }}
+                              {{ if $renderVersioned }}
+                                  {{ range $variantIndex, $variantHtml := $versionedHtml }}
+                                      {{ $versionInfo := index $apiVersionsList $variantIndex | default (dict "date" (printf "variant-%d" $variantIndex)) }}
+                                      {{ $date := $versionInfo.date }}
+                                      <div class="api-versioned-pane {{ if ne $date $baseVersion }}d-none{{ end }}"
+                                           data-api-date-version="{{ $date }}"
+                                           data-operation-id="{{ $operationid }}">
+                                          {{ if in $variantHtml "schema-table" }}
+                                              {{ $variantHtml | safeHTML }}
+                                          {{ else }}
+                                              <div class="table-request schema-table row {{ if not (in $variantHtml "js-collapse-trigger") }}has-no-expands{{ end }} {{ if (in $variantHtml "hide-table") }}d-none{{ end }}">
+                                                <p class="expand-all js-expand-all text-primary text-end">Expand All</p>
+                                                <div class="col-12">
+                                                  <div class="row table-header">
+                                                    <div class="col-4 column"><p class="font-semibold">{{ i18n "field" }}</p></div>
+                                                    <div class="col-2 column"><p class="font-semibold">{{ i18n "type" }}</p></div>
+                                                    <div class="col-6 column"><p class="font-semibold">{{ i18n "description" }}</p></div>
+                                                  </div>
+                                                  {{ $variantHtml | safeHTML }}
+                                                </div>
+                                              </div>
+                                          {{ end }}
+                                      </div>
+                                  {{ end }}
+                              {{ else if in $html "schema-table" }}
                                   {{ $html | safeHTML }}
                               {{ else }}
                                   <div class="table-request schema-table row {{ if not (in $html "js-collapse-trigger") }}has-no-expands{{ end }} {{ if (in $html "hide-table") }}d-none{{ end }}">
@@ -96,6 +153,19 @@
 
                           </div>
                           <div role="tabpanel" class="tab-pane js-tab-example" id="{{ $operationid | lower }}-{{ $version }}-request-example" data-title="{{ i18n "example" }}">
+                              {{ if $renderVersioned }}
+                                {{ range $variantIndex, $variantJson := $versionedJson }}
+                                    {{ $versionInfo := index $apiVersionsList $variantIndex | default (dict "date" (printf "variant-%d" $variantIndex)) }}
+                                    {{ $date := $versionInfo.date }}
+                                    <div class="api-versioned-pane {{ if ne $date $baseVersion }}d-none{{ end }}"
+                                         data-api-date-version="{{ $date }}"
+                                         data-operation-id="{{ $operationid }}">
+                                        <div class="code-snippet-wrapper append-copy-btn">
+                                            {{ $variantJson }}
+                                        </div>
+                                    </div>
+                                {{ end }}
+                              {{ else }}
                               <div class="code-snippet-wrapper">
 
                                 {{ $fileNonExistCount := 0 }}
@@ -138,7 +208,9 @@
                                 {{ end }}
 
                               </div>
+                              {{ end }}
                           </div>
+                      </div>
                       </div>
                   {{ end }}
               {{ end }}

--- a/hugo/layouts/partials/api/request-body.html
+++ b/hugo/layouts/partials/api/request-body.html
@@ -80,17 +80,7 @@
                       {{ $versionedJson := ($s.Get "versionedJson") }}
                       {{ $isVersionedSchema := index $schema "x-datadog-api-versioned" | default false }}
                       {{ $renderVersioned := and $isVersionedSchema $isDateVersioned (gt (len $apiVersionsList) 0) (gt (len $versionedHtml) 0) }}
-                      {{ $showSchemaPanel := and $isDateVersioned (gt (len $apiVersionsList) 0) }}
-
-                      <div class="{{ if $showSchemaPanel }}api-schema-panel{{ end }}">
-                      {{ if $showSchemaPanel }}
-                      <div class="api-schema-toolbar">
-                          <div class="api-schema-namespace">
-                              <span class="api-schema-namespace-label">Schema</span>
-                              <code>{{ $version }} / <span class="api-version-header-value" data-operation-id="{{ $operationid }}">{{ $baseVersion }}</span></code>
-                          </div>
-                      {{ end }}
-                      <ul class="nav nav-tabs border-none response-toggle {{ if $showSchemaPanel }}api-schema-tabs{{ end }}">
+                      <ul class="nav nav-tabs border-none response-toggle">
                           <li class="nav-item">
                               <a class="nav-link me-1  js-model-link active" href="#" data-bs-toggle="tab">{{ i18n "model" }}</a>
                           </li>
@@ -98,11 +88,7 @@
                               <a class="nav-link me-1  js-example-link"  href="#" data-bs-toggle="tab">{{ i18n "example" }}</a>
                           </li>
                       </ul>
-                      {{ if $showSchemaPanel }}
-                      </div>
-                      {{ end }}
-
-                      <div class="tab-content {{ if $showSchemaPanel }}api-schema-panel-body{{ end }}">
+                      <div class="tab-content">
                           <div role="tabpanel" class="tab-pane active js-tab-model" id="{{ $operationid | lower }}-request-model" data-title="{{ i18n "model" }}">
 
                               {{ if $renderVersioned }}
@@ -210,7 +196,6 @@
                               </div>
                               {{ end }}
                           </div>
-                      </div>
                       </div>
                   {{ end }}
               {{ end }}

--- a/hugo/layouts/partials/api/response.html
+++ b/hugo/layouts/partials/api/response.html
@@ -4,21 +4,37 @@
 {{ $resourcePage := .resourcePage }}
 {{ $translate_action := .translate_action }}
 {{ $version := .version }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $apiVersionsList := .apiVersionsList | default slice }}
+{{ $baseVersion := .baseVersion | default "" }}
 {{ $s := newScratch }}
 
 <h3 class="mt-3 mb-2">{{ i18n "response" }}</h3>
 
-<ul class="nav nav-tabs border-none response-toggle px-0" style="z-index: 10;">
+<div class="{{ if $isDateVersioned }}api-response-panel{{ end }}">
+<ul class="nav nav-tabs border-none response-toggle px-0 {{ if $isDateVersioned }}api-response-status-tabs{{ end }}" style="z-index: 10;">
+    {{ if $isDateVersioned }}
+        <li class="api-response-status-label">Status</li>
+    {{ end }}
     {{ $count := 0}}
     {{ range $response_code, $response := $responses }}
+        {{ $statusDescription := $response.description | default "" }}
+        {{ with $translate_action.responses }}
+            {{ with index . $response_code }}
+                {{ $statusDescription = .description | default $statusDescription }}
+            {{ end }}
+        {{ end }}
         <li class="nav-item">
-            <a class="nav-link me-1  {{ if eq $count 0}}active{{end}}"  href="#{{ $operationid }}-{{ $response_code }}-{{ $version }}"  data-bs-toggle="tab" data-bs-target="#{{ $operationid }}-{{ $response_code }}-{{ $version }}">{{ $response_code }}</a>
+            <a class="nav-link me-1 {{ if eq $count 0}}active{{end}}" href="#{{ $operationid }}-{{ $response_code }}-{{ $version }}" data-bs-toggle="tab" data-bs-target="#{{ $operationid }}-{{ $response_code }}-{{ $version }}">
+                <span class="api-response-status-code">{{ $response_code }}</span>
+                {{ with $statusDescription }}<span class="api-response-status-description">{{ . }}</span>{{ end }}
+            </a>
         </li>
         {{ $count = add $count 1 }}
     {{ end }}
 </ul>
 
-<div class="tab-content mb-3">
+<div class="tab-content mb-3 {{ if $isDateVersioned }}api-response-tab-content{{ end }}">
     {{ $count := 0}}
     {{ range $response_code, $response := $responses }}
 
@@ -29,7 +45,9 @@
         <div role="tabpanel" class="tab-pane {{ if eq $count 0}} active {{end}}" id="{{ $operationid }}-{{ $response_code }}-{{ $version }}" data-title="{{ $response_code }}">
             {{ with $response.content }}
 
-                <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>
+                {{ if not $isDateVersioned }}
+                    <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>
+                {{ end }}
 
                 {{ range $content := . }}
 
@@ -41,6 +59,8 @@
                             <!-- Get Json and HTML -->
                             {{ $s.Set "json" "" }}
                             {{ $s.Set "html" "" }}
+                            {{ $s.Set "versionedHtml" slice }}
+                            {{ $s.Set "versionedJson" slice }}
                             {{ with $resourcePage.Resources.Match "examples.json" }}
                                 {{ range . }}
                                     {{ $data := . | unmarshal}}
@@ -52,6 +72,18 @@
                                                 {{ $jsonifiedData = replace (replace $jsonifiedData "\\u003c" "<") "\\u003e" ">"  }}
                                                 {{ $s.Set "json" (highlight ($jsonifiedData) "json" "") }}
                                                 {{ $s.Set "html" (index $res "html") }}
+                                                {{ with (index $res "versionedHtml") }}
+                                                    {{ $s.Set "versionedHtml" . }}
+                                                {{ end }}
+                                                {{ with (index $res "versionedJson") }}
+                                                    {{ $highlightedList := slice }}
+                                                    {{ range . }}
+                                                        {{ $jsonData := . | jsonify (dict "indent" "  ") }}
+                                                        {{ $jsonData = replace (replace $jsonData "\\u003c" "<") "\\u003e" ">" }}
+                                                        {{ $highlightedList = append (highlight $jsonData "json" "") $highlightedList }}
+                                                    {{ end }}
+                                                    {{ $s.Set "versionedJson" $highlightedList }}
+                                                {{ end }}
                                             {{ else }}
                                                 {{ warnf "Could not load html/json response code %q in %q" $response_code $operationid }}
                                             {{ end }}
@@ -65,6 +97,8 @@
                             {{ end }}
                             {{ $json := ($s.Get "json") }}
                             {{ $html := ($s.Get "html") }}
+                            {{ $versionedHtml := ($s.Get "versionedHtml") }}
+                            {{ $versionedJson := ($s.Get "versionedJson") }}
 
                             {{/*
                                 If we are missing json/html lets build from an examples entry in data if it exists
@@ -97,7 +131,19 @@
                               {{ end }}
                             {{ end }}
 
-                            <ul class="nav nav-tabs border-none response-toggle px-0">
+                            {{ $isVersionedSchema := index $schema "x-datadog-api-versioned" | default false }}
+                            {{ $renderVersioned := and $isVersionedSchema $isDateVersioned (gt (len $apiVersionsList) 0) (gt (len $versionedHtml) 0) }}
+                            {{ $showSchemaPanel := and $isDateVersioned (gt (len $apiVersionsList) 0) }}
+
+                            <div class="{{ if $showSchemaPanel }}api-schema-panel{{ end }}">
+                            {{ if $showSchemaPanel }}
+                            <div class="api-schema-toolbar">
+                                <div class="api-schema-namespace">
+                                    <span class="api-schema-namespace-label">Schema</span>
+                                    <code>{{ $version }} / <span class="api-version-header-value" data-operation-id="{{ $operationid }}">{{ $baseVersion }}</span></code>
+                                </div>
+                            {{ end }}
+                            <ul class="nav nav-tabs border-none response-toggle px-0 {{ if $showSchemaPanel }}api-schema-tabs{{ end }}">
                                 <li class="nav-item">
                                     <a class="nav-link me-1  js-model-link active"  href="#" data-bs-toggle="tab">{{ i18n "model" }}</a>
                                 </li>
@@ -105,53 +151,92 @@
                                     <a class="nav-link me-1  js-example-link"  href="#" data-bs-toggle="tab">{{ i18n "example" }}</a>
                                 </li>
                             </ul>
+                            {{ if $showSchemaPanel }}
+                            </div>
+                            {{ end }}
 
-                            <div class="tab-content">
+                            <div class="tab-content {{ if $showSchemaPanel }}api-schema-panel-body{{ end }}">
                                 <div role="tabpanel" class="tab-pane active js-tab-model" id="{{ $operationid }}-{{ $response_code }}-model" data-title="{{ i18n "model" }}">
 
                                     {{ with $schema.description }}
                                         <p>{{- . | markdownify -}}</p>
                                     {{ end }}
 
-
-                                    {{ if in $html "schema-table" }}
-                                        {{ $html | safeHTML }}
+                                    {{ if $renderVersioned }}
+                                        {{ range $variantIndex, $variantHtml := $versionedHtml }}
+                                            {{ $versionInfo := index $apiVersionsList $variantIndex | default (dict "date" (printf "variant-%d" $variantIndex)) }}
+                                            {{ $date := $versionInfo.date }}
+                                            <div class="api-versioned-pane {{ if ne $date $baseVersion }}d-none{{ end }}"
+                                                 data-api-date-version="{{ $date }}"
+                                                 data-operation-id="{{ $operationid }}">
+                                                {{ if in $variantHtml "schema-table" }}
+                                                    {{ $variantHtml | safeHTML }}
+                                                {{ else }}
+                                                    <div class="table-response schema-table row {{ if not (in $variantHtml "js-collapse-trigger") }}has-no-expands{{ end }} {{ if (in $variantHtml "hide-table") }}d-none{{ end }}">
+                                                      <p class="expand-all js-expand-all text-primary text-end">Expand All</p>
+                                                      <div class="col-12">
+                                                        <div class="row table-header">
+                                                          <div class="col-4 column"><p class="font-semibold">{{ i18n "field" }}</p></div>
+                                                          <div class="col-2 column"><p class="font-semibold">{{ i18n "type" }}</p></div>
+                                                          <div class="col-6 column"><p class="font-semibold">{{ i18n "description" }}</p></div>
+                                                        </div>
+                                                        {{ $variantHtml | safeHTML }}
+                                                      </div>
+                                                    </div>
+                                                {{ end }}
+                                            </div>
+                                        {{ end }}
                                     {{ else }}
-                                        <div class="table-response schema-table row {{ if not (in $html "js-collapse-trigger") }}has-no-expands{{ end }} {{ if (in $html "hide-table") }}d-none{{ end }}">
-                                          <p class="expand-all js-expand-all text-primary text-end">Expand All</p>
-                                          <div class="col-12">
-                                            <div class="row table-header">
-                                              <div class="col-4 column">
-                                                <p class="font-semibold">{{ i18n "field" }}</p>
-                                              </div>
-                                              <div class="col-2 column">
-                                                <p class="font-semibold">{{ i18n "type" }}</p>
-                                              </div>
-                                              <div class="col-6 column">
-                                                <p class="font-semibold">{{ i18n "description" }}</p>
+                                        {{ if in $html "schema-table" }}
+                                            {{ $html | safeHTML }}
+                                        {{ else }}
+                                            <div class="table-response schema-table row {{ if not (in $html "js-collapse-trigger") }}has-no-expands{{ end }} {{ if (in $html "hide-table") }}d-none{{ end }}">
+                                              <p class="expand-all js-expand-all text-primary text-end">Expand All</p>
+                                              <div class="col-12">
+                                                <div class="row table-header">
+                                                  <div class="col-4 column"><p class="font-semibold">{{ i18n "field" }}</p></div>
+                                                  <div class="col-2 column"><p class="font-semibold">{{ i18n "type" }}</p></div>
+                                                  <div class="col-6 column"><p class="font-semibold">{{ i18n "description" }}</p></div>
+                                                </div>
+                                                {{ $html | safeHTML }}
                                               </div>
                                             </div>
-                                            {{ $html | safeHTML }}
-                                          </div>
-                                        </div>
+                                        {{ end }}
                                     {{ end }}
 
                                 </div>
                                 <div role="tabpanel" class="tab-pane js-tab-example" id="{{ $operationid }}-{{ $response_code }}-example" data-title="{{ i18n "example" }}">
-                                    <div class="code-snippet-wrapper append-copy-btn">
-                                        {{/*  $json is a highlight hugo function  */}}
-                                        {{ $json }}
-                                    </div>
+                                    {{ if $renderVersioned }}
+                                        {{ range $variantIndex, $variantJson := $versionedJson }}
+                                            {{ $versionInfo := index $apiVersionsList $variantIndex | default (dict "date" (printf "variant-%d" $variantIndex)) }}
+                                            {{ $date := $versionInfo.date }}
+                                            <div class="api-versioned-pane {{ if ne $date $baseVersion }}d-none{{ end }}"
+                                                 data-api-date-version="{{ $date }}"
+                                                 data-operation-id="{{ $operationid }}">
+                                                <div class="code-snippet-wrapper append-copy-btn">
+                                                    {{ $variantJson }}
+                                                </div>
+                                            </div>
+                                        {{ end }}
+                                    {{ else }}
+                                        <div class="code-snippet-wrapper append-copy-btn">
+                                            {{ $json }}
+                                        </div>
+                                    {{ end }}
                                 </div>
+                            </div>
                             </div>
 
                         {{ end }}
                     {{ end }}
                 {{ end }}
             {{ else }}
-                <p class="mb-2">{{ $response.description | default "No response content" }}</p>
+                {{ if not $isDateVersioned }}
+                    <p class="mb-2">{{ $response.description | default "No response content" }}</p>
+                {{ end }}
             {{ end}}
         </div>
         {{ $count = add $count 1 }}
     {{ end }}
+</div>
 </div>

--- a/hugo/layouts/partials/api/response.html
+++ b/hugo/layouts/partials/api/response.html
@@ -11,30 +11,17 @@
 
 <h3 class="mt-3 mb-2">{{ i18n "response" }}</h3>
 
-<div class="{{ if $isDateVersioned }}api-response-panel{{ end }}">
-<ul class="nav nav-tabs border-none response-toggle px-0 {{ if $isDateVersioned }}api-response-status-tabs{{ end }}" style="z-index: 10;">
-    {{ if $isDateVersioned }}
-        <li class="api-response-status-label">Status</li>
-    {{ end }}
+<ul class="nav nav-tabs border-none response-toggle px-0" style="z-index: 10;">
     {{ $count := 0}}
     {{ range $response_code, $response := $responses }}
-        {{ $statusDescription := $response.description | default "" }}
-        {{ with $translate_action.responses }}
-            {{ with index . $response_code }}
-                {{ $statusDescription = .description | default $statusDescription }}
-            {{ end }}
-        {{ end }}
         <li class="nav-item">
-            <a class="nav-link me-1 {{ if eq $count 0}}active{{end}}" href="#{{ $operationid }}-{{ $response_code }}-{{ $version }}" data-bs-toggle="tab" data-bs-target="#{{ $operationid }}-{{ $response_code }}-{{ $version }}">
-                <span class="api-response-status-code">{{ $response_code }}</span>
-                {{ with $statusDescription }}<span class="api-response-status-description">{{ . }}</span>{{ end }}
-            </a>
+            <a class="nav-link me-1  {{ if eq $count 0}}active{{end}}"  href="#{{ $operationid }}-{{ $response_code }}-{{ $version }}"  data-bs-toggle="tab" data-bs-target="#{{ $operationid }}-{{ $response_code }}-{{ $version }}">{{ $response_code }}</a>
         </li>
         {{ $count = add $count 1 }}
     {{ end }}
 </ul>
 
-<div class="tab-content mb-3 {{ if $isDateVersioned }}api-response-tab-content{{ end }}">
+<div class="tab-content mb-3">
     {{ $count := 0}}
     {{ range $response_code, $response := $responses }}
 
@@ -45,9 +32,7 @@
         <div role="tabpanel" class="tab-pane {{ if eq $count 0}} active {{end}}" id="{{ $operationid }}-{{ $response_code }}-{{ $version }}" data-title="{{ $response_code }}">
             {{ with $response.content }}
 
-                {{ if not $isDateVersioned }}
-                    <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>
-                {{ end }}
+                <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>
 
                 {{ range $content := . }}
 
@@ -133,17 +118,7 @@
 
                             {{ $isVersionedSchema := index $schema "x-datadog-api-versioned" | default false }}
                             {{ $renderVersioned := and $isVersionedSchema $isDateVersioned (gt (len $apiVersionsList) 0) (gt (len $versionedHtml) 0) }}
-                            {{ $showSchemaPanel := and $isDateVersioned (gt (len $apiVersionsList) 0) }}
-
-                            <div class="{{ if $showSchemaPanel }}api-schema-panel{{ end }}">
-                            {{ if $showSchemaPanel }}
-                            <div class="api-schema-toolbar">
-                                <div class="api-schema-namespace">
-                                    <span class="api-schema-namespace-label">Schema</span>
-                                    <code>{{ $version }} / <span class="api-version-header-value" data-operation-id="{{ $operationid }}">{{ $baseVersion }}</span></code>
-                                </div>
-                            {{ end }}
-                            <ul class="nav nav-tabs border-none response-toggle px-0 {{ if $showSchemaPanel }}api-schema-tabs{{ end }}">
+                            <ul class="nav nav-tabs border-none response-toggle px-0">
                                 <li class="nav-item">
                                     <a class="nav-link me-1  js-model-link active"  href="#" data-bs-toggle="tab">{{ i18n "model" }}</a>
                                 </li>
@@ -151,11 +126,7 @@
                                     <a class="nav-link me-1  js-example-link"  href="#" data-bs-toggle="tab">{{ i18n "example" }}</a>
                                 </li>
                             </ul>
-                            {{ if $showSchemaPanel }}
-                            </div>
-                            {{ end }}
-
-                            <div class="tab-content {{ if $showSchemaPanel }}api-schema-panel-body{{ end }}">
+                            <div class="tab-content">
                                 <div role="tabpanel" class="tab-pane active js-tab-model" id="{{ $operationid }}-{{ $response_code }}-model" data-title="{{ i18n "model" }}">
 
                                     {{ with $schema.description }}
@@ -225,18 +196,14 @@
                                     {{ end }}
                                 </div>
                             </div>
-                            </div>
 
                         {{ end }}
                     {{ end }}
                 {{ end }}
             {{ else }}
-                {{ if not $isDateVersioned }}
-                    <p class="mb-2">{{ $response.description | default "No response content" }}</p>
-                {{ end }}
+                <p class="mb-2">{{ $response.description | default "No response content" }}</p>
             {{ end}}
         </div>
         {{ $count = add $count 1 }}
     {{ end }}
-</div>
 </div>

--- a/hugo/layouts/partials/api/version-code-namespace.html
+++ b/hugo/layouts/partials/api/version-code-namespace.html
@@ -1,0 +1,28 @@
+{{/*
+  Rewrites a generated SDK example to use the namespace for one date-based API
+  version. Language identifiers use underscores where hyphens are invalid.
+
+  Params: body, language, apiMajorVersion (v1/v2), date (YYYY-MM-DD)
+*/}}
+{{ $body := .body }}
+{{ $language := .language }}
+{{ $majorLower := lower .apiMajorVersion }}
+{{ $majorUpper := upper .apiMajorVersion }}
+{{ $dateCompact := replace .date "-" "" }}
+
+{{ if eq $language "go" }}
+  {{ $namespace := printf "datadog%s" $majorUpper }}
+  {{ $body = replace $body (printf "/api/%s\"" $namespace) (printf "/api/%s-%s\"" $namespace $dateCompact) }}
+{{ else if or (eq $language "python") (eq $language "python-legacy") }}
+  {{ $body = replace $body (printf "datadog_api_client.%s." $majorLower) (printf "datadog_api_client.%s_%s." $majorLower $dateCompact) }}
+{{ else if eq $language "java" }}
+  {{ $body = replace $body (printf "com.datadog.api.client.%s." $majorLower) (printf "com.datadog.api.client.%s_%s." $majorLower $dateCompact) }}
+{{ else if or (eq $language "ruby") (eq $language "ruby-legacy") }}
+  {{ $body = replace $body (printf "DatadogAPIClient::%s" $majorUpper) (printf "DatadogAPIClient::%s_%s" $majorUpper $dateCompact) }}
+{{ else if eq $language "typescript" }}
+  {{ $body = replaceRE (printf `\b%s\b` $majorLower) (printf "%s_%s" $majorLower $dateCompact) $body }}
+{{ else if eq $language "rust" }}
+  {{ $body = replace $body (printf "datadog%s" $majorUpper) (printf "datadog%s_%s" $majorUpper $dateCompact) }}
+{{ end }}
+
+{{ return $body }}


### PR DESCRIPTION
## Summary

- port the date-based operation versioning POC to the refactored Hugo API operation pages
- add per-operation version selection across request and response schemas, models, examples, cURL headers, and SDK namespaces
- make selected versions shareable through the `datadog-api-version` query parameter
- annotate fields added or removed between adjacent date-based schema versions
- reuse the existing API page presentation and established language/site dropdown styles
- add a placeholder API versioning overview page

## Test plan

- `yarn jest-test --runInBand` — 201 passed, 3 skipped
- verified direct version URLs, dropdown URL updates, preserved query parameters and anchors, and reload behavior in local Chrome
- verified version-specific request and response panes, Go SDK namespaces, cURL headers, and deprecated/EOL state
- verified non-versioned operation pages do not render versioning controls or custom presentation wrappers

## Dependency

This is a stacked PR based on #38956. Review only the changes relative to `reorg-fix/pr-38028`.