### PR TITLE
Clarify flag allocation sync is destructive

### DIFF
--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -1117,7 +1117,7 @@ Checks if a feature flag is implemented in code.
 ### `sync_datadog_feature_flag_allocations`
 *Toolset: **feature-flags***\
 *Permissions Required: `Feature Flag Write`*\
-Syncs feature flag allocations for a specific environment.
+Syncs feature flag allocations for a specific environment. This replaces all existing allocations for the flag in that environment. Confirm the change before applying.
 
 - Sync the allocations for flag `new-checkout-flow` in production.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dd042e5f-8c30-4589-8d14-d969cccadeef","source":"chat","resourceId":"9fab49fa-a671-4553-8767-7a01f04f02bd","workflowId":"f58835ed-e309-4b93-a9be-1fed2edbc14b","codeChangeId":"f58835ed-e309-4b93-a9be-1fed2edbc14b","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies the `sync_datadog_feature_flag_allocations` MCP tool description in `hugo/content/en/mcp_server/tools.md` to explain that syncing replaces all existing allocations for the flag in the selected environment, and that the change should be confirmed before applying.

This documents the behavior surfaced by the source PR: https://github.com/ddoghq/dd-source/pull/60187

### Changes

- Extended the `sync_datadog_feature_flag_allocations` description to note that a sync replaces the complete allocation set for the flag in that environment.
- Added a "Confirm the change before applying." sentence, matching the confirmation phrasing already used for destructive tools on this page.

### Testing

- Reviewed the rendered section for format and voice parity with neighboring tool entries. Vale is unavailable in this environment; the added wording was checked manually against the repo style substitutions and temporal-word rules.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): made the documentation edit and prepared this PR.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9fab49fa-a671-4553-8767-7a01f04f02bd)

Comment @datadog to request changes