### PR TITLE
Cross-link APM Architecture Center articles from the trace pipeline docs

### DIFF
--- a/hugo/content/en/tracing/guide/ingestion_sampling_use_cases.md
+++ b/hugo/content/en/tracing/guide/ingestion_sampling_use_cases.md
@@ -6,6 +6,12 @@ further_reading:
 - link: "/tracing/guide/trace_ingestion_volume_control/"
   tag: "Guide"
   text: "How to control ingested volumes"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
+- link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+  tag: "Architecture Center"
+  text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 ---
 
 ## Overview

--- a/hugo/content/en/tracing/guide/leveraging_diversity_sampling.md
+++ b/hugo/content/en/tracing/guide/leveraging_diversity_sampling.md
@@ -5,6 +5,9 @@ further_reading:
 - link: "/tracing/trace_pipeline/trace_retention/"
   tag: "Documentation"
   text: "Controlling trace indexing for retention"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
 ---
 
 ## Ingesting and retaining the traces you care about

--- a/hugo/content/en/tracing/guide/resource_based_sampling.md
+++ b/hugo/content/en/tracing/guide/resource_based_sampling.md
@@ -10,6 +10,9 @@ further_reading:
 - link: "/tracing/trace_pipeline/ingestion_controls"
   tag: "Documentation"
   text: "Ingestion Control Page"
+- link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+  tag: "Architecture Center"
+  text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 ---
 
 

--- a/hugo/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/hugo/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -6,6 +6,9 @@ further_reading:
 - link: "/tracing/trace_pipeline/ingestion_controls/"
   tag: "Documentation"
   text: "Ingestion Control Page"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
 ---
 
 ## Overview

--- a/hugo/content/en/tracing/trace_pipeline/_index.md
+++ b/hugo/content/en/tracing/trace_pipeline/_index.md
@@ -9,6 +9,12 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/apm-rate-limit-retention"
   tag: "Learning Center"
   text: "APM Rate Limiting and Retention"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
+- link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+  tag: "Architecture Center"
+  text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 
 ---
 

--- a/hugo/content/en/tracing/trace_pipeline/adaptive_sampling.md
+++ b/hugo/content/en/tracing/trace_pipeline/adaptive_sampling.md
@@ -12,6 +12,9 @@ further_reading:
     - link: "/tracing/trace_pipeline/ingestion_controls"
       tag: "Documentation"
       text: "Ingestion Controls"
+    - link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+      tag: "Architecture Center"
+      text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 ---
 
 ## Overview

--- a/hugo/content/en/tracing/trace_pipeline/ingestion_controls.md
+++ b/hugo/content/en/tracing/trace_pipeline/ingestion_controls.md
@@ -15,6 +15,12 @@ further_reading:
 - link: "/tracing/trace_pipeline/metrics/"
   tag: "Documentation"
   text: "Usage Metrics"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
+- link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+  tag: "Architecture Center"
+  text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 ---
 
 {{< img src="tracing/apm_lifecycle/ingestion_sampling_rules.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Ingestion Sampling Rules" >}}

--- a/hugo/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/hugo/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -19,6 +19,12 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/apm-rate-limit-retention"
   tag: "Learning Center"
   text: "APM Rate Limiting and Retention"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
+- link: "https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/"
+  tag: "Architecture Center"
+  text: "Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces"
 
 ---
 

--- a/hugo/content/en/tracing/trace_pipeline/trace_retention.md
+++ b/hugo/content/en/tracing/trace_pipeline/trace_retention.md
@@ -20,6 +20,9 @@ further_reading:
 - link: "https://learn.datadoghq.com/courses/apm-rate-limit-retention"
   tag: "Learning Center"
   text: "APM Rate Limiting and Retention"
+- link: "https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/"
+  tag: "Architecture Center"
+  text: "Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling"
 
 ---
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds "Further Reading" links from the trace-pipeline/sampling docs to the two APM Architecture Center articles that don't yet have any inbound docs links:

- [Mastering Distributed tracing: data volume challenges, and Datadog's approach to efficient sampling](https://www.datadoghq.com/architecture/mastering-distributed-tracing-data-volume-challenges-and-datadogs-approach-to-efficient-sampling/)
- [Optimizing Distributed Tracing: Best practices for remaining within budget and capturing critical traces](https://www.datadoghq.com/architecture/optimizing-distributed-tracing-best-practices-for-remaining-within-budget-and-capturing-critical-traces/)

Cross-linking from product docs is the top engagement lever for Architecture Center content (docs pages get roughly 1,160x the traffic). This closes the identified gap for the APM domain:

**Exact-match pages (originally identified gaps):**
- `tracing/trace_pipeline/ingestion_controls.md` — both articles
- `tracing/trace_pipeline/trace_retention.md` — data-volume/sampling article
- `tracing/guide/resource_based_sampling.md` — budget/critical-traces article (exact feature match)
- `tracing/trace_pipeline/adaptive_sampling.md` — budget/critical-traces article (exact feature match)

**Additional pages found in a full cross-linking review of the trace pipeline docs tree:**
- `tracing/trace_pipeline/ingestion_mechanisms.md` — both articles (the shared hub page every page above already links back to)
- `tracing/trace_pipeline/_index.md` — both articles (the Trace Pipeline landing page)
- `tracing/guide/ingestion_sampling_use_cases.md` — both articles (direct use-case content match)
- `tracing/guide/trace_ingestion_volume_control.md` — data-volume/sampling article
- `tracing/guide/leveraging_diversity_sampling.md` — data-volume/sampling article (covers the same diversity-sampling mechanism)

Out of scope for this PR: one further candidate surfaced during the source review, `docs.datadoghq.com/tracing/` (the APM landing page), tied to a different Architecture Center article ("Observability in Event-Driven Architectures") outside this backlog's APM section — flagging for a separate PR/owner rather than folding it in here.

Every added link uses the site's existing `tag: "Architecture Center"` convention (matching the pattern already in use on `logs/_index.md` and `tracing/trace_collection/_index.md`), and the link text matches each article's published title verbatim. Translated files (`fr`, `ja`, `ko`, `es`) were left untouched per the contributing guide.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code for the full change: read the source backlog doc, verified each candidate docs page's current Further Reading block via live fetch, ran the additional full-review sweep of the trace_pipeline/guide content tree for further gaps, authored the front-matter edits, and ran `vale` locally against every changed file (all findings are pre-existing content issues on lines this PR doesn't touch).

### Additional notes

Awaiting review/approval from John Richter, then handing off to the documentation team for their review and merge.