### PR TITLE
[DOCS-15378] Add scheduled blog linker workflow

### DIFF
--- a/.github/chainguard/documentation.blog-linker-write.sts.yaml
+++ b/.github/chainguard/documentation.blog-linker-write.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: "repo:DataDog/documentation:ref:refs/heads/master"
+
+permissions:
+  contents: write
+  pull_requests: write
+
+claim_pattern:
+  repository: "DataDog/documentation"
+  ref: "refs/heads/master"
+  ref_type: "branch"
+  event_name: "schedule|workflow_dispatch"
+  job_workflow_ref: "DataDog/documentation/.github/workflows/blog_linker.yml@refs/heads/master"

--- a/.github/workflows/blog_linker.yml
+++ b/.github/workflows/blog_linker.yml
@@ -154,7 +154,8 @@ jobs:
             --head "$branch" \
             --title "Add blog links to further_reading (week of ${date_stamp})" \
             --body-file pr_body.md \
-            --label "WORK IN PROGRESS"
+            --label "WORK IN PROGRESS" \
+            --reviewer jeff-morgan-dd
 
       - name: Upload summary
         if: always()

--- a/.github/workflows/blog_linker.yml
+++ b/.github/workflows/blog_linker.yml
@@ -1,0 +1,165 @@
+name: Blog linker
+
+# Adds Datadog blog post links to the further_reading section of the docs pages
+# each post references, then opens a draft PR with the result.
+#
+# The script itself lives in DataDog/websites-images
+# (services/webops-site-build/bin/docs-ci/blog_linker.py) and is fetched at run
+# time, so this workflow always uses the current version.
+
+on:
+  schedule:
+    # Tuesdays at 12:00 UTC (08:00 ET)
+    - cron: '0 12 * * 2'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'Look back this many days for blog posts'
+        required: false
+        default: '7'
+      dry_run:
+        description: 'Report what would change without opening a PR'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: blog-linker
+  cancel-in-progress: false
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # The cron is weekly, so 7 days. The script's own default is 14.
+      SINCE: ${{ inputs.since || '7' }}
+    steps:
+      # Read access to websites-images, where the script lives.
+      - name: Get token for websites-images
+        id: sts-scripts
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/websites-images
+          policy: documentation.blog-linker
+
+      # Write access to this repo, so the branch and PR are created by an
+      # identity that triggers the normal PR checks (Vale and the rest).
+      - name: Get token for documentation
+        id: sts-docs
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/documentation
+          policy: documentation.blog-linker-write
+
+      - name: Check out documentation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.sts-docs.outputs.token }}
+
+      - name: Fetch the blog linker script
+        env:
+          GH_TOKEN: ${{ steps.sts-scripts.outputs.token }}
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          git clone --depth 1 --filter=blob:none --sparse \
+            "https://x-access-token:${GH_TOKEN}@github.com/DataDog/websites-images.git" "$tmp"
+          git -C "$tmp" sparse-checkout set services/webops-site-build/bin/docs-ci
+          cp "$tmp/services/webops-site-build/bin/docs-ci/blog_linker.py" ./blog_linker.py
+          rm -rf "$tmp"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install feedparser requests beautifulsoup4 ruamel.yaml
+
+      - name: Run the blog linker
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=(--since "$SINCE")
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python ./blog_linker.py "${args[@]}" | tee summary.txt
+
+      # The script only writes to hugo/content/en. Scoping to that path keeps
+      # the workflow's own files (blog_linker.py, summary.txt) out of the commit.
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet -- hugo/content/en; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No docs pages changed. Nothing to open a PR for."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- hugo/content/en
+          fi
+
+      - name: Open a draft PR
+        if: steps.changes.outputs.changed == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ steps.sts-docs.outputs.token }}
+        run: |
+          set -euo pipefail
+          date_stamp=$(date -u +%Y-%m-%d)
+          branch="blog-linker/weekly-${date_stamp}"
+
+          git config user.name "dd-octo-sts[bot]"
+          git config user.email "200755185+dd-octo-sts[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # Same path scope as the check above: content changes only.
+          git add -- hugo/content/en
+          git commit -m "Add blog links to further_reading (week of ${date_stamp})"
+          git push origin "$branch"
+
+          {
+            echo '### What does this PR do? What is the motivation?'
+            echo
+            echo "Adds Datadog blog post links to the \`further_reading\` section of the docs pages"
+            echo "those posts reference. Opened automatically by the [blog linker workflow][1];"
+            echo "covers posts from the last ${SINCE} days."
+            echo
+            echo '<details><summary>Script output</summary>'
+            echo
+            echo '```'
+            cat summary.txt
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo '### Merge readiness'
+            echo
+            echo '- [ ] Ready for merge'
+            echo
+            echo '### Additional notes'
+            echo
+            echo 'Each entry pairs a blog post with a docs page that post links to.'
+            echo
+            echo "[1]: https://github.com/DataDog/documentation/blob/master/.github/workflows/blog_linker.yml"
+          } > pr_body.md
+
+          gh pr create \
+            --draft \
+            --base master \
+            --head "$branch" \
+            --title "Add blog links to further_reading (week of ${date_stamp})" \
+            --body-file pr_body.md \
+            --label "WORK IN PROGRESS"
+
+      - name: Upload summary
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: blog-linker-summary
+          path: summary.txt
+          if-no-files-found: ignore

--- a/.github/workflows/blog_linker.yml
+++ b/.github/workflows/blog_linker.yml
@@ -16,7 +16,7 @@ on:
       since:
         description: 'Look back this many days for blog posts'
         required: false
-        default: '7'
+        default: '14'
       dry_run:
         description: 'Report what would change without opening a PR'
         type: boolean
@@ -36,8 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      # The cron is weekly, so 7 days. The script's own default is 14.
-      SINCE: ${{ inputs.since || '7' }}
+      # Two weeks, against a weekly cron: every post falls in two runs, so a
+      # dropped or failed run doesn't lose a week. The script skips posts
+      # already linked, so the second pass is a no-op.
+      SINCE: ${{ inputs.since || '14' }}
     steps:
       # Read access to websites-images, where the script lives.
       - name: Get token for websites-images


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15378

Adds a scheduled workflow that runs the blog linker script every Tuesday and opens a draft PR on a branch with the result, plus the dd-octo-sts trust policy it needs.

The blog linker script adds Datadog blog post links to the `further_reading` section of the docs pages those posts reference. It has been run manually on a regular basis; this action automates the run itself. The output opens a draft PR on a branch for manual review prior to the standard docs PR review process.

Two files:

- `.github/workflows/blog_linker.yml` — the weekly job run via cron
- `.github/chainguard/documentation.blog-linker-write.sts.yaml` — the trust policy that lets it push a branch and open the PR

The script lives in `DataDog/websites-images` (`services/webops-site-build/bin/docs-ci/blog_linker.py`) and is fetched at run time, per the convention that build scripts live in the image rather than the docs repo. The companion PR adding the matching read policy there is [DataDog/websites-images#479](https://github.com/DataDog/websites-images/pull/479).

### About the write permission

The policy grants `contents: write` and `pull_requests: write`, which the job needs to push its branch and open the PR.

It is pinned as narrowly as the claims allow: 
- Only this repo
- Only from `refs/heads/master`
- Only `schedule` or `workflow_dispatch` events
- Only when the running job is `blog_linker.yml@refs/heads/master`

A PR that adds a workflow, or any run from a feature branch, matches nothing and gets no token. Tokens are short-lived and expire with the job.

Written to follow the SECENG guidance in [High-level recommendations for ID token verification](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6222446815): 
- GitHub issuer verified
- `subject`, `ref`, `ref_type`, `event_name`, and `job_workflow_ref` all specified
-- `ref_protected` is deliberately omitted, since it is true on all branches org-wide and no longer narrows anything
- All actions are pinned to commit SHAs and `id-token: write` is scoped to the single job

### Testing

After both PRs merge, I'll run a manual `workflow_dispatch` with `dry_run: true`, which reports what it would change without opening a PR. The workflow can't run from a branch.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Lots of Claude and Codex for writing and testing, with guidance and final review from me.

### Additional notes

Nothing lands under `hugo/`, so there is no site build impact.
