### PR TITLE
Hide write-only fields from response examples

### DIFF
--- a/hugo/assets/scripts/build-api-pages.js
+++ b/hugo/assets/scripts/build-api-pages.js
@@ -977,6 +977,10 @@ const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, p
     if (typeof data === 'object') {
       Object.entries(data).forEach(([key, value]) => {
 
+        if(tableType === "response" && value.writeOnly) {
+          return;
+        }
+
         // calculate child data in advance
         // we do this here so that we can add classes to html with this knowledge
         let childData = null;

--- a/hugo/assets/scripts/build-api-pages.js
+++ b/hugo/assets/scripts/build-api-pages.js
@@ -359,11 +359,10 @@ const filterJson = (actionType, data, parentExample = null, requiredKeys = [], l
         }
       }
 
-      if(actionType === "request" && value.readOnly) {
-        // skip
-      } else if(actionType === "curl" && value.readOnly) {
-        // skip
-      } else {
+      const shouldSkip = ((actionType === "request" || actionType === "curl") && value.readOnly)
+        || (actionType === "response" && value.writeOnly);
+
+      if(!shouldSkip) {
 
         let prefixType = '';
         let suffixType = '';

--- a/hugo/assets/scripts/tests/build-api-pages.test.js
+++ b/hugo/assets/scripts/tests/build-api-pages.test.js
@@ -929,6 +929,31 @@ describe(`filterExampleJson`, () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should hide writeonly fields on response json', () => {
+    const mockSchema = {
+      "description": "This is a test with writeonly",
+      "properties": {
+        "secret": {
+          "description": "This is a write only field",
+          "writeOnly": true,
+          "type": "string"
+        },
+        "metric": {
+          "description": "This is explicitly not writeonly",
+          "writeOnly": false,
+          "type": "string"
+        },
+        "length": {
+          "description": "This is implicitly by omission not writeonly",
+          "type": "string"
+        }
+      }
+    };
+    const actual = bp.filterExampleJson('response', mockSchema);
+    const expected = {'metric':'string', 'length': 'string'};
+    expect(actual).toEqual(expected);
+  });
+
   it('should show boolean without quotes', () => {
     const mockSchema = {
       "description": "A dashboard is Datadog’s tool for visually tracking, analyzing, and displaying\nkey performance metrics, which enable you to monitor the health of your infrastructure.",

--- a/hugo/assets/scripts/tests/build-api-pages.test.js
+++ b/hugo/assets/scripts/tests/build-api-pages.test.js
@@ -2640,6 +2640,25 @@ describe(`descColumn`, () => {
 
 describe(`rowRecursive`, () => {
 
+  it('should hide writeonly fields in response models', () => {
+    const mockData = {
+      "secretField": {
+        "type": "string",
+        "writeOnly": true
+      },
+      "visibleField": {
+        "type": "string"
+      }
+    };
+
+    const response = bp.rowRecursive("response", mockData, false);
+    const request = bp.rowRecursive("request", mockData, false);
+
+    expect(response).not.toContain('secretField');
+    expect(response).toContain('visibleField');
+    expect(request).toContain('secretField');
+  });
+
   it('should handle fields named required (properties->required)', () => {
     /*
     Required fields are usually an array of string e.g ['foo'.'bar']


### PR DESCRIPTION
### What does this PR do? What is the motivation?

API reference response examples are synthesized from their schemas. The renderer filters `readOnly` properties from requests but currently includes `writeOnly` properties in responses, which can produce payloads that the API never returns.

Exclude `writeOnly` properties from synthesized response examples for all API reference pages.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Used pi to trace the renderer behavior, implement the filter, and add the regression test.

### Additional notes

Found while reviewing the Workflow Automation preview for DataDog/datadog-api-spec#6506.
