### PR TITLE
Add Default Blocked IP Limit for AAP Denylist

### DIFF
--- a/hugo/content/en/security/application_security/threat_protection/policies/_index.md
+++ b/hugo/content/en/security/application_security/threat_protection/policies/_index.md
@@ -123,4 +123,4 @@ As important as it is for you to be able to apply protection granularly and redu
 [17]: https://docs.datadoghq.com/actions/workflows/
 [18]: https://app.datadoghq.com/workflow/blueprints?selected_category=SECURITY
 [20]: /security/application_security/threat_protection/security_signals/
-[21]: https://docs.datadoghq.com/help/
+[21]: /help/

--- a/hugo/content/en/security/application_security/threat_protection/policies/_index.md
+++ b/hugo/content/en/security/application_security/threat_protection/policies/_index.md
@@ -49,6 +49,8 @@ Create workflows from the available [blueprints][18] and run them directly from 
 
 Attackers' IP addresses and authenticated users that are permanently or temporarily blocked are added to the _Denylist_. Manage the list on the [Denylist page][7]. A denylist supports blocking individual IPs as well as a range of IPs (CIDR blocks).
 
+**Note**: By default, your Denylist can contain up to 2,500 entries (IP addresses, CIDR ranges, and authenticated users combined). Entries added beyond this limit are accepted in the Datadog UI but aren't included in the enforced Denylist configuration, so blocking doesn't take effect for them. If you need to block more entries than this limit allows, contact [Datadog Support][21] to request an increase.
+
 ## Passlist
 
 You can use the _Passlist_ to permanently allow specific IP addresses access to your application. For example, you may wish to add internal IP addresses to your passlist, or IP addresses that regularly run security audits on your application. You can also add specific paths to ensure uninterrupted access. Manage the list from the [Passlist page][8].
@@ -121,3 +123,4 @@ As important as it is for you to be able to apply protection granularly and redu
 [17]: https://docs.datadoghq.com/actions/workflows/
 [18]: https://app.datadoghq.com/workflow/blueprints?selected_category=SECURITY
 [20]: /security/application_security/threat_protection/security_signals/
+[21]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
This PR adds a note under our Application & API Protection Policies Denylist mentioning the default limit set for blocked IPs, as requested by our customers. 

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
Used Claude Code for initial draft.


<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
