### PR TITLE
fix(tag-pipelines): fix first-match example tags to match UI screenshot

### DIFF
--- a/hugo/content/en/cloud_cost_management/allocation/tag_pipelines.md
+++ b/hugo/content/en/cloud_cost_management/allocation/tag_pipelines.md
@@ -91,7 +91,7 @@ For example, if you want to add information about which VPs, organizations, and 
 
 {{< img src="cloud_cost/pipelines-map-multiple-tags-2.png" alt="Add account metadata like customer_name using reference tables for tag pipelines" style="width:60%;" >}}
 
-Similar to [Alias tag keys](#alias-tag-keys), the rule stops executing for each resource after the first match is found. For example, if an `aws_member_account_id` is found, then the rule no longer attempts to find a `subscriptionid`.
+Similar to [Alias tag keys](#alias-tag-keys), the rule stops executing for each resource after the first match is found. For example, if an `application` is found, then the rule no longer attempts to find a `subscription_id`.
 
 Under the {{< ui >}}Additional options{{< /ui >}} section, you have the following options:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Updates the first-match example in the **Map multiple tags** section of the Tag Pipelines docs to match the current UI screenshot.
The existing text referenced `aws_member_account_id` and `subscriptionid`, but the screenshot shows `application` and `subscription_id`. This mismatch between the example and the visual may cause confusion for customers following the documentation.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
