### PR TITLE
Add searchable collection_errors values to OTel mapping warning reference

### DIFF
--- a/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
+++ b/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
@@ -865,30 +865,33 @@ Mapping warnings are detected at ingestion. They do not affect billing or span r
 
 A span can display warnings not listed in the following table if Datadog adds checks. These render with a generated title based on the check that triggered the warning.
 
-| Warning | Attribute | Fix |
-|---------|-----------|-----|
-| Malformed model identifier | On `gen_ai.request.model` | Emit `gen_ai.response.model` directly, so the model name doesn't need to be parsed out of `gen_ai.request.model`. |
-| Missing input and output | Expected `gen_ai.input.messages` | Set `gen_ai.input.messages` and `gen_ai.output.messages`. |
-| Malformed input | On `gen_ai.input.messages` | Emit `gen_ai.input.messages` as a valid JSON array of messages. |
-| Malformed output | On `gen_ai.output.messages` | Emit `gen_ai.output.messages` as a valid JSON array of messages. |
-| Malformed message | On `gen_ai.input.messages` | Emit each message with a `role` and `content` field. |
-| Empty message content | On `gen_ai.output.messages` | Emit a `content` string, or `parts` entries with a recognized `type`, for example `text`, `tool_call`, `tool_call_response`. |
-| Missing embedding input | Expected `gen_ai.input.messages` | Set `gen_ai.input.messages` to the embedded text. |
-| Malformed embedding input | On `gen_ai.input.messages` | Emit `gen_ai.input.messages` as a valid JSON array of messages. |
-| Unreadable token counts | On `gen_ai.usage.input_tokens` | Emit token counts as integers, not strings or objects. |
-| Invalid token counts | On `gen_ai.usage.input_tokens` | Emit non-negative integer token counts. |
-| Unreadable cost metrics | On `gen_ai.cost.estimated_total` | Emit cost metrics as integers or floats, not strings or objects. |
-| Invalid cost metrics | On `gen_ai.cost.estimated_total` | Emit non-negative cost values. |
-| Malformed invocation parameters | On invocation parameters | Emit invocation parameters as a valid JSON object, or set them individually as `gen_ai.request.*` attributes (such as `temperature`, `top_p`, and `max_tokens`). |
-| Malformed tool definitions | On `gen_ai.tool.definitions` | Emit `gen_ai.tool.definitions` as a valid JSON array of tool definitions. |
-| Malformed tool definition | On `gen_ai.tool.definitions` | Give each tool definition a `name`, and make its `parameters` a JSON object. |
-| Missing tool name | Expected `gen_ai.tool.name` | Set `gen_ai.tool.name` on tool spans. |
-| Missing tool call name | On `gen_ai.output.messages` | Give each tool call a `name`. |
-| Missing operation name | Expected `gen_ai.operation.name` | Set `gen_ai.operation.name` to one of `chat`, `text_completion`, `embeddings`, `execute_tool`, `invoke_agent`, or `retriever`. |
-| Malformed span events | On `events` | Emit valid JSON in span events, or set `gen_ai.input.messages` and `gen_ai.output.messages` directly. |
-| Unreadable document score | On `output.documents` | Emit each document score as a number. |
-| Malformed document metadata | On `output.documents` | Emit each document's metadata as a JSON object. |
-| Unrecognized instrumentation | Expected `gen_ai.operation.name` | Set `gen_ai.operation.name` and `gen_ai.system` so Datadog can identify the instrumentation. |
+The **Search value** column lists the value stored on the span. Use it with the `@collection_errors` attribute to find flagged spans, for example `@collection_errors:otel_warning_missing_model_name`. The UI strips the `otel_warning_` prefix when it displays a warning, so the label you see does not match the value you search for.
+
+| Warning | Search value (`@collection_errors:`) | Attribute | Fix |
+|---------|--------------------------------------|-----------|-----|
+| Missing model name | `otel_warning_missing_model_name` | Expected `gen_ai.response.model` | Emit `gen_ai.response.model` directly, so the model name doesn't need to be parsed out of `gen_ai.request.model`. |
+| Missing model provider | `otel_warning_missing_model_provider` | Expected `gen_ai.provider.name` | Emit `gen_ai.provider.name` directly, so the provider doesn't need to be inferred from `gen_ai.system`. |
+| Malformed model identifier | `otel_warning_strands_model_malformed` | On `gen_ai.request.model` | Emit `gen_ai.response.model` directly, so the model name doesn't need to be parsed out of `gen_ai.request.model`. |
+| Malformed input | `otel_warning_input_malformed` | On `gen_ai.input.messages` | Emit `gen_ai.input.messages` as a valid JSON array of messages. |
+| Malformed output | `otel_warning_output_malformed` | On `gen_ai.output.messages` | Emit `gen_ai.output.messages` as a valid JSON array of messages. |
+| Malformed message | `otel_warning_message_malformed` | On `gen_ai.input.messages` | Emit each message with a `role` and `content` field. |
+| Empty message content | `otel_warning_invalid_parts` | On `gen_ai.output.messages` | Emit a `content` string, or `parts` entries with a recognized `type`, for example `text`, `tool_call`, `tool_call_response`. |
+| Missing embedding input | `otel_warning_embedding_input_missing` | Expected `gen_ai.input.messages` | Set `gen_ai.input.messages` to the embedded text. |
+| Malformed embedding input | `otel_warning_embedding_input_malformed` | On `gen_ai.input.messages` | Emit `gen_ai.input.messages` as a valid JSON array of messages. |
+| Unreadable token counts | `otel_warning_token_usage_unparseable` | On `gen_ai.usage.input_tokens` | Emit token counts as integers, not strings or objects. |
+| Invalid token counts | `otel_warning_token_usage_invalid` | On `gen_ai.usage.input_tokens` | Emit non-negative integer token counts. |
+| Unreadable cost metrics | `otel_warning_cost_metrics_unparseable` | On `gen_ai.cost.estimated_total` | Emit cost metrics as integers or floats, not strings or objects. |
+| Invalid cost metrics | `otel_warning_cost_metrics_invalid` | On `gen_ai.cost.estimated_total` | Emit non-negative cost values. |
+| Malformed invocation parameters | `otel_warning_params_malformed` | On invocation parameters | Emit invocation parameters as a valid JSON object, or set them individually as `gen_ai.request.*` attributes (such as `temperature`, `top_p`, and `max_tokens`). |
+| Malformed tool definitions | `otel_warning_tool_definitions_malformed` | On `gen_ai.tool.definitions` | Emit `gen_ai.tool.definitions` as a valid JSON array of tool definitions. |
+| Malformed tool definition | `otel_warning_tool_definition_entry_malformed` | On `gen_ai.tool.definitions` | Give each tool definition a `name`, and make its `parameters` a JSON object. |
+| Missing tool name | `otel_warning_tool_span_name_missing` | Expected `gen_ai.tool.name` | Set `gen_ai.tool.name` on tool spans. |
+| Missing tool call name | `otel_warning_tool_call_name_missing` | On `gen_ai.output.messages` | Give each tool call a `name`. |
+| Missing operation name | `otel_warning_operation_missing` | Expected `gen_ai.operation.name` | Set `gen_ai.operation.name` to one of `chat`, `text_completion`, `embeddings`, `execute_tool`, `invoke_agent`, or `retriever`. |
+| Malformed span events | `otel_warning_failed_to_parse_span_events` | On `events` | Emit valid JSON in span events, or set `gen_ai.input.messages` and `gen_ai.output.messages` directly. |
+| Unreadable document score | `otel_warning_failed_to_parse_document_score` | On `output.documents` | Emit each document score as a number. |
+| Malformed document metadata | `otel_warning_document_metadata_malformed` | On `output.documents` | Emit each document's metadata as a JSON object. |
+| Unrecognized instrumentation | `otel_warning_spec_version_unknown` | Expected `gen_ai.operation.name` | Set `gen_ai.operation.name` and `gen_ai.system` so Datadog can identify the instrumentation. |
 
 ### Find raw span attributes for a flagged span
 

--- a/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
+++ b/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
@@ -865,7 +865,7 @@ Mapping warnings are detected at ingestion. They do not affect billing or span r
 
 A span can display warnings not listed in the following table if Datadog adds checks. These render with a generated title based on the check that triggered the warning.
 
-The **Search value** column lists the value stored on the span. Use it with the `@collection_errors` attribute to find flagged spans, for example `@collection_errors:otel_warning_missing_model_name`.
+**Search value** shows the value stored on the span. Use it with the `@collection_errors` attribute to find flagged spans, for example `@collection_errors:otel_warning_missing_model_name`.
 
 | Warning | Search value (`@collection_errors:`) | Attribute | Fix |
 |---------|--------------------------------------|-----------|-----|

--- a/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
+++ b/hugo/content/en/llm_observability/instrument/otel_instrumentation.md
@@ -865,7 +865,7 @@ Mapping warnings are detected at ingestion. They do not affect billing or span r
 
 A span can display warnings not listed in the following table if Datadog adds checks. These render with a generated title based on the check that triggered the warning.
 
-The **Search value** column lists the value stored on the span. Use it with the `@collection_errors` attribute to find flagged spans, for example `@collection_errors:otel_warning_missing_model_name`. The UI strips the `otel_warning_` prefix when it displays a warning, so the label you see does not match the value you search for.
+The **Search value** column lists the value stored on the span. Use it with the `@collection_errors` attribute to find flagged spans, for example `@collection_errors:otel_warning_missing_model_name`.
 
 | Warning | Search value (`@collection_errors:`) | Attribute | Fix |
 |---------|--------------------------------------|-----------|-----|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a **Search value** column to the mapping warning reference table in the Agent Observability OpenTelemetry instrumentation docs, listing the `otel_warning_*` value stored on each flagged span.

The UI strips the `otel_warning_` prefix when it displays a warning, so the label in the span detail panel doesn't match what you search for. This PR documents both, plus a sentence explaining the gap and showing the `@collection_errors:` query syntax.

Also:
- Adds rows for `otel_warning_missing_model_name` and `otel_warning_missing_model_provider`, which weren't in the table.
- Removes the "Missing input and output" row. There is no corresponding collection error; the input/output warnings are the four malformed/missing-embedding-input entries already listed.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

