### PR TITLE
[DOCS-15523] Add Bitbucket Cloud to Code Security setup docs

### DIFF
--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -17,7 +17,7 @@ further_reading:
     text: "IaC Security Rules"
 ---
 
-Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, or Azure DevOps repositories.
+Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, Azure DevOps, or Bitbucket Cloud repositories.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}
@@ -89,6 +89,30 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
     - To enable it for a single repository, toggle the {{< ui >}}IaC{{< /ui >}} switch to ON for that repository.
 
 [1]: /integrations/azure-devops-source-code/#source-code-functionality
+[2]: https://app.datadoghq.com/security/configuration/code-security/setup
+
+{{% /tab %}}
+{{% tab "Bitbucket" %}}
+
+### Install the Bitbucket integration
+
+To connect your Bitbucket Cloud workspace and enable PR comments, see the setup instructions in [Bitbucket Source Code][1].
+
+### Enable IaC Security for your repositories
+
+After setting up the Bitbucket integration, enable IaC Security for your repositories.
+
+1. On the [Code Security Setup page][2], expand the {{< ui >}}Activate scanning for your repositories{{< /ui >}} section.
+1. Under {{< ui >}}Select your source code management provider{{< /ui >}}, select {{< ui >}}Bitbucket{{< /ui >}}.
+1. Under {{< ui >}}Select where your scans should run{{< /ui >}}, select {{< ui >}}Datadog{{< /ui >}}.
+1. Under {{< ui >}}Connect your Bitbucket repositories{{< /ui >}}, do one of the following:
+    - To connect a new Bitbucket Cloud workspace, click {{< ui >}}Connect Bitbucket Account{{< /ui >}}.
+    - To enable IaC Security for an existing workspace, click {{< ui >}}Select repositories{{< /ui >}}, or {{< ui >}}Edit{{< /ui >}} if Code Security is already enabled.
+1. To enable IaC Security, do one of the following:
+    - To enable it for all repositories, toggle {{< ui >}}Enable Infrastructure as Code Scanning (IaC){{< /ui >}} to the ON position.
+    - To enable it for a single repository, toggle the {{< ui >}}IaC{{< /ui >}} switch to ON for that repository.
+
+[1]: /integrations/bitbucket-source-code/#setup
 [2]: https://app.datadoghq.com/security/configuration/code-security/setup
 
 {{% /tab %}}

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -92,7 +92,7 @@ After setting up the Azure DevOps integration, enable IaC Security for your repo
 [2]: https://app.datadoghq.com/security/configuration/code-security/setup
 
 {{% /tab %}}
-{{% tab "Bitbucket" %}}
+{{% tab "Bitbucket Cloud" %}}
 
 ### Install the Bitbucket integration
 

--- a/hugo/content/en/security/code_security/iac_security/setup.md
+++ b/hugo/content/en/security/code_security/iac_security/setup.md
@@ -17,7 +17,7 @@ further_reading:
     text: "IaC Security Rules"
 ---
 
-Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, Azure DevOps, or Bitbucket Cloud repositories.
+Use the following instructions to enable Infrastructure as Code (IaC) Security for Code Security. IaC Security supports multiple IaC configurations stored in GitHub, GitLab, Azure DevOps, or Bitbucket Cloud Premium repositories.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}

--- a/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -69,7 +69,7 @@ You can run Datadog Static SCA scans directly on Datadog infrastructure. Support
 - [GitHub](/security/code_security/software_composition_analysis/setup_static/?tab=github#select-your-source-code-management-provider) (excluding repositories that use [Git Large File Storage][21])
 - [GitLab.com and GitLab Self-Managed](/security/code_security/software_composition_analysis/setup_static/?tab=gitlab#select-your-source-code-management-provider)
 - [Azure DevOps](/security/code_security/software_composition_analysis/setup_static/?tab=azuredevops#select-your-source-code-management-provider)
-- [Bitbucket Cloud](/security/code_security/software_composition_analysis/setup_static/?tab=bitbucket#select-your-source-code-management-provider)
+- [Bitbucket Cloud](/security/code_security/software_composition_analysis/setup_static/?tab=bitbucketcloud#select-your-source-code-management-provider)
 
 To get started, navigate to the [{{< ui >}}Code Security{{< /ui >}} page][2].
 
@@ -135,11 +135,11 @@ See the [Azure source code setup instructions][4] to connect Azure DevOps reposi
 [5]: /getting_started/site/
 
 {{% /tab %}}
-{{% tab "Bitbucket" %}}
+{{% tab "Bitbucket Cloud" %}}
 
-See the [Bitbucket source code setup instructions][23] to connect Bitbucket Cloud workspaces to Datadog.
+See the [Bitbucket source code setup instructions][1] to connect Bitbucket Cloud workspaces to Datadog.
 
-[23]: /integrations/bitbucket-source-code/#setup
+[1]: /integrations/bitbucket-source-code/#setup
 
 {{% /tab %}}
 {{% tab "Other" %}}

--- a/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -69,6 +69,7 @@ You can run Datadog Static SCA scans directly on Datadog infrastructure. Support
 - [GitHub](/security/code_security/software_composition_analysis/setup_static/?tab=github#select-your-source-code-management-provider) (excluding repositories that use [Git Large File Storage][21])
 - [GitLab.com and GitLab Self-Managed](/security/code_security/software_composition_analysis/setup_static/?tab=gitlab#select-your-source-code-management-provider)
 - [Azure DevOps](/security/code_security/software_composition_analysis/setup_static/?tab=azuredevops#select-your-source-code-management-provider)
+- [Bitbucket Cloud](/security/code_security/software_composition_analysis/setup_static/?tab=bitbucket#select-your-source-code-management-provider)
 
 To get started, navigate to the [{{< ui >}}Code Security{{< /ui >}} page][2].
 
@@ -96,7 +97,7 @@ If your Java project checks third-party JARs directly into the repository instea
 
 ## Select your source code management provider
 
-Regardless of the scanning mode you use, connect your source code management provider to enable native features such as inline code snippets and pull request comments. Datadog SCA supports all providers and offers native support for GitHub, GitLab, and Azure DevOps.
+Regardless of the scanning mode you use, connect your source code management provider to enable native features such as inline code snippets and pull request comments. Datadog SCA supports all providers and offers native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}
@@ -132,6 +133,13 @@ See the [Azure source code setup instructions][4] to connect Azure DevOps reposi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: /integrations/azure-devops-source-code/#setup
 [5]: /getting_started/site/
+
+{{% /tab %}}
+{{% tab "Bitbucket" %}}
+
+See the [Bitbucket source code setup instructions][23] to connect Bitbucket Cloud workspaces to Datadog.
+
+[23]: /integrations/bitbucket-source-code/#setup
 
 {{% /tab %}}
 {{% tab "Other" %}}

--- a/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -97,7 +97,7 @@ If your Java project checks third-party JARs directly into the repository instea
 
 ## Select your source code management provider
 
-Regardless of the scanning mode you use, connect your source code management provider to enable native features such as inline code snippets and pull request comments. Datadog SCA supports all providers and offers native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud.
+Regardless of the scanning mode you use, connect your source code management provider to enable native features such as inline code snippets and pull request comments. Datadog SCA supports all providers and offers native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud Premium.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}

--- a/hugo/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/hugo/content/en/security/code_security/static_analysis/setup/_index.md
@@ -44,7 +44,7 @@ Next, run Static Code Analysis by following instructions for your chosen CI prov
 {{< /whatsnext >}}
 
 ## Select your source code management provider
-Datadog Static Code Analysis supports all source code management providers, with native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud.
+Datadog Static Code Analysis supports all source code management providers, with native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud Premium.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}

--- a/hugo/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/hugo/content/en/security/code_security/static_analysis/setup/_index.md
@@ -27,6 +27,7 @@ You can run Datadog Static Code Analysis (SAST) scans directly on Datadog infras
 - [GitHub][18] (excluding repositories that use [Git Large File Storage][17])
 - [GitLab.com and GitLab Self-Managed][20]
 - [Azure DevOps][19]
+- [Bitbucket Cloud][21]
 
 To get started, navigate to the [{{< ui >}}Code Security{{< /ui >}} page][1].
 
@@ -43,7 +44,7 @@ Next, run Static Code Analysis by following instructions for your chosen CI prov
 {{< /whatsnext >}}
 
 ## Select your source code management provider
-Datadog Static Code Analysis supports all source code management providers, with native support for GitHub, GitLab, and Azure DevOps.
+Datadog Static Code Analysis supports all source code management providers, with native support for GitHub, GitLab, Azure DevOps, and Bitbucket Cloud.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}
@@ -80,6 +81,13 @@ See the [Azure source code setup instructions][4] to connect Azure DevOps reposi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: /integrations/azure-devops-source-code/#setup
 [5]: /getting_started/site/
+
+{{% /tab %}}
+{{% tab "Bitbucket" %}}
+
+See the [Bitbucket source code setup instructions][23] to connect Bitbucket Cloud workspaces to Datadog.
+
+[23]: /integrations/bitbucket-source-code/#setup
 
 {{% /tab %}}
 {{% tab "Other" %}}
@@ -270,6 +278,7 @@ Datadog stores findings in accordance with our [Data Retention Periods](https://
 [18]: /security/code_security/static_analysis/setup/?tab=github#select-your-source-code-management-provider
 [19]: /security/code_security/static_analysis/setup/?tab=azuredevops#select-your-source-code-management-provider
 [20]: /security/code_security/static_analysis/setup/?tab=gitlab#select-your-source-code-management-provider
+[21]: /security/code_security/static_analysis/setup/?tab=bitbucket#select-your-source-code-management-provider
 [22]: https://docs.datadoghq.com/internal_developer_portal/catalog/entity_model/?tab=v30#migrating-to-v30
 [24]: https://docs.datadoghq.com/account_management/teams/
 [25]: https://github.com/DataDog/datadog-static-analyzer/blob/main/doc/legacy_config.md

--- a/hugo/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/hugo/content/en/security/code_security/static_analysis/setup/_index.md
@@ -83,11 +83,11 @@ See the [Azure source code setup instructions][4] to connect Azure DevOps reposi
 [5]: /getting_started/site/
 
 {{% /tab %}}
-{{% tab "Bitbucket" %}}
+{{% tab "Bitbucket Cloud" %}}
 
-See the [Bitbucket source code setup instructions][23] to connect Bitbucket Cloud workspaces to Datadog.
+See the [Bitbucket source code setup instructions][1] to connect Bitbucket Cloud workspaces to Datadog.
 
-[23]: /integrations/bitbucket-source-code/#setup
+[1]: /integrations/bitbucket-source-code/#setup
 
 {{% /tab %}}
 {{% tab "Other" %}}
@@ -278,7 +278,7 @@ Datadog stores findings in accordance with our [Data Retention Periods](https://
 [18]: /security/code_security/static_analysis/setup/?tab=github#select-your-source-code-management-provider
 [19]: /security/code_security/static_analysis/setup/?tab=azuredevops#select-your-source-code-management-provider
 [20]: /security/code_security/static_analysis/setup/?tab=gitlab#select-your-source-code-management-provider
-[21]: /security/code_security/static_analysis/setup/?tab=bitbucket#select-your-source-code-management-provider
+[21]: /security/code_security/static_analysis/setup/?tab=bitbucketcloud#select-your-source-code-management-provider
 [22]: https://docs.datadoghq.com/internal_developer_portal/catalog/entity_model/?tab=v30#migrating-to-v30
 [24]: https://docs.datadoghq.com/account_management/teams/
 [25]: https://github.com/DataDog/datadog-static-analyzer/blob/main/doc/legacy_config.md


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15523

Adds Bitbucket Cloud as a supported source code management provider in the Code Security setup docs, alongside GitHub, GitLab, and Azure DevOps:

- Static Code Analysis (SAST) setup
- Software Composition Analysis (SCA) setup
- Infrastructure as Code (IaC) Security setup

Each doc now lists Bitbucket Cloud under Datadog-hosted scanning support and adds a "Bitbucket" tab under "Select your source code management provider," linking to the Bitbucket Source Code integration doc.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft the Bitbucket provider tabs and supporting text based on the existing GitHub/GitLab/Azure DevOps sections and the Bitbucket Source Code integration doc.

### Additional notes