### PR TITLE
Clarify that only mapped Jira statuses sync back to Security cases

### DIFF
--- a/hugo/content/en/security/ticketing_integrations.md
+++ b/hugo/content/en/security/ticketing_integrations.md
@@ -206,6 +206,7 @@ The following steps create a bidirectional ticket for a Security finding.
 
 **Notes**:
 - Bidirectional sync with Jira is available for certain Jira ticket attributes, such as status, assignee, and comments, but not all Jira fields are available.
+- Jira ticket status changes only sync back to a Datadog case status when that Jira status has been explicitly mapped to a case status in the ticketing integration configuration. Status changes on unmapped Jira statuses are not reflected on the Datadog case.
 {{% /collapse-content %}}
 
 {{% collapse-content title="ServiceNow ticket" level="h4" expanded=false %}}


### PR DESCRIPTION
## What does this PR do?

Adds a note to the Security ticketing integrations page clarifying that Jira ticket status changes only sync back to a Datadog case when the Jira status is explicitly mapped to a case status. Users were confused when Jira status changes silently didn't sync back, because unmapped statuses were not called out anywhere.

Related web-ui change (adds a matching in-app warning): ddoghq/web-ui#5354

## Motivation

SEC-33671: https://datadoghq.atlassian.net/browse/SEC-33671