### PR TITLE
Clarify BYOC Logs reverse connection pods

### DIFF
--- a/hugo/content/en/byoc-logs/introduction/network.md
+++ b/hugo/content/en/byoc-logs/introduction/network.md
@@ -37,7 +37,7 @@ If your environment uses an HTTP proxy, BYOC Logs supports standard proxy config
 
 Only **searcher** pods establish the reverse connection. Indexers, the control plane, the metastore, and the janitor do not initiate any connection to Datadog.
 
-<div class="alert alert-warning">Keep at least one searcher pod running when using the reverse connection. If all searcher pods are unavailable or scaled to <code>0</code>, Datadog cannot route queries or index management requests through the reverse connection until a searcher pod starts and reconnects. The BYOC Logs control plane does not provide a fallback reverse connection.</div>
+<div class="alert alert-warning">Keep at least one searcher pod running when using the reverse connection. If all searcher pods are unavailable or scaled to <code>0</code>, Datadog cannot route queries or index management requests through the reverse connection until a searcher pod starts and reconnects.</div>
 
 ## Public ingress (optional)
 

--- a/hugo/content/en/byoc-logs/introduction/network.md
+++ b/hugo/content/en/byoc-logs/introduction/network.md
@@ -37,6 +37,8 @@ If your environment uses an HTTP proxy, BYOC Logs supports standard proxy config
 
 Only **searcher** pods establish the reverse connection. Indexers, the control plane, the metastore, and the janitor do not initiate any connection to Datadog.
 
+<div class="alert alert-warning">Keep at least one searcher pod running when using the reverse connection. If all searcher pods are unavailable or scaled to <code>0</code>, Datadog cannot route queries or index management requests through the reverse connection until a searcher pod starts and reconnects. The BYOC Logs control plane does not provide a fallback reverse connection.</div>
+
 ## Public ingress (optional)
 
 It is also possible to configure BYOC Logs to deploy a public ingress so Datadog can establish the connection in the other direction.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Clarifies that BYOC Logs searcher pods maintain the reverse connection to Datadog.

Adds a warning that at least one searcher pod must be running when using the reverse connection. If all searcher pods are unavailable or scaled to `0`, Datadog cannot route queries or index management requests through the reverse connection until a searcher pod reconnects.

Replaces #39545 with a verified commit.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
