### PR TITLE
[DOCS-15484] Clarify Session Replay masking is permanent

### DIFF
--- a/hugo/content/en/data_security/_index.md
+++ b/hugo/content/en/data_security/_index.md
@@ -102,7 +102,7 @@ Synthetic testing simulates requests and business transactions from testing loca
 
 You can modify the data collected by Real User Monitoring in the browser to protect personally identifiable information and to sample the RUM data you're collecting. Read [Modifying RUM Data and Context][21] for details.
  
-Session Replay privacy options default to protecting end-user privacy and preventing sensitive organizational information from being collected. Read about masking, overriding, and hiding elements from a session replay in [Session Replay Privacy Options][22]. Session Replay masking is permanent and distinct from the Sensitive Data Scanner Mask action described above: masked values never leave the device and cannot be unmasked later.
+Session Replay privacy options default to protecting end-user privacy and preventing sensitive organizational information from being collected. Read about masking, overriding, and hiding elements from a session replay in [Session Replay Privacy Options][22]. Session Replay masking is permanent: Masked values never leave the device and cannot be unmasked later. This differs from the [Sensitive Data Scanner Mask action][26], which obfuscates matching values on ingestion and allows users with the `Data Scanner Unmask` permission to view the original value.
 
 ### Database Monitoring
 

--- a/hugo/content/en/data_security/_index.md
+++ b/hugo/content/en/data_security/_index.md
@@ -166,3 +166,4 @@ Continuous Integration pipelines and tests
 [23]: /database_monitoring/data_collected/#sensitive-information
 [24]: /getting_started/tagging/
 [25]: /tracing/glossary/
+[26]: /security/sensitive_data_scanner/setup/telemetry_data/?tab=logs#mask-action

--- a/hugo/content/en/data_security/_index.md
+++ b/hugo/content/en/data_security/_index.md
@@ -102,7 +102,7 @@ Synthetic testing simulates requests and business transactions from testing loca
 
 You can modify the data collected by Real User Monitoring in the browser to protect personally identifiable information and to sample the RUM data you're collecting. Read [Modifying RUM Data and Context][21] for details.
  
-Session Replay privacy options default to protecting end-user privacy and preventing sensitive organizational information from being collected. Read about masking, overriding, and hiding elements from a session replay in [Session Replay Privacy Options][22].
+Session Replay privacy options default to protecting end-user privacy and preventing sensitive organizational information from being collected. Read about masking, overriding, and hiding elements from a session replay in [Session Replay Privacy Options][22]. Session Replay masking is permanent and distinct from the Sensitive Data Scanner Mask action described above: masked values never leave the device and cannot be unmasked later.
 
 ### Database Monitoring
 

--- a/hugo/content/en/data_security/real_user_monitoring.md
+++ b/hugo/content/en/data_security/real_user_monitoring.md
@@ -158,3 +158,4 @@ See [privacy options specific to Session Replay][19]. Masking in Session Replay 
 [18]: https://app.datadoghq.com/organization-settings/sensitive-data-scanner/configuration
 [19]: /session_replay/privacy_options?platform=browser
 [20]: https://www.datadoghq.com/private-beta/product-analytics/
+[21]: /security/sensitive_data_scanner/setup/telemetry_data/?tab=logs#mask-action

--- a/hugo/content/en/data_security/real_user_monitoring.md
+++ b/hugo/content/en/data_security/real_user_monitoring.md
@@ -132,7 +132,7 @@ In addition to removing client IPs, you can also choose to disable the collectio
 [Sensitive Data Scanner][17] allows you to proactively search and scrub sensitive data upon ingestion by Datadog. RUM events are scanned on the stream before any data is stored within Datadog. The tool has the power to scrub, hash, or partially redact PII data before it is stored. It works by applying out-of-the-box or customer-developed pattern matching rules. If you've enabled this feature, you can find it on the [{{< ui >}}Manage Sensitive Data{{< /ui >}} page][18].
 
 ## Session Replay-specific privacy options
-See [privacy options specific to Session Replay][19].
+See [privacy options specific to Session Replay][19]. Masking in Session Replay is permanent: masked values never leave the device and cannot be recovered later. This differs from [Sensitive Data Scanner masking][17], which allows users with the `Data Scanner Unmask` permission to view the original value.
 
 ### Further Reading
 

--- a/hugo/content/en/data_security/real_user_monitoring.md
+++ b/hugo/content/en/data_security/real_user_monitoring.md
@@ -132,7 +132,7 @@ In addition to removing client IPs, you can also choose to disable the collectio
 [Sensitive Data Scanner][17] allows you to proactively search and scrub sensitive data upon ingestion by Datadog. RUM events are scanned on the stream before any data is stored within Datadog. The tool has the power to scrub, hash, or partially redact PII data before it is stored. It works by applying out-of-the-box or customer-developed pattern matching rules. If you've enabled this feature, you can find it on the [{{< ui >}}Manage Sensitive Data{{< /ui >}} page][18].
 
 ## Session Replay-specific privacy options
-See [privacy options specific to Session Replay][19]. Masking in Session Replay is permanent: masked values never leave the device and cannot be recovered later. This differs from [Sensitive Data Scanner masking][17], which allows users with the `Data Scanner Unmask` permission to view the original value.
+See [privacy options specific to Session Replay][19]. Masking in Session Replay is permanent: Masked values never leave the device and cannot be unmasked later. This differs from [Sensitive Data Scanner masking][21], which obfuscates matching values on ingestion but allows users with the `Data Scanner Unmask` permission to view the original value.
 
 ### Further Reading
 

--- a/hugo/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/privacy_options.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/privacy_options.mdoc.md
@@ -20,6 +20,8 @@ By enabling Session Replay, you can automatically mask sensitive elements from b
 By enabling Mobile Session Replay, you can automatically mask sensitive elements from being recorded through the RUM Mobile SDK. When data is masked, that data is not collected in its original form by Datadog's SDKs and thus is not sent to the backend.
 {% /if %}
 
+**Note**: Masking in Session Replay is permanent. The original, unmasked value never leaves the device, so there is no way to recover or unmask it later. This differs from [Sensitive Data Scanner masking][5], which obfuscates matching values on ingestion but allows users with the `Data Scanner Unmask` permission to view the original value.
+
 <!-- Browser -->
 {% if equals($platform, "browser") %}
 ## Configuration
@@ -1612,3 +1614,4 @@ The following chart shows how we apply different image masking strategies:
 [2]: https://github.com/DataDog/dd-sdk-reactnative
 [3]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes
 [4]: /help
+[5]: /security/sensitive_data_scanner/setup/telemetry_data/?tab=logs#mask-action

--- a/hugo/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/privacy_options.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/privacy_options.mdoc.md
@@ -20,7 +20,7 @@ By enabling Session Replay, you can automatically mask sensitive elements from b
 By enabling Mobile Session Replay, you can automatically mask sensitive elements from being recorded through the RUM Mobile SDK. When data is masked, that data is not collected in its original form by Datadog's SDKs and thus is not sent to the backend.
 {% /if %}
 
-**Note**: Masking in Session Replay is permanent. The original, unmasked value never leaves the device, so there is no way to recover or unmask it later. This differs from [Sensitive Data Scanner masking][5], which obfuscates matching values on ingestion but allows users with the `Data Scanner Unmask` permission to view the original value.
+**Note**: Session Replay masking is permanent and cannot be reversed later. This differs from [Sensitive Data Scanner masking][5], which obfuscates matching values on ingestion but allows users with the `Data Scanner Unmask` permission to view the original value.
 
 <!-- Browser -->
 {% if equals($platform, "browser") %}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15484

Clarifies that masking in RUM/Session Replay is permanent — masked values never leave the device and are never sent to Datadog in their original form, so they can't be recovered or unmasked later. Distinguishes this from Sensitive Data Scanner's "Mask" action, which is reversible for users with the `Data Scanner Unmask` permission.

Adds a short note to:
- Session Replay Privacy Options (covers browser and all mobile SDK platforms via the shared partial)
- RUM Data Security page
- Data Security overview page, where SDS masking and Session Replay masking are both described in the same section

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code: identified the terminology ambiguity, drafted the clarifying language, and verified with Vale.

### Additional notes