### PR TITLE
Document Runtime SCA impacted infrastructure

### DIFF
--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -89,11 +89,15 @@ To assist in prioritizing remediation, Datadog modifies the base CVSS score into
 | Exploit availability              | Availability of public exploits for the vulnerability.               | Decreased if no exploit is available.                  |
 | Exploitation probability (EPSS)   | Likelihood of real-world exploitation based on EPSS data.            | Decreased when the probability of exploitation is low. |
 
-#### View impacted services
+#### View runtime vulnerabilities
 
-Runtime SCA identifies vulnerable library versions that are loaded by running services. Select a vulnerability in Vulnerabilities Explorer to open its side panel. The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
+Runtime SCA identifies vulnerable library versions that are loaded by running services. Click on a vulnerability in Vulnerabilities Explorer to open its side panel.
 
-#### View impacted infrastructure
+##### View impacted services
+
+The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
+
+##### View impacted infrastructure
 
 To view the affected infrastructure, select the host count in {{< ui >}}Impacted Services{{< /ui >}}, or select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -89,17 +89,21 @@ To assist in prioritizing remediation, Datadog modifies the base CVSS score into
 | Exploit availability              | Availability of public exploits for the vulnerability.               | Decreased if no exploit is available.                  |
 | Exploitation probability (EPSS)   | Likelihood of real-world exploitation based on EPSS data.            | Decreased when the probability of exploitation is low. |
 
-#### View runtime vulnerabilities
+#### View vulnerability details
 
-Runtime SCA identifies vulnerable library versions that are loaded by running services. Click on a vulnerability in Vulnerabilities Explorer to open its side panel.
+Click on a vulnerability in Vulnerabilities Explorer to open its side panel.
 
-##### View impacted services
+##### Repositories
 
-The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
+The {{< ui >}}Repositories{{< /ui >}} section lists the files and repositories where Static SCA detected the library vulnerability. For each finding, it displays associated services and teams, the finding status, and triage actions. Expand a row to view its severity breakdown and, when available, reachable locations.
 
-##### View impacted infrastructure
+##### Impacted services
 
-To view the affected infrastructure, select the host count in {{< ui >}}Impacted Services{{< /ui >}}, or select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
+The {{< ui >}}Impacted services{{< /ui >}} section lists the services where Runtime SCA detected the library vulnerability. For each service, it displays environments, dependency details, reachability, associated teams, finding status, and when Datadog last detected it.
+
+##### Impacted infrastructure
+
+When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructure{{< /ui >}} section lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time. Select a host count in {{< ui >}}Impacted services{{< /ui >}} to filter this section to that service.
 
 Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -103,9 +103,14 @@ The {{< ui >}}Impacted services{{< /ui >}} section lists the services where Runt
 
 ##### Impacted infrastructure
 
-When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructure{{< /ui >}} section lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time. Select a host count in {{< ui >}}Impacted services{{< /ui >}} to filter this section to that service.
+When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructure{{< /ui >}} section lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
 
-Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
+To investigate the affected infrastructure:
+
+1. In {{< ui >}}Impacted services{{< /ui >}}, select a host count to filter {{< ui >}}Impacted Infrastructure{{< /ui >}} to that service.
+1. Review the affected hosts, services, environments, and last deployment time.
+1. Select {{< ui >}}View Host{{< /ui >}} to investigate a host.
+1. Select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
 
 ### View findings by repository
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -74,7 +74,7 @@ When Datadog identifies a public exploit for a vulnerability from any of these s
 
 ### Review and prioritize vulnerabilities
 
-The [Vulnerabilities Explorer][11] provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST, IAST, Secrets Scanning, and IaC). Each vulnerability can be detected in the latest scanned commit on a repository's default branch, affect a running service, or both. Select a vulnerability to open its side panel. Depending on the available evidence, the side panel can show repository findings, impacted services, or both.
+The [Vulnerabilities Explorer][11] provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST, IAST, Secrets Scanning, and IaC). All vulnerabilities in the explorer are either detected on the default branch at the last commit of a scanned repository, or are affecting a running service.
 
 #### Datadog severity score
 
@@ -89,7 +89,17 @@ To assist in prioritizing remediation, Datadog modifies the base CVSS score into
 | Exploit availability              | Availability of public exploits for the vulnerability.               | Decreased if no exploit is available.                  |
 | Exploitation probability (EPSS)   | Likelihood of real-world exploitation based on EPSS data.            | Decreased when the probability of exploitation is low. |
 
-#### View findings by repository
+#### View impacted services
+
+Runtime SCA identifies vulnerable library versions that are loaded by running services. Select a vulnerability in Vulnerabilities Explorer to open its side panel. The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
+
+#### View impacted infrastructure
+
+To view the affected infrastructure, select the host count in {{< ui >}}Impacted Services{{< /ui >}}, or select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
+
+Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
+
+### View findings by repository
 
 The [Repositories Explorer][12] provides a repository-centric view of all scan results across Static Code Analysis (SAST), Software Composition Analysis (SCA), Secrets Scanning, and Infrastructure as Code (IaC). Click on a repository to analyze {{< ui >}}Library Vulnerabilities{{< /ui >}} and {{< ui >}}Library Catalog{{< /ui >}} results from SCA scoped to your chosen branch and commit.
 * The {{< ui >}}Library Vulnerabilities{{< /ui >}} tab contains the vulnerable library versions found by Datadog SCA
@@ -104,16 +114,6 @@ Every row represents a unique library and version combination. Each combination 
 Click on a library with a vulnerability to open a side panel that contains information about remediation steps.
 
 <!-- {{< img src="code_security/software_composition_analysis/sca-violation.png" alt="Side panel for a SCA violation" style="width:80%;">}} -->
-
-#### View impacted services
-
-Runtime SCA identifies vulnerable library versions that are loaded by running services. The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
-
-#### View impacted infrastructure
-
-To view the affected infrastructure, select the host count in {{< ui >}}Impacted Services{{< /ui >}}, or select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
-
-Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
 
 ### Remediation
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -109,7 +109,7 @@ Click on a library with a vulnerability to open a side panel that contains infor
 
 For Runtime SCA vulnerabilities, select a vulnerability to open its side panel, then select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
 
-Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review its open host vulnerabilities.
+Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
 
 ### Remediation
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -74,7 +74,7 @@ When Datadog identifies a public exploit for a vulnerability from any of these s
 
 ### Review and prioritize vulnerabilities
 
-The [Vulnerabilities Explorer][11] provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST, IAST, Secrets Scanning, and IaC). All vulnerabilities in the explorer are either detected on the default branch at the last commit of a scanned repository, or are affecting a running service.
+The [Vulnerabilities Explorer][11] provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST, IAST, Secrets Scanning, and IaC). Each vulnerability can be detected in the latest scanned commit on a repository's default branch, affect a running service, or both. Select a vulnerability to open its side panel. Depending on the available evidence, the side panel can show repository findings, impacted services, or both.
 
 #### Datadog severity score
 
@@ -89,7 +89,7 @@ To assist in prioritizing remediation, Datadog modifies the base CVSS score into
 | Exploit availability              | Availability of public exploits for the vulnerability.               | Decreased if no exploit is available.                  |
 | Exploitation probability (EPSS)   | Likelihood of real-world exploitation based on EPSS data.            | Decreased when the probability of exploitation is low. |
 
-### View findings by repository
+#### View findings by repository
 
 The [Repositories Explorer][12] provides a repository-centric view of all scan results across Static Code Analysis (SAST), Software Composition Analysis (SCA), Secrets Scanning, and Infrastructure as Code (IaC). Click on a repository to analyze {{< ui >}}Library Vulnerabilities{{< /ui >}} and {{< ui >}}Library Catalog{{< /ui >}} results from SCA scoped to your chosen branch and commit.
 * The {{< ui >}}Library Vulnerabilities{{< /ui >}} tab contains the vulnerable library versions found by Datadog SCA
@@ -105,9 +105,13 @@ Click on a library with a vulnerability to open a side panel that contains infor
 
 <!-- {{< img src="code_security/software_composition_analysis/sca-violation.png" alt="Side panel for a SCA violation" style="width:80%;">}} -->
 
+#### View impacted services
+
+Runtime SCA identifies vulnerable library versions that are loaded by running services. The {{< ui >}}Impacted Services{{< /ui >}} tab lists the services where Datadog detected the affected library version, the number of impacted hosts, and when Datadog last detected it.
+
 #### View impacted infrastructure
 
-For Runtime SCA vulnerabilities, select a vulnerability to open its side panel, then select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
+To view the affected infrastructure, select the host count in {{< ui >}}Impacted Services{{< /ui >}}, or select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
 
 Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -103,7 +103,7 @@ The {{< ui >}}Impacted services{{< /ui >}} section lists the services where Runt
 
 ##### Impacted infrastructure
 
-When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructure{{< /ui >}} section lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
+When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructure{{< /ui >}} section lists the hosts where the affected library version runs. It also shows associated services, environments, and last deployment time.
 
 To investigate the affected infrastructure:
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -105,6 +105,12 @@ Click on a library with a vulnerability to open a side panel that contains infor
 
 <!-- {{< img src="code_security/software_composition_analysis/sca-violation.png" alt="Side panel for a SCA violation" style="width:80%;">}} -->
 
+#### View impacted infrastructure
+
+For Runtime SCA vulnerabilities, select a vulnerability to open its side panel, then select the {{< ui >}}Impacted Infrastructure{{< /ui >}} tab. This tab lists the hosts where the affected library version runs, along with the associated services, environments, and last deployment time.
+
+Select {{< ui >}}View Host{{< /ui >}} to investigate a host, or select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review its open host vulnerabilities.
+
 ### Remediation
 
 Datadog SCA supports using coding agents and [Bits Code][31] to apply fixes for vulnerable libraries. You can also use [Bits Code Automation][32] to automatically generate fixes for vulnerabilities as they are found or on a schedule.

--- a/hugo/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/_index.md
@@ -107,7 +107,6 @@ When Runtime SCA detects impacted services, the {{< ui >}}Impacted Infrastructur
 
 To investigate the affected infrastructure:
 
-1. In {{< ui >}}Impacted services{{< /ui >}}, select a host count to filter {{< ui >}}Impacted Infrastructure{{< /ui >}} to that service.
 1. Review the affected hosts, services, environments, and last deployment time.
 1. Select {{< ui >}}View Host{{< /ui >}} to investigate a host.
 1. Select {{< ui >}}View Vulnerabilities in Cloud Security{{< /ui >}} to review the host's open vulnerabilities.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the Impacted Infrastructure tab for Runtime SCA vulnerabilities, including affected hosts, associated services and environments, deployment time, and investigation links.

### Merge readiness

- [x] Ready for merge

### AI assistance

Used AI assistance to draft the documentation update and validate the Markdown diff.

### Additional notes

No DOCS ticket is linked to this documentation update.