### PR TITLE
[SEC-36327] Add Security findings to Preview in DAC

### DIFF
--- a/hugo/content/en/account_management/rbac/data_access.md
+++ b/hugo/content/en/account_management/rbac/data_access.md
@@ -78,6 +78,7 @@ The following are available as a Preview upon request:
 - Hosts
 - Processes
 - Containers
+- Security findings (Cloud Security findings only)
 
 ## Advanced configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds "Security findings (Cloud Security findings only)" to the list of data types available as a Preview upon request in the DAC documentation.

**[Preview](https://docs-staging.datadoghq.com/hugo/sec-36327-security-findings-preview/account_management/rbac/data_access)**