### PR TITLE
Add VMWare prefix to vSphere entries in k8s distribution docs

### DIFF
--- a/hugo/content/en/containers/kubernetes/distributions.md
+++ b/hugo/content/en/containers/kubernetes/distributions.md
@@ -38,8 +38,8 @@ These configurations can then be customized to add any Datadog feature.
 * [Red Hat OpenShift](#Openshift)
 * [Rancher](#Rancher)
 * [Oracle Container Engine for Kubernetes (OKE)](#OKE)
-* [vSphere Kubernetes Service (VKS)](#VKS)
-* [vSphere Tanzu Kubernetes Grid (TKG)](#TKG)
+* [VMware vSphere Kubernetes Service (VKS)](#VKS)
+* [VMware vSphere Tanzu Kubernetes Grid (TKG)](#TKG)
 
 ## AWS Elastic Kubernetes Service (EKS) {#EKS}
 
@@ -678,7 +678,7 @@ agents:
 
 No specific configuration is required.
 
-## vSphere Kubernetes Service (VKS) {#VKS}
+## VMware vSphere Kubernetes Service (VKS) {#VKS}
 
 VKS requires the namespace where the Datadog Agent is deployed to use the privileged Pod Security Standard. Before deploying the Datadog Agent, replace `<namespace>` with the namespace where you deploy `datadog-agent` and run:
 
@@ -752,7 +752,7 @@ agents:
 
 {{< /tabs >}}
 
-## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
+## VMware vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 
 TKG requires some small configuration changes, shown below. For example, setting a toleration is required for the controller to schedule the Node Agent on the `master` nodes.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Updates the vSphere entries in the Kubernetes Distributions page to be prefixed by VMWare, based on external feedback.

Follow-up to this PR: https://github.com/DataDog/documentation/pull/39507

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
