### PR TITLE
[CONTINT-5559] Add VKS Kubernetes distribution docs

### DIFF
--- a/hugo/content/en/containers/kubernetes/distributions.md
+++ b/hugo/content/en/containers/kubernetes/distributions.md
@@ -680,7 +680,7 @@ No specific configuration is required.
 
 ## vSphere Kubernetes Service (VKS) {#VKS}
 
-VKS requires the namespace that the Datadog Agent is deployed to use the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
+VKS requires the namespace where the Datadog Agent is deployed to use the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
 
 ```shell
 kubectl label --overwrite ns <namespace> \

--- a/hugo/content/en/containers/kubernetes/distributions.md
+++ b/hugo/content/en/containers/kubernetes/distributions.md
@@ -38,6 +38,7 @@ These configurations can then be customized to add any Datadog feature.
 * [Red Hat OpenShift](#Openshift)
 * [Rancher](#Rancher)
 * [Oracle Container Engine for Kubernetes (OKE)](#OKE)
+* [vSphere Kubernetes Service (VKS)](#VKS)
 * [vSphere Tanzu Kubernetes Grid (TKG)](#TKG)
 
 ## AWS Elastic Kubernetes Service (EKS) {#EKS}
@@ -676,6 +677,80 @@ agents:
 ## Oracle Container Engine for Kubernetes (OKE) {#OKE}
 
 No specific configuration is required.
+
+## vSphere Kubernetes Service (VKS) {#VKS}
+
+VKS requires the same small configuration changes as TKG, plus a namespace label for the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
+
+```shell
+kubectl label --overwrite ns <namespace> \
+  pod-security.kubernetes.io/enforce=privileged
+```
+
+For Agent configuration, setting a toleration is required for the controller to schedule the Node Agent on the `master` nodes.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+DatadogAgent Kubernetes Resource:
+
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    eventCollection:
+      collectKubernetesEvents: true
+    kubeStateMetricsCore:
+      enabled: true
+  global:
+    clusterName: <CLUSTER_NAME>
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+    kubelet:
+      tlsVerify: false
+  override:
+    nodeAgent:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  clusterName: <CLUSTER_NAME>
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  kubelet:
+    # Set tlsVerify to false since the Kubelet certificates are self-signed
+    tlsVerify: false
+  # Disable the `kube-state-metrics` dependency chart installation.
+  kubeStateMetricsEnabled: false
+  # Enable the new `kubernetes_state_core` check.
+  kubeStateMetricsCore:
+    enabled: true
+# Add a toleration so that the agent can be scheduled on the control plane nodes.
+agents:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 

--- a/hugo/content/en/containers/kubernetes/distributions.md
+++ b/hugo/content/en/containers/kubernetes/distributions.md
@@ -680,14 +680,14 @@ No specific configuration is required.
 
 ## vSphere Kubernetes Service (VKS) {#VKS}
 
-VKS requires the same small configuration changes as TKG, plus a namespace label for the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
+VKS requires the namespace that the Datadog Agent is deployed to use the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
 
 ```shell
 kubectl label --overwrite ns <namespace> \
   pod-security.kubernetes.io/enforce=privileged
 ```
 
-For Agent configuration, setting a toleration is required for the controller to schedule the Node Agent on the `master` nodes.
+Use the following configuration to enable Kubernetes event collection and kube-state-metrics core, disable Kubelet TLS verification for self-signed certificates, and add a toleration so the Agent can be scheduled on control plane nodes.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"68c5c696-084a-4c31-8546-31ffd19fafe0","source":"chat","resourceId":"895885aa-fb6f-48b7-8adc-f9d6af3a6dc9","workflowId":"aeea1f0c-c0ef-49fc-8df2-92057bed0169","codeChangeId":"aeea1f0c-c0ef-49fc-8df2-92057bed0169","sourceType":"chat"} -->
### What does this PR do? What is the motivation?

Motivation: Add public Kubernetes distribution documentation for vSphere Kubernetes Service (VKS), including its namespace Pod Security prerequisite and Datadog Agent setup.

Changes:
- Added VKS to the Kubernetes distributions list in hugo/content/en/containers/kubernetes/distributions.md.
- Added a VKS section with the required namespace label command.
- Included Datadog Operator and Helm configuration examples for VKS.
- Made the VKS section self-contained so it does not rely on cross-references to adjacent distribution content.

Testing:
- Ran `git diff --check`.
- Reviewed the VKS section wording.
- Reviewed the tab shortcode structure in hugo/content/en/containers/kubernetes/distributions.md.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to draft and verify the documentation change.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/895885aa-fb6f-48b7-8adc-f9d6af3a6dc9)

Comment @datadog to request changes