### PR TITLE
[DOCS-15461] Add log field data type warning to Databricks

### DIFF
--- a/hugo/content/en/observability_pipelines/destinations/databricks.md
+++ b/hugo/content/en/observability_pipelines/destinations/databricks.md
@@ -101,7 +101,14 @@ Configure the Databricks (Zerobus) destination when you [set up a pipeline][6]. 
 
 After you select the Databricks (Zerobus) destination in the pipeline UI:
 
-<div class="alert alert-warning">Databricks (Zerobus) doesn't convert timestamps in string format to Databricks' <a href="https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-type"><code>TIMESTAMP</code> type</a>. If your table uses a timestamp column, see <a href="#convert-string-timestamps-to-timestamp-format">Convert string timestamps to timestamp format</a> for more information.</div>
+<div class="alert alert-warning">
+
+<ul>
+<li>Databricks (Zerobus) doesn't convert timestamps in string format to Databricks' <a href="https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-type"><code>TIMESTAMP</code> type</a>. If your table uses a timestamp column, see <a href="#convert-string-timestamps-to-timestamp-format">Convert string timestamps to timestamp format</a> for more information.
+
+<li> Log field values must match the data type of their corresponding column in the table schema. See <a href="#data-type-of-log-field-values">Data type of log field values</a> for more information.
+</ul>
+</div>
 
 1. Enter the {{< ui >}}Ingestion Endpoint{{< /ui >}} for your Databricks workspace, such as `https://<workspace_id>.zerobus.<region>.cloud.databricks.com`. The Worker sends logs to this endpoint.
 1. Enter the {{< ui >}}Table Name{{< /ui >}} in the format `catalog.schema.table`, such as `main.obs_pipelines.apache_common_logs`.
@@ -117,7 +124,7 @@ After you select the Databricks (Zerobus) destination in the pipeline UI:
 
 {{% observability_pipelines/destination_buffer %}}
 
-### Convert string timestamps to timestamp format
+## Convert string timestamps to timestamp format
 
 If your logs have timestamps in string format and your Databricks table has a timestamp column declared as a [`TIMESTAMP` type][11], you must convert the string to timestamp format before sending logs to the Databricks (Zerobus) destination. Databricks (Zerobus) can only convert the timestamp format to its `TIMESTAMP` type.
 
@@ -135,6 +142,16 @@ To convert timestamps in string format to timestamp format:
     .timestamp = parse_timestamp!(.timestamp, format: "%+")
     ```
     See [parse_timestamp][13] for more information.
+
+## Data type of log field values
+
+Log field values must match the data type of their corresponding column in the table schema. For example, if the table schema defines `message` as `STRING`, but an incoming log's `message` field is an object, such as `{"message": {"some": "string"}}`, the Worker can't encode the event and drops the entire batch and throws an error similar to:
+
+```
+error=Some(EncodingError { message: "Failed to encode batch: SerializingError(Arrow JSON decoding error: Json error: whilst decoding field 'message': expected string got {...})" }) request_id=1142 error_type="request_failed" stage="sending"
+```
+
+To prevent this error, use the [Custom Processor][17] to convert log fields to the data type expected by the table schema.
 
 ## Secret defaults
 
@@ -186,3 +203,4 @@ A batch of events is flushed when one of these parameters is met. See [Destinati
 [14]: /observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics/#component-metrics
 [15]: /observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics/#destination-buffer-metrics
 [16]: /observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics/
+[17]: /observability_pipelines/processors/custom_processor/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a warning and section about log field data type matching the table schema.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
