### PR TITLE
Document annotation queue access

### DIFF
--- a/hugo/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/hugo/content/en/llm_observability/evaluations/annotation_queues.md
@@ -132,6 +132,17 @@ For each trace:
 
 The Annotations list page displays a progress bar for each queue showing the ratio of reviewed interactions to total interactions. Use this to monitor annotation completion across queues at a glance.
 
+### Managing queue access
+
+Queue owners manage the reviewer list, access settings, and assignments from the queue details. Only the queue owner can change the reviewer list, access settings, or assignments.
+
+Access restrictions apply independently, so you can enable either restriction or both:
+- Reviewer restriction limits unassigned interactions to designated reviewers.
+- Assignee restriction limits assigned interactions to their assignees.
+- When both restrictions are enabled, reviewers can annotate unassigned interactions and assignees can annotate their assigned interactions.
+
+The queue owner retains access and can annotate all interactions.
+
 ### Filtering traces by annotation labels
 
 use the {{< ui >}}Annotation Labels{{< /ui >}} facet to filter traces by labels applied in annotation queues. This allows you to:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b1b3d8ef-0a4d-4eda-a2b0-c30fb858880e","source":"chat","resourceId":"a7cd3d59-771d-4dc9-b413-ffc573b9f1be","workflowId":"94ed552c-9f5b-47a2-ba80-af285018a381","codeChangeId":"94ed552c-9f5b-47a2-ba80-af285018a381","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Motivation:
- Documents customer-visible annotation queue access controls added by https://github.com/ddoghq/dd-source/pull/55068 and https://github.com/ddoghq/dd-source/pull/55071.

Changes:
- Adds a Managing queue access subsection to hugo/content/en/llm_observability/evaluations/annotation_queues.md.
- Explains queue-owner control over reviewer lists, access settings, and assignments.
- Explains how reviewer and assignee restrictions determine who can annotate queue interactions.

Testing:
- Ran `git diff --check`.
- Attempted `vale hugo/content/en/llm_observability/evaluations/annotation_queues.md`, but Vale is not installed in this environment.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code powered by Codex CLI to draft the documentation update and run local checks.

### Additional notes

Source pull requests:
- https://github.com/ddoghq/dd-source/pull/55068
- https://github.com/ddoghq/dd-source/pull/55071

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a7cd3d59-771d-4dc9-b413-ffc573b9f1be)

Comment @datadog to request changes