### PR TITLE
[DOCS-14497] Clarify Link Dockerfile to vulnerabilities is CLI-only

### DIFF
--- a/hugo/content/en/security/cloud_security_management/setup/ci_cd/_index.md
+++ b/hugo/content/en/security/cloud_security_management/setup/ci_cd/_index.md
@@ -190,6 +190,10 @@ datadog-security-cli image myapp:latest --output json
 
 ## Link Dockerfile to vulnerabilities
 
+<div class="alert alert-info">
+Linking a Dockerfile to vulnerabilities is only supported when scanning with the Datadog Security CLI in CI/CD. This feature is not available for images scanned by the Datadog Agent or through agentless scanning.
+</div>
+
 To enable Datadog to link detected vulnerabilities back to the source code (Dockerfile), you must include specific **OCI image annotations** when building your container image.
 
 This allows Datadog to:

--- a/hugo/content/en/security/cloud_security_management/setup/ci_cd/_index.md
+++ b/hugo/content/en/security/cloud_security_management/setup/ci_cd/_index.md
@@ -191,7 +191,7 @@ datadog-security-cli image myapp:latest --output json
 ## Link Dockerfile to vulnerabilities
 
 <div class="alert alert-info">
-Linking a Dockerfile to vulnerabilities is only supported when scanning with the Datadog Security CLI in CI/CD. This feature is not available for images scanned by the Datadog Agent or through agentless scanning.
+Linking a Dockerfile to vulnerabilities is supported only when scanning with the Datadog Security CLI in CI/CD. This feature isn't available for images scanned by the Datadog Agent or through agentless scanning.
 </div>
 
 To enable Datadog to link detected vulnerabilities back to the source code (Dockerfile), you must include specific **OCI image annotations** when building your container image.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-14497

Adds a note to the "Link Dockerfile to vulnerabilities" section of the Container Image Scanning in CI/CD page clarifying that this feature is only supported when scanning with the Datadog Security CLI, and is not available for images scanned by the Datadog Agent or through agentless scanning.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the target section and draft the clarifying note.

### Additional notes