### PR TITLE
Add WebdriverIO and logging support to Test Optimization docs

### DIFF
--- a/hugo/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/hugo/content/en/tests/correlate_logs_and_tests/_index.md
@@ -40,8 +40,8 @@ Use the following environment variables to enable and configure Agentless log su
 
 Agentless log submission is supported for the following tracer versions and logging libraries:
 
-- `dd-trace-js >= 4.48.0` or `dd-trace-js >= 5.24.0` with `winston`.
-- `dd-trace-js >= 5.124.0` or `dd-trace-js >= 6.13.0` with `pino` or `bunyan`.
+- `dd-trace-js v4.48.0 or later` on the v4 release line, or `dd-trace-js v5.24.0 or later` on the v5 release line, with `winston`.
+- `dd-trace-js v5.124.0 or later` on the v5 release line, or `dd-trace-js v6.13.0 or later` on the v6 release line, with `pino` or `bunyan`.
 
 Use the following environment variables to enable and configure Agentless log submission:
 

--- a/hugo/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/hugo/content/en/tests/correlate_logs_and_tests/_index.md
@@ -41,6 +41,7 @@ Use the following environment variables to enable and configure Agentless log su
 Agentless log submission is supported for the following tracer versions and logging libraries:
 
 - `dd-trace-js >= 5.24.0` or `dd-trace-js >= 4.48.0` with `winston`.
+- `dd-trace-js` v4.48.0 or later, or v5.24.0 or later, with `winston`.
 - `dd-trace-js` v5.124.0 or later, or v6.13.0 or later, with `pino` or `bunyan`.
 
 Use the following environment variables to enable and configure Agentless log submission:

--- a/hugo/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/hugo/content/en/tests/correlate_logs_and_tests/_index.md
@@ -36,11 +36,12 @@ Use the following environment variables to enable and configure Agentless log su
 | `DD_AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE` (optional) | Sets the maximum size of pending logs queue | `1024`        |
 | `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional)        | Sets custom URL for submitting logs         | -             |
 
-### Javascript/Typescript
+### JavaScript/TypeScript
 
-Agentless log submission is supported for the following languages and frameworks:
+Agentless log submission is supported for the following tracer versions and logging libraries:
 
--   `dd-trace-js >= 5.24.0` and `dd-trace-js >= 4.48.0` and `winston`.
+- `dd-trace-js >= 5.24.0` or `dd-trace-js >= 4.48.0` with `winston`.
+- `dd-trace-js` v5.124.0 or later, or v6.13.0 or later, with `pino` or `bunyan`.
 
 Use the following environment variables to enable and configure Agentless log submission:
 

--- a/hugo/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/hugo/content/en/tests/correlate_logs_and_tests/_index.md
@@ -40,9 +40,8 @@ Use the following environment variables to enable and configure Agentless log su
 
 Agentless log submission is supported for the following tracer versions and logging libraries:
 
-- `dd-trace-js >= 5.24.0` or `dd-trace-js >= 4.48.0` with `winston`.
-- `dd-trace-js` v4.48.0 or later, or v5.24.0 or later, with `winston`.
-- `dd-trace-js` v5.124.0 or later, or v6.13.0 or later, with `pino` or `bunyan`.
+- `dd-trace-js >= 4.48.0` or `dd-trace-js >= 5.24.0` with `winston`.
+- `dd-trace-js >= 5.124.0` or `dd-trace-js >= 6.13.0` with `pino` or `bunyan`.
 
 Use the following environment variables to enable and configure Agentless log submission:
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -34,7 +34,8 @@ further_reading:
 | Cucumber | >= 7.0.0 |
 | Cypress | >= 12.0.0 |
 | Playwright | >= 1.38.0 |
-| Vitest | >= 1.6.0 | [`test.concurrent`](https://vitest.dev/api/#test-concurrent) is supported from `dd-trace>=6.1.0`. |
+| Vitest | >= 1.6.0 | [`test.concurrent`](https://vitest.dev/api/#test-concurrent) is supported from `dd-trace>=6.1.0`. [Browser mode](https://vitest.dev/guide/browser/) is supported from `dd-trace>=6.8.0`. |
+| WebdriverIO | >= 9.0.0 | Supported with the Mocha and Jasmine framework adapters from `dd-trace>=6.10.0`. |
 
 `dd-trace` v6 requires Node.js 22 or later.
 
@@ -48,7 +49,8 @@ further_reading:
 | Cucumber | >= 7.0.0 |
 | Cypress | >= 6.7.0 |
 | Playwright | >= 1.18.0 |
-| Vitest | >= 1.6.0 | Supported from `dd-trace>=5.18.0`. [`test.concurrent`](https://vitest.dev/api/#test-concurrent) is supported from `dd-trace>=5.112.0`. |
+| Vitest | >= 1.6.0 | Supported from `dd-trace>=5.18.0`. [`test.concurrent`](https://vitest.dev/api/#test-concurrent) is supported from `dd-trace>=5.112.0`. [Browser mode](https://vitest.dev/guide/browser/) is supported from `dd-trace>=5.119.0`. |
+| WebdriverIO | >= 9.0.0 | Supported with the Mocha and Jasmine framework adapters from `dd-trace>=5.121.0`. |
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -443,12 +445,13 @@ To enable screenshot uploads, set the `DD_TEST_FAILURE_SCREENSHOTS_ENABLED` envi
 [10]: https://docs.cypress.io/app/references/configuration#Screenshots
 {{% /tab %}}
 
-{{% tab "Vitest" %}}
+{{% tab "Vitest/WebdriverIO" %}}
 <div class="alert alert-danger">
   <strong>Note</strong>: <a href="https://github.com/vitest-dev/vitest?tab=readme-ov-file#features">Vitest is ESM first</a>, so its configuration is different from other test frameworks.
 </div>
 
-Use a Node.js version supported by your `dd-trace` major version for Vitest instrumentation:
+Use a Node.js version supported by your `dd-trace` major version for Vitest and WebdriverIO instrumentation:
+
 - `dd-trace` v5 requires Node.js 18.19+ or Node.js 20.6+.
 - `dd-trace` v6 requires Node.js 22 or later.
 
@@ -463,12 +466,13 @@ NODE_OPTIONS="--import dd-trace/register.js -r dd-trace/ci/init" DD_TEST_SESSION
 {{< code-block lang="json" filename="package.json" >}}
 {
   "scripts": {
-    "test": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" vitest run"
+    "test:vitest": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" vitest run",
+    "test:webdriverio": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" wdio run ./wdio.conf.js"
   }
 }
 {{< /code-block >}}
 
-### Adding custom tags or measures to tests
+### Adding custom tags or measures to Vitest tests
 
 You can add custom tags to your tests by using the current active span:
 
@@ -626,7 +630,7 @@ For more information about `service` and `env` reserved tags, see [Unified Servi
   <strong>Note</strong>: The manual testing API is available starting in <code>dd-trace</code> versions <code>5.23.0</code> and <code>4.47.0</code>.
 </div>
 
-If you use Jest, Mocha, Cypress, Playwright, Cucumber, or Vitest, **do not use the manual testing API**, as Test Optimization automatically instruments them and sends the test results to Datadog. The manual testing API is **incompatible** with already supported testing frameworks.
+If you use Jest, Mocha, Cypress, Playwright, Cucumber, Vitest, or WebdriverIO, **do not use the manual testing API**. Test Optimization automatically instruments these frameworks and sends the test results to Datadog. The manual testing API is **incompatible** with supported testing frameworks.
 
 Use the manual testing API only if you use an unsupported testing framework or have a different testing mechanism.
 
@@ -763,9 +767,6 @@ Jest's [--forceExit][15] option may cause data loss. Datadog tries to send data 
 ### Mocha's `--exit`
 Mocha's [--exit][16] option may cause data loss. Datadog tries to send data immediately after your tests finish, but shutting down the process abruptly can cause some requests to fail. Use `--exit` with caution.
 
-### Vitest's browser mode
-Vitest's [browser mode][17] is not supported.
-
 ### Vitest's test duration overhead
 
 By default, Vitest's [`isolate`][21] option is `true`, so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][20] for instrumentation, which incurs a setup cost every time a suite starts. With isolation, that setup cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
@@ -856,7 +857,6 @@ The test session name should be unique within a repository to help you distingui
 [13]: https://docs.cypress.io/app/core-concepts/test-isolation
 [15]: https://jestjs.io/docs/cli#--forceexit
 [16]: https://mochajs.org/running/cli/#--exit
-[17]: https://vitest.dev/guide/browser/
 [18]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
 [19]: https://www.npmjs.com/package/mocha-each
 [20]: https://github.com/nodejs/import-in-the-middle

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -445,12 +445,12 @@ To enable screenshot uploads, set the `DD_TEST_FAILURE_SCREENSHOTS_ENABLED` envi
 [10]: https://docs.cypress.io/app/references/configuration#Screenshots
 {{% /tab %}}
 
-{{% tab "Vitest/WebdriverIO" %}}
+{{% tab "Vitest" %}}
 <div class="alert alert-danger">
   <strong>Note</strong>: <a href="https://github.com/vitest-dev/vitest?tab=readme-ov-file#features">Vitest is ESM first</a>, so its configuration is different from other test frameworks.
 </div>
 
-Use a Node.js version supported by your `dd-trace` major version for Vitest and WebdriverIO instrumentation:
+Use a Node.js version supported by your `dd-trace` major version for Vitest instrumentation:
 
 - `dd-trace` v5 requires Node.js 18.19+ or Node.js 20.6+.
 - `dd-trace` v6 requires Node.js 22 or later.
@@ -466,13 +466,12 @@ NODE_OPTIONS="--import dd-trace/register.js -r dd-trace/ci/init" DD_TEST_SESSION
 {{< code-block lang="json" filename="package.json" >}}
 {
   "scripts": {
-    "test:vitest": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" vitest run",
-    "test:webdriverio": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" wdio run ./wdio.conf.js"
+    "test": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" vitest run"
   }
 }
 {{< /code-block >}}
 
-### Adding custom tags or measures to Vitest tests
+### Adding custom tags or measures to tests
 
 You can add custom tags to your tests by using the current active span:
 
@@ -501,6 +500,70 @@ test('sum function can sum', () => {
   testSpan.setTag('memory_allocations', 16)
 
   expect(1 + 2).toBe(3)
+})
+```
+
+For more information about custom measures, see the [Add Custom Measures Guide][2].
+
+[1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
+[2]: /tests/guides/add_custom_measures/?tab=javascripttypescript
+{{% /tab %}}
+
+{{% tab "WebdriverIO" %}}
+Use a Node.js version supported by your `dd-trace` major version for WebdriverIO instrumentation:
+
+- `dd-trace` v5 requires Node.js 18.19+ or Node.js 20.6+.
+- `dd-trace` v6 requires Node.js 22 or later.
+
+Set the `NODE_OPTIONS` environment variable to `--import dd-trace/register.js -r dd-trace/ci/init`. Run your tests as you normally would, optionally specifying a name for your test session with `DD_TEST_SESSION_NAME`:
+
+```bash
+NODE_OPTIONS="--import dd-trace/register.js -r dd-trace/ci/init" DD_TEST_SESSION_NAME=e2e-tests yarn test:e2e
+```
+
+**Note**: If you set a value for `NODE_OPTIONS`, make sure it does not overwrite `--import dd-trace/register.js -r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
+
+{{< code-block lang="json" filename="package.json" >}}
+{
+  "scripts": {
+    "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" wdio run ./wdio.conf.js"
+  }
+}
+{{< /code-block >}}
+
+### Adding custom tags or measures to tests
+
+You can add custom tags to your tests by using the current active span:
+
+```javascript
+import tracer from 'dd-trace'
+
+describe('home page', () => {
+  it('displays the heading', async () => {
+    const testSpan = tracer.scope().active()
+    testSpan.setTag('team_owner', 'my_team')
+
+    await browser.url('/')
+    await expect($('h1')).toBeDisplayed()
+  })
+})
+```
+
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][1] section of the Node.js custom instrumentation documentation.
+
+You can also add custom measures to your tests by using the current active span:
+
+```javascript
+import tracer from 'dd-trace'
+
+describe('home page', () => {
+  it('displays the heading', async () => {
+    const testSpan = tracer.scope().active()
+    testSpan.setTag('memory_allocations', 16)
+
+    await browser.url('/')
+    await expect($('h1')).toBeDisplayed()
+  })
 })
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents Test Optimization support for WebdriverIO 9 with the Mocha and Jasmine adapters, including the required `dd-trace` versions and instrumentation steps.

Also documents the `dd-trace` versions that added Vitest browser mode support and the upcoming versions that add agentless log submission for Pino and Bunyan.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Codex to research `dd-trace-js` release versions and assist with drafting and validation.

### Additional notes

Pino and Bunyan support targets the unreleased `dd-trace` v5.124.0 and v6.13.0 minor versions.

Validation:

- Vale reports no findings on changed lines.
- `git diff --check` passes.
- The English Hugo site renders the changed pages. The full command exits with three unrelated missing governance-data errors in the local environment.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
