### PR TITLE
[CCR-3693] Add Azure Foundry prompt caching recommendation

### DIFF
--- a/hugo/content/en/cloud_cost_management/recommendations/_index.md
+++ b/hugo/content/en/cloud_cost_management/recommendations/_index.md
@@ -444,6 +444,12 @@ multifiltersearch:
       recommendation_type: Delete Container Registry
       recommendation_description: A Container Registry that has never received successful pulls.
       recommendation_prerequisites: ""
+    - category: Configure
+      cloud_provider: Azure
+      resource_type: Foundry Account
+      recommendation_type: Optimize Prompt Caching
+      recommendation_description: Identifies Azure Foundry accounts already using prompt caching below the target hit rate and recommends improving cache configuration to reduce input token costs.
+      recommendation_prerequisites: ""
     - category: Terminate
       cloud_provider: Azure
       resource_type: Data Explorer Cluster


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes CCR-3693

Adds the released Azure Foundry prompt caching recommendation to the Cloud Cost Recommendations documentation.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Codex to regenerate and verify the released recommendation table.

### Additional notes

The documentation table matches the released recommender generator output after this addition.