### PR TITLE
[DOCS-14984] Add rum_roku site support id to Roku RUM pages

### DIFF
--- a/hugo/content/en/real_user_monitoring/application_monitoring/roku/_index.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/roku/_index.md
@@ -14,6 +14,7 @@ further_reading:
 - link: /real_user_monitoring
   tag: Documentation
   text: Explore Datadog RUM
+site_support_id: rum_roku
 ---
 ## Overview
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/roku/troubleshooting.mdoc.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/roku/troubleshooting.mdoc.md
@@ -8,5 +8,6 @@ further_reading:
 - link: /real_user_monitoring
   tag: Documentation
   text: Explore Real User Monitoring
+site_support_id: rum_roku
 ---
 {% partial file="sdk/troubleshooting/roku.mdoc.md" /%}

--- a/hugo/content/en/real_user_monitoring/application_monitoring/roku/web_view_tracking.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/roku/web_view_tracking.md
@@ -3,6 +3,7 @@ title: Roku Web View Tracking
 description: "Monitor web views within Roku channels to track performance and user interactions between Roku and web-based content."
 aliases:
   - /real_user_monitoring/mobile_and_tv_monitoring/roku/web_view_tracking
+site_support_id: rum_roku
 ---
 
 {{< include-markdown "real_user_monitoring/application_monitoring/web_view_tracking" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds `site_support_id: rum_roku` to the three Roku RUM pages that currently render no unsupported-site banner on `?site=gov` / `?site=gov2`:

- `roku/_index.md`
- `roku/troubleshooting.mdoc.md`
- `roku/web_view_tracking.md`

Seven sibling pages in the same directory already carry this id, so these three were the gap. Federal Support internal review flagged the landing page as misleading — it renders full setup-oriented RUM content on `?site=gov` with no availability signal, and Roku RUM is not supported on Datadog for Government sites.

No `params.yaml` change: `rum_roku: [gov,gov2]` is already registered under `unsupported_sites`.

`troubleshooting.md` is generated from `troubleshooting.mdoc.md` and inherits the id from its source, so it needs no separate edit.

### Merge readiness

- [x] Ready for merge

### Review checklist

- Verify the banner renders on `?site=gov` and `?site=gov2` for all three pages after merge.