### PR TITLE
docs: remove stale Salesforce Incidents integration redirects

### DIFF
--- a/hugo/content/en/integrations/_index.md
+++ b/hugo/content/en/integrations/_index.md
@@ -18,8 +18,6 @@ aliases:
     - /integrations/coreos/
     - /integrations/ubuntu/
     - /integrations/amazon-opsworks/
-    - /integrations/salesforce_incidents/
-    - /integrations/salesforce-incidents/
 description: Gather data from all of your systems, apps, & services
 algolia:
     tags: ['integration', 'integration setup']


### PR DESCRIPTION
## Summary

Remove stale redirect aliases for the deprecated Salesforce Incidents integration page. The integration page itself was already removed previously — only these redirects remained, pointing `/integrations/salesforce_incidents/` and `/integrations/salesforce-incidents/` to the integrations index.

This is NOT the API reference removal (that's handled by the spec repo at DataDog/datadog-api-spec#6529). This is just cleaning up leftover redirects for the manually-authored integration page.

**Related:** ddoghq/dogweb#3287 (endpoint removal)