### PR TITLE
[DOCS-15452] Document regex support in Log Explorer

### DIFF
--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -13,7 +13,7 @@ Use Calculated Fields Extractions to extract values from your logs in the Log Ex
 
 ## Overview
 
-Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer, enabling you to extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs.
+Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer, enabling you to extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs. You can also write an extraction pattern as a regular expression (regex) with named capture groups. See the [Regex](#regex) section.
 
 To create an extraction calculated field, see [Create a calculated field][1].
 
@@ -94,6 +94,64 @@ country=%{word:country} duration=%{integer:duration} path=%{notSpace:request_pat
 - `#duration = 123`
 - `#request_path = /index.html`
 - `#status = 200 OK`
+
+## Regex
+
+In addition to Grok patterns, you can write an extraction pattern as a regular expression (regex) with named capture groups. Datadog evaluates the pattern when you run a query, so nothing is reindexed, and you can add, edit, or remove a pattern at any time.
+
+Extractions run before formulas, so a calculated field formula can reference a field that an extraction produces. The reverse is not possible: you cannot extract from a calculated field.
+
+### Supported syntax
+
+| Feature | Example | What it matches |
+|---|---|---|
+| Literal text | `error` | Those characters, exactly |
+| Any character | `.` | Any single character |
+| Character classes | `[a-z0-9]`, `[^abc]` | Any one character in the set, or any one character not in the set |
+| Shorthand classes | `\d`, `\w`, `\s`, `\D`, `\W`, `\S` | A digit, word character, or whitespace character, and their negations |
+| Unicode property classes | `\p{L}+` | Characters by Unicode property, such as any letter |
+| Alternation | `error\|timeout` | Either alternative |
+| Groups | `(error\|timeout)`, `(?:error\|timeout)` | Groups part of a pattern. `(?:…)` groups without capturing |
+| Named capture groups | `(?<status>\d+)` | Captures the match under a name. Required for extraction |
+| Quantifiers | `a*`, `a+`, `a?`, `a{2,4}` | Repetition: zero or more, one or more, optional, or a bounded range. Matches as much as possible |
+| Lazy quantifiers | `.*?end` | The same repetition, but matching as little as possible |
+| Anchors | `^ERROR`, `timeout$` | The start or the end of the value |
+| Word boundaries | `\berror\b` | A position between a word and a non-word character, so `error` matches but `errors` does not |
+| Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
+| Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |
+
+### Write a regex extraction pattern
+
+A pattern must follow three rules:
+
+- It must contain at least one capture group.
+- Every capture group must be named. Use `(?<name>…)`, not `(…)`. Use `(?:…)` to group without creating a field.
+- Each name must be unique. The name becomes the name of the extracted field.
+
+Given this log line:
+
+```plaintext
+10.0.0.14 GET /api/v1/orders 503
+```
+
+this pattern:
+
+```plaintext
+(?<ip>\S+) (?<method>\S+) (?<path>\S+) (?<status>\d+)
+```
+
+produces four fields you can filter, group, and sort by:
+
+| Field | Value |
+|---|---|
+| `ip` | `10.0.0.14` |
+| `method` | `GET` |
+| `path` | `/api/v1/orders` |
+| `status` | `503` |
+
+Logs where the pattern does not match have no value for those fields.
+
+Extracted values are always strings. Unlike a Grok rule such as `%{integer:status}`, regex extraction does not convert types. To use the value as a number, reference it in an arithmetic formula.
 
 ## Further reading
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -97,7 +97,7 @@ country=%{word:country} duration=%{integer:duration} path=%{notSpace:request_pat
 
 ## Regex
 
-In addition to Grok patterns, you can write an extraction pattern as a regex with named capture groups. Datadog evaluates the pattern when you run a query. This means no data is reindexed, and you can add, edit, or remove a pattern at any time.
+Datadog evaluates the regex pattern when you run a query. This means no data is reindexed, and you can add, edit, or remove a pattern at any time.
 
 Extractions run before formulas, so a calculated field formula can reference a field that an extraction produces. The reverse is not possible: you cannot extract from a calculated field.
 
@@ -122,6 +122,10 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 | Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
 | Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |
 
+Constructs that are not listed, such as lookahead (`(?=…)`), lookbehind (`(?<=…)`), and backreferences (`\1`), are not supported.
+
+Write patterns with a single backslash, as shown. In [formula regex functions][2], a pattern is a quoted string argument and each backslash must be doubled.
+
 ### Capture group rules
 
 A pattern must follow these rules:
@@ -144,20 +148,21 @@ A pattern must follow these rules:
 **Extraction regex pattern**:
 
 ```plaintext
-(?<ip>\S+) (?<method>\S+) (?<path>\S+) (?<status>\d+)
+(?<ip>\S+) (?<method>\S+) /api/(?:v\d+)/(?<resource>\S+) (?<status>\d+)
 ```
 
 **Resulting calculated fields**:
 
 - `#ip = 10.0.0.14`
 - `#method = GET`
-- `#path = /api/v1/orders`
+- `#resource = orders`
 - `#status = 503`
 
-You can filter, group, and sort by these fields. Logs where the pattern does not match have no value for them.
+The `(?:v\d+)` group matches the API version segment without creating a field for it. You can filter, group, and sort by the extracted fields. Logs where the pattern does not match have no value for them.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/explorer/calculated_fields/#create-a-calculated-field
+[2]: /logs/explorer/calculated_fields/formulas/#regex

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -117,7 +117,7 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 | Named capture groups | `(?<status>\d+)` | Captures the match under a name. Required for extraction |
 | Quantifiers | `a*`, `a+`, `a?`, `a{2,4}` | Repetition: zero or more, one or more, optional, or a bounded range. Matches as much as possible |
 | Lazy quantifiers | `.*?end` | The same repetition, but matching as little as possible |
-| Anchors | `^ERROR`, `timeout$` | The start or the end of the value, not each line |
+| Anchors | `^ERROR`, `timeout$` | The start or the end of the value |
 | Word boundaries | `\berror\b` | A position between a word and a non-word character, so `error` matches but `errors` does not |
 | Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
 | Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -151,6 +151,13 @@ A pattern must follow these rules:
 (?<ip>\S+) (?<method>\S+) /api/(?:v\d+)/(?<resource>\S+) (?<status>\d+)
 ```
 
+This pattern follows the capture group rules:
+
+- Four groups have a name: `ip`, `method`, `resource`, and `status`.
+- Each name is unique.
+- Each name uses only letters.
+- The group `(?:v\d+)` has no name. It groups the version segment, but does not create a field.
+
 **Resulting calculated fields**:
 
 - `#ip = 10.0.0.14`
@@ -158,7 +165,19 @@ A pattern must follow these rules:
 - `#resource = orders`
 - `#status = 503`
 
-The `(?:v\d+)` group matches the API version segment without creating a field for it. You can filter, group, and sort by the extracted fields. Logs where the pattern does not match have no value for them.
+You can filter, group, and sort by the extracted fields. Logs where the pattern does not match have no value for them.
+
+### Invalid patterns
+
+Each pattern below breaks one capture group rule.
+
+| Pattern | Problem |
+|---|---|
+| `\S+ \S+ \S+ \S+` | No named group. A pattern needs at least one. |
+| `(\S+) (?<method>\S+)` | The first group has no name. Add a name, or use `(?:...)` to group without a name. |
+| `(?<ip>\S+) (?<ip>\S+)` | The name `ip` is used twice. Each name must be unique. |
+| `(?<client-ip>\S+)` | The name has a hyphen. A name can have only letters and digits. |
+| `(?<1status>\d+)` | The name starts with a digit. A name must start with a letter. |
 
 ## Further reading
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -145,7 +145,7 @@ A pattern must follow these rules:
 10.0.0.14 GET /api/v1/orders 503
 ```
 
-**Extraction regex pattern**:
+**Regex pattern**:
 
 ```plaintext
 (?<ip>\S+) (?<method>\S+) /api/(?:v\d+)/(?<resource>\S+) (?<status>\d+)

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -117,12 +117,12 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 | Named capture groups | `(?<status>\d+)` | Captures the match under a name. Required for extraction |
 | Quantifiers | `a*`, `a+`, `a?`, `a{2,4}` | Repetition: zero or more, one or more, optional, or a bounded range. Matches as much as possible |
 | Lazy quantifiers | `.*?end` | The same repetition, but matching as little as possible |
-| Anchors | `^ERROR`, `timeout$` | The start or the end of the value |
+| Anchors | `^ERROR`, `timeout$` | By default, the start or the end of the whole value |
 | Word boundaries | `\berror\b` | A position between a word and a non-word character, so `error` matches but `errors` does not |
 | Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
 | Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |
 
-Constructs that are not listed, such as lookahead (`(?=…)`), lookbehind (`(?<=…)`), and backreferences (`\1`), are not supported.
+Only the constructs listed here are supported. A pattern that uses any other construct might still run, but its behavior is not guaranteed.
 
 A value can contain multiple lines, such as a stack trace. To match a newline with `.`, add `(?s)` to the start of the pattern. To match `^` and `$` at the start and end of each line, add `(?m)` to the start of the pattern.
 
@@ -177,7 +177,7 @@ Each pattern below breaks one capture group rule.
 |---|---|
 | `(?:\S+) (?:\S+) (?:\S+) (?:\S+)` | No named group. A pattern needs at least one. |
 | `(?<ip>\S+) (?<ip>\S+)` | The name `ip` is used twice. Each name must be unique. |
-| `(?<client-ip>\S+)` | The name has a hyphen. A name can have only letters and digits. |
+| `(?<client_ip>\S+)` | The name has an underscore. A name can have only letters and digits. |
 | `(?<1status>\d+)` | The name starts with a digit. A name must start with a letter. |
 
 ## Further reading

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -155,7 +155,7 @@ This pattern follows the capture group rules:
 
 - Four groups have a name: `ip`, `method`, `resource`, and `status`.
 - Each name is unique.
-- Each name uses only letters.
+- Each name uses only letters and digits.
 - The group `(?:v\d+)` has no name. It groups the version segment, but does not create a field.
 
 **Resulting calculated fields**:
@@ -173,8 +173,7 @@ Each pattern below breaks one capture group rule.
 
 | Pattern | Problem |
 |---|---|
-| `\S+ \S+ \S+ \S+` | No named group. A pattern needs at least one. |
-| `(\S+) (?<method>\S+)` | The first group has no name. Add a name, or use `(?:...)` to group without a name. |
+| `(?:\S+) (?:\S+) (?:\S+) (?:\S+)` | No named group. A pattern needs at least one. |
 | `(?<ip>\S+) (?<ip>\S+)` | The name `ip` is used twice. Each name must be unique. |
 | `(?<client-ip>\S+)` | The name has a hyphen. A name can have only letters and digits. |
 | `(?<1status>\d+)` | The name starts with a digit. A name must start with a letter. |

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -13,7 +13,7 @@ Use Calculated Fields Extractions to extract values from your logs in the Log Ex
 
 ## Overview
 
-Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer, enabling you to extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs. You can also write an extraction pattern as a regular expression (regex) with named capture groups. See the [Regex](#regex) section.
+Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer. This lets you to extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs. You can also write an extraction pattern as a regular expression (regex) with named capture groups. See the [Regex](#regex) section.
 
 To create an extraction calculated field, see [Create a calculated field][1].
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -180,6 +180,12 @@ Each pattern below breaks one capture group rule.
 | `(?<client_ip>\S+)` | The name has an underscore. A name can have only letters and digits. |
 | `(?<1status>\d+)` | The name starts with a digit. A name must start with a letter. |
 
+### Pattern performance
+
+Datadog matches a pattern fastest when it can tell where a match must start. A pattern that begins with `^` or with literal text gives it that starting point. A pattern that begins with `.*` does not, so it is tried at every position in the value.
+
+On a short value the difference is negligible. On a large value, such as a stack trace, an unanchored pattern can slow the query. It can also fail the query with an error rather than returning no match. Anchor the pattern with `^` where the value has a predictable start, and avoid wrapping a literal in `.*` on both sides.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -122,11 +122,12 @@ Extractions run before formulas, so a calculated field formula can reference a f
 
 ### Write a regex extraction pattern
 
-A pattern must follow three rules:
+A pattern must follow four rules:
 
 - It must contain at least one capture group.
 - Every capture group must be named. Use `(?<name>…)`, not `(…)`. Use `(?:…)` to group without creating a field.
 - Each name must be unique. The name becomes the name of the extracted field.
+- Each name must start with a letter, and contain only letters and digits (`[A-Za-z][A-Za-z0-9]*`). Names like `client_ip`, `http.status`, or `client-ip` are not valid capture group names.
 
 Given this log line:
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -124,7 +124,7 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 
 ### Capture group rules
 
-A pattern must follow four rules:
+A pattern must follow these rules:
 
 - It must contain at least one capture group.
 - Every capture group must be named.

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -97,7 +97,7 @@ country=%{word:country} duration=%{integer:duration} path=%{notSpace:request_pat
 
 ## Regex
 
-In addition to Grok patterns, you can write an extraction pattern as a regular expression (regex) with named capture groups. Datadog evaluates the pattern when you run a query, so nothing is reindexed, and you can add, edit, or remove a pattern at any time.
+In addition to Grok patterns, you can write an extraction pattern as a regular expression (regex) with named capture groups. Datadog evaluates the pattern when you run a query. This means nothing is reindexed, and you can add, edit, or remove a pattern at any time.
 
 Extractions run before formulas, so a calculated field formula can reference a field that an extraction produces. The reverse is not possible: you cannot extract from a calculated field.
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -108,7 +108,7 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 | Feature | Example | Description |
 |---|---|---|
 | Literal text | `error` | The literal characters |
-| Any character | `.` | Any single character |
+| Any character | `.` | Any character except a newline |
 | Character classes | `[a-z0-9]`, `[^abc]` | Any one character in the set, or any one character not in the set |
 | Shorthand classes | `\d`, `\w`, `\s`, `\D`, `\W`, `\S` | A digit, word character, or whitespace character, and their negations |
 | Unicode property classes | `\p{L}+` | Characters by Unicode property, such as any letter |
@@ -117,12 +117,14 @@ Extracted values are always strings. Unlike a Grok rule such as `%{integer:statu
 | Named capture groups | `(?<status>\d+)` | Captures the match under a name. Required for extraction |
 | Quantifiers | `a*`, `a+`, `a?`, `a{2,4}` | Repetition: zero or more, one or more, optional, or a bounded range. Matches as much as possible |
 | Lazy quantifiers | `.*?end` | The same repetition, but matching as little as possible |
-| Anchors | `^ERROR`, `timeout$` | The start or the end of the value |
+| Anchors | `^ERROR`, `timeout$` | The start or the end of the value, not each line |
 | Word boundaries | `\berror\b` | A position between a word and a non-word character, so `error` matches but `errors` does not |
 | Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
 | Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |
 
 Constructs that are not listed, such as lookahead (`(?=…)`), lookbehind (`(?<=…)`), and backreferences (`\1`), are not supported.
+
+A value can contain multiple lines, such as a stack trace. To match a newline with `.`, add `(?s)` to the start of the pattern. To match `^` and `$` at the start and end of each line, add `(?m)` to the start of the pattern.
 
 Write patterns with a single backslash, as shown. In [formula regex functions][2], a pattern is a quoted string argument and each backslash must be doubled.
 

--- a/hugo/content/en/logs/explorer/calculated_fields/extractions.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/extractions.md
@@ -13,7 +13,7 @@ Use Calculated Fields Extractions to extract values from your logs in the Log Ex
 
 ## Overview
 
-Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer. This lets you to extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs. You can also write an extraction pattern as a regular expression (regex) with named capture groups. See the [Regex](#regex) section.
+Calculated Fields Extractions lets you apply Grok parsing rules at query time in the Log Explorer. This lets you extract values from raw log messages or attributes without modifying pipelines or re-ingesting data. You can generate extraction rules automatically with AI-powered parsing, or manually define your own Grok patterns to match your specific needs. You can also write an extraction pattern as a [regular expression (regex)](#regex) with named capture groups.
 
 To create an extraction calculated field, see [Create a calculated field][1].
 
@@ -97,15 +97,17 @@ country=%{word:country} duration=%{integer:duration} path=%{notSpace:request_pat
 
 ## Regex
 
-In addition to Grok patterns, you can write an extraction pattern as a regular expression (regex) with named capture groups. Datadog evaluates the pattern when you run a query. This means nothing is reindexed, and you can add, edit, or remove a pattern at any time.
+In addition to Grok patterns, you can write an extraction pattern as a regex with named capture groups. Datadog evaluates the pattern when you run a query. This means no data is reindexed, and you can add, edit, or remove a pattern at any time.
 
 Extractions run before formulas, so a calculated field formula can reference a field that an extraction produces. The reverse is not possible: you cannot extract from a calculated field.
 
+Extracted values are always strings. Unlike a Grok rule such as `%{integer:status}`, regex extraction does not convert types. To use an extracted value as a number, reference it in an arithmetic formula.
+
 ### Supported syntax
 
-| Feature | Example | What it matches |
+| Feature | Example | Description |
 |---|---|---|
-| Literal text | `error` | Those characters, exactly |
+| Literal text | `error` | The literal characters |
 | Any character | `.` | Any single character |
 | Character classes | `[a-z0-9]`, `[^abc]` | Any one character in the set, or any one character not in the set |
 | Shorthand classes | `\d`, `\w`, `\s`, `\D`, `\W`, `\S` | A digit, word character, or whitespace character, and their negations |
@@ -120,39 +122,39 @@ Extractions run before formulas, so a calculated field formula can reference a f
 | Character escapes | `\n`, `\r`, `\t` | Newline, carriage return, tab |
 | Metacharacter escapes | `\.`, `\*`, `\(` | The character itself, rather than its special meaning |
 
-### Write a regex extraction pattern
+### Capture group rules
 
 A pattern must follow four rules:
 
 - It must contain at least one capture group.
-- Every capture group must be named. Use `(?<name>…)`, not `(…)`. Use `(?:…)` to group without creating a field.
+- Every capture group must be named.
+  - Use `(?<name>…)`, not `(…)`.
+  - Use `(?:…)` to group without creating a field.
 - Each name must be unique. The name becomes the name of the extracted field.
 - Each name must start with a letter, and contain only letters and digits (`[A-Za-z][A-Za-z0-9]*`). Names like `client_ip`, `http.status`, or `client-ip` are not valid capture group names.
 
-Given this log line:
+### Example
+
+**Log line**:
 
 ```plaintext
 10.0.0.14 GET /api/v1/orders 503
 ```
 
-this pattern:
+**Extraction regex pattern**:
 
 ```plaintext
 (?<ip>\S+) (?<method>\S+) (?<path>\S+) (?<status>\d+)
 ```
 
-produces four fields you can filter, group, and sort by:
+**Resulting calculated fields**:
 
-| Field | Value |
-|---|---|
-| `ip` | `10.0.0.14` |
-| `method` | `GET` |
-| `path` | `/api/v1/orders` |
-| `status` | `503` |
+- `#ip = 10.0.0.14`
+- `#method = GET`
+- `#path = /api/v1/orders`
+- `#status = 503`
 
-Logs where the pattern does not match have no value for those fields.
-
-Extracted values are always strings. Unlike a Grok rule such as `%{integer:status}`, regex extraction does not convert types. To use the value as a number, reference it in an arithmetic formula.
+You can filter, group, and sort by these fields. Logs where the pattern does not match have no value for them.
 
 ## Further reading
 

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -47,6 +47,7 @@ The available functions are categorized as follows:
 - [Arithmetic](#arithmetic)
 - [String](#string)
 - [Logical](#logical)
+- [Regex](#regex)
 
 
 ### Arithmetic
@@ -315,7 +316,47 @@ Checks if an attribute or expression is null.
 
 {{% /collapse-content %}}
 
+---
+
+### Regex
+
+Regex functions match or transform a value using a regular expression (regex). Patterns support the same regex constructs as [regex extraction][1] (literals, character classes, quantifiers, and so on). Unlike extraction, capture groups here do not need a name: `regexp_replace` can reference an unnamed group positionally with `$1` through `$9`.
+
+<h4>regexp_like(<i>str</i> value, <i>str</i> pattern)</h4>
+
+Returns `true` when the pattern matches anywhere in the value, and `false` otherwise.
+
+{{% collapse-content title="Example" level="h5" expanded=false %}}
+
+| Example  | Formula | Result |
+|----------|-------------|---------|
+| A log event has the following attribute:<br>`message` = "connection timeout after 30s" | `#is_timeout = regexp_like(message, "timeout\|deadline exceeded")` | `#is_timeout` = "true" |
+
+{{% /collapse-content %}}
+
+
+<h4>regexp_replace(<i>str</i> value, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
+
+Returns the value with matched text replaced. Use `$1` through `$9` in the replacement to insert a capture group's match, or `${name}` for a named group. To write a literal `$`, escape it as `\$`.
+
+By default, only the first match is replaced. Two optional arguments change that:
+
+| Argument | Meaning |
+|---|---|
+| `start` | The character position to start matching from, counting from 1. Defaults to the first character |
+| `N` | Which match to replace. `1` (the default) replaces the first match; `N` replaces the Nth match; `0` replaces every match |
+
+{{% collapse-content title="Example" level="h5" expanded=false %}}
+
+| Example  | Formula | Result |
+|----------|-------------|---------|
+| A log event has the following attribute:<br>`@path` = "/api/v1/orders" | `#resource = regexp_replace(@path, "^/api/v[0-9]+/(.*)$", "$1")` | `#resource` = "orders" |
+
+{{% /collapse-content %}}
+
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /logs/explorer/calculated_fields/extractions/#regex

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -337,7 +337,7 @@ Returns `true` when the pattern matches anywhere in the value, and `false` other
 
 <h4>regexp_replace(<i>str</i> value, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
 
-Returns the value with matched text replaced. Use `$1` through `$9` in the replacement to insert a capture group's match, or `${name}` for a named group. To write a literal `$`, escape it as `\$`.
+Returns the value with matched text replaced. Use `$1` through `$9` in the replacement to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: write a literal `$` as `"\\$"`, and likewise use `"\\d"` rather than `"\d"` for shorthand classes in the pattern.
 
 By default, only the first match is replaced. Two optional arguments change that:
 

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -320,7 +320,7 @@ Checks if an attribute or expression is null.
 
 ### Regex
 
-Regex functions match or transform a value using a regular expression (regex). Patterns support the same regex constructs as [regex extraction][1] (literals, character classes, quantifiers, and so on). Unlike extraction, capture groups here do not need a name: `regexp_replace` can reference an unnamed group positionally with `$1` through `$9`.
+Regex functions match or transform a value using a regular expression (regex). Patterns support the same regex constructs as [regex extraction][1], such as literals, character classes, and quantifiers. Escaping differs: an extraction pattern is a bare field, while a pattern here is a double-quoted string argument. Unlike extraction, capture groups here do not need a name: `regexp_replace` can reference an unnamed group positionally with `$1` through `$9`.
 
 <h4>regexp_like(<i>str</i> value, <i>str</i> pattern)</h4>
 
@@ -337,14 +337,14 @@ Returns `true` when the pattern matches anywhere in the value, and `false` other
 
 <h4>regexp_replace(<i>str</i> input, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
 
-Returns `input` with matched text replaced. Use `$1` through `$9` in `replacement` to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: use `"\\d"` rather than `"\d"` for shorthand classes in `pattern`. To insert a literal `$` in `replacement`, first escape its special meaning with `\$`, then escape that backslash for the string literal, giving `"\\$"`.
+Returns `input` with matched text replaced. Use `$1` through `$9` in `replacement` to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so you need to escape backslashes. For example, write `"\\d"` rather than `"\d"` for shorthand classes in `pattern`. To insert a literal `$` in `replacement`, escape its special meaning with `\$`, then escape that backslash for the string literal: `"\\$"`.
 
 | Argument | Meaning |
 |---|---|
 | `input` | The text to transform |
 | `pattern` | The regex pattern to match |
 | `replacement` | The regex transformation pattern, often using capture groups |
-| `start` | Optional. The character index to begin matching from, counting from 0. Defaults to `0` |
+| `start` | Optional. The zero-based character index to begin matching from. Defaults to `0` |
 | `N` | Optional. The maximum number of matches to replace. Defaults to `1`. `0` replaces every match |
 
 {{% collapse-content title="Example" level="h5" expanded=false %}}

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -337,7 +337,7 @@ Returns `true` when the pattern matches anywhere in the value, and `false` other
 
 <h4>regexp_replace(<i>str</i> input, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
 
-Returns `input` with matched text replaced. Use `$1` through `$9` in `replacement` to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: write a literal `$` as `"\\$"`, and likewise use `"\\d"` rather than `"\d"` for shorthand classes in `pattern`.
+Returns `input` with matched text replaced. Use `$1` through `$9` in `replacement` to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: use `"\\d"` rather than `"\d"` for shorthand classes in `pattern`. To insert a literal `$` in `replacement`, first escape its special meaning with `\$`, then escape that backslash for the string literal, giving `"\\$"`.
 
 | Argument | Meaning |
 |---|---|

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -320,7 +320,7 @@ Checks if an attribute or expression is null.
 
 ### Regex
 
-Regex functions match or transform a value using a regular expression (regex). Patterns support the same regex constructs as [regex extraction][1], such as literals, character classes, and quantifiers. Escaping differs: an extraction pattern is a bare field, while a pattern here is a double-quoted string argument. Unlike extraction, capture groups here do not need a name: `regexp_replace` can reference an unnamed group positionally with `$1` through `$9`.
+Regex functions match or transform a value using a regular expression (regex). Patterns support the same regex constructs as [regex extraction][1], such as literals, character classes, and quantifiers. Escaping differs: an extraction pattern is a bare field, while a pattern here is a double-quoted string argument. Unlike extraction, capture groups here do not need a name: `regexp_replace` can reference an unnamed group positionally with `$1` through `$9`. The same [pattern performance][2] guidance applies.
 
 <h4>regexp_like(<i>str</i> value, <i>str</i> pattern)</h4>
 
@@ -361,3 +361,4 @@ Returns `input` with matched text replaced. Use `$1` through `$9` in `replacemen
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/explorer/calculated_fields/extractions/#regex
+[2]: /logs/explorer/calculated_fields/extractions/#pattern-performance

--- a/hugo/content/en/logs/explorer/calculated_fields/formulas.md
+++ b/hugo/content/en/logs/explorer/calculated_fields/formulas.md
@@ -335,16 +335,17 @@ Returns `true` when the pattern matches anywhere in the value, and `false` other
 {{% /collapse-content %}}
 
 
-<h4>regexp_replace(<i>str</i> value, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
+<h4>regexp_replace(<i>str</i> input, <i>str</i> pattern, <i>str</i> replacement, [<i>int</i> start, <i>int</i> N])</h4>
 
-Returns the value with matched text replaced. Use `$1` through `$9` in the replacement to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: write a literal `$` as `"\\$"`, and likewise use `"\\d"` rather than `"\d"` for shorthand classes in the pattern.
-
-By default, only the first match is replaced. Two optional arguments change that:
+Returns `input` with matched text replaced. Use `$1` through `$9` in `replacement` to insert a capture group's match, or `${name}` for a named group. Formula arguments are double-quoted string literals, so a backslash must itself be escaped: write a literal `$` as `"\\$"`, and likewise use `"\\d"` rather than `"\d"` for shorthand classes in `pattern`.
 
 | Argument | Meaning |
 |---|---|
-| `start` | The character position to start matching from, counting from 1. Defaults to the first character |
-| `N` | Which match to replace. `1` (the default) replaces the first match; `N` replaces the Nth match; `0` replaces every match |
+| `input` | The text to transform |
+| `pattern` | The regex pattern to match |
+| `replacement` | The regex transformation pattern, often using capture groups |
+| `start` | Optional. The character index to begin matching from, counting from 0. Defaults to `0` |
+| `N` | Optional. The maximum number of matches to replace. Defaults to `1`. `0` replaces every match |
 
 {{% collapse-content title="Example" level="h5" expanded=false %}}
 


### PR DESCRIPTION
## What is this PR?

Reopens #39286, which was accidentally reverted by #39345 shortly after merging. This restores the original content unchanged: a new page documenting regex-based field extraction (named capture groups) in the Log Explorer, plus the `regexp_like`/`regexp_replace` calculated field functions, cross-linked from `extractions.md` and `formulas.md`.

## Verification

Reapplied by reverting the revert commit (`git revert e2bb027e8b`) on top of current `master`, which merged with no conflicts. Diffed the reapplied changes against the original merged PR diff — byte-for-byte identical.

## Limitations

None beyond the original PR's scope. Fixes DOCS-15452.