### PR TITLE
[K9CODESEC-3793] Document Swift and Dart AI-native SAST support

### DIFF
--- a/hugo/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/hugo/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -96,6 +96,8 @@ AI-native SAST uses a two-phase approach:
 | Ruby       | Available   |
 | Rust       | Available   |
 | Elixir     | Available   |
+| Swift      | Available   |
+| Dart       | Available   |
 
 ### Detected vulnerability types
 

--- a/hugo/content/en/security/code_security/static_analysis/configuration.md
+++ b/hugo/content/en/security/code_security/static_analysis/configuration.md
@@ -26,6 +26,7 @@ When AI-native SAST is enabled, its default rulesets run for the supported langu
 | Language | Ruleset |
 | --- | --- |
 | C# | `csharp-ai_sast` |
+| Dart | `dart-ai_sast` |
 | Elixir | `elixir-ai_sast` |
 | Go | `go-ai_sast` |
 | Java | `java-ai_sast` |
@@ -35,6 +36,7 @@ When AI-native SAST is enabled, its default rulesets run for the supported langu
 | Python | `python-ai_sast` |
 | Ruby | `ruby-ai_sast` |
 | Rust | `rust-ai_sast` |
+| Swift | `swift-ai_sast` |
 | TypeScript | `typescript-ai_sast` |
 
 The `use-default-rulesets` setting applies to both traditional SAST and AI-native SAST rulesets. If you set `use-default-rulesets: false`, include every traditional and AI-native SAST ruleset that you want to run. For example, the following configuration runs the Ruby security and AI-native SAST rulesets:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Adds Swift and Dart to the documented AI-native SAST supported languages and lists their `swift-ai_sast` and `dart-ai_sast` ruleset names. This helps users identify available language coverage and configure these rulesets explicitly.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Codex was used to compare the documented language and ruleset coverage with the AI-native SAST registry and prepare this update.

### Additional notes

Vale completed with zero errors. Its warnings and suggestions are on pre-existing lines outside this change.
