### PR TITLE
Hide BYOC Logs Agent ingest page

### DIFF
--- a/hugo/content/en/byoc-logs/ingest/agent.md
+++ b/hugo/content/en/byoc-logs/ingest/agent.md
@@ -1,5 +1,6 @@
 ---
 title: Send logs to BYOC Logs with the Datadog Agent
+private: true
 aliases:
 - /cloudprem/ingest_logs/datadog_agent/
 - /cloudprem/ingest/agent/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Marks the BYOC Logs Datadog Agent ingest page as private so it is hidden from the public docs navigation.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
