### PR TITLE
[On-Call] Clarify escalation logic for Live Call Routing

### DIFF
--- a/hugo/content/en/incident_response/on-call/pages/live_call_routing.md
+++ b/hugo/content/en/incident_response/on-call/pages/live_call_routing.md
@@ -61,7 +61,7 @@ Responders then have the following options:
 
 #### Escalation logic
 
-For direct call routing, the page escalates based on the outcome of each call, not on the **Escalate after X minutes** delay configured in the escalation policy. When every call at an escalation step completes without a responder answering, On-Call escalates to the next step immediately so the caller isn't left waiting. The configured step delay still appears in the escalation policy because a policy can be shared across page types, but it does not apply to direct call routing pages.
+For direct call routing, On-Call calls the responders in each step of the escalation policy. If no one answers, On-Call immediately advances to the next step and calls its responders. It does not wait for the delay configured between steps, helping connect the caller to an available responder as quickly as possible.
 
 Escalation proceeds as follows:
 

--- a/hugo/content/en/incident_response/on-call/pages/live_call_routing.md
+++ b/hugo/content/en/incident_response/on-call/pages/live_call_routing.md
@@ -61,7 +61,9 @@ Responders then have the following options:
 
 #### Escalation logic
 
-For direct call routing, escalation proceeds as follows:
+For direct call routing, the page escalates based on the outcome of each call, not on the **Escalate after X minutes** delay configured in the escalation policy. When every call at an escalation step completes without a responder answering, On-Call escalates to the next step immediately so the caller isn't left waiting. The configured step delay still appears in the escalation policy because a policy can be shared across page types, but it does not apply to direct call routing pages.
+
+Escalation proceeds as follows:
 
 - **Multiple responders at the same level**: All responders are called simultaneously. The first to answer is connected.
 - **Responder rejects a call**: The system immediately escalates to the next responder.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a clarification to the Live Call Routing page explaining that escalation
for direct call routing is triggered by call outcomes rather than the step delay
configured in the escalation policy. Also notes that the configured step delay
still appears in the policy UI (because policies can be shared across page types)
but does not apply to direct call routing pages.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code used to draft the PR title and description.

### Additional notes
