### PR TITLE
[DOCS-15427] Update Kubernetes Explorer

### DIFF
--- a/hugo/content/en/containers/monitoring/kubernetes_explorer.md
+++ b/hugo/content/en/containers/monitoring/kubernetes_explorer.md
@@ -80,6 +80,8 @@ For manual setup, see [Set up Kubernetes Explorer with a DaemonSet][1].
 
 You can populate the Kubernetes Explorer using a native OpenTelemetry pipeline instead of the Datadog Agent. This setup uses the [`k8sobjects`][1] receiver to collect Kubernetes resource data and forwards it through the [Datadog Exporter's][2] orchestrator explorer functionality.
 
+{{< site-region region="gov,gov2" >}}<div class="alert alert-warning">This feature is not available for {{< region-param key="dd_site_name" >}}.</div>{{< /site-region >}}
+
 #### Prerequisites
 
 - OpenTelemetry Collector Contrib [v0.154.0][3] or later.
@@ -303,6 +305,8 @@ The [`opentelemetry-kube-stack`][1] Helm chart installs the OpenTelemetry Operat
 
 - **`cluster`** (Deployment): Scrapes kube-state-metrics, watches Kubernetes objects, and enables `orchestrator_explorer` to populate Kubernetes Explorer.
 - **`daemon`** (DaemonSet): Collects host and kubelet metrics, and exposes an OTLP endpoint for application telemetry data.
+
+{{< site-region region="gov,gov2" >}}<div class="alert alert-warning">This feature is not available for {{< region-param key="dd_site_name" >}}.</div>{{< /site-region >}}
 
 #### Prerequisites
 


### PR DESCRIPTION
## [DOCS-15427] Documentation Portal Update: Kubernetes Explorer for OTEL

**Jira:** [DOCS-15427](https://datadoghq.atlassian.net/browse/DOCS-15427)

**Changes:** No declarative changes needed. Added gov/gov2 unsupported-notice site-region banners before the Prerequisites heading in both the OpenTelemetry Collector and OpenTelemetry Kube Stack tabs on the Kubernetes Explorer page; no other site-region blocks existed on the page to rebalance.

[DOCS-15427]: https://datadoghq.atlassian.net/browse/DOCS-15427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-15427]: https://datadoghq.atlassian.net/browse/DOCS-15427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ