### PR TITLE
Switch gif-checker to a shallow clone

### DIFF
--- a/.github/workflows/gif_check.yml
+++ b/.github/workflows/gif_check.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
     # Branch Name Validation to be run prior to workflow


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Switches the gif-checker action to use a shallow clone, which should dramatically decrease the time it takes to complete.

### Merge readiness

- [x] Ready for merge
