### PR TITLE
[DOCS-15492] Fix incorrect eu CDN region in Browser SDK setup snippets

### DIFF
--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -74,7 +74,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v7/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -180,7 +180,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/eu/v7/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/eu1/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
@@ -66,7 +66,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v7/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -172,7 +172,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/eu/v7/datadog-rum.js"
+    src="https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum.js"
     type="text/javascript"
     crossorigin>
 </script>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15492

The setup instructions for the RUM Browser SDK and the Browser Logs SDK had a broken link for customers on the `eu` Datadog site. If you selected `eu` as your site, the code snippet you were told to copy pointed to a URL that gives a 404 error, so the SDK wouldn't load. This PR corrects the link so `eu` customers get a working snippet, just like every other site.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Investigated the reported 404 and identified the fix with Claude Code; verified against the site's existing region-code mapping conventions before applying the two-line fix per file.

### Additional notes