### PR TITLE
[DOCS-15531] Add Get Started guide for Datadog on Stripe Projects

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -141,6 +141,11 @@ menu:
       url: getting_started/integrations/terraform/
       weight: 1205
       parent: getting_started_integrations
+    - name: Stripe
+      identifier: getting_started_with_stripe
+      url: getting_started/integrations/stripe/
+      weight: 1206
+      parent: getting_started_integrations
     - name: Internal Developer Portal
       identifier: getting_started_internal_developer_portal
       url: getting_started/internal_developer_portal/

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -5,9 +5,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/datadog-stripe-projects/'
       tag: 'Blog'
       text: 'Provision Datadog on Stripe Projects'
-    - link: 'https://docs.stripe.com/cli'
+    - link: 'https://docs.stripe.com/projects'
       tag: 'Documentation'
-      text: 'Stripe CLI documentation'
+      text: 'Stripe Projects CLI documentation'
 ---
 
 <div class="alert alert-info">Datadog provisioning through Stripe Projects is limited to the US1 site. The email address on your Stripe account must not already be associated with a Datadog account.</div>

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -8,9 +8,6 @@ further_reading:
     - link: 'https://docs.stripe.com/projects'
       tag: 'Documentation'
       text: 'Stripe Projects CLI documentation'
-    - link: '/getting_started/agent/'
-      tag: 'Documentation'
-      text: 'Getting Started with the Datadog Agent'
 ---
 
 <div class="alert alert-info">Datadog provisioning through Stripe Projects is limited to the US1 site. The email address on your Stripe account must not already be associated with a Datadog account.</div>
@@ -57,13 +54,9 @@ Use [Stripe Projects][1] to provision and manage Datadog from the Stripe CLI. Th
 
 1. Confirm that your `.env` file contains your Datadog API key, site, and organization name.
 
-### Send data to Datadog
-
-Use the API key and site in your `.env` file to configure the [Datadog Agent][3] or a [Datadog library][4] for your application.
-
 ### Access Datadog
 
-1. Go to the [Datadog login page][5].
+1. Go to the [Datadog login page](https://app.datadoghq.com/account/login).
 1. Select **Sign in with Google** if you use a Google account to sign in to Stripe. Otherwise, select **Forgot password?** and enter the email address from your Stripe account to set a Datadog password.
 
 ## Upgrade your plan
@@ -91,6 +84,3 @@ This stops management of your Datadog organization through Stripe Projects. It d
 
 [1]: https://docs.stripe.com/projects
 [2]: https://docs.stripe.com/cli/install
-[3]: /getting_started/agent/
-[4]: /libraries/
-[5]: https://app.datadoghq.com/account/login

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -1,0 +1,96 @@
+---
+title: Get Started with Datadog on Stripe Projects
+description: Provision and manage a Datadog organization from the Stripe CLI using Stripe Projects.
+further_reading:
+    - link: 'https://www.datadoghq.com/blog/datadog-stripe-projects/'
+      tag: 'Blog'
+      text: 'Provision Datadog on Stripe Projects'
+    - link: 'https://docs.stripe.com/projects'
+      tag: 'Documentation'
+      text: 'Stripe Projects CLI documentation'
+    - link: '/getting_started/agent/'
+      tag: 'Documentation'
+      text: 'Getting Started with the Datadog Agent'
+---
+
+<div class="alert alert-info">Datadog provisioning through Stripe Projects is limited to the US1 site. The email address on your Stripe account must not already be associated with a Datadog account.</div>
+
+## Overview
+
+Use [Stripe Projects][1] to provision and manage Datadog from the Stripe CLI. This flow creates a Datadog organization and adds its API key, site, and organization name to your application's `.env` file.
+
+## Prerequisites
+
+- A Stripe account with an email address that isn't associated with an existing Datadog account
+
+## Setup
+
+### Install the Stripe CLI and Projects plugin
+
+1. Install the [Stripe CLI][2] version 1.43.3 or later:
+
+   ```shell
+   npm install -g @stripe/cli
+   ```
+
+   For other installation methods, see [Install the Stripe CLI][2].
+
+1. Install the Stripe Projects plugin:
+
+   ```shell
+   stripe plugin install projects
+   ```
+
+### Provision Datadog
+
+1. Initialize Stripe Projects:
+
+   ```shell
+   stripe projects init
+   ```
+
+1. Add Datadog Observability:
+
+   ```shell
+   stripe projects add datadog/observability
+   ```
+
+1. Confirm that your `.env` file contains your Datadog API key, site, and organization name.
+
+### Send data to Datadog
+
+Use the API key and site in your `.env` file to configure the [Datadog Agent][3] or a [Datadog library][4] for your application.
+
+### Access Datadog
+
+1. Go to the [Datadog login page][5].
+1. Select **Sign in with Google** if you use a Google account to sign in to Stripe. Otherwise, select **Forgot password?** and enter the email address from your Stripe account to set a Datadog password.
+
+## Upgrade your plan
+
+If your Stripe account has a saved payment method, upgrade your Datadog plan to pay-as-you-go with one command:
+
+```shell
+stripe projects upgrade datadog-observability
+```
+
+## Remove Datadog from Stripe Projects
+
+Remove Datadog from your Stripe project and update your local environment variables:
+
+```shell
+stripe projects remove datadog-observability
+stripe projects env --pull
+```
+
+This stops management of your Datadog organization through Stripe Projects. It doesn't delete your Datadog account or organization.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.stripe.com/projects
+[2]: https://docs.stripe.com/cli/install
+[3]: /getting_started/agent/
+[4]: /libraries/
+[5]: https://app.datadoghq.com/account/login

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -5,9 +5,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/datadog-stripe-projects/'
       tag: 'Blog'
       text: 'Provision Datadog on Stripe Projects'
-    - link: 'https://docs.stripe.com/projects'
+    - link: 'https://docs.stripe.com/cli'
       tag: 'Documentation'
-      text: 'Stripe Projects CLI documentation'
+      text: 'Stripe CLI documentation'
 ---
 
 <div class="alert alert-info">Datadog provisioning through Stripe Projects is limited to the US1 site. The email address on your Stripe account must not already be associated with a Datadog account.</div>

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -54,12 +54,7 @@ Use [Stripe Projects][1] to provision and manage Datadog from the Stripe CLI. Th
 
 1. Confirm that your `.env` file contains your Datadog API key, site, and organization name.
 
-### Access Datadog
-
-1. Go to the [Datadog login page](https://app.datadoghq.com/account/login).
-1. Select **Sign in with Google** if you use a Google account to sign in to Stripe. Otherwise, select **Forgot password?** and enter the email address from your Stripe account to set a Datadog password.
-
-### Upgrade Your Plan
+### Upgrade your plan
 
 If your Stripe account has a saved payment method, upgrade your Datadog plan to pay-as-you-go with one command:
 
@@ -77,6 +72,11 @@ stripe projects env --pull
 ```
 
 This stops management of your Datadog organization through Stripe Projects. It doesn't delete your Datadog account or organization.
+
+## Access Datadog
+
+1. Go to the [Datadog login page](https://app.datadoghq.com/account/login).
+1. Select **Sign in with Google** if you use a Google account to sign in to Stripe. Otherwise, select **Forgot password?** and enter the email address from your Stripe account to set a Datadog password.
 
 ## Further Reading
 

--- a/hugo/content/en/getting_started/integrations/stripe.md
+++ b/hugo/content/en/getting_started/integrations/stripe.md
@@ -59,7 +59,7 @@ Use [Stripe Projects][1] to provision and manage Datadog from the Stripe CLI. Th
 1. Go to the [Datadog login page](https://app.datadoghq.com/account/login).
 1. Select **Sign in with Google** if you use a Google account to sign in to Stripe. Otherwise, select **Forgot password?** and enter the email address from your Stripe account to set a Datadog password.
 
-## Upgrade your plan
+### Upgrade Your Plan
 
 If your Stripe account has a saved payment method, upgrade your Datadog plan to pay-as-you-go with one command:
 
@@ -67,7 +67,7 @@ If your Stripe account has a saved payment method, upgrade your Datadog plan to 
 stripe projects upgrade datadog-observability
 ```
 
-## Remove Datadog from Stripe Projects
+### Remove Datadog from Stripe Projects
 
 Remove Datadog from your Stripe project and update your local environment variables:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a new Getting Started guide, "Get Started with Datadog on Stripe Projects," under Integrations > Integration Guides. It documents how to install the Stripe CLI and Projects plugin, provision a Datadog organization, upgrade the plan, remove Datadog from a Stripe project, and access the new Datadog account. Also adds the page to the English site navigation.

The blog post is linked, but its a new method for provisioning a Datadog account which launched a few weeks ago - https://www.datadoghq.com/blog/datadog-stripe-projects/

### Merge readiness

- [ ] Ready for merge

### AI assistance

Drafted with Claude Code from an engineer-authored draft, with copy revised to follow the repository's style guide (Vale substitutions, imperative voice, no filler words) and formatted to match existing Get Started integration guides (frontmatter, structure, navigation entry).

### Additional notes