### PR TITLE
[DOCS-15509] Clarify Microsoft Edge support for the browser test recorder

### DIFF
--- a/hugo/content/en/synthetics/browser_tests/_index.md
+++ b/hugo/content/en/synthetics/browser_tests/_index.md
@@ -253,7 +253,7 @@ For more information, see [Synthetic Monitoring notifications][9].
 
 ## Record your steps
 
-Tests can be only recorded from [Google Chrome][10] and [Microsoft Edge][18]. To record your test, download the [Datadog Record Test extension][11].
+Tests can be recorded from [Google Chrome][10]. To record your test, download the [Datadog Record Test extension][11]. Because Microsoft Edge is Chromium-based, you can also install the Chrome extension in Edge after you turn on **Allow extensions from other stores**. See Microsoft's [guide to adding extensions from other stores][18] for instructions.
 
 You can switch tabs in a browser test recording to perform an action on your application (such as clicking on a link that opens another tab) and add another test step. Your browser test must interact with the page first (through a click) before it can perform an [assertion][12]. By recording all of the test steps, the browser test can switch tabs automatically at test execution.
 
@@ -387,5 +387,5 @@ Use [granular access control][17] to limit who has access to your test based on 
 [15]: /account_management/rbac#custom-roles
 [16]: /account_management/rbac/#create-a-custom-role
 [17]: /account_management/rbac/granular_access
-[18]: https://www.microsoft.com/edge
+[18]: https://support.microsoft.com/en-us/edge/add-turn-off-or-remove-extensions-in-microsoft-edge
 [19]: /synthetics/guide/how-synthetics-monitors-trigger-alerts/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15509

The Datadog Record Test browser extension is only published to the Chrome Web Store, but the docs implied native Microsoft Edge support for recording browser tests. This PR clarifies that recording requires Google Chrome, and adds a note that Edge users can still use the extension after turning on **Allow extensions from other stores** (since Edge is Chromium-based), linking to Microsoft's support article for that setting.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the affected doc section, draft the corrected copy, and verify the rendered page in a local preview.

### Additional notes