### PR TITLE
Document get_llmobs_model_pricing MCP tool

### DIFF
--- a/hugo/content/en/llm_observability/mcp_server.md
+++ b/hugo/content/en/llm_observability/mcp_server.md
@@ -401,6 +401,11 @@ The `llmobs` toolset includes the following tools:
 `get_llmobs_pattern_points`
 : Get a cursor-paginated page of clustering points (individual spans) assigned to a single topic. Each point includes the `span_id`, `session_id`, and a span input preview. Pass `next_page_token` back as `page_token` to continue paging.
 
+### Pricing tools
+
+`get_llmobs_model_pricing`
+: Retrieve provider and model pricing tiers in USD per million tokens. Supply at least one of `provider` or `model`, where `provider` is an optional hint that scopes the lookup. When a tier's `rates` omits a component such as cache read or cache write, the provider does not define a price for that component. Do not read the omission as a zero-cost rate.
+
 ## Recommended workflows
 
 ### Trace analysis


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6e0e4539-ebd4-4332-a74d-8b187e5e120f","source":"chat","resourceId":"7f80c5bc-880f-4fd2-b027-b21b06b4f096","workflowId":"832381bd-b43a-4de8-b226-d89bae9d38c8","codeChangeId":"832381bd-b43a-4de8-b226-d89bae9d38c8","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the customer-facing `get_llmobs_model_pricing` MCP tool on the Agent Observability MCP page so users know how to look up provider and model pricing and how to interpret the updated pricing response.

Source PR: https://github.com/ddoghq/dd-source/pull/55443

**Changes**
- Adds a `Pricing tools` subsection under `## Available tools` in `hugo/content/en/llm_observability/mcp_server.md` documenting `get_llmobs_model_pricing`.
- Describes that the tool returns provider and model pricing tiers in USD per million tokens, that `provider` is an optional scoping hint, and that at least one of `provider` or `model` must be supplied.
- Clarifies the response semantics: a pricing component missing from a tier's `rates` (such as cache read or cache write) means the provider does not define a price for it and must not be read as a zero-cost rate.

**Testing**
- Verified the new entry matches the existing definition-list format and subsection style used elsewhere in `## Available tools`.
- Manually checked the wording against the repo style guide substitutions (Vale was unavailable in this environment).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Datadog AI agent) and reviewed manually.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7f80c5bc-880f-4fd2-b027-b21b06b4f096)

Comment @datadog to request changes