### PR TITLE
RUM: fix the retention quotas API reference link

### DIFF
--- a/hugo/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
+++ b/hugo/content/en/real_user_monitoring/rum_without_limits/retention_quotas.md
@@ -58,4 +58,4 @@ Retention quotas can also be managed through [APIs][1].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /api/latest/rum-retention-quota/
+[1]: /api/latest/rum-retention-quotas/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The RUM Retention Quota API reference moved from `/api/latest/rum-retention-quota/` to `/api/latest/rum-retention-quotas/`. The link in the API section of the retention quotas page still points at the old path, so this updates it.

Both directories currently exist under `hugo/content/en/api/`, but the plural one is the live target: it was regenerated from the spec repo on 2026-08-24 (#39401), while the singular one was last touched on 2026-08-20 (#39257) and is a leftover from before the rename.

This is the only reference to the old path outside of `content/en/api/` itself.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Claude Code to make the edit and open the PR.
