### PR TITLE
Change xe_collection to collect_xe in configuration

### DIFF
--- a/hugo/content/en/database_monitoring/guide/sql_extended_events.md
+++ b/hugo/content/en/database_monitoring/guide/sql_extended_events.md
@@ -325,10 +325,10 @@ ALTER EVENT SESSION datadog_query_errors ON DATABASE STATE = START;
 GO
 ```
 
-2. In the Datadog Agent configuration, enable `xe_collection` in `sqlserver.d/conf.yaml`.
+2. In the Datadog Agent configuration, enable `collect_xe` in `sqlserver.d/conf.yaml`.
 See the [sample conf.yaml.example][3] for all available configuration options.
 ```yaml
-  xe_collection:
+  collect_xe:
     query_completions:
       enabled: true
     query_errors:


### PR DESCRIPTION
Updated configuration key from 'xe_collection' to 'collect_xe' in Datadog Agent setup. This was an old option already updated in other places on this page but missed for Azure.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
