### PR TITLE
Change DNS record name from '*' to '@'

### DIFF
--- a/hugo/content/en/agent/guide/azure-private-link.md
+++ b/hugo/content/en/agent/guide/azure-private-link.md
@@ -51,7 +51,7 @@ You can configure Azure Private Link to expose a private IP address for each Dat
 5. After the Private DNS zone is created, select it from the list.
 6. In the panel that opens, select {{< ui >}}+ Record set{{< /ui >}}.
 7. In the {{< ui >}}Add record set{{< /ui >}} panel, configure the following:
-   - For {{< ui >}}Name{{< /ui >}}, enter `*`.
+   - For {{< ui >}}Name{{< /ui >}}, enter `@`.
    - For {{< ui >}}Type{{< /ui >}}, select {{< ui >}}A - Address record{{< /ui >}}.
    - For {{< ui >}}IP address{{< /ui >}}, enter the IP address you noted at the end of the previous section.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Reported by a customer: "@ is the indicator in DNS for apex records, not *."

### Merge readiness

- [x] Ready for merge

### AI assistance

None

### Additional notes
