### PR TITLE
[CONTP-1976] Document default DDI controller enablement

### DIFF
--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -39,8 +39,8 @@ Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `
 
 To use `DatadogInstrumentation` (DDI), a controller in your Agent must be enabled to track and reconcile each CR.
 
-<div class="alert alert-info">Skip setup if you're using <code>v1.30+</code> of the Datadog Operator or <code>v3.241.0+</code> of the Datadog Helm Chart. The DDI controller
-is enabled by default, requiring no setup.</div>
+<div class="alert alert-info">Skip setup if you're using <code>v1.30+</code> of the Datadog Operator or <code>v3.241.0+</code> of the Datadog Helm Chart since the
+controller is enabled by default starting from these versions.</div>
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -39,7 +39,7 @@ Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `
 
 To use `DatadogInstrumentation` (DDI), a controller in your Agent must be enabled to track and reconcile each CR.
 
-<div class="alert alert-info">Skip setup if you're using `v1.30+` of the Datadog Operator or `v3.241.0+` of the Datadog Helm Chart. The DDI controller
+<div class="alert alert-info">Skip setup if you're using <code>v1.30+</code> of the Datadog Operator or <code>v3.241.0+</code> of the Datadog Helm Chart. The DDI controller
 is enabled by default, requiring no setup.</div>
 
 {{< tabs >}}

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -37,7 +37,7 @@ Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `
 
 ## Setup
 
-The `DatadogInstrumentation` controller runs in the Cluster Agent and is disabled by default. Enable it with the Datadog Operator or Helm.
+The `DatadogInstrumentation` controller runs in the Cluster Agent. It is enabled by default for Agent and Cluster Agent v7.82.0 or later. This default applies with Datadog Operator v1.30.0+ and Datadog Helm chart v3.241.0+.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
@@ -54,7 +54,7 @@ helm repo update
 helm upgrade datadog-operator datadog/datadog-operator
 ```
 
-3. Add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
+3. If you use Datadog Operator v1.29, add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. With Datadog Operator v1.30.0+, the controller is enabled by default.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -68,7 +68,7 @@ spec:
     [...]
 ```
 
-4. Apply the change:
+4. If you added the annotation, apply the change:
 
 ```shell
 kubectl apply -f datadog-agent.yaml
@@ -85,7 +85,7 @@ The Operator sets the required Cluster Agent and Node Agent environment variable
 helm repo update
 ```
 
-2. In your `datadog-values.yaml` file, enable the controller:
+2. If you use Datadog Helm chart v3.236.0 through v3.240.x, enable the controller in your `datadog-values.yaml` file. With Datadog Helm chart v3.241.0+, the controller is enabled by default.
 
 ```yaml
 datadog:

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -56,7 +56,7 @@ helm repo update
 helm upgrade datadog-operator datadog/datadog-operator
 ```
 
-3. Add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource.
+3. Add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. The Cluster Agent must be v7.82.0 or later.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -37,12 +37,13 @@ Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `
 
 ## Setup
 
-The `DatadogInstrumentation` controller runs in the Cluster Agent.
+To use `DatadogInstrumentation` (DDI), a controller in your Agent must be enabled to track and reconcile each CR.
+
+<div class="alert alert-info">Skip setup if you're using `v1.30+` of the Datadog Operator or `v3.241.0+` of the Datadog Helm Chart. The DDI controller
+is enabled by default, requiring no setup.</div>
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
-
-**Note**: Starting in Datadog Operator v1.30.0, the controller is enabled by default. If you use v1.30.0 or later, skip the following setup steps.
 
 1. Update your Helm repositories:
 
@@ -80,8 +81,6 @@ The Operator sets the required Cluster Agent and Node Agent environment variable
 
 {{% /tab %}}
 {{% tab "Helm" %}}
-
-**Note**: Starting in Datadog Helm chart v3.241.0, the controller is enabled by default. If you use v3.241.0 or later, skip the following setup steps.
 
 1. Update your Helm repositories:
 

--- a/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
+++ b/hugo/content/en/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd.md
@@ -37,10 +37,12 @@ Upgrade to  **v7.82+**  of the Datadog Agent and Cluster Agent and install the `
 
 ## Setup
 
-The `DatadogInstrumentation` controller runs in the Cluster Agent. It is enabled by default for Agent and Cluster Agent v7.82.0 or later. This default applies with Datadog Operator v1.30.0+ and Datadog Helm chart v3.241.0+.
+The `DatadogInstrumentation` controller runs in the Cluster Agent.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
+
+**Note**: Starting in Datadog Operator v1.30.0, the controller is enabled by default. If you use v1.30.0 or later, skip the following setup steps.
 
 1. Update your Helm repositories:
 
@@ -54,7 +56,7 @@ helm repo update
 helm upgrade datadog-operator datadog/datadog-operator
 ```
 
-3. If you use Datadog Operator v1.29, add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource. With Datadog Operator v1.30.0+, the controller is enabled by default.
+3. Add the `agent.datadoghq.com/instrumentation-crd-enabled` annotation to your `DatadogAgent` resource.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -68,7 +70,7 @@ spec:
     [...]
 ```
 
-4. If you added the annotation, apply the change:
+4. Apply the change:
 
 ```shell
 kubectl apply -f datadog-agent.yaml
@@ -79,13 +81,15 @@ The Operator sets the required Cluster Agent and Node Agent environment variable
 {{% /tab %}}
 {{% tab "Helm" %}}
 
+**Note**: Starting in Datadog Helm chart v3.241.0, the controller is enabled by default. If you use v3.241.0 or later, skip the following setup steps.
+
 1. Update your Helm repositories:
 
 ```shell
 helm repo update
 ```
 
-2. If you use Datadog Helm chart v3.236.0 through v3.240.x, enable the controller in your `datadog-values.yaml` file. With Datadog Helm chart v3.241.0+, the controller is enabled by default.
+2. In your `datadog-values.yaml` file, enable the controller:
 
 ```yaml
 datadog:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the DatadogInstrumentation setup guide to explain that the controller is enabled by default with Operator v1.30.0+ or Helm chart v3.241.0+ when Agent and Cluster Agent are v7.82.0 or later. Keeps the opt-in steps for earlier supported releases.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI-assisted research and drafting.

### Additional notes

