### PR TITLE
Rename product menu to Agent Observability

### DIFF
--- a/hugo/data/products.yaml
+++ b/hugo/data/products.yaml
@@ -144,7 +144,7 @@ products:
                 link: watchdog/
                 description: Detect and surface application and infrastructure anomalies
                 short_description: Anomaly detection
-              - title: LLM Observability
+              - title: Agent Observability
                 link: llm_observability/
                 description: Trace, monitor, and secure your LLM applications
                 short_description: LLM monitoring and security


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1badd8ed-cbdb-43c0-8a9b-fee4ebbf4925","source":"chat","resourceId":"cec5dceb-735a-499a-ac39-00c887779534","workflowId":"8c1473dd-1e94-43f7-9c8e-ea03028f7060","codeChangeId":"8c1473dd-1e94-43f7-9c8e-ea03028f7060","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

The docs product menu still labels the renamed product as LLM Observability. This updates the visible title so the docs navigation consistently presents Agent Observability.

### Changes

- Rename the AI product menu entry from LLM Observability to Agent Observability.
- Preserve the existing destination, description, and short description.

### Testing

- Parsed `hugo/data/products.yaml` with Ruby's YAML parser.
- Ran `git diff --check`.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to locate, update, and validate the product menu entry.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/cec5dceb-735a-499a-ac39-00c887779534)

Comment @datadog to request changes