### PR TITLE
Remove US1-FED/US2-FED notice from Logs Findings explorer guide

### DIFF
--- a/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
+++ b/hugo/content/en/security/sensitive_data_scanner/guide/investigate_sensitive_data_findings.md
@@ -37,10 +37,6 @@ Navigate to the [Findings][1] page to see all sensitive data findings within the
 {{< tabs >}}
 {{% tab "Logs" %}}
 
-{{< site-region region="gov,gov2" >}}
-<div class="alert alert-danger">The Logs Findings explorer is not available for the selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 The Logs Findings explorer is an updated experience for investigating log findings. If you have at least one log finding, this explorer opens by default. APM, RUM, and Events findings are not available in this explorer. To view those findings, click {{< ui >}}Go back{{< /ui >}} in the banner at the top of the page.
 
 To investigate a log finding:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Logs Findings explorer (Sensitive Data Scanner) is now available on the Datadog for Government sites (US1-FED, US2-FED). This removes the `site-region` alert on the "Logs" tab of the Investigate Sensitive Data Findings guide that previously noted this experience wasn't available there.

No ticket reference; this is docs-only cleanup requested directly by SDS product management.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Change identified and drafted with Claude Code, reviewed by me.

### Additional notes