### PR TITLE
Document Rollout target support for DatadogInstrumentation

### DIFF
--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -131,7 +131,7 @@ You can target the following Kubernetes resources:
 | StatefulSet | `apps/v1/statefulsets` | 7.82.0 | |
 | CronJob | `batch/v1/cronjobs` | 7.82.0 | |
 | Job | `batch/v1/jobs` | 7.82.0 | |
-| Service | `core/v1/services` | 7.82.0 | Supports checks only. See [Service targets](#service-targets). |
+| Service | `core/v1/services` | 7.82.0 | Supports checks only. See [Target services](#target-services). |
 | Rollout | `argoproj.io/v1alpha1/rollouts` | 7.83.0 | Requires [Argo Rollouts][7]. |
 
 This example configures a [Redis integration][4] for a `StatefulSet` named `redis`, mirroring this [annotation-based example][2].

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -190,7 +190,7 @@ Each entry in `checks` accepts the following fields:
 
 Each entry in `logs` accepts the same log collection options as Autodiscovery log annotations, such as `tags`, `type`, and `path`. Each entry requires a `containerName` matching a container in the pod.
 
-### Target Services
+### Target services
 
 Targeting a `Service` configures an [endpoint check][6] similar to an annotation on a Kubernetes service.
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -124,12 +124,15 @@ helm upgrade --install datadog-crds datadog/datadog-crds
 
 You can target the following Kubernetes resources:
 
-- Deployment
-- DaemonSet
-- StatefulSet
-- CronJob
-- Job
-- Service (see the [Service targets](#service-targets) section)
+| Target | Group/version/resource | Minimum Agent version | Notes |
+|---|---|---|---|
+| Deployment | `apps/v1/deployments` | 7.82.0 | |
+| DaemonSet | `apps/v1/daemonsets` | 7.82.0 | |
+| StatefulSet | `apps/v1/statefulsets` | 7.82.0 | |
+| CronJob | `batch/v1/cronjobs` | 7.82.0 | |
+| Job | `batch/v1/jobs` | 7.82.0 | |
+| Service | `core/v1/services` | 7.82.0 | Supports checks only. See [Service targets](#service-targets). |
+| Rollout | `argoproj.io/v1alpha1/rollouts` | 7.83.0 | Requires [Argo Rollouts][7]. |
 
 This example configures a [Redis integration][4] for a `StatefulSet` named `redis`, mirroring this [annotation-based example][2].
 
@@ -274,3 +277,4 @@ Auto-discovery IDs:
 [4]: /integrations/redisdb/
 [5]: /containers/guide/template_variables/
 [6]: /containers/cluster_agent/endpointschecks/
+[7]: https://argoproj.github.io/rollouts/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the `DatadogInstrumentation` Autodiscovery guide with a target compatibility table listing each supported GVR and minimum Agent version. Adds Argo Rollout target support starting in Agent 7.83.0 and clarifies that Service targets support checks only.

### Merge readiness

- [ ] Agent version `7.83` is released

## For Datadog employees:

* ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
* 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI-assisted implementation and verification.

### Additional notes