### PR TITLE
Add OCI Integration Configurations to granular access page

### DIFF
--- a/hugo/content/en/account_management/rbac/granular_access.md
+++ b/hugo/content/en/account_management/rbac/granular_access.md
@@ -32,6 +32,7 @@ Use the different principals to control access patterns in your organization and
 | [Logs Pipelines][24]                             | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Monitors][3]                                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Notebooks][4]                                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [OCI Integration Configurations][27]             | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Observability Pipelines][23]                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [On-Call][22]                                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Private Action Runner][18]                      | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
@@ -76,3 +77,4 @@ A user with the `user_access_manage` permission can elevate their access to any 
 [24]: /logs/log_configuration/pipelines/#pipeline-permissions
 [25]: /getting_started/feature_flags/
 [26]: /security/cloud_siem/detect_and_monitor/critical_assets/#restrict-edit-permissions
+[27]: /integrations/oracle_cloud_infrastructure/#limit-edit-access


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds a row for **OCI Integration Configurations** to the supported-resources table on the [Granular Access Control](https://docs.datadoghq.com/account_management/rbac/granular_access/) page, with all three access types (team-based, role-based, user/service account-based) checked. The entry links to the new "Limit edit access" section in the OCI integration documentation.

The OCI integration now supports granular access controls at the tenancy level via the `oci-integration-configuration` resource type (viewer/editor relations). This is the account_management listing step of the granular access controls onboarding guide.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). Branch: `yuhuyoyo/add-oci-granular-access`
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

This PR was authored with assistance from Claude Code (model claude-glm-5.2), which made the edits to the granular access table and link reference.

### Additional notes

- from @claude