### PR TITLE
Add id=jira so we can use #jira anchor like we do for ServiceNow and Linear

### DIFF
--- a/hugo/content/en/incident_response/work_management/notifications_integrations.md
+++ b/hugo/content/en/incident_response/work_management/notifications_integrations.md
@@ -95,7 +95,7 @@ To automatically trigger a page, configure automated paging rules in your projec
 ## Third party tickets
 In Project Settings, you can manage membership, configure the auto-closing of work items, and set up third-party integrations like Jira and ServiceNow.
 
-{{% collapse-content title="Jira Configuration" level="h3" expanded=false %}}
+{{% collapse-content title="Jira Configuration" level="h3" expanded=false id="jira" %}}
 1. Ensure the Jira integration is configured.
 1. In Work Management project settings, enable **Jira** for manual Jira issue creation from the project.
 1. Select a Jira account, a project to create issues in, and the desired issue type (such as story, epic, bug, or task).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The URL:

- https://docs.datadoghq.com/incident_response/work_management/notifications_integrations/#linear
- https://docs.datadoghq.com/incident_response/work_management/notifications_integrations/#servicenow

works properly, but 

- https://docs.datadoghq.com/incident_response/work_management/notifications_integrations/#jira

doesn't.

This PR adds `id=jira` to the Jira section, so the anchor can work for Jira too

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
