### PR TITLE
Fix Allowed Resources field name in FDD deployment gate rule docs

### DIFF
--- a/hugo/content/en/deployment_gates/setup/jit.md
+++ b/hugo/content/en/deployment_gates/setup/jit.md
@@ -106,8 +106,8 @@ The analysis is automatically performed for all APM-instrumented services, and n
 **Options**:
 
 - `duration`: The period of time (in seconds) for which the analysis runs. For optimal analysis confidence, this value should be at least 900 seconds (15 minutes) after a deployment starts. Maximum is 7200 seconds (2 hours).
-- `included_resources` (optional): [APM resources][2] to include in the analysis. When specified, only the listed resources are analyzed.
-- `excluded_resources` (optional): [APM resources][2] to ignore (such as low-volume or low-priority endpoints).
+- `allowed_resources` (optional): [APM resources][2] to include in the analysis. When specified, only the listed resources are analyzed. Mutually exclusive with `excluded_resources`.
+- `excluded_resources` (optional): [APM resources][2] to ignore (such as low-volume or low-priority endpoints). Mutually exclusive with `allowed_resources`.
 
 Example inline rule:
 

--- a/hugo/content/en/deployment_gates/setup/preconfigured.md
+++ b/hugo/content/en/deployment_gates/setup/preconfigured.md
@@ -91,8 +91,8 @@ The analysis is automatically performed for all APM-instrumented services, and n
 
 - {{< ui >}}Operation Name{{< /ui >}}: Auto-populated from the service's [APM primary operation][3] settings.
 - {{< ui >}}Duration{{< /ui >}}: The period of time (in seconds) for which the analysis runs. For optimal analysis confidence, this value should be at least 900 seconds (15 minutes) after a deployment starts. Maximum is 7200 seconds (2 hours).
-- {{< ui >}}Included Resources{{< /ui >}} (optional): A comma-separated list of [APM resources][2] to include in the analysis. When specified, only the listed resources are analyzed.
-- {{< ui >}}Excluded Resources{{< /ui >}} (optional): A comma-separated list of [APM resources][2] to ignore (such as low-volume or low-priority endpoints).
+- {{< ui >}}Allowed Resources{{< /ui >}} (optional): A comma-separated list of [APM resources][2] to include in the analysis. When specified, only the listed resources are analyzed. Mutually exclusive with {{< ui >}}Excluded Resources{{< /ui >}}.
+- {{< ui >}}Excluded Resources{{< /ui >}} (optional): A comma-separated list of [APM resources][2] to ignore (such as low-volume or low-priority endpoints). Mutually exclusive with {{< ui >}}Allowed Resources{{< /ui >}}.
 
 **Notes**:
 - The rule is evaluated for each [additional primary tag][4] value as well as an aggregate analysis. To consider only a single primary tag, specify it when [requesting a gate evaluation](#evaluate-a-gate-from-your-pipeline).


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The JIT and preconfigured Deployment Gates setup guides called the FDD resource allow-list "Included Resources" / `included_resources`, which doesn't match the actual API field name or UI label (`allowed_resources`). Renamed both to match, and noted the mutual exclusivity with Excluded Resources.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code.

### Additional notes