### PR TITLE
[DOCS-15428] Update params.yaml

### DIFF
--- a/hugo/config/_default/params.yaml
+++ b/hugo/config/_default/params.yaml
@@ -288,6 +288,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  ai_credit_limits: [gov, gov2]
   amazon-security-lake: [gov, gov2]
   resource_catalog_policies: [gov, gov2]
   runtime_prioritization_engine: [gov, gov2]


### PR DESCRIPTION
## [DOCS-15428] Mark AI credit limits in billing as not supported for US1\US2-FED

**Jira:** [DOCS-15428](https://datadoghq.atlassian.net/browse/DOCS-15428)

**Changes:** Added [gov, gov2] to `ai_credit_limits`.

[DOCS-15428]: https://datadoghq.atlassian.net/browse/DOCS-15428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-15428]: https://datadoghq.atlassian.net/browse/DOCS-15428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Banner at https://docs-staging.datadoghq.com/auto/DOCS-15428-2026-08-27/account_management/billing/ai_credit_limits/?site=gov2