### PR TITLE
(DOCS-14725) Add support banner to LLM Observability dataset

### DIFF
--- a/hugo/config/_default/params.yaml
+++ b/hugo/config/_default/params.yaml
@@ -382,6 +382,7 @@ unsupported_sites:
   linear_error_tracking: [gov,gov2]
   live_debugger: [gov,gov2]
   llm_observability: [gov,gov2]
+  dd.llm_observability.dataset: [gov,gov2]
   mcp_server: [gov,gov2]
   mobile_app_testing: [gov,gov2]
   nebius-cloud: [gov,gov2]


### PR DESCRIPTION
### What does this PR do? What is the motivation?

I'm a little surprised this worked TBH. Adds a banner to US1-FED and US2-FED for `/ddsql_reference/data_directory/dd/dd.llm_observability.dataset/`

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->