### PR TITLE
Add Slack threading notifications section

### DIFF
--- a/hugo/content/en/monitors/notify/_index.md
+++ b/hugo/content/en/monitors/notify/_index.md
@@ -92,7 +92,7 @@ An @notification must have a space between it and the last line character:
 {{% /collapse-content %}}
 
 ### Threading notifications in Slack
-Monitor notifications sent to Slack through [notification rules][22] can be threaded. When threaded, all monitor alerts for a given alert cycle group under a single Slack thread with the top-level message reflecting the latest status of the monitor. To enable monitor threading, set up or edit a [notification rule][22] scoped to the monitor alerts you would like targeted. Select **Thread Notifications** and save.
+Monitor notifications sent to Slack through [notification rules][22] can be threaded. When threading is enabled, all monitor alerts for a given alert cycle are grouped under a single Slack thread, with the top-level message reflecting the latest status of the monitor. To enable monitor threading, set up or edit a [notification rule][22] scoped to the monitor alerts you want to target. Select Thread Notifications and save.
 
 **Note**: An alert cycle is defined as starting from a non-recovered state to a recovered state. 
 

--- a/hugo/content/en/monitors/notify/_index.md
+++ b/hugo/content/en/monitors/notify/_index.md
@@ -91,6 +91,11 @@ An @notification must have a space between it and the last line character:
 {{% notifications-email %}}
 {{% /collapse-content %}}
 
+### Threading notifications in Slack
+Monitor notifications sent to Slack through [notification rules][22] can be threaded. When threaded, all monitor alerts for a given alert cycle group under a single Slack thread with the top-level message reflecting the latest status of the monitor. To enable monitor threading, set up or edit a [notification rule][22] scoped to the monitor alerts you would like targeted. Select **Thread Notifications** and save.
+
+**Note**: An alert cycle is defined as starting from a non-recovered state to a recovered state. 
+
 ### Bulk editing monitor @-handles
 Datadog supports editing alert message recipients across multiple monitors at once. Use this feature to efficiently add, remove, or replace `@-handles` in the monitor message body. Use cases include:
 


### PR DESCRIPTION
Added information about threading notifications in Slack, including setup instructions and a note on alert cycles.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
