### PR TITLE
[CCM] Clarify RDS Provisioned IOPS recommendation excludes Aurora

### DIFF
--- a/hugo/content/en/cloud_cost_management/recommendations/_index.md
+++ b/hugo/content/en/cloud_cost_management/recommendations/_index.md
@@ -298,7 +298,7 @@ multifiltersearch:
       cloud_provider: AWS
       resource_type: RDS Instance
       recommendation_type: Downsize RDS Instance Provisioned IOPS
-      recommendation_description: RDS instances using less than 80% of provisioned IOPS over the past two weeks.
+      recommendation_description: RDS instances using less than 80% of provisioned IOPS over the past two weeks. Not applicable to Amazon Aurora instances, which do not have a configurable provisioned IOPS setting.
       recommendation_prerequisites: ""
     - category: Migrate
       cloud_provider: AWS


### PR DESCRIPTION
## Summary
- The "Downsize RDS Instance Provisioned IOPS" recommendation description didn't mention that it never applies to Amazon Aurora instances, since Aurora has no configurable provisioned IOPS setting.
- Root-caused via [SREVENG-5954](https://datadoghq.atlassian.net/browse/SREVENG-5954): org 681919's entire RDS fleet is Aurora, so this recommendation correctly never fires for them, but the docs gave support/customers no way to know that was expected.

## Test plan
- [ ] Docs preview renders the recommendation table correctly

[SREVENG-5954]: https://datadoghq.atlassian.net/browse/SREVENG-5954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ