### PR TITLE
NDM SNMP Traps: setcap no longer required on Agent v7.71.0+

### DIFF
--- a/hugo/content/en/network_monitoring/devices/snmp_traps.md
+++ b/hugo/content/en/network_monitoring/devices/snmp_traps.md
@@ -71,7 +71,20 @@ You can also view SNMP traps directly from the NDM device view. Select a device 
 
 ### Using the default SNMP trap port 162
 
-Binding to a port number under `1024` requires elevated permissions. To bind to a port number such as the default SNMP Trap port `162`, use the following instructions:
+Binding to a port number under `1024` requires elevated permissions.
+
+Starting with Agent v7.71.0, no additional configuration is required to use the default SNMP Trap port `162`. The Agent's systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE` by default, which allows the Agent to bind to privileged ports (below `1024`) while running as the `dd-agent` user.
+
+To disable this behavior, create a systemd drop-in file (for example, `/etc/systemd/system/datadog-agent.service.d/disable-capability.conf`) with the following content:
+
+```
+[Service]
+AmbientCapabilities=
+```
+
+**Warning**: Do not run `setcap` on the Agent binary on v7.71.0 or later. Setting a file capability causes the binary to run in secure-execution mode (`AT_SECURE`) when it is started by the non-root `dd-agent` user. In that mode, the dynamic linker stops resolving the Agent's bundled libraries through its executable-relative library path (`RPATH`), and the Agent fails to start with an error such as `error while loading shared libraries: libdatadog-agent-rtloader.so: cannot open shared object file`. The file capability also does not persist across upgrades, because each upgrade installs the Agent binary in a new versioned directory.
+
+**Agent versions earlier than v7.71.0**
 
 1. Grant access to the port using the `setcap` command:
 

--- a/hugo/content/en/network_monitoring/devices/snmp_traps.md
+++ b/hugo/content/en/network_monitoring/devices/snmp_traps.md
@@ -75,14 +75,14 @@ Binding to a port number under `1024` requires elevated permissions.
 
 Starting with Agent v7.71.0, no additional configuration is required to use the default SNMP Trap port `162`. The Agent's systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE` by default, which allows the Agent to bind to privileged ports (below `1024`) while running as the `dd-agent` user.
 
-To disable this behavior, create a systemd drop-in file (for example, `/etc/systemd/system/datadog-agent.service.d/disable-capability.conf`) with the following content:
+To disable this behavior, create a systemd drop-in file, such as `/etc/systemd/system/datadog-agent.service.d/disable-capability.conf`, with the following content:
 
 ```
 [Service]
 AmbientCapabilities=
 ```
 
-**Warning**: Do not run `setcap` on the Agent binary on v7.71.0 or later. Setting a file capability causes the binary to run in secure-execution mode (`AT_SECURE`) when it is started by the non-root `dd-agent` user. In that mode, the dynamic linker stops resolving the Agent's bundled libraries through its executable-relative library path (`RPATH`), and the Agent fails to start with an error such as `error while loading shared libraries: libdatadog-agent-rtloader.so: cannot open shared object file`. The file capability also does not persist across upgrades, because each upgrade installs the Agent binary in a new versioned directory.
+<div class="alert alert-warning">Do not run <code>setcap</code> on the Agent binary on v7.71.0 or later. Setting a file capability causes the binary to run in secure-execution mode (<code>AT_SECURE</code>) when it is started by the non-root <code>dd-agent</code> user. In that mode, the dynamic linker stops resolving the Agent's bundled libraries through its executable-relative library path (<code>RPATH</code>), and the Agent fails to start with an error such as <code>error while loading shared libraries: libdatadog-agent-rtloader.so: cannot open shared object file</code>. The file capability also does not persist across upgrades because each upgrade installs the Agent binary in a new versioned directory.</div>
 
 **Agent versions earlier than v7.71.0**
 

--- a/hugo/content/en/network_monitoring/devices/troubleshooting.md
+++ b/hugo/content/en/network_monitoring/devices/troubleshooting.md
@@ -244,7 +244,11 @@ Check for any rules blocking UDP traffic on your configured ports. For example:`
    ```
 
    **Solution**:
-   Add a net bind capability to the Agent binary, which allows the Agent to bind to reserved ports:
+   Starting with Agent v7.71.0, the Agent can bind to privileged ports (below `1024`) by default, because its systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE`. If you see this error on v7.71.0 or later, confirm the capability is present with `systemctl show datadog-agent -p AmbientCapabilities`.
+
+   Do not use `setcap` to grant the capability on v7.71.0 or later. A file capability makes the Agent run in secure-execution mode for the `dd-agent` user, which prevents it from loading its bundled libraries (for example, `libdatadog-agent-rtloader.so: cannot open shared object file`). See [Using the default SNMP Trap port 162][8] for details.
+
+   On Agent versions earlier than v7.71.0, add a net bind capability to the Agent binary:
 
    ```shell
    sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent

--- a/hugo/content/en/network_monitoring/devices/troubleshooting.md
+++ b/hugo/content/en/network_monitoring/devices/troubleshooting.md
@@ -244,9 +244,9 @@ Check for any rules blocking UDP traffic on your configured ports. For example:`
    ```
 
    **Solution**:
-   Starting with Agent v7.71.0, the Agent can bind to privileged ports (below `1024`) by default, because its systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE`. If you see this error on v7.71.0 or later, confirm the capability is present with `systemctl show datadog-agent -p AmbientCapabilities`.
+   Starting with Agent v7.71.0, the Agent can bind to privileged ports (below `1024`) by default because its systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE`. If you see this error on v7.71.0 or later, confirm the capability is present with `systemctl show datadog-agent -p AmbientCapabilities`.
 
-   Do not use `setcap` to grant the capability on v7.71.0 or later. A file capability makes the Agent run in secure-execution mode for the `dd-agent` user, which prevents it from loading its bundled libraries (for example, `libdatadog-agent-rtloader.so: cannot open shared object file`). See [Using the default SNMP Trap port 162][8] for details.
+   Do not use `setcap` to grant the capability on v7.71.0 or later. A file capability makes the Agent run in secure-execution mode for the `dd-agent` user, which prevents it from loading its bundled libraries, such as `libdatadog-agent-rtloader.so: cannot open shared object file`. See [Using the default SNMP Trap port 162][8] for details.
 
    On Agent versions earlier than v7.71.0, add a net bind capability to the Agent binary:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Since **Agent v7.71.0**, the Agent's systemd unit sets `AmbientCapabilities=CAP_NET_BIND_SERVICE` by default, so the Agent can bind to privileged ports (including the default SNMP Trap port `162`) while running as the `dd-agent` user — no `setcap` needed. Ref: [Agent 7.71.0 release notes](https://github.com/DataDog/datadog-agent/releases/tag/7.71.0).

The current SNMP Traps and NDM troubleshooting pages still instruct users to run `setcap` on the Agent binary. On v7.71.0+ (installer/Fleet Automation layout) this is not only unnecessary, it actively breaks the Agent: setting a file capability puts the binary into secure-execution mode (`AT_SECURE`) for the non-root `dd-agent` user, which makes glibc stop expanding the binary's `$ORIGIN`-relative `RPATH`. The Agent can then no longer find its bundled libraries and fails to start with:

```
error while loading shared libraries: libdatadog-agent-rtloader.so: cannot open shared object file: No such file or directory
```

This was reproduced on a customer host and resolved by removing the file capability (`setcap -r`).

### Changes

- **`snmp_traps.md`** (Using the default SNMP trap port 162): document that no action is required on v7.71.0+ (ambient capability set by default), how to disable it via a systemd drop-in, and a warning against using `setcap` on v7.71.0+. The `setcap`/`getcap` steps are retained, scoped to Agent versions earlier than v7.71.0.
- **`troubleshooting.md`** (Traps not being received): update the "permission denied" solution to reflect the default ambient capability on v7.71.0+, warn against `setcap`, and scope the `setcap` fallback to versions earlier than v7.71.0.

Only the English (`en`) source files are changed; translations are left to the docs localization process.

Made with [Cursor](https://cursor.com)