### PR TITLE
Fix broken TOC anchor links from collapse-content shortcode

### DIFF
--- a/hugo/layouts/shortcodes/collapse-content.html
+++ b/hugo/layouts/shortcodes/collapse-content.html
@@ -11,7 +11,8 @@
       </div>
       <div class="header-text">
         {{- $title := .Get "title" | .Page.RenderString -}}
-        {{ printf "<%s class='header-text-inner'>%s</%s>" $headingLevel $title $headingLevel | safeHTML }}
+        {{- $headingId := $title | plainify | anchorize -}}
+        {{ printf "<%s id='%s' class='header-text-inner'>%s</%s>" $headingLevel $headingId $title $headingLevel | safeHTML }}
       </div>
     </div>
   </summary>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

On pages that use the `collapse-content` shortcode (expandable/collapsible sections), the "On this Page" sidebar links for those section titles don't work. Clicking one of these links in the sidebar does nothing, instead of jumping down to the matching section.

This happens because the shortcode renders each section title as a heading, but never gives that heading an `id`. Normal Markdown headings get an `id` automatically from Hugo, which is what the sidebar links point to. Without an `id` on these particular headings, the sidebar has nothing to link to and falls back to a dead link (`href="#"`).

This PR adds an `id` to the heading generated by the shortcode, using the same slug format Hugo already uses for other headings on the site (for example, "Option 1: Manual client-side setup" becomes `option-1-manual-client-side-setup`). This makes the sidebar links for collapsible sections work the same way they do for regular headings.

<img width="908" height="646" alt="Screenshot 2026-08-20 at 10 48 02 AM" src="https://github.com/user-attachments/assets/6944f5c2-8ea7-47e8-a11d-edb4c36d345c" />

Verified in an isolated minimal Hugo build that the shortcode now renders `<h3 id="option-1-manual-client-side-setup" ...>` instead of a heading with no `id`.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Investigated and fixed with Claude Code: root-caused the broken "On this Page" sidebar links by tracing the client-side TOC-rebuild script, then patched the `collapse-content` shortcode template and verified the fix against a minimal standalone Hugo build.

### Additional notes

Found while debugging an unrelated "On this Page" menu issue on `/real_user_monitoring/setup/install/`. This shortcode is used in 222 places across the docs, so the fix should apply broadly.
