### PR TITLE
[CCC-2397] Clarify cloud cost data freshness

### DIFF
--- a/hugo/content/en/cloud_cost_management/_index.md
+++ b/hugo/content/en/cloud_cost_management/_index.md
@@ -130,12 +130,14 @@ For a detailed breakdown of requirements by page, see [Permissions][9].
 
 Monitor the freshness and processing status of your cloud cost data on the {{< ui >}}Cloud Cost{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Data History{{< /ui >}} page.
 
-- {{< ui >}}Last Bill Received{{< /ui >}}: When your cloud or SaaS provider generated the billing data visible in CCM.
+- {{< ui >}}Last Bill Received{{< /ui >}}: When Datadog last received billing data from your cloud or SaaS provider. This timestamp does not indicate the latest usage or cost date in that data.
 - {{< ui >}}Last Processed{{< /ui >}}: When Datadog last processed billing data from your cloud provider, including:
   - Tag pipeline rules (retroactively processes up to 3 months of historical data by default)
   - Cost allocation rules (retroactively processes up to 1 month of historical data by default)
 
 Use this page to troubleshoot data delays or confirm that recent tag pipelines and cost allocation changes have taken effect.
+
+Cloud cost data can only be as recent as the data supplied by your provider. If costs are missing for an expected date, compare your provider's bill or export with CCM. Contact your provider if the source does not contain costs for the expected date. Contact [Datadog Support][11] if the source contains those costs but CCM does not.
 
 ## Use AI for cost analysis
 
@@ -157,3 +159,4 @@ Use the [Cloud Cost Skill in Bits Chat][10] to investigate cost changes, identif
 [8]: /cloud_cost_management/datadog_costs
 [9]: /cloud_cost_management/setup/permissions
 [10]: /cloud_cost_management/cloud_cost_skill/
+[11]: /help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes CCC-2397

Clarifies how Cloud Cost Management Data History timestamps relate to data freshness:

- Defines Last Bill Received as the time Datadog received provider billing data, not the latest cost date in that data.
- Directs users to the cloud provider or Datadog Support based on whether the expected costs exist in the source bill or export.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Codex to research, draft, review, and validate this documentation update.

### Additional notes

