### PR TITLE
Document Azure DevOps Bits Code support

### DIFF
--- a/hugo/content/en/bits_ai/bits_code/_index.md
+++ b/hugo/content/en/bits_ai/bits_code/_index.md
@@ -54,9 +54,10 @@ Click a session to view its details and continue working with Bits Code. To remo
 Bits Code supports the following source code providers:
 - **GitHub**: GitHub.com, [GitHub Enterprise Cloud][30], [GitHub Enterprise Cloud with data residency][31], and [GitHub Enterprise Server][38].
 - **GitLab**: GitLab.com and GitLab Self-Managed.
+- **Azure DevOps**: Azure DevOps Services.
 
-The following plans are not supported:
-- **Azure DevOps**: Neither Azure DevOps Cloud nor Azure DevOps Server (On-Prem) is supported by Bits Code. Datadog [Source Code Integration][37] does not support Azure DevOps Server (On-Prem).
+The following are not supported:
+- **Azure DevOps**: Azure DevOps Server (On-Prem). Datadog [Source Code Integration][37] does not support Azure DevOps Server (On-Prem).
 - **Bitbucket**: Neither Bitbucket.org, Bitbucket Data Center, nor Bitbucket Data Server (On-Prem) are supported by Bits Code. Datadog [Source Code Integration][37] does not support On-Prem Bitbucket deployments.
 
 ## Supported Datadog products
@@ -109,7 +110,7 @@ Bits Code also [ingests custom instructions][33] defined in your repository and 
 
 Bits Code integrates with [source code providers](#supported-source-code-providers) to:
 - Create pull or merge requests, generating titles and descriptions based on your repository's pull or merge request template
-- Iterate on pull requests in response to comments (GitHub only); mention `@Datadog` in a comment to prompt Bits for updates
+- Start or continue Bits Code sessions from GitHub or Azure DevOps pull request comments. Mention `@Datadog` in a comment to prompt Bits Code for updates, including on Azure DevOps pull requests Bits Code did not create
 - Monitor CI logs and pull or merge request state to fix failures and merge blockers
 
 Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is working on in {{< ui >}}Bits AI{{< /ui >}} > {{< ui >}}Bits Code{{< /ui >}} > [{{< ui >}}Sessions{{< /ui >}}][7].

--- a/hugo/content/en/bits_ai/bits_code/setup.md
+++ b/hugo/content/en/bits_ai/bits_code/setup.md
@@ -65,6 +65,15 @@ Set up Bits Code for one of the [supported source code providers][11].
 [7]: https://docs.gitlab.com/user/profile/personal_access_tokens/
 {{% /tab %}}
 
+{{% tab "Azure DevOps" %}}
+1. Install and configure the [Azure DevOps Source Code integration][1] for Azure DevOps Services. For full installation and configuration steps, see the [Azure DevOps Source Code integration guide][2].
+1. To start or continue Bits Code sessions from Azure DevOps pull request comments, mention `@Datadog`. The commenter needs the [`Bits Code Write` (`bits_dev_write`) permission][3] and write access to the repository.
+
+[1]: https://app.datadoghq.com/integrations/azure-devops-source-code/
+[2]: /integrations/azure-devops-source-code/
+[3]: /account_management/rbac/permissions/#bits-ai
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Additional configuration  


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5fff9848-4820-463b-ae6e-14b2b3b4d332","source":"chat","resourceId":"3e9c4c25-d29d-43ab-95c7-4146ab5da01f","workflowId":"b08b6000-416f-43a1-915a-ce9b27a02bbb","codeChangeId":"b08b6000-416f-43a1-915a-ce9b27a02bbb","sourceType":"llm-obs-docs-agent"} -->
### What does this PR do? What is the motivation?

Update the Bits Code docs to document Azure DevOps Services support and Azure DevOps pull request comment behavior.

Changes:
- Lists Azure DevOps Services as a supported source code provider and keeps Azure DevOps Server (On-Prem) unsupported.
- Removes the GitHub-only qualifier from pull request comment collaboration and describes Azure DevOps comment-triggered sessions.
- Adds an Azure DevOps setup tab with Source Code integration links and comment-trigger prerequisites.

Testing:
- Ran `git diff --check`.
- Attempted `vale hugo/content/en/bits_ai/bits_code/_index.md hugo/content/en/bits_ai/bits_code/setup.md`, but Vale is not installed in the sandbox.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code powered by Codex CLI to update the docs and run local validation.

### Additional notes

Source PR: https://github.com/DataDog/code-gen-backend/pull/14370

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3e9c4c25-d29d-43ab-95c7-4146ab5da01f)

Comment @datadog to request changes