### PR TITLE
Update Bits Code Admin settings links

### DIFF
--- a/hugo/content/en/bits_ai/bits_code/automations.md
+++ b/hugo/content/en/bits_ai/bits_code/automations.md
@@ -110,5 +110,5 @@ You can pause or resume any automation, but you can only edit or delete automati
 [4]: /integrations/slack/
 [5]: /internal_developer_portal/catalog/
 [6]: /account_management/rbac/permissions/#bits-ai
-[7]: https://app.datadoghq.com/code/settings
+[7]: https://app.datadoghq.com/code/settings/admin
 [8]: /account_management/billing/ai_credits/

--- a/hugo/content/en/bits_ai/bits_code/setup.md
+++ b/hugo/content/en/bits_ai/bits_code/setup.md
@@ -83,7 +83,7 @@ You can also configure service-to-repository mapping manually in Bits Code setti
 
 Auto-push allows Bits Code to create branches, push code, and open PRs or MRs when it detects something it can help you with. Auto-push only opens PRs or MRs and pushes changes; it never merges code. When auto-push is disabled, you must review code in Datadog before it gets pushed.
 
-To enable auto-push, navigate to {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}General{{< /ui >}}][6].
+To enable auto-push, navigate to {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}Admin{{< /ui >}}][6].
 
 
 #### Security considerations
@@ -103,7 +103,7 @@ Bits Code ingests custom instruction files from your repository, including:
 - `.windsurfrules`
 - `copilot-instructions.md`
 
-You can also define global custom instructions that apply to all Bits Code sessions in {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}General{{< /ui >}}][6], in the {{< ui >}}Global Agent Instructions{{< /ui >}} section.
+You can also define global custom instructions that apply to all Bits Code sessions in {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}Admin{{< /ui >}}][13], in the {{< ui >}}Global Agent Instructions{{< /ui >}} section.
 
 A custom instruction file is a good place to mention [custom skills][12] you'd like Bits Code to use.
 
@@ -113,7 +113,7 @@ Configure Bits Code's runtime environment, including network access policies and
 
 ### Configure internet access
 
-By default, Bits Code has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}General{{< /ui >}}][6], and find the {{< ui >}}Internet Access{{< /ui >}} section. Choose from the following access policies: {{< ui >}}No Internet Access{{< /ui >}}, {{< ui >}}Default Allowlist{{< /ui >}}, {{< ui >}}Custom + Default Allowlist{{< /ui >}}, or {{< ui >}}Custom Allowlist{{< /ui >}}.
+By default, Bits Code has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to {{< ui >}}Bits Code{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > [{{< ui >}}Admin{{< /ui >}}][14], and find the {{< ui >}}Internet Access{{< /ui >}} section. Choose from the following access policies: {{< ui >}}No Internet Access{{< /ui >}}, {{< ui >}}Default Allowlist{{< /ui >}}, {{< ui >}}Custom + Default Allowlist{{< /ui >}}, or {{< ui >}}Custom Allowlist{{< /ui >}}.
 
 The default allowlist includes the following domains. This list will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
 
@@ -161,11 +161,13 @@ In some cases, especially in repositories with many branches, GitHub does not ru
 [2]: https://app.datadoghq.com/integrations/github
 [4]: /integrations/guide/source-code-integration/?tab=go#tag-your-apm-telemetry-with-git-information
 [5]: https://app.datadoghq.com/code/settings?tab=repositories
-[6]: https://app.datadoghq.com/code/settings
+[6]: https://app.datadoghq.com/code/settings/admin
 [7]: /bits_ai/bits_code/#start-a-session
 [8]: /bits_ai/bits_code/
 [11]: /bits_ai/bits_code/#supported-source-code-providers
 [12]: /bits_ai/bits_code/#custom-agent-skills-and-instructions
+[13]: https://app.datadoghq.com/code/settings/admin#agent-instructions
+[14]: https://app.datadoghq.com/code/settings/admin#internet-access
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Updates Bits Code documentation to match the Admin settings destination:

- Renames the General settings references to Admin.
- Links organization settings to `/code/settings/admin`.
- Links global instructions and internet access directly to their Admin sections.
- Preserves the existing Repositories destination.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

An AI coding assistant updated the links and terminology and checked the resulting diff.

### Additional notes

Keep this PR in draft until the Admin settings route is available to users.
