### PR TITLE
[DOCS-15068] Work Management AI page: standard site-support banner

### DIFF
--- a/hugo/config/_default/params.yaml
+++ b/hugo/config/_default/params.yaml
@@ -428,3 +428,4 @@ unsupported_sites:
   workflow-automation: [gov,gov2]
   workflows: [gov,gov2]
   workload_security_active_protection: [gov,gov2]
+  work_management_ai_site_support: [gov,gov2]

--- a/hugo/content/en/incident_response/work_management/ai/_index.md
+++ b/hugo/content/en/incident_response/work_management/ai/_index.md
@@ -5,11 +5,8 @@ aliases:
 - /service_management/case_management/mcp_server/
 - /incident_response/case_management/mcp_server/
 - /incident_response/case_management/ai/
+site_support_id: work_management_ai_site_support
 ---
-
-{{< site-region region="gov" >}}
-<div class="alert alert-danger">AI features for Work Management are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
 
 Datadog Work Management lets you assign work items to AI agents alongside people. It integrates with the Datadog MCP Server and custom agents built with Bits Agent Builder to automate work item triage, assignment, and resolution.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15068

Replaces a hand-written, gov-only support-status alert on the Work Management AI page with the standard site-support banner mechanism, extended to cover both US1-FED and US2-FED.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the standard site-support mechanism and apply the change.

### Additional notes