### PR TITLE
[DOCS-15417] Point to new example Agent config files

### DIFF
--- a/hugo/content/en/administrators_guide/getting_started.md
+++ b/hugo/content/en/administrators_guide/getting_started.md
@@ -94,6 +94,7 @@ The [Datadog Agent][2] is open-source and published in GitHub. The Agent GitHub 
 
 Here are a few examples:
 
+* [Agent Config Examples][3]
 * [Integration Config Specs][4]   
 * [Fleet Automation][5]
 
@@ -108,6 +109,7 @@ To successfully create a new Datadog installation, review the [plan][11] page. Y
 
 [1]: https://learn.datadoghq.com/
 [2]: https://github.com/DataDog/datadog-agent
+[3]: https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example
 [4]: https://github.com/DataDog/integrations-core
 [5]: https://app.datadoghq.com/fleet
 [6]: /getting_started/tagging/unified_service_tagging/

--- a/hugo/content/en/agent/configuration/agent-configuration-files.md
+++ b/hugo/content/en/agent/configuration/agent-configuration-files.md
@@ -16,12 +16,12 @@ algolia:
 
 The location of the Agent configuration file differs depending on the operating system.
 
-| Platform                             | Command                              |
-|:-------------------------------------|:-------------------------------------|
-| AIX                                  | `/etc/datadog-agent/datadog.yaml`    |
-| Linux                                | `/etc/datadog-agent/datadog.yaml`    |
-| macOS                                | `/opt/datadog-agent/etc/datadog.yaml`      |
-| Windows                              | `%ProgramData%\Datadog\datadog.yaml` |
+| Platform | Command                               | Example config                            |
+|:---------|:--------------------------------------|:------------------------------------------|
+| AIX      | `/etc/datadog-agent/datadog.yaml`     | [`datadog.yaml.example`][3]               |
+| Linux    | `/etc/datadog-agent/datadog.yaml`     | [`datadog-agent_linux.yaml.example`][4]   |
+| macOS    | `/opt/datadog-agent/etc/datadog.yaml` | [`datadog-agent_darwin.yaml.example`][5]  |
+| Windows  | `%ProgramData%\Datadog\datadog.yaml`  | [`datadog-agent_windows.yaml.example`][6] |
 
 ## Agent configuration directory
 
@@ -70,3 +70,7 @@ For log collection, the Agent does not accept multiple YAML files that point to 
 JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is a list of all the beans that the Datadog Agent collects by default. This way, you do not need to list all of the beans manually when you configure a check through [Docker labels or k8s annotations][2].
 
 [2]: /agent/kubernetes/integrations/#configuration
+[3]: https://github.com/DataDog/datadog-unix-agent/blob/master/docs/datadog.yaml.example
+[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
+[5]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_darwin.yaml.example
+[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example

--- a/hugo/content/en/agent/configuration/dual-shipping.md
+++ b/hugo/content/en/agent/configuration/dual-shipping.md
@@ -424,6 +424,7 @@ and add the relevant settings to `customAgentConfig`.
 
   # agents.customAgentConfig -- Specify custom contents for the datadog agent config (datadog.yaml)
   ## ref: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/?tab=agentv6
+  ## ref: https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example
   ## Note the `agents.useConfigMap` needs to be set to `true` for this parameter to be taken into account.
   customAgentConfig:
     additional_endpoints:

--- a/hugo/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/hugo/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -115,6 +115,8 @@ The log page displays the Agent logs being output to `agent.log`. Logs can be so
 
 The settings page displays the contents of the Agent's main configuration file `datadog.yaml`. You can edit this file directly from the Datadog Agent Manager. After making a change, click {{< ui >}}Save{{< /ui >}} in the upper right then [restart the Agent](#restart-agent).
 
+For a full list of available options, see the [example `datadog.yaml` file for Windows][6].
+
 ### Checks
 
 #### Manage checks
@@ -143,3 +145,4 @@ Clicking {{< ui >}}Restart Agent{{< /ui >}} from the left navigation bar restart
 [3]: /integrations/
 [4]: /help/
 [5]: /agent/troubleshooting/send_a_flare/
+[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example

--- a/hugo/content/en/agent/logs/_index.md
+++ b/hugo/content/en/agent/logs/_index.md
@@ -39,6 +39,8 @@ logs_config:
     force_use_http: true
 {{< /code-block >}}
 
+For all available configuration options, see the [example Agent configuration files][6] for your operating system.
+
 <div class="alert alert-info">Starting with Agent v6.19+/v7.19+, HTTPS transport is the default transport used. For more details, see <a href="/agent/logs/log_transport/">Agent transport</a>.</div>
 
 To send logs with **environment variables**, configure the following:
@@ -255,6 +257,7 @@ For both file and journald tailer types, if an `end` or `beginning` position is 
 [3]: /containers/kubernetes/log/
 [4]: /containers/docker/log/
 [5]: /agent/configuration/agent-configuration-files/
+[6]: https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example
 [7]: /agent/logs/log_transport/
 [8]: /agent/configuration/agent-commands/#restart-the-agent
 [9]: /agent/configuration/agent-commands/#agent-status-and-information

--- a/hugo/content/en/agent/supported_platforms/linux.md
+++ b/hugo/content/en/agent/supported_platforms/linux.md
@@ -58,7 +58,7 @@ The Datadog Agent configuration file is located in `/etc/datadog-agent/datadog.y
 - `proxy`: HTTP/HTTPS proxy endpoints for outbound traffic (see [Datadog Agent Proxy Configuration][8])
 - Default tags, log level, and Datadog configurations
 
-A fully commented reference file, located in `/etc/datadog-agent/datadog.yaml.example`, lists every available option for comparison or to copy and paste.
+A fully commented reference file, located in `/etc/datadog-agent/datadog.yaml.example`, lists every available option for comparison or to copy and paste. Alternatively, see the [example Agent configuration file for Linux][11] on GitHub.
 
 ### Integration files
 Configuration files for integrations live in `/etc/datadog-agent/conf.d/`. Each integration has its own sub-directory, `<INTEGRATION>.d/`, that contains:
@@ -158,3 +158,4 @@ See the instructions on how to [add packages to the embedded Agent][3] for more 
 [8]: https://docs.datadoghq.com/agent/configuration/proxy/
 [9]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/
 [10]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/linux
+[11]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example

--- a/hugo/content/en/agent/supported_platforms/osx.md
+++ b/hugo/content/en/agent/supported_platforms/osx.md
@@ -65,7 +65,7 @@ The [Datadog Agent configuration file][7] is located in `/opt/datadog-agent`. Th
 - `proxy`: HTTP/HTTPS proxy endpoints for outbound traffic (see [Datadog Agent Proxy Configuration][9])
 - Default tags, log levels, and Datadog configurations.
 
-A fully commented reference file, located in `/opt/datadog-agent/etc/datadog.yaml.example`, lists every available option for comparison or copy-paste.
+A fully commented reference file, located in `/opt/datadog-agent/etc/datadog.yaml.example`, lists every available option for comparison or copy-paste. Alternatively, see the [example Agent configuration file for macOS][10] on GitHub.
 
 ### Integration files
 Configuration files for integrations are found in `/opt/datadog-agent/etc/conf.d/`. Each integration has its own sub-directory, `<INTEGRATION>.d/`, which contains:
@@ -105,4 +105,5 @@ See the instructions on how to [add packages to the embedded Agent][3] for more 
 [7]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [8]: https://app.datadoghq.com/organization-settings/api-keys
 [9]: /agent/configuration/proxy/
+[10]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_darwin.yaml.example
 [11]: https://install.datadoghq.com/scripts/uninstall_mac_os.sh

--- a/hugo/content/en/agent/supported_platforms/sccm.md
+++ b/hugo/content/en/agent/supported_platforms/sccm.md
@@ -61,7 +61,7 @@ Microsoft SCCM (Systems Center Configuration Manager) is a configuration managem
 
 SCCM packages allow you to deploy configuration files to your Datadog Agents, overwriting their default settings. An Agent configuration consists of a `datadog.yaml` configuration file and optional `conf.yaml` files for each integration. You must create a package for each configuration file you want to deploy.
 
-1. Collect your `datadog.yaml` and `conf.yaml` files in a local SCCM machine folder.
+1. Collect your `datadog.yaml` and `conf.yaml` files in a local SCCM machine folder. See the [example Agent configuration file for Windows][4] for all available configuration options.
 1. Create an SCCM Package and select {{< ui >}}Standard program{{< /ui >}}.
 1. Select the location that contains the configuration file that you want to deploy to your Agents.
 1. Select a [Device collection][5] to deploy the changes to.
@@ -83,5 +83,6 @@ Restart the Agent service to observe your configuration changes:
 [1]: https://learn.microsoft.com/en-us/mem/configmgr/core/servers/deploy/configure/manage-content-and-content-infrastructure
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [3]: /agent/basic_agent_usage/windows/?tab=commandline#configuration
+[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example
 [5]: https://learn.microsoft.com/en-us/mem/configmgr/core/clients/manage/collections/create-collections#bkmk_create
 [6]: /agent/basic_agent_usage/windows/#agent-commands

--- a/hugo/content/en/agent/supported_platforms/windows.md
+++ b/hugo/content/en/agent/supported_platforms/windows.md
@@ -108,7 +108,7 @@ Set the `/log <FILENAME>` msiexec option to configure an installation log file. 
 The main Agent configuration file is located at
 `C:\ProgramData\Datadog\datadog.yaml`. This file is used for host-wide settings such as the API key, selected Datadog site, proxy parameters, host tags, and log level.
 
-There is also a `datadog.yaml.example` file in the same directory, which is a fully commented reference with all available configuration options, useful for reference and copying specific settings.
+There is also a `datadog.yaml.example` file in the same directory, which is a fully commented reference with all available configuration options, useful for reference and copying specific settings. Alternatively, see the [example Agent configuration file for Windows][19] on GitHub.
 
 
 Configuration files for integrations are in:
@@ -285,5 +285,6 @@ After configuration is complete, [restart the Agent][11].
 [16]: https://app.datadoghq.com/fleet/install-agent/latest?platform=windows
 [17]: /agent/faq/windows-agent-ddagent-user/
 [18]: https://docs.datadoghq.com/agent/troubleshooting/
+[19]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example
 [400]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
 [500]: https://app.datadoghq.com/organization-settings/api-keys

--- a/hugo/content/en/containers/docker/apm.md
+++ b/hugo/content/en/containers/docker/apm.md
@@ -77,6 +77,8 @@ Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (d
 
 Use the following environment variables to configure tracing for the Docker Agent.
 
+For all available options and their defaults, see the `apm_config` section of the [example Agent configuration file][8].
+
 `DD_API_KEY`                      
 : required - _string_
 <br/>Your [Datadog API key][1].
@@ -395,3 +397,4 @@ Refer to the [language-specific APM instrumentation docs][3] for tracer settings
 [5]: /tracing/guide/ignoring_apm_resources/
 [6]: /tracing/troubleshooting/agent_rate_limits
 [7]: /getting_started/site/
+[8]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example

--- a/hugo/content/en/containers/guide/operator-eks-addon.md
+++ b/hugo/content/en/containers/guide/operator-eks-addon.md
@@ -103,7 +103,7 @@ Follow the instructions to set up the Datadog Agent by using the `DatadogAgent` 
 
    For all configuration options, see the [Operator configuration spec][6].
 
-   **Note:** If access to IMDS v1 is blocked on the node, the Agent cannot resolve the cluster name, and certain features (for example, [Orchestrator Explorer][6]) do not work. Hence, Datadog recommends adding `spec.global.ClusterName` in the `DatadogAgent` manifest. See this [comment][8] on how to configure the Agent to request metadata using IMDS v2.
+   **Note:** If access to IMDS v1 is blocked on the node, the Agent cannot resolve the cluster name, and certain features (for example, [Orchestrator Explorer][6]) do not work. Hence, Datadog recommends adding `spec.global.ClusterName` in the `DatadogAgent` manifest. For how to configure the Agent to request metadata using IMDS v2, see the `ec2_prefer_imdsv2` parameter in the [example Agent configuration file][8].
 
 4. Deploy the Datadog Agent:
    ```bash
@@ -151,6 +151,6 @@ To delete the add-on, run:
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 [6]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
 [7]: https://docs.datadoghq.com/infrastructure/containers/orchestrator_explorer/?tab=datadogoperator
-[8]: https://github.com/DataDog/datadog-agent/blob/4896a45f586f74de1da2e985f98988f0181afc36/pkg/config/config_template.yaml#L407-L416
+[8]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 [9]: https://github.com/DataDog/datadog-operator/issues/654
 [10]: /integrations/eks_fargate/#setup

--- a/hugo/content/en/getting_started/agent/_index.md
+++ b/hugo/content/en/getting_started/agent/_index.md
@@ -46,8 +46,7 @@ The Agent's main configuration file is `datadog.yaml`. The required parameters a
 - Your [Datadog API key][16], which is used to associate the Agent's data with your organization. 
 - Your [Datadog site][41] ({{< region-param key="dd_site" code="true" >}}).
 
-You can adjust the Agent configuration files to take advantage of other Datadog features.
-
+For all available configuration options, see the [example Agent configuration files][23] for your operating system. You can adjust the Agent configuration files to take advantage of other Datadog features.
 
 ## Installation
 
@@ -282,6 +281,7 @@ For help troubleshooting the Agent:
 [20]: https://app.datadoghq.com/event/explorer
 [21]: /extend/service_checks/#visualize-your-service-check-in-datadog
 [22]: https://app.datadoghq.com/metric/summary
+[23]: https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example
 [24]: /getting_started/tagging/
 [25]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [26]: /agent/configuration/agent-commands/#restart-the-agent

--- a/hugo/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
+++ b/hugo/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
@@ -39,4 +39,4 @@ kubernetes_kubeconfig_path: /path/to/file
 [1]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
 [2]: https://kubernetes.io/docs/concepts/configuration/secret
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig
-[4]: https://github.com/DataDog/datadog-agent/blob/a9e0c4f534482170817300edb3cce01df9abea4a/pkg/config/config_template.yaml#L687-L692
+[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example

--- a/hugo/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
+++ b/hugo/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
@@ -20,4 +20,4 @@ Note: The old host in the Infrastructure List takes time before disappearing.
 [1]: https://docs.datadoghq.com/integrations/vsphere/
 [2]: https://app.datadoghq.com/infrastructure
 [3]: https://github.com/DataDog/integrations-core/blob/21a90b00f603b00250c4baa6534e47ee5529ed3c/vsphere/datadog_checks/vsphere/data/conf.yaml.example#L301-L308
-[4]: https://github.com/DataDog/datadog-agent/blob/6ba10dc8cd0c1aa89adcebe6b5941571caf25d50/pkg/config/config_template.yaml#L56-L61
+[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example

--- a/hugo/content/en/integrations/guide/azure-advanced-configuration.md
+++ b/hugo/content/en/integrations/guide/azure-advanced-configuration.md
@@ -137,7 +137,7 @@ The protected settings include:
 This example shows how to specify a configuration for the Datadog Agent to use.
 The Datadog Agent configuration URI must be an Azure blob storage URI.
 The Datadog Windows Agent Azure Extension checks that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
-The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder.
+The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder (see the [example Agent configuration file for Windows][101] for all available configuration options).
 
 <div class="alert alert-info">
 To reuse the configuration of an existing Agent:
@@ -173,6 +173,7 @@ Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "Datadog
 {{< /code-block >}}
 
 [100]: https://learn.microsoft.com/powershell/module/az.compute/set-azvmextension
+[101]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example
 {{% /tab %}}
 {{% tab "Linux" %}}
 
@@ -206,7 +207,7 @@ The protected settings include:
 This example shows how to specify a configuration for the Datadog Agent to use.
 - The Datadog Agent configuration URI must be an Azure blob storage URI.
 - The Datadog Linux Agent Azure Extension checks that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
-- The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder.
+- The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder (see the [example Agent configuration file for Linux][201] for all available configuration options).
 
 <div class="alert alert-info">
 To reuse the configuration of an existing Agent by saving its <code>/etc/datadog-agent</code> folder as a ZIP file:
@@ -230,6 +231,7 @@ az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --ver
 
 
 [200]: https://learn.microsoft.com/cli/azure/vm/extension
+[201]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/hugo/content/en/logs/guide/increase-number-of-log-files-tailed.md
+++ b/hugo/content/en/logs/guide/increase-number-of-log-files-tailed.md
@@ -24,9 +24,9 @@ logs_config:
 
 For containerized environments you can set the `DD_LOGS_CONFIG_OPEN_FILES_LIMIT` environment variable.
 
-The default value varies depending on the Agent version and operating system. To check the default value for your Agent version, see the [config_template.yaml file][1] in the Datadog Agent repository. Be sure to select the tag corresponding to your Agent version to see the correct defaults.
+The default value varies depending on the Agent version and operating system. To check the default value for your Agent version, see the [example Agent configuration files][1] in the Datadog Agent repository. Open the file for your operating system. Be sure to select the tag corresponding to your Agent version to see the correct defaults.
 
 **Note**: Increasing the tailed logs files limit might increase the resource consumption of the Agent.
 
-[1]: https://github.com/DataDog/datadog-agent/blob/369a8dbb39dc6e8601d82c8f43caaaf88d6a0a55/pkg/config/config_template.yaml#L987-L993
+[1]: https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example
 

--- a/hugo/content/en/metrics/types.md
+++ b/hugo/content/en/metrics/types.md
@@ -118,11 +118,10 @@ If you send `X` values for a HISTOGRAM metric `<METRIC_NAME>` in a given time in
 **Notes**:
 
 - Configure which aggregations you want to send to Datadog with the `histogram_aggregates` parameter in your [`datadog.yaml` configuration file][1]. By default, only `max`, `median`, `avg`, and `count` aggregations are sent to Datadog. `sum` and `min` are also available.
-- Configure which percentile aggregation you want to send to Datadog with the `histogram_percentiles` parameter in your [`datadog.yaml` configuration file][2]. By default, only the `95percentile` is sent to Datadog.
+- Configure which percentile aggregation you want to send to Datadog with the `histogram_percentiles` parameter in your [`datadog.yaml` configuration file][1]. By default, only the `95percentile` is sent to Datadog.
 
 
-[1]: https://github.com/DataDog/datadog-agent/blob/04d8ae9dd4bc6c7a64a8777e8a38127455ae3886/pkg/config/config_template.yaml#L106-L114
-[2]: https://github.com/DataDog/datadog-agent/blob/04d8ae9dd4bc6c7a64a8777e8a38127455ae3886/pkg/config/config_template.yaml#L116-L121
+[1]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 

--- a/hugo/content/en/network_monitoring/devices/guide/cluster-agent.md
+++ b/hugo/content/en/network_monitoring/devices/guide/cluster-agent.md
@@ -209,6 +209,7 @@ clusterAgent:
   #
   datadog_cluster_yaml:
 
+    # See here for all `network_devices.autodiscovery` configs: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
     autodiscovery:
       workers: 2
       discovery_interval: 10

--- a/hugo/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/hugo/content/en/network_monitoring/devices/snmp_metrics.md
@@ -113,7 +113,7 @@ To use Autodiscovery with Network Device Monitoring:
 
 2. Edit the [`datadog.yaml`][8] Agent configuration file to include all the subnets for Datadog to scan. The following sample config provides required parameters, default values, and examples for Autodiscovery.
 
-3. Optionally, enable de-duplication of devices during Autodiscovery of the Agent. This feature is disabled by default and requires Agent version `7.67+`.
+3. Optionally, enable de-duplication of devices during Autodiscovery of the Agent. This feature is disabled by default and requires Agent version 7.67+. For details, see the `use_deduplication` parameter in the [example Agent configuration file][11].
 
    ```yaml
    network_devices:
@@ -231,3 +231,4 @@ For all available `interface_configs` options, see the [sample snmp.d/conf.yaml]
 [8]: /agent/configuration/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file
 [9]: https://github.com/DataDog/datadog-agent/blob/51dd4482466cc052d301666628b7c8f97a07662b/pkg/config/config_template.yaml#L855
 [10]: /agent/configuration/agent-commands/#agent-status-and-information
+[11]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example

--- a/hugo/content/en/network_monitoring/netflow/_index.md
+++ b/hugo/content/en/network_monitoring/netflow/_index.md
@@ -108,13 +108,13 @@ From the [{{< ui >}}Enrichment{{< /ui >}} settings page][10], click {{< ui >}}+ 
 
 Enable Reverse DNS private IP enrichment to perform DNS lookups for hostnames associated with source or destination IP addresses. When enabled, the Agent conducts reverse DNS lookups on source and destination IPs within private address ranges, enriching NetFlow records with the corresponding hostnames.
 
-By [default][7], the Reverse DNS IP enrichment in your `datadog.yaml` file is disabled. To enable, see the [Configuration](#configuration) section of this page.
+By default, the Reverse DNS IP enrichment in your [`datadog.yaml` file][7] is disabled. To enable, see the [Configuration](#configuration) section of this page.
 
 Search for DNS in the {{< ui >}}+ Filter{{< /ui >}} menu to locate flows associated with Reverse DNS IP enrichment:
 
 {{< img src="network_device_monitoring/netflow/dns_ip_enrichmen_2.png" alt="Filter menu enhanced to show the reverse DNS destination and source facets" width="100%" >}}
 
-**Note**: Reverse DNS entries are cached and subject to rate limiting to minimize DNS queries and reduce the load on DNS servers. For more configuration options, including modifying default caching and rate limiting, see the [full configuration file][8].
+**Note**: Reverse DNS entries are cached and subject to rate limiting to minimize DNS queries and reduce the load on DNS servers. For more configuration options, including modifying default caching and rate limiting, see the `reverse_dns_enrichment` section of the [example Agent configuration file][7].
 
 ## IP details
 
@@ -376,8 +376,7 @@ Use the `netstat -s` command to see if there are any dropped UDP packets:
 [4]: /agent/configuration/agent-commands/?tab=agentv6v7#start-stop-and-restart-the-agent
 [5]: https://app.datadoghq.com/devices/netflow
 [6]: /monitors/types/netflow/
-[7]: https://github.com/DataDog/datadog-agent/blob/f6ae461a7d22aaf398de5a94d9330694d69560d6/pkg/config/config_template.yaml#L4201
-[8]: https://github.com/DataDog/datadog-agent/blob/f6ae461a7d22aaf398de5a94d9330694d69560d6/pkg/config/config_template.yaml#L4203-L4275
+[7]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 [9]: /network_monitoring/devices/troubleshooting#traps-or-flows-not-being-received-at-all
 [10]: https://app.datadoghq.com/devices/settings/enrichment/ip
 [11]: /network_monitoring/network_path/setup/#dynamic-tests-for-netflow-experimental

--- a/hugo/content/en/network_monitoring/network_path/setup.md
+++ b/hugo/content/en/network_monitoring/network_path/setup.md
@@ -374,7 +374,7 @@ Agent `v7.73+` is required.
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
-[3]: https://github.com/DataDog/datadog-agent/blob/2c8d60b901f81768f44a798444af43ae8d338843/pkg/config/config_template.yaml#L1731
+[3]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -442,7 +442,7 @@ Agent `v7.73+` is required.
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
-[3]: https://github.com/DataDog/datadog-agent/blob/2c8d60b901f81768f44a798444af43ae8d338843/pkg/config/config_template.yaml#L1731
+[3]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example
 
 {{% /tab %}}
 {{% tab "Helm" %}}

--- a/hugo/content/en/opentelemetry/mapping/service_entry_spans.md
+++ b/hugo/content/en/opentelemetry/mapping/service_entry_spans.md
@@ -33,7 +33,7 @@ The new service-entry span identification logic can be enabled by setting the `t
 
 The new service-entry span identification logic can be enabled by adding `"enable_otlp_compute_top_level_by_span_kind"` to [apm_config.features][1] in the Datadog Agent config.
 
-[1]: https://github.com/DataDog/datadog-agent/blob/7.53.0/pkg/config/config_template.yaml#L1585-L1591
+[1]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/hugo/content/en/opentelemetry/setup/ddot_collector/install/linux.md
+++ b/hugo/content/en/opentelemetry/setup/ddot_collector/install/linux.md
@@ -116,7 +116,7 @@ DDOT automatically binds the OpenTelemetry Collector to ports 4317 (grpc) and 43
 
 <div class="alert alert-warning">Enabling these features may incur additional charges. Review the <a href="https://www.datadoghq.com/pricing/">pricing page</a> and talk to your Customer Success Manager before proceeding.</div>
 
-For a complete list of available options, see the fully commented reference file at `/etc/datadog-agent/datadog.yaml.example`.
+For a complete list of available options, see the fully commented reference file at `/etc/datadog-agent/datadog.yaml.example`. Alternatively, see the [example Agent configuration file for Linux][12] on GitHub.
 
 When enabling additional Datadog features, always use the Datadog or OpenTelemetry Collector configuration files instead of relying on Datadog environment variables.
 
@@ -336,4 +336,5 @@ View metrics from the DDOT Collector to monitor the Collector health.
 [9]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/src/main/java/com/otel/service/CalendarService.java#L27-L48
 [10]: /opentelemetry/correlate/
 [11]: /opentelemetry/integrations/collector_health_metrics/
+[12]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_linux.yaml.example
 [13]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/run-otel-local.sh

--- a/hugo/content/en/opentelemetry/setup/ddot_collector/install/windows.md
+++ b/hugo/content/en/opentelemetry/setup/ddot_collector/install/windows.md
@@ -118,7 +118,7 @@ DDOT automatically binds the OpenTelemetry Collector to ports 4317 (grpc) and 43
 
 <div class="alert alert-warning">Enabling these features may incur additional charges. Review the <a href="https://www.datadoghq.com/pricing/">pricing page</a> and talk to your Customer Success Manager before proceeding.</div>
 
-For a complete list of available options, see the fully commented reference file at `C:\ProgramData\Datadog\datadog.yaml.example`.
+For a complete list of available options, see the fully commented reference file at `C:\ProgramData\Datadog\datadog.yaml.example`. Alternatively, see the [example Agent configuration file for Windows][12] on GitHub.
 
 When enabling additional Datadog features, always use the Datadog or OpenTelemetry Collector configuration files instead of relying on Datadog environment variables.
 
@@ -338,5 +338,6 @@ View metrics from the DDOT Collector to monitor the Collector health.
 [9]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/src/main/java/com/otel/service/CalendarService.java#L27-L48
 [10]: /opentelemetry/correlate/
 [11]: /opentelemetry/integrations/collector_health_metrics/
+[12]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/example/datadog-agent_windows.yaml.example
 [13]: https://github.com/DataDog/opentelemetry-examples/blob/main/apps/rest-services/java/calendar/run-otel-local.sh
 [14]: /agent/supported_platforms/windows/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15417

The historical Agent `config_template.yaml` was removed and has been replaced by a set of [example YAML configs](https://github.com/DataDog/datadog-agent/tree/main/pkg/config/example). @brett0000FF removed the docs build dependency on the old file (https://github.com/DataDog/documentation/pull/39006), and removed references to the old file in various docs pages (https://github.com/DataDog/documentation/pull/39062) to prevent 404s. 

This PR:

* Adds back removed links, repointing them to the correct new example files (in some cases, changing the wording around the links) -- ecc89c79d5c408d01eed5994cfb8c84d6358d67a and b0ad294f7dacf9914df091b11767c2e5d352b68e
* Replaces links that were pinned to specific commits and/or line numbers in the old file -- 612605eb8e1e4549d0408ef127c7575bb8fdf145

One note: I didn't replace the link [removed from the Agent 6 doc](https://github.com/DataDog/documentation/pull/39062/changes#diff-21314ef748b9a186642d35ccaf6948caa81251769dfd3e77d71fe24d0242045d) because that version EOL and the page is hidden anyway.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

### AI assistance

I walked through each file myself, using Claude Code to do a lot of the replacing. Also had it check through Brett's PRs and linked tickets to make sure I didn't miss any files.

### Additional notes
