### PR TITLE
[DOCS-15516] Update Instrumenting Node.js Serverless Applications

### DIFF
--- a/hugo/config/_default/params.yaml
+++ b/hugo/config/_default/params.yaml
@@ -288,6 +288,7 @@ core_product:
 
 # Unsupported sites for each product
 unsupported_sites:
+  durable_functions: [gov, gov2]
   ownership_of_views: [gov, gov2]
   ai_credit_limits: [gov, gov2]
   amazon-security-lake: [gov, gov2]

--- a/hugo/content/en/serverless/aws_lambda/instrumentation/nodejs.md
+++ b/hugo/content/en/serverless/aws_lambda/instrumentation/nodejs.md
@@ -407,6 +407,8 @@ To configure Datadog using SST v3, follow these steps:
 
 ## Durable Function
 
+{{< site-region region="gov,gov2" >}}<div class="alert alert-warning">This feature is not available for {{< region-param key="dd_site_name" >}}.</div>{{< /site-region >}}
+
 {{% svl-lambda-durable-function %}}
 
 ## What's next?

--- a/hugo/content/en/serverless/aws_lambda/instrumentation/python.md
+++ b/hugo/content/en/serverless/aws_lambda/instrumentation/python.md
@@ -423,6 +423,8 @@ To configure Datadog using SST v3, follow these steps:
 
 ## Durable Function
 
+{{< site-region region="gov,gov2" >}}<div class="alert alert-warning">This feature is not available for {{< region-param key="dd_site_name" >}}.</div>{{< /site-region >}}
+
 {{% svl-lambda-durable-function %}}
 
 ## What's next?


### PR DESCRIPTION
## [DOCS-15516] GovCloud Documentation Portal Update: Monitoring AWS Lambda Durable Functions

**Jira:** [DOCS-15516](https://datadoghq.atlassian.net/browse/DOCS-15516)

**Changes:** Added [gov, gov2] to `durable_functions`. Added a gov/gov2 unsupported-notice site-region banner to the Durable Function section of the Node.js Lambda instrumentation page; no other site-region blocks exist on this page requiring rebalancing. Added a gov,gov2 site-region unavailability notice above the Durable Function shortcode on python.md, matching the existing notice on nodejs.md; no other site-region blocks exist on the page to rebalance.

[DOCS-15516]: https://datadoghq.atlassian.net/browse/DOCS-15516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-15516]: https://datadoghq.atlassian.net/browse/DOCS-15516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ