### PR TITLE
[error-tracking] Document the error.handling_stack attribute for stack traces

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -4783,6 +4783,11 @@ menu:
       parent: tracing_error_tracking
       identifier: tracing_error_tracking_error_grouping
       weight: 1303
+    - name: Stack Traces
+      url: tracing/error_tracking/stack_traces
+      parent: tracing_error_tracking
+      identifier: tracing_error_tracking_stack_traces
+      weight: 1304
     - name: Monitors
       url: tracing/error_tracking/monitors
       parent: tracing_error_tracking

--- a/hugo/content/en/tracing/error_tracking/_index.md
+++ b/hugo/content/en/tracing/error_tracking/_index.md
@@ -38,9 +38,16 @@ To get started with configuring your repository, see the [Source Code Integratio
 
 The Datadog SDKs collect errors through integrations and the manual instrumentation of your backend services' source code. An error span must contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] and belong to a complete trace to be tracked. If an error is reported multiple times within a service, only the top-most error is kept.
 
+<div class="alert alert-warning">
+The Go tracer introduced a change of attributes used to report stack traces in its v2.7.0 version.
+For older Go tracer versions (before v2.7.0), the stack trace is reported in the <code>error.stack</code> span attribute.
+Starting with v2.7.0, the Go tracer reports the handling stack trace in the <code>error.handling_stack</code> span attribute (with <code>error.stack</code> now carrying the throwing stack when available).
+See <a href="/tracing/error_tracking/stack_traces/">Stack Traces in Error Tracking</a> for details.
+</div>
+
 {{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors" style="width:100%;" >}}
 
-Error Tracking computes a fingerprint for each error span it processes using the error type, the error message, and the frames that form the stack trace. Errors with the same fingerprint are grouped together and belong to the same issue. For more information, see the [Trace Explorer documentation][2].
+Error Tracking computes a fingerprint for each error span it processes. The fingerprint uses the error type, the error message, and the frames that form the stack trace. Errors with the same fingerprint are grouped together and belong to the same issue. For more information, see the [Trace Explorer documentation][2].
 
 ## Control which errors are tracked
 

--- a/hugo/content/en/tracing/error_tracking/stack_traces.md
+++ b/hugo/content/en/tracing/error_tracking/stack_traces.md
@@ -1,0 +1,44 @@
+---
+title: Stack Traces in Error Tracking
+description: Learn how Error Tracking uses stack traces to fingerprint and group errors.
+further_reading:
+- link: '/tracing/error_tracking/'
+  tag: 'Documentation'
+  text: 'Learn about Error Tracking for Backend Services'
+- link: '/tracing/error_tracking/error_grouping/'
+  tag: 'Documentation'
+  text: 'Learn about Error Grouping'
+---
+
+## Overview
+
+Error Tracking uses stack traces on error spans to fingerprint errors, group them into issues, and show where they occurred. This page describes which span attribute Error Tracking reads for the stack trace, and how that varies by your service's language and tracer version.
+
+## Stack trace span attributes
+
+An error span reports its stack trace in the `error.stack` [span attribute][1]. For most tracers, `error.stack` contains the stack trace captured when the error was handled (for example, at a `catch` block or middleware). This isn't always where the error was thrown.
+
+For Go services instrumented with `dd-trace-go` v2.7.0 or later, the handling stack trace is reported separately, in the `error.handling_stack` attribute. In this case, `error.stack` instead contains the stack trace captured at the point the error was thrown, if available.
+
+## Which stack trace is used by Error Tracking
+
+### For Go services
+
+For Go services, Error Tracking has a fallback mechanism to decide which stack trace to use:
+
+- Go tracer v2.7.0 and later:
+  - The throwing stack is reported in `error.stack`. This stack is used if available.
+  - The handling stack is reported in `error.handling_stack`. This stack is used if the throwing stack is not available.
+- Go tracer earlier than v2.7.0:
+  - The throwing stack is reported in `error.details`. This stack is used if available.
+  - The handling stack is reported in `error.stack`. This stack is used if the throwing stack is not available.
+
+### For all other languages
+
+For all other languages, the handling stack is captured and reported in `error.stack`. This attribute is used by Error Tracking to group issues and derive information such as the suspect commit.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/visualization/trace/?tab=spantags#more-information

--- a/hugo/layouts/shortcodes/mdoc/en/error_tracking/grouping/overview.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/error_tracking/grouping/overview.mdoc.md
@@ -1,23 +1,22 @@
-## Default Grouping
+## Default grouping
 
 Error Tracking intelligently groups similar errors into issues. This grouping is based on the following error properties:
 
 - `service`: The service where the error occurred.
 - `error.type` or `error.kind`: The class of the error.
 - `error.message`: A description of the error.
-- `error.stack`: The filename and function name of the top-most meaningful stack frame.
+- `error.stack`: The filename and function name of the top-most meaningful stack frame. See [Stack Traces in Error Tracking](/tracing/error_tracking/stack_traces/) for details.
 
 The error stack trace is the code path followed by an error between being thrown and being captured by Datadog instrumentation. Error Tracking evaluates the topmost stack frame (the **location** of the error) and uses it to group the error.
 
 If any stack frame properties differ for two given errors, the two errors are grouped under different issues. For example, Error Tracking does not group issues across services or error types. Error Tracking also ignores numbers, punctuation, and anything that is between quotes or parentheses: only word-like tokens are used.
 
 {% alert level="info" %}
-**Tip:** To ensure optimal grouping, enclose variables in your error messages in quotes or parentheses.
+- To help ensure optimal grouping, enclose variables in your error messages in quotes or parentheses.
+- To improve grouping accuracy, Error Tracking removes variable stack frame properties such as versions, ids, dates, and so on.
 {% /alert %}
 
-**Note**: To improve grouping accuracy, Error Tracking removes variable stack frame properties such as versions, ids, dates, and so on.
-
-## Custom Grouping
+## Custom grouping
 
 Error Tracking intelligently groups similar errors into issues with a default strategy. By using _custom fingerprinting_, you can gain full control over the grouping decision and customize the grouping behavior for your error spans.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Clarify attributes used by the Go tracers to report stack traces, and how Error Tracking decides which stack trace to use for a given issue.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
