### PR TITLE
Fix Azure Key Vault and AWS Secrets Manager backend_type values in secrets management docs

### DIFF
--- a/hugo/content/en/observability_pipelines/configuration/secrets_management.md
+++ b/hugo/content/en/observability_pipelines/configuration/secrets_management.md
@@ -41,7 +41,7 @@ Datadog recommends using the [instance profile method][1] of retrieving secrets 
 After you [install the Worker][1], configure the Worker's [bootstrap file][2] to resolve secrets using AWS Secrets Manager:
 
 ```yaml
-backend_type: aws.secrets
+backend_type: aws
 backend_config:
   aws_session:
     aws_region: <region_name>
@@ -58,7 +58,7 @@ Before you [install the Worker][1], add the bootstrap configuration to the [`dat
 bootstrap:
   config:
     secret:
-      backend_type: aws.secrets
+      backend_type: aws
       backend_config:
         aws_session:
           aws_region: <region_name>

--- a/hugo/content/en/observability_pipelines/configuration/secrets_management.md
+++ b/hugo/content/en/observability_pipelines/configuration/secrets_management.md
@@ -147,7 +147,7 @@ To access your Key Vault, create a Managed Identity and assign it to your VM. Th
 After you [install the Worker][1], configure the Worker's [bootstrap file][2] to resolve secrets using Azure Key Vault:
 
 ```yaml
-backend_type: azure.keyvault
+backend_type: azure
 backend_config:
   keyvaulturl: <key_vault_url>
 ```
@@ -163,7 +163,7 @@ Before you [install the Worker][1], add the bootstrap configuration to the [`dat
 bootstrap:
   config:
     secret:
-      backend_type: azure.keyvault
+      backend_type: azure
       backend_config:
         keyvaulturl: <key_vault_url>
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Corrects two incorrect `backend_type` values in the Observability Pipelines Worker secrets management docs:

- Azure Key Vault: `azure.keyvault` → `azure`
- AWS Secrets Manager: `aws.secrets` → `aws`

Using the documented (incorrect) values prevented the Worker from starting.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate and fix the incorrect values.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
