### PR TITLE
Document passphrase-protected Snowflake keys

### DIFF
--- a/hugo/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
+++ b/hugo/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
@@ -529,7 +529,7 @@ The examples in this guide use `datadog_experiments_user` and `datadog_experimen
 
 ### Create a dedicated service user and role in Snowflake
 
-1. Use the [Snowflake documentation][18] to create a public-private key pair for enhanced authentication. Datadog only supports unencrypted private keys.
+1. Use the [Snowflake documentation][18] to create a public-private key pair for enhanced authentication. Datadog supports both unencrypted private keys and passphrase-protected PKCS#8 private keys.
 1. Run the following commands in Snowflake to create the user and role in the service account. Replace `<public_key>` with the public key you generated in the previous step.
 
 ```sql
@@ -596,7 +596,7 @@ To connect your Snowflake account to Datadog for warehouse-native experiment ana
 1. Add your {% ui %}Account URL{% /ui %}. To find your account URL, see the [Snowflake guide][19].
 1. Toggle off all resources (these are not needed for experiment analysis).
 1. Enter the Snowflake {% ui %}User Name{% /ui %} you created in [Step 1](#step-1-prepare-the-snowflake-service-account) (for example, `datadog_experiments_user`).
-1. Scroll to the {% ui %}Configure a key pair authentication{% /ui %} section and upload your unencrypted {% ui %}private key{% /ui %}.
+1. Scroll to the {% ui %}Configure a key pair authentication{% /ui %} section and upload your {% ui %}private key{% /ui %}. If your private key is passphrase-protected, enter the passphrase in the {% ui %}Private Key Password{% /ui %} field.
 1. Click {% ui %}Save{% /ui %}.
 
 {% alert %}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e0491c73-00d9-4e54-9ff2-1d544dcdd02b","source":"chat","resourceId":"4ef96d31-1032-41d5-87d7-933e028f6173","workflowId":"ea8e4eb9-9346-41c0-9255-02e4208b0ef6","codeChangeId":"ea8e4eb9-9346-41c0-9255-02e4208b0ef6","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Datadog Experiments supports passphrase-protected private keys for Snowflake key-pair authentication, in addition to unencrypted keys. This updates the Snowflake setup flow in the warehouse-native experiment analysis guide so the documented options match what the integration accepts.

Source PR: https://github.com/ddoghq/dd-source/pull/64048

### Changes

- Step 1: replaced the statement that Datadog only supports unencrypted private keys with guidance that it supports both unencrypted private keys and passphrase-protected PKCS#8 private keys.
- Step 2: updated the key-pair authentication upload step to cover uploading a passphrase-protected private key and entering its passphrase in the Private Key Password field, while retaining the unencrypted-key path.

### Testing

Reviewed the diff against the surrounding steps to confirm the edits match the existing numbered-list format, `{% ui %}` label conventions, tense, and style guidelines. Change is documentation-only.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code, Datadog's AI agent.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4ef96d31-1032-41d5-87d7-933e028f6173)

Comment @datadog to request changes