### PR TITLE
RUM: mention API configuration on the retention quotas page

### DIFF
--- a/hugo/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
+++ b/hugo/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
@@ -50,6 +50,12 @@ The retention filters page shows a breakdown of retained user sessions, includin
 
 {{< img src="real_user_monitoring/rum_without_limits/retention-quotas-usage.png" alt="A daily breakdown chart showing user sessions retained by custom filters, sessions retained by permanent filters, and sessions blocked once the quota was reached." style="width:100%" >}}
 
+## API
+
+Retention quotas can also be managed through [APIs][1].
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /api/latest/rum-retention-quota/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Retention quotas can now be configured through the public API, but the docs page only documents the in-app setup flow. This adds a short `## API` section at the end of the page pointing to the [RUM Retention Quota API reference](https://docs.datadoghq.com/api/latest/rum-retention-quota/).

Deliberately minimal — it mirrors the equivalent section on the [retention filters page](https://docs.datadoghq.com/real_user_monitoring/rum_without_limits/retention_filters#api) rather than duplicating endpoint documentation that the API reference already owns.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code to make the edit and open the PR.
