### PR TITLE
Add annotation queue tools to MCP docs

### DIFF
--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -409,6 +409,44 @@ The `llmobs` toolset includes the following tools:
 `get_llmobs_pattern_points`
 : Get a cursor-paginated page of clustering points (individual spans) assigned to a single topic. Each point includes the `span_id`, `session_id`, and a span input preview. Pass `next_page_token` back as `page_token` to continue paging.
 
+### Annotation queue tools
+
+`list_llmobs_annotation_queues`
+: List all [annotation queues][10] for the org.
+
+`create_llmobs_annotation_queue`
+: Create an annotation queue for human review of traces, optionally defining its label schema at creation time.
+
+`update_llmobs_annotation_queue`
+: Update an annotation queue's name, description, or label schema.
+
+`delete_llmobs_annotation_queue`
+: Delete an annotation queue.
+
+`get_llmobs_annotation_label_schema`
+: Get the label schema for an annotation queue, which defines the labels annotators apply during review.
+
+`update_llmobs_annotation_label_schema`
+: Create or replace the label schema for an annotation queue.
+
+`add_llmobs_annotation_queue_interactions`
+: Add one or more traces to an annotation queue for review.
+
+`delete_llmobs_annotation_queue_interactions`
+: Remove traces from an annotation queue.
+
+`get_llmobs_annotated_interactions`
+: Get the annotated interactions in an annotation queue along with the labels annotators applied to them.
+
+`get_llmobs_annotations_by_content_ids`
+: Get the annotations applied to specific traces or sessions by their content IDs.
+
+`upsert_llmobs_annotations`
+: Create or update the annotations applied to interactions in a queue.
+
+`delete_llmobs_annotations`
+: Delete annotations applied to interactions in a queue.
+
 ## Recommended workflows
 
 ### Trace analysis
@@ -492,3 +530,4 @@ For custom visualizations that go beyond standard Datadog widgets, like comparis
 [7]: /account_management/org_settings/service_accounts/
 [8]: https://github.com/datadog-labs/agent-skills
 [9]: /llm_observability/build_with_ai/claude_code_skills
+[10]: /llm_observability/investigate/annotation_queues

--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -424,7 +424,7 @@ The `llmobs` toolset includes the following tools:
 : Delete an annotation queue.
 
 `get_llmobs_annotation_label_schema`
-: Get the label schema for an annotation queue, which defines the labels annotators apply during review.
+: Get the label schema for an annotation queue, which defines the labels that annotators apply during review.
 
 `update_llmobs_annotation_label_schema`
 : Create or replace the label schema for an annotation queue.

--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -436,7 +436,7 @@ The `llmobs` toolset includes the following tools:
 : Remove traces from an annotation queue.
 
 `get_llmobs_annotated_interactions`
-: Get the annotated interactions in an annotation queue along with the labels annotators applied to them.
+: Get the annotated interactions in an annotation queue along with the labels that annotators applied to them.
 
 `get_llmobs_annotations_by_content_ids`
 : Get the annotations applied to specific traces or sessions by their content IDs.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"80e18de6-90a9-440f-b32d-9534eeeb5f6f","source":"chat","resourceId":"b6bb496d-e120-4512-8224-6cdece094d07","workflowId":"17b4b728-2b6d-41f4-b323-a72e8b8559f3","codeChangeId":"17b4b728-2b6d-41f4-b323-a72e8b8559f3","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the newly customer-available annotation queue tools in the `llmobs` MCP toolset on the Agent Observability MCP page. These tools let users manage annotation queues, label schemas, queue interactions, and annotations from an MCP-compatible client. The tools were made customer-available in https://github.com/ddoghq/dd-source/pull/70028.

**What changed:**
- Add an `Annotation queue tools` subsection to the `## Available tools` section of `hugo/content/en/llm_observability/build_with_ai/mcp_server.md`, alongside the existing tool-category subsections. It documents 12 tools in the page's existing definition-list style: `list_llmobs_annotation_queues`, `create_llmobs_annotation_queue`, `update_llmobs_annotation_queue`, `delete_llmobs_annotation_queue`, `get_llmobs_annotation_label_schema`, `update_llmobs_annotation_label_schema`, `add_llmobs_annotation_queue_interactions`, `delete_llmobs_annotation_queue_interactions`, `get_llmobs_annotated_interactions`, `get_llmobs_annotations_by_content_ids`, `upsert_llmobs_annotations`, and `delete_llmobs_annotations`.
- Link the subsection to the existing Annotation Queues guide.

**How verified:**
- Confirmed the new entries match the surrounding definition-list format and imperative voice used by the other tool subsections.
- Verified the new `[10]` reference resolves to the existing Annotation Queues guide page.
- Manually checked the new copy against the datadog-vale substitution rules (no flagged terms).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code): generated the subsection from the source PR's tool list and aligned the wording with the existing Annotation Queues guide and page conventions. Reviewed by a human.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b6bb496d-e120-4512-8224-6cdece094d07)

Comment @datadog to request changes