### PR TITLE
RUM: document account.* attributes for the mobile SDKs

### DIFF
--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/android.mdoc.md
@@ -286,6 +286,47 @@ To identify user sessions, use the `setUserInfo` API, for example:
 Datadog.setUserInfo('1234', 'John Doe', 'john@doe.com')
 ```
 
+### Track user accounts
+
+If your application is used by organizations, workspaces, or tenants, add account information to your RUM sessions to:
+
+* Analyze performance and errors by account
+* Know which accounts are the most impacted by an issue
+* Prioritize fixes based on account value
+
+Account information is set alongside user information, not instead of it.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
+
+To identify accounts, use the `setAccountInfo` API, for example:
+
+```kotlin
+Datadog.setAccountInfo("acct-1234", "Acme Corp", mapOf("tier" to "enterprise"))
+```
+
+Keys passed in `extraInfo` are added to the `account` attribute, so `tier` is reported as `account.tier`.
+
+To append attributes to the account you already set, use `addAccountExtraInfo`. Call `setAccountInfo` first: adding extra info before an account exists has no effect.
+
+```kotlin
+Datadog.addAccountExtraInfo(mapOf("seats" to 42))
+```
+
+To clear the account (for example, when the user signs out), use `clearAccountInfo`.
+
+```kotlin
+Datadog.clearAccountInfo()
+```
+
+Account information is attached to RUM events, logs, traces, and crash reports.
+
+{% alert level="info" %}
+Clearing the account empties the `account` attribute on the active session and the active view. To retain the account on data already collected, stop the session with `GlobalRumMonitor.get().stopSession()` or the view with `GlobalRumMonitor.get().stopView()` before clearing.
+{% /alert %}
+
 ### Track attributes
 
 ```kotlin

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/cpp.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/cpp.mdoc.md
@@ -322,8 +322,8 @@ A parallel API is available for associating an account (such as an organization,
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `acc.id` | String | (Required) Unique account identifier. |
-| `acc.name` | String | (Optional) Account name, displayed in the Datadog UI. |
+| `account.id` | String | (Required) Unique account identifier. |
+| `account.name` | String | (Optional) Account name, displayed in the Datadog UI. |
 
 {% tabs %}
 {% tab label="C++" %}

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/flutter.mdoc.md
@@ -392,6 +392,55 @@ DatadogSdk.instance.addUserExtraInfo({
 });
 ```
 
+### Track user accounts
+
+If your application is used by organizations, workspaces, or tenants, add account information to your RUM sessions to:
+
+* Analyze performance and errors by account
+* Know which accounts are the most impacted by an issue
+* Prioritize fixes based on account value
+
+Account information is set alongside user information, not instead of it.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
+
+To identify accounts, use `DatadogSdk.setAccountInfo`.
+
+For example:
+
+```dart
+DatadogSdk.instance.setAccountInfo(
+  id: 'acct-1234',
+  name: 'Acme Corp',
+  extraInfo: {'tier': 'enterprise'},
+);
+```
+
+Keys passed in `extraInfo` are added to the `account` attribute, so `tier` is reported as `account.tier`.
+
+To append attributes to the account you already set, use `addAccountExtraInfo`. Call `setAccountInfo` first: adding extra info before an account exists has no effect. To remove an existing attribute, set it to `null`.
+
+```dart
+DatadogSdk.instance.addAccountExtraInfo({
+  'seats': 42,
+});
+```
+
+To clear the account (for example, when the user signs out), use `clearAccountInfo`.
+
+```dart
+DatadogSdk.instance.clearAccountInfo();
+```
+
+Account information is attached to RUM events, logs, and traces.
+
+{% alert level="info" %}
+Clearing the account empties the `account` attribute on the active session and the active view. To retain the account on data already collected, stop the session with `DatadogRum.stopSession` or the view with `DatadogRum.stopView` before clearing.
+{% /alert %}
+
 ## Clear all data
 
 Use `clearAllData` to clear all data that has not been sent to Datadog.

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
@@ -250,6 +250,64 @@ Datadog.setUserInfo(id: "1234", name: "John Doe", email: "john@doe.com")
 {% /tab %}
 {% /tabs %}
 
+### Track user accounts
+
+If your application is used by organizations, workspaces, or tenants, add account information to your RUM sessions to:
+
+* Analyze performance and errors by account
+* Know which accounts are the most impacted by an issue
+* Prioritize fixes based on account value
+
+Account information is set alongside user information, not instead of it.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
+
+To identify accounts, use the `Datadog.setAccountInfo(id:name:extraInfo:)` API.
+
+For example:
+
+{% tabs %}
+{% tab label="Swift" %}
+
+```swift
+import DatadogCore
+
+Datadog.setAccountInfo(id: "acct-1234", name: "Acme Corp", extraInfo: ["tier": "enterprise"])
+```
+
+{% /tab %}
+{% tab label="Objective-C" %}
+
+```objective-c
+[DDDatadog setAccountInfoWithAccountId:@"acct-1234" name:@"Acme Corp" extraInfo:@{@"tier": @"enterprise"}];
+```
+
+{% /tab %}
+{% /tabs %}
+
+Keys passed in `extraInfo` are added to the `account` attribute, so `tier` is reported as `account.tier`.
+
+To append attributes to the account you already set, use `Datadog.addAccountExtraInfo(_:)`. Call `Datadog.setAccountInfo(id:name:extraInfo:)` first: adding extra info before an account exists has no effect.
+
+```swift
+Datadog.addAccountExtraInfo(["seats": 42])
+```
+
+To clear the account (for example, when the user signs out), use `Datadog.clearAccountInfo()`.
+
+```swift
+Datadog.clearAccountInfo()
+```
+
+Account information is attached to RUM events, logs, traces, and crash reports.
+
+{% alert level="info" %}
+Clearing the account empties the `account` attribute on the active session and the active view. To retain the account on data already collected, stop the session with `RUMMonitor.stopSession()` or the view with `stopView(viewController:attributes:)` before clearing.
+{% /alert %}
+
 ## Track background events
 
 {% alert level="info" %}

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/kotlin_multiplatform.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/kotlin_multiplatform.mdoc.md
@@ -163,6 +163,47 @@ To identify user sessions, use the `setUserInfo` API, for example:
 Datadog.setUserInfo('1234', 'John Doe', 'john@doe.com')
 ```
 
+### Track user accounts
+
+If your application is used by organizations, workspaces, or tenants, add account information to your RUM sessions to:
+
+* Analyze performance and errors by account
+* Know which accounts are the most impacted by an issue
+* Prioritize fixes based on account value
+
+Account information is set alongside user information, not instead of it.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
+
+To identify accounts, use the `setAccountInfo` API, for example:
+
+```kotlin
+Datadog.setAccountInfo("acct-1234", "Acme Corp", mapOf("tier" to "enterprise"))
+```
+
+Keys passed in `extraInfo` are added to the `account` attribute, so `tier` is reported as `account.tier`.
+
+To append attributes to the account you already set, use `addAccountExtraInfo`. Call `setAccountInfo` first: adding extra info before an account exists has no effect.
+
+```kotlin
+Datadog.addAccountExtraInfo(mapOf("seats" to 42))
+```
+
+To clear the account (for example, when the user signs out), use `clearAccountInfo`.
+
+```kotlin
+Datadog.clearAccountInfo()
+```
+
+Account information is attached to RUM events and logs.
+
+{% alert level="info" %}
+Clearing the account empties the `account` attribute on the active session and the active view. To retain the account on data already collected, stop the session with `GlobalRumMonitor.get().stopSession()` or the view with `GlobalRumMonitor.get().stopView()` before clearing.
+{% /alert %}
+
 ### Track attributes
 
 ```kotlin

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/maui.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/maui.mdoc.md
@@ -143,9 +143,14 @@ DdSdk.AddUserExtraInfo(new Dictionary<string, object> { { "subscription", "annua
 DdSdk.ClearUserInfo();
 ```
 
-### Track account sessions
+### Track user accounts
 
 For B2B applications, `DdSdk.SetAccountInfo` attaches an account identity to every event. Use it together with — not instead of — user info.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
 
 ```csharp
 DdSdk.SetAccountInfo("acct-456", "Acme Corp",
@@ -155,6 +160,8 @@ DdSdk.AddAccountExtraInfo(new Dictionary<string, object> { { "region", "us-east"
 
 DdSdk.ClearAccountInfo();
 ```
+
+Keys passed in the extra info dictionary are added to the `account` attribute, so `tier` is reported as `account.tier`. Call `SetAccountInfo` before `AddAccountExtraInfo`: adding extra info before an account exists has no effect.
 
 ### Track global attributes
 

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/react_native.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/advanced_config/react_native.mdoc.md
@@ -440,6 +440,55 @@ If you want to clear the user information (for example, when the user signs out)
 DdSdkReactNative.clearUserInfo();
 ```
 
+### Track user accounts
+
+If your application is used by organizations, workspaces, or tenants, add account information to your RUM sessions to:
+
+* Analyze performance and errors by account
+* Know which accounts are the most impacted by an issue
+* Prioritize fixes based on account value
+
+Account information is set alongside user information, not instead of it.
+
+| Attribute      | Type   | Description                                                 |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `account.id`   | String | (Required) Unique account identifier.                       |
+| `account.name` | String | (Optional) Account friendly name, displayed in the RUM UI.  |
+
+To identify accounts, use the `setAccountInfo` API, for example:
+
+```js
+DdSdkReactNative.setAccountInfo({
+    id: 'acct-1234',
+    name: 'Acme Corp',
+    extraInfo: {
+        tier: 'enterprise'
+    }
+});
+```
+
+Keys passed in `extraInfo` are added to the `account` attribute, so `tier` is reported as `account.tier`.
+
+If you want to add or update account information, use the `addAccountExtraInfo` API. Call `setAccountInfo` first: adding extra info before an account exists is skipped and logs a warning.
+
+```js
+DdSdkReactNative.addAccountExtraInfo({
+    seats: 42
+});
+```
+
+If you want to clear the account information (for example, when the user signs out), you can do so by calling the `clearAccountInfo` API:
+
+```js
+DdSdkReactNative.clearAccountInfo();
+```
+
+Account information is attached to RUM events, logs, and traces.
+
+{% alert level="info" %}
+Clearing the account empties the `account` attribute on the active session and the active view. To retain the account on data already collected, stop the session or the view before clearing.
+{% /alert %}
+
 ### Global attributes
 
 You can keep global attributes to track information about a specific session, such as A/B testing configuration, ad campaign origin, or cart status. These attributes are attached to all future Logs, Spans, and RUM events.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The SDK-level account APIs (`setAccountInfo` / `addAccountExtraInfo` / `clearAccountInfo`) shipped in the mobile SDKs in June 2025, but `account.*` is only documented for the Browser SDK. Customers on mobile currently have no way to discover the feature — the only mention anywhere in the English docs is an incidental mock-SDK snippet on the Expo page.

This PR adds a `### Track user accounts` section next to the existing `### Track user sessions` section in Advanced Configuration, mirroring the Browser page's `## Account` section, for every platform whose SDK actually exposes the API:

| Platform | API | Since |
|---|---|---|
| iOS | `Datadog.setAccountInfo(id:name:extraInfo:)` | 2.29.0 |
| Android | `Datadog.setAccountInfo(id, name, extraInfo)` | 2.23.0 |
| Flutter | `DatadogSdk.instance.setAccountInfo(...)` | 2.12.0 |
| React Native | `DdSdkReactNative.setAccountInfo({...})` | 3.0.0 |
| Kotlin Multiplatform | `Datadog.setAccountInfo(id, name, extraInfo)` | 1.2.0 |

Each section documents the `account.id` / `account.name` attributes, the set → append → clear lifecycle, that `extraInfo` keys are reported under `account.<key>`, that `addAccountExtraInfo` before `setAccountInfo` is a no-op, and that clearing empties `account` on the active session and view (stop them first to retain it).

Two related fixes in the same area:

- **MAUI** already documented the API. Added the missing attribute table and renamed the heading from `Track account sessions` to `Track user accounts` for consistency with the other platforms.
- **C++** documented the attributes as `acc.id` / `acc.name`, but the SDK serializes an `account` object ([`logging.hpp#L42`](https://github.com/DataDog/dd-sdk-cpp/blob/main/src/datadog/impl/core/feature_types/logging.hpp), [`crash_handling.cpp#L118`](https://github.com/DataDog/dd-sdk-cpp/blob/main/src/datadog/impl/rum/crash_processing/crash_handling.cpp)), so the queryable attributes are `account.id` / `account.name`. A customer following the current page would query on an attribute that does not exist.

All API names, signatures, versions, and behavior notes were verified against the SDK source, not inferred from the Browser docs.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code to cross-check each SDK's source for API availability, exact signatures, and introduction versions, and to draft the sections. Reviewed manually.

### Additional notes

Deliberately out of scope, but worth flagging for the owning teams:

- **Unity** documents `Track user sessions` but the Unity SDK exposes no account API at all (only `SetUserInfo`). That's an SDK gap, not a docs one. Roku likewise has no account API.
- [`tracing/guide/users-accounts.md`](https://github.com/DataDog/documentation/blob/master/hugo/content/en/tracing/guide/users-accounts.md) says user and account info can be propagated from "browser or mobile" applications, then gives only the browser APIs.
- [`product_analytics/profiles/_index.md`](https://github.com/DataDog/documentation/blob/master/hugo/content/en/product_analytics/profiles/_index.md) points only at `datadogRum.setAccount`, so mobile-only customers can't tell Account Profiles apply to them.
- The mobile `data_collected` pages don't list `account.*` among collected attributes.

Happy to fold any of these in if reviewers prefer them here rather than as follow-ups.
