### PR TITLE
Document enabling query metrics for self-hosted MongoDB 8.0

### DIFF
--- a/hugo/content/en/database_monitoring/setup_mongodb/selfhosted.md
+++ b/hugo/content/en/database_monitoring/setup_mongodb/selfhosted.md
@@ -203,7 +203,7 @@ Or pass it on the command line:
 mongod --setParameter internalQueryStatsSampleRate=1.0
 {{< /code-block >}}
 
-To enable it at runtime without restarting, run the following against each `mongod` or `mongos` process. This change is not persistent and resets when the server restarts:
+To enable it at runtime without restarting (not persistent — resets on restart), run:
 
 {{< code-block lang="javascript" >}}
 db.adminCommand({setParameter: 1, internalQueryStatsSampleRate: 1.0})

--- a/hugo/content/en/database_monitoring/setup_mongodb/selfhosted.md
+++ b/hugo/content/en/database_monitoring/setup_mongodb/selfhosted.md
@@ -186,6 +186,30 @@ Datadog recommends installing the Agent directly on the MongoDB host, as that en
 {{% /tab %}}
 {{< /tabs >}}
 
+## Query Metrics
+
+Query metrics for self-hosted MongoDB require MongoDB 8.0 or later and rely on the `$queryStats` aggregation pipeline. Query stats collection is disabled by default on the MongoDB server. To enable it, set the `internalQueryStatsSampleRate` server parameter to `1.0` (100% sampling) on each `mongod` or `mongos` process.
+
+Add the parameter to the MongoDB configuration file:
+
+{{< code-block lang="yaml" >}}
+setParameter:
+  internalQueryStatsSampleRate: 1.0
+{{< /code-block >}}
+
+Or pass it on the command line:
+
+{{< code-block lang="shell" >}}
+mongod --setParameter internalQueryStatsSampleRate=1.0
+{{< /code-block >}}
+
+To enable it at runtime without restarting, run the following against each `mongod` or `mongos` process. This change is not persistent and resets when the server restarts:
+
+{{< code-block lang="javascript" >}}
+db.adminCommand({setParameter: 1, internalQueryStatsSampleRate: 1.0})
+{{< /code-block >}}
+
+For more information about the server parameters that control query stats collection, see the [MongoDB Query Stats documentation][4].
 
 ## Data Collected
 
@@ -235,3 +259,4 @@ instances:
 [1]: /account_management/api-app-keys/
 [2]: /integrations/mongo/?tab=standalone#metrics
 [3]: /database_monitoring/query_metrics/
+[4]: https://github.com/mongodb/mongo/blob/master/src/mongo/db/query/query_stats/README.md#server-parameters


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a **Query Metrics** section to the [self-hosted MongoDB DBM setup page](https://docs.datadoghq.com/database_monitoring/setup_mongodb/selfhosted) explaining that query metrics for self-hosted MongoDB require MongoDB 8.0+ and that query stats collection is disabled by default on the server.

The mongo DBM integration's query metrics feature reads via the `$queryStats` aggregation pipeline, but the integration cannot enable collection itself — users must set the `internalQueryStatsSampleRate` server parameter on each `mongod`/`mongos`. Without this section, self-hosted MongoDB 8.0 users would not know they need to enable a server parameter to get query metrics.

The section shows the three ways to set the parameter (config file, command line, and runtime `setParameter`), notes that the runtime form is not persistent, and links to the MongoDB Query Stats server-parameters documentation.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code for research (MongoDB `$queryStats` server parameter behavior) and initial draft of the doc section; manually reviewed and adjusted.

### Additional notes

The `internalQueryStatsSampleRate=1.0` value (100% sampling) matches what was validated in the DBM agent integration environment. Users can lower the value to reduce overhead.
