### PR TITLE
chore(k9-iac): Add IaC CI setup doc

### DIFF
--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -1,20 +1,20 @@
 ---
 title: Set up IaC Security
 aliases:
-    - /security/cloud_security_management/setup/iac_scanning/
+  - /security/cloud_security_management/setup/iac_scanning/
 further_reading:
-    - link: '/security/code_security'
-      tag: 'Documentation'
-      text: 'Code Security'
-    - link: '/security/code_security/iac_security'
-      tag: 'Documentation'
-      text: 'IaC Security'
-    - link: '/security/code_security/iac_security/configuration'
-      tag: 'Documentation'
-      text: 'Configure IaC Security'
-    - link: '/security/code_security/iac_security/iac_rules/'
-      tag: 'Documentation'
-      text: 'IaC Security Rules'
+  - link: "/security/code_security"
+    tag: "Documentation"
+    text: "Code Security"
+  - link: "/security/code_security/iac_security"
+    tag: "Documentation"
+    text: "IaC Security"
+  - link: "/security/code_security/iac_security/configuration"
+    tag: "Documentation"
+    text: "Configure IaC Security"
+  - link: "/security/code_security/iac_security/iac_rules/"
+    tag: "Documentation"
+    text: "IaC Security Rules"
 ---
 
 Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, or Azure DevOps repositories.
@@ -98,9 +98,9 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 
 ### Overview
 
-If you don't use GitHub Actions, GitLab CI/CD, or Azure DevOps, you can run the [Datadog IaC Scanner][8] directly in your CI pipeline and upload IaC scan results to Datadog using the [`datadog-ci` CLI][9].
+If you don't use GitHub Actions, GitLab CI/CD, or Azure DevOps, you can run the [Datadog IaC Scanner][8] directly in your CI pipeline. Upload IaC scan results to Datadog using the [`datadog-ci` CLI][9].
 
-**If you are running IaC Security on a non-GitHub repository**, ensure that the first scan runs on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, attempt an upload for your repository and then manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterwards, uploads from non-default branches succeed.
+**If you are running IaC Security on a non-GitHub repository**, help ensure that the first scan runs on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, attempt an upload for your repository. Then manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterward, uploads from non-default branches succeed.
 
 Prerequisites:
 
@@ -114,7 +114,7 @@ Configure the following environment variables:
 | Name         | Description                                                                                                                                                 | Required | Default         |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------- |
 | `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][4] and should be stored as a secret.                                               | Yes      |                 |
-| `DD_APP_KEY` | Your Datadog application key. This key, created by your [Datadog organization][4], should include the `code_analysis_read` scope and be stored as a secret. | Yes      |                 |
+| `DD_APP_KEY` | Your application key. This key, created by your [Datadog organization][4], should include the `code_analysis_read` scope and be stored as a secret. | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][5] to send information to. Your Datadog site is `datadoghq.com`.                                                                         | No       | `datadoghq.com` |
 
 Add the following to your CI pipeline:
@@ -158,39 +158,35 @@ To upload a SARIF report:
 2. Optionally, set a [`DD_SITE` variable][5] (this defaults to `datadoghq.com`).
 3. Install the `datadog-ci` utility (version 2.0 or later):
 
-    ```bash
-    npm install -g @datadog/datadog-ci
-    ```
+   ```bash
+   npm install -g @datadog/datadog-ci
+   ```
 
 4. Run the third-party IaC scanning tool (e.g., Checkov, Trivy, KICS) on your code and output the results in the SARIF v2.1.0 format.
 5. Upload the results to Datadog:
 
-    ```bash
-    datadog-ci sarif upload $OUTPUT_LOCATION
-    ```
-    - Upload Options
-        - `--tags:` Add custom tags (format: `key:value`)
-        - `--max-concurrency:` Set concurrent uploads (default: 20)
-        - `--dry-run:` Validate without uploading
-
+   ```bash
+   datadog-ci sarif upload $OUTPUT_LOCATION
+   ```
+   - Upload Options
+       - `--tags:` Add custom tags (format: `key:value`)
+       - `--max-concurrency:` Set concurrent uploads (default: 20)
+       - `--dry-run:` Validate without uploading
 ### Required SARIF Attributes
-
 To ensure proper ingestion and display in Datadog IaC Scanning for third-party scanners (excluding Checkov), your SARIF file MUST include the following attributes to be recognized as an IaC security finding:
-
 1. `Runs[...].tool.driver.name: Datadog IaC Scanning`
 2. `Runs[...].tool.driver.version: "code_update"` or `"full_scan"`
     - `"full_scan”` for complete repository scans
     - `"code_update"` for pull request / incremental scans
-3. `Runs[...].tool.driver.rules[...].properties.tags:`
+4. `Runs[...].tool.driver.rules[...].properties.tags:`
     - `["DATADOG_RULE_TYPE:IAC_SCANNING"]`
-    - `[“DATADOG_SCANNED_FILE_COUNT: <number>”]`, where `"number"` specifies the number of scanned files
-4. `Runs[...].results[...].locations[...].physicalLocation:`
+    - `[“DATADOG_SCANNED_FILE_COUNT: <number>”]`, where `"number"` specifies the number of scanned files 
+5. `Runs[...].results[...].locations[...].physicalLocation:`
     - `artifactLocation.uri`: Relative path to file from repository root
     - `region.startLine`: Starting line number
     - `region.endLine`: Ending line number
     - `region.startColumn`: Starting column number
     - `region.endColumn`: Ending column number
-
 <div class="alert alert-info">Suppressions silently drop violations. If <code>results[ ].suppressions</code> exists, the violation is completely ignored.</div>
 
 ## Further reading

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -1,20 +1,20 @@
 ---
 title: Set up IaC Security
 aliases:
-  - /security/cloud_security_management/setup/iac_scanning/
+    - /security/cloud_security_management/setup/iac_scanning/
 further_reading:
-  - link: "/security/code_security"
-    tag: "Documentation"
-    text: "Code Security"
-  - link: "/security/code_security/iac_security"
-    tag: "Documentation"
-    text: "IaC Security"
-  - link: "/security/code_security/iac_security/configuration"
-    tag: "Documentation"
-    text: "Configure IaC Security"
-  - link: "/security/code_security/iac_security/iac_rules/"
-    tag: "Documentation"
-    text: "IaC Security Rules"
+    - link: '/security/code_security'
+      tag: 'Documentation'
+      text: 'Code Security'
+    - link: '/security/code_security/iac_security'
+      tag: 'Documentation'
+      text: 'IaC Security'
+    - link: '/security/code_security/iac_security/configuration'
+      tag: 'Documentation'
+      text: 'Configure IaC Security'
+    - link: '/security/code_security/iac_security/iac_rules/'
+      tag: 'Documentation'
+      text: 'IaC Security Rules'
 ---
 
 Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, or Azure DevOps repositories.
@@ -94,6 +94,57 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 {{% /tab %}}
 {{< /tabs >}}
 
+## Set up IaC with a Generic CI Provider
+
+### Overview
+
+If you don't use GitHub Actions, GitLab CI/CD, or Azure DevOps, you can run the [Datadog IaC Scanner][8] directly in your CI pipeline and upload IaC scan results to Datadog using the [`datadog-ci` CLI][9].
+
+**If you are running IaC Security on a non-GitHub repository**, ensure that the first scan runs on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, attempt an upload for your repository and then manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterwards, uploads from non-default branches succeed.
+
+Prerequisites:
+
+- Node.js and npm
+- `curl`
+- `tar`
+- Permission to install the scanner in `/usr/local/bin`
+
+Configure the following environment variables:
+
+| Name         | Description                                                                                                                                                 | Required | Default         |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------- |
+| `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][4] and should be stored as a secret.                                               | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key, created by your [Datadog organization][4], should include the `code_analysis_read` scope and be stored as a secret. | Yes      |                 |
+| `DD_SITE`    | The [Datadog site][5] to send information to. Your Datadog site is `datadoghq.com`.                                                                         | No       | `datadoghq.com` |
+
+Add the following to your CI pipeline:
+
+```bash
+# Set the Datadog site to send information to
+export DD_SITE="datadoghq.com"
+
+# Install dependencies
+npm install -g @datadog/datadog-ci
+
+# Download the latest DataDog IaC Scanner
+export IAC_SCANNER_URL="https://github.com/DataDog/datadog-iac-scanner/releases/latest/download/datadog-iac-scanner_linux_amd64.tar.gz"
+curl -L "${IAC_SCANNER_URL}" -o /tmp/datadog-iac-scanner.tar.gz
+tar xfz /tmp/datadog-iac-scanner.tar.gz -C /tmp
+mv /tmp/datadog-iac-scanner /usr/local/bin/datadog-iac-scanner
+
+# Run the DataDog IaC scanner
+exit_code=0
+/usr/local/bin/datadog-iac-scanner scan -p . -o /tmp || exit_code=$?
+if [ $exit_code -lt 20 -o $exit_code -gt 60 ]; then echo "IaC scan failed" ; exit $exit_code ; fi
+
+# Upload results
+datadog-ci sarif upload /tmp/datadog-iac-scanner-result.sarif
+```
+
+<div class="alert alert-info">
+  This example uses the x86_64 Linux version of the Datadog IaC Scanner. If you're using a different OS or architecture, select the appropriate release from the <a href="https://github.com/DataDog/datadog-iac-scanner/releases">GitHub Releases</a> page and update the <code>DATADOG_IAC_SCANNER_URL</code> value.
+</div>
+
 ## Upload third-party static analysis results to IaC Security
 
 <div class="alert alert-info">
@@ -107,35 +158,39 @@ To upload a SARIF report:
 2. Optionally, set a [`DD_SITE` variable][5] (this defaults to `datadoghq.com`).
 3. Install the `datadog-ci` utility (version 2.0 or later):
 
-   ```bash
-   npm install -g @datadog/datadog-ci
-   ```
+    ```bash
+    npm install -g @datadog/datadog-ci
+    ```
 
 4. Run the third-party IaC scanning tool (e.g., Checkov, Trivy, KICS) on your code and output the results in the SARIF v2.1.0 format.
 5. Upload the results to Datadog:
 
-   ```bash
-   datadog-ci sarif upload $OUTPUT_LOCATION
-   ```
-   - Upload Options
-       - `--tags:` Add custom tags (format: `key:value`)
-       - `--max-concurrency:` Set concurrent uploads (default: 20)
-       - `--dry-run:` Validate without uploading
+    ```bash
+    datadog-ci sarif upload $OUTPUT_LOCATION
+    ```
+    - Upload Options
+        - `--tags:` Add custom tags (format: `key:value`)
+        - `--max-concurrency:` Set concurrent uploads (default: 20)
+        - `--dry-run:` Validate without uploading
+
 ### Required SARIF Attributes
+
 To ensure proper ingestion and display in Datadog IaC Scanning for third-party scanners (excluding Checkov), your SARIF file MUST include the following attributes to be recognized as an IaC security finding:
+
 1. `Runs[...].tool.driver.name: Datadog IaC Scanning`
 2. `Runs[...].tool.driver.version: "code_update"` or `"full_scan"`
     - `"full_scan”` for complete repository scans
     - `"code_update"` for pull request / incremental scans
-4. `Runs[...].tool.driver.rules[...].properties.tags:`
+3. `Runs[...].tool.driver.rules[...].properties.tags:`
     - `["DATADOG_RULE_TYPE:IAC_SCANNING"]`
-    - `[“DATADOG_SCANNED_FILE_COUNT: <number>”]`, where `"number"` specifies the number of scanned files 
-5. `Runs[...].results[...].locations[...].physicalLocation:`
+    - `[“DATADOG_SCANNED_FILE_COUNT: <number>”]`, where `"number"` specifies the number of scanned files
+4. `Runs[...].results[...].locations[...].physicalLocation:`
     - `artifactLocation.uri`: Relative path to file from repository root
     - `region.startLine`: Starting line number
     - `region.endLine`: Ending line number
     - `region.startColumn`: Starting column number
     - `region.endColumn`: Ending column number
+
 <div class="alert alert-info">Suppressions silently drop violations. If <code>results[ ].suppressions</code> exists, the violation is completely ignored.</div>
 
 ## Further reading
@@ -149,3 +204,6 @@ To ensure proper ingestion and display in Datadog IaC Scanning for third-party s
 [5]: /getting_started/site/
 [6]: https://docs.datadoghq.com/security/code_security/static_analysis/setup/?tab=github#upload-third-party-static-analysis-results-to-datadog
 [7]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif
+[8]: https://github.com/DataDog/datadog-iac-scanner
+[9]: https://github.com/DataDog/datadog-ci?tab=readme-ov-file#sarif
+[10]: https://app.datadoghq.com/source-code/repositories

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -94,7 +94,7 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 {{% /tab %}}
 {{< /tabs >}}
 
-## Set up IaC with a Generic CI Provider
+## Set up IaC with a generic CI provider
 
 ### Overview
 
@@ -142,7 +142,7 @@ datadog-ci sarif upload /tmp/datadog-iac-scanner-result.sarif
 ```
 
 <div class="alert alert-info">
-  This example uses the x86_64 Linux version of the Datadog IaC Scanner. If you're using a different OS or architecture, select the appropriate release from the <a href="https://github.com/DataDog/datadog-iac-scanner/releases">GitHub Releases</a> page and update the <code>DATADOG_IAC_SCANNER_URL</code> value.
+  This example uses the x86_64 Linux version of the Datadog IaC Scanner. If you're using a different OS or architecture, select the appropriate release from the <a href="https://github.com/DataDog/datadog-iac-scanner/releases">GitHub Releases</a> page and update the <code>IAC_SCANNER_URL</code> value.
 </div>
 
 ## Upload third-party static analysis results to IaC Security

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -100,7 +100,7 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 
 If you don't use GitHub Actions, GitLab CI/CD, or Azure DevOps, you can run the [Datadog IaC Scanner][8] directly in your CI pipeline. Upload IaC scan results to Datadog using the [`datadog-ci` CLI][9].
 
-**If you are running IaC Security on a non-GitHub repository**, run the first scan on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, upload a first scan for your repository. Then, manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterward, uploads from non-default branches succeed.
+**If you are running IaC Security on a non-GitHub repository**, run the first scan on your default branch. If your default branch uses a name other than `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, upload a first scan for your repository. Then, manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10] so that future scans from non-default branches are uploaded and correctly processed.
 
 ### Prerequisites
 

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -100,11 +100,11 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 
 If you don't use GitHub Actions, GitLab CI/CD, or Azure DevOps, you can run the [Datadog IaC Scanner][8] directly in your CI pipeline. Upload IaC scan results to Datadog using the [`datadog-ci` CLI][9].
 
-**If you are running IaC Security on a non-GitHub repository**, help ensure that the first scan runs on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, attempt an upload for your repository. Then manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterward, uploads from non-default branches succeed.
+**If you are running IaC Security on a non-GitHub repository**, run the first scan on your default branch. If your default branch is not one of `master`, `main`, `default`, `stable`, `source`, `prod`, or `develop`, upload a first scan for your repository. Then, manually override the default branch in [{{< ui >}}Repository Settings{{< /ui >}}][10]. Afterward, uploads from non-default branches succeed.
 
-Prerequisites:
+### Prerequisites
 
-- Node.js and npm
+- Node.js 20 or later and npm
 - `curl`
 - `tar`
 - Permission to install the scanner in `/usr/local/bin`
@@ -113,8 +113,8 @@ Configure the following environment variables:
 
 | Name         | Description                                                                                                                                                 | Required | Default         |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------- |
-| `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][4] and should be stored as a secret.                                               | Yes      |                 |
-| `DD_APP_KEY` | Your application key. This key, created by your [Datadog organization][4], should include the `code_analysis_read` scope and be stored as a secret. | Yes      |                 |
+| `DD_API_KEY` | Your Datadog API key. Create this key in your [Datadog organization][4] and store the key as a secret.                                                     | Yes      |                 |
+| `DD_APP_KEY` | Your application key. Create this key in your [Datadog organization][4] and include the `code_analysis_read` scope. Store the key as a secret.              | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][5] to send information to. Your Datadog site is `datadoghq.com`.                                                                         | No       | `datadoghq.com` |
 
 Add the following to your CI pipeline:
@@ -126,13 +126,13 @@ export DD_SITE="datadoghq.com"
 # Install dependencies
 npm install -g @datadog/datadog-ci
 
-# Download the latest DataDog IaC Scanner
+# Download the latest Datadog IaC Scanner (x86_64/amd64 Linux; see GitHub Releases for arm64 and other platforms)
 export IAC_SCANNER_URL="https://github.com/DataDog/datadog-iac-scanner/releases/latest/download/datadog-iac-scanner_linux_amd64.tar.gz"
 curl -L "${IAC_SCANNER_URL}" -o /tmp/datadog-iac-scanner.tar.gz
 tar xfz /tmp/datadog-iac-scanner.tar.gz -C /tmp
 mv /tmp/datadog-iac-scanner /usr/local/bin/datadog-iac-scanner
 
-# Run the DataDog IaC scanner
+# Run the Datadog IaC scanner
 exit_code=0
 /usr/local/bin/datadog-iac-scanner scan -p . -o /tmp || exit_code=$?
 if [ $exit_code -lt 20 -o $exit_code -gt 60 ]; then echo "IaC scan failed" ; exit $exit_code ; fi
@@ -142,7 +142,7 @@ datadog-ci sarif upload /tmp/datadog-iac-scanner-result.sarif
 ```
 
 <div class="alert alert-info">
-  This example uses the x86_64 Linux version of the Datadog IaC Scanner. If you're using a different OS or architecture, select the appropriate release from the <a href="https://github.com/DataDog/datadog-iac-scanner/releases">GitHub Releases</a> page and update the <code>IAC_SCANNER_URL</code> value.
+  This example uses the x86_64 (amd64) Linux version of the Datadog IaC Scanner. The scanner also supports arm64 Linux, as well as macOS and Windows. If you're using a different OS or architecture, select the appropriate release from the <a href="https://github.com/DataDog/datadog-iac-scanner/releases">GitHub Releases</a> page and update the <code>IAC_SCANNER_URL</code> value.
 </div>
 
 ## Upload third-party static analysis results to IaC Security


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/K9CODESEC-5096

### What does this PR do? What is the motivation?

"In [SAST](https://docs.datadoghq.com/security/code_security/static_analysis/generic_ci_providers/) and [SCA](https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/generic_ci_providers/), we show how to run the tool for a generic CI provider. [It does not seem we do that for IaC](https://docs.datadoghq.com/security/code_security/iac_security/setup/?tab=github). Can someone fix this?"

## [New section added](https://docs-staging.datadoghq.com/valery.neira/iac-update-ci-docs/security/code_security/iac_security/setup/?tab=github)
<img width="736" height="852" alt="image" src="https://github.com/user-attachments/assets/c0ecd4fe-8b37-4fda-a6f8-06c80fb5818d" />


### Merge readiness

- [x] Documentation preview is correct https://docs-staging.datadoghq.com/valery.neira/iac-update-ci-docs/security/code_security/iac_security/setup/?tab=github
- [x] Script follows exactly what's used on https://app.datadoghq.com/security/configuration/code-security/setup?executionEnvironment=ci&steps=static

### AI assistance

Codex used to adapt content to IAC from [SAST](https://docs.datadoghq.com/security/code_security/static_analysis/generic_ci_providers/) equivalent page

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
