### PR TITLE
[APPSEC-68968] Add Azure API Management setup docs for App and API Protection

### DIFF
--- a/hugo/content/en/security/application_security/setup/_index.md
+++ b/hugo/content/en/security/application_security/setup/_index.md
@@ -87,4 +87,5 @@ Learn how to enable App and API Protection on all the following supported platfo
 
 {{< appsec-integrations >}}
   {{< appsec-integration name="Azure App Service" avatar="azure-appserviceenvironment" link="./azure/app-service" >}}
+  {{< appsec-integration name="Azure API Management" src="integrations_logos/azure_api_management.png" link="./azure/api-management" >}}
 {{< /appsec-integrations >}}

--- a/hugo/content/en/security/application_security/setup/_index.md
+++ b/hugo/content/en/security/application_security/setup/_index.md
@@ -87,5 +87,5 @@ Learn how to enable App and API Protection on all the following supported platfo
 
 {{< appsec-integrations >}}
   {{< appsec-integration name="Azure App Service" avatar="azure-appserviceenvironment" link="./azure/app-service" >}}
-  {{< appsec-integration name="Azure API Management" src="integrations_logos/azure_api_management.png" link="./azure/api-management" >}}
+  {{< appsec-integration name="Azure API Management" avatar="azure-apimanagement" link="./azure/api-management" >}}
 {{< /appsec-integrations >}}

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -32,8 +32,6 @@ App and API Protection for Azure API Management adds threat detection and blocki
 
 Protection applies at the gateway, so it covers every API behind it in any language. That includes third-party and legacy APIs you do not own.
 
-This integration is available starting in Datadog Go tracer v2.8.0.
-
 ## How it works
 
 Azure API Management evaluates policies on the way in and on the way out. The Datadog policy adds a [`send-request`][1] callout to the Datadog callout service at each stage, then reads the decision back from a policy variable.
@@ -45,7 +43,7 @@ The exchange uses four calls:
 3. **Outbound, response headers.**
 4. **Outbound, response body.** Runs only when the previous phase asked for the body.
 
-The request ID ties all four phases to a single WAF evaluation context. If the decision is block, APIM returns the block response to the client and never calls your backend. If the decision is continue, APIM injects Datadog trace-context headers and forwards the request as usual.
+The request ID ties all four phases to a single WAF evaluation context. If an inbound phase returns a block decision, APIM returns the block response to the client and never calls your backend. If an outbound phase returns a block decision, the backend has already run, and APIM replaces its response with the block response. If the decision is continue, APIM injects Datadog trace-context headers and forwards the request as usual.
 
 The integration is fail-open at every stage. Each callout sets `ignore-error="true"`, so if the callout service is unreachable, times out, or answers with anything other than `200`, traffic proceeds unmodified. A misconfiguration shows up as missing security data rather than as broken traffic.
 
@@ -103,7 +101,7 @@ The callout service only inspects traffic the gateway sends to it, so attach the
 You have two options:
 
 - Set `deployPolicy` to `true` and let the deployment inject the policy for you. The `targetApiIds` parameter selects which APIs receive it, and defaults to all APIs.
-- Apply the provided policy XML yourself in the APIM policy editor, replacing the placeholder host with the hostname of your deployed callout service.
+- Apply the provided policy XML yourself in the APIM policy editor. Replace every occurrence of the whole placeholder URL `https://<dd-apim-callout-host>:8080` with the `calloutBaseUrl` output of the deployment, not the hostname alone. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it carries no port. Leaving the `https` scheme or the `:8080` suffix in place makes the policy miss the service and fail open.
 
 For the policy contents, attachment scopes, and how a block becomes a client response, see [Azure API Management policies for App and API Protection][2].
 
@@ -122,14 +120,9 @@ curl -v -A dd-test-scanner-log-block "https://<apim-gateway-host>/<api-path>"
 Then confirm the data reached Datadog:
 
 1. Open [Security > App and API Protection][6]. The simulated attack appears as a signal.
-2. Open [APM > Service Catalog][7] and look for the `dd-apim-callout` service. Its spans carry the tag `component:apim-callout`.
+2. Open [APM > Service Catalog][7] and look for the `apim-callout` service. Its spans carry the tag `component:apim-callout`. To publish it under a different name, set `DD_SERVICE` on the callout container.
 
-To check the callout service itself, request its health endpoint on port `8081`:
-
-```shell
-curl -s http://<callout-host>:8081/
-# {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
-```
+The callout service also exposes a health endpoint on port `8081`. The Container Apps ingress publishes only port `8080`, so that endpoint is reachable from inside the container alone. Azure Container Apps uses it for the liveness and readiness probes. To check it, review replica health in the Azure portal.
 
 ## Performance
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -28,9 +28,9 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
 {{< /callout >}}
 
-App and API Protection for Azure API Management adds threat detection and blocking to your APIM gateway without any change to your backend code. Azure API Management is a managed service, so it cannot run an in-process tracer. Instead, Datadog provides a small HTTP callout service that the gateway calls from an APIM policy. On each call, the service runs the Datadog Web Application Firewall (WAF) and returns a decision: continue, or block.
+App and API Protection for Azure API Management adds threat detection and blocking to your APIM gateway without any change to your backend code. Azure API Management is a managed service, so it cannot run an in-process tracer. Instead, Datadog provides an HTTP callout service that the gateway calls from an APIM policy. On each call, the service runs the Datadog Web Application Firewall (WAF) and returns a decision: continue or block.
 
-Because protection is applied at the gateway, it covers every API behind that gateway in any language, including third-party and legacy APIs that you do not own.
+Protection applies at the gateway, so it covers every API behind it in any language. That includes third-party and legacy APIs you do not own.
 
 This integration is available starting in Datadog Go tracer v2.8.0.
 
@@ -38,7 +38,7 @@ This integration is available starting in Datadog Go tracer v2.8.0.
 
 Azure API Management evaluates policies on the way in and on the way out. The Datadog policy adds a [`send-request`][1] callout to the Datadog callout service at each stage, then reads the decision back from a policy variable.
 
-Azure uses a four-call pattern:
+The exchange uses four calls:
 
 1. **Inbound, request headers.** The service returns a request ID, Datadog trace propagation headers, and, when body inspection applies, the number of body bytes it accepts.
 2. **Inbound, request body.** Runs only when the previous phase asked for the body.
@@ -60,8 +60,6 @@ For the policy internals, see [Azure API Management policies for App and API Pro
 - Optional: an existing Log Analytics workspace to collect Container Apps logs.
 
 ## Deploy the callout service
-
-The one-click deployment stands up everything the callout service needs and wires it into your existing APIM instance.
 
 [Deploy to Azure][4]
 
@@ -98,14 +96,14 @@ To deploy from the command line or from your own infrastructure-as-code instead,
 
 ## Apply the Datadog policy
 
-The callout service only inspects traffic that the gateway sends to it, so the Datadog policy must be attached to the APIs you want to protect.
+The callout service only inspects traffic the gateway sends to it, so attach the Datadog policy to the APIs you want to protect.
 
 You have two options:
 
 - Set `deployPolicy` to `true` and let the deployment inject the policy for you. The `targetApiIds` parameter selects which APIs receive it, and defaults to all APIs.
 - Apply the provided policy XML yourself in the APIM policy editor, replacing the placeholder host with the hostname of your deployed callout service.
 
-For the policy contents, the scopes you can attach it to, and how a block decision becomes a client response, see [Azure API Management policies for App and API Protection][2].
+For the policy contents, attachment scopes, and how a block becomes a client response, see [Azure API Management policies for App and API Protection][2].
 
 ## Validate the deployment
 
@@ -118,8 +116,6 @@ curl -v https://<apim-gateway-host>/<api-path>
 # Simulated attack: returns 403
 curl -v -A dd-test-scanner-log-block "https://<apim-gateway-host>/<api-path>"
 ```
-
-The first request succeeds. The second returns `403`.
 
 Then confirm the data reached Datadog:
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -1,0 +1,163 @@
+---
+title: Enabling App and API Protection for Azure API Management
+further_reading:
+    - link: "/security/application_security/setup/azure/api-management/configuration"
+      tag: "Documentation"
+      text: "Configuring the Azure API Management callout"
+    - link: "/security/application_security/setup/azure/api-management/policies"
+      tag: "Documentation"
+      text: "Azure API Management policies for App and API Protection"
+    - link: 'https://github.com/DataDog/dd-trace-go/tree/main/contrib/azure/apim-callout'
+      tag: "Source Code"
+      text: "App and API Protection Azure API Management callout source code"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
+{{< callout url="#" btn_hidden="true" header="App and API Protection for Azure API Management is in Preview" >}}
+To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
+{{< /callout >}}
+
+App and API Protection for Azure API Management adds threat detection and blocking to your APIM gateway without any change to your backend code. Azure API Management is a managed service, so it cannot run an in-process tracer. Instead, Datadog provides a small HTTP callout service that the gateway calls from an APIM policy. On each call, the service runs the Datadog Web Application Firewall (WAF) and returns a decision: continue, or block.
+
+Because protection is applied at the gateway, it covers every API behind that gateway in any language, including third-party and legacy APIs that you do not own.
+
+This integration is available starting in Datadog Go tracer v2.8.0.
+
+## How it works
+
+Azure API Management evaluates policies on the way in and on the way out. The Datadog policy adds a [`send-request`][1] callout to the Datadog callout service at each stage, then reads the decision back from a policy variable.
+
+Azure uses a four-call pattern:
+
+1. **Inbound, request headers.** The service returns a request ID, Datadog trace propagation headers, and, when body inspection applies, the number of body bytes it accepts.
+2. **Inbound, request body.** Runs only when the previous phase asked for the body.
+3. **Outbound, response headers.**
+4. **Outbound, response body.** Runs only when the previous phase asked for the body.
+
+The request ID ties all four phases to a single WAF evaluation context. If the decision is block, APIM returns the block response to the client and never calls your backend. If the decision is continue, APIM injects Datadog trace-context headers and forwards the request as usual.
+
+The integration is fail-open at every stage. Each callout sets `ignore-error="true"`, so if the callout service is unreachable, times out, or answers with anything other than `200`, traffic proceeds unmodified. A misconfiguration shows up as missing security data rather than as broken traffic.
+
+For the policy internals, see [Azure API Management policies for App and API Protection][2].
+
+## Prerequisites
+
+- An Azure subscription.
+- An existing Azure API Management instance on the **Developer**, **Standard v2**, or **Premium** tier. This integration places the callout service inside a virtual network and requires APIM virtual network integration, so the **Consumption** tier is not supported.
+- A [Datadog API key][3].
+- Permission to deploy ARM or Bicep templates into the target resource group, and to edit APIM policies.
+- Optional: an existing Log Analytics workspace to collect Container Apps logs.
+
+## Deploy the callout service
+
+The one-click deployment stands up everything the callout service needs and wires it into your existing APIM instance.
+
+[Deploy to Azure][4]
+
+Two parameters are required:
+
+| Parameter         | Value                                                                                                                                       |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `datadogApiKey`   | Your Datadog API key. In the Azure portal, select **Reference a Key Vault secret** to use an existing Key Vault secret instead of the value. |
+| `apimServiceName` | The name of the existing APIM instance to protect.                                                                                          |
+
+Every other parameter has a default. The template provisions:
+
+- A virtual network with separate subnets for APIM, the callout service, and the Datadog Agent. It also creates network security groups and a NAT gateway for egress.
+- The callout service on Azure Container Apps with KEDA HTTP autoscaling. Ingress is on port `8080`, the health probe on port `8081`, and the service scales from 1 to 10 replicas at 20 concurrent requests per replica.
+- The Datadog Agent on Azure Container Instances in a private subnet. The callout service sends traces and security events to it.
+- A private DNS zone and virtual network link so APIM resolves the internal Container Apps hostname.
+- Virtual network integration on the existing APIM instance, and optionally the Datadog policy itself.
+
+Useful defaults:
+
+| Parameter                     | Default                                              |
+|-------------------------------|------------------------------------------------------|
+| `namePrefix`                  | `dd-apim`                                            |
+| `datadogSite`                 | {{< region-param key="dd_site" code="true" >}}       |
+| `deployPolicy`                | `false`                                              |
+| `enableHttps`                 | `false`                                              |
+| `containerImage`              | `ghcr.io/datadog/dd-trace-go/apim-callout:latest`    |
+| `vnetAddressPrefix`           | `10.0.0.0/16`                                        |
+| `minReplicas` / `maxReplicas` | `1` / `10`                                           |
+| `concurrentRequestsThreshold` | `20`                                                 |
+| `targetApiIds`                | empty, which applies to all APIs                     |
+
+To deploy from the command line or from your own infrastructure-as-code instead, see [Configuring the Azure API Management callout][5].
+
+## Apply the Datadog policy
+
+The callout service only inspects traffic that the gateway sends to it, so the Datadog policy must be attached to the APIs you want to protect.
+
+You have two options:
+
+- Set `deployPolicy` to `true` and let the deployment inject the policy for you. The `targetApiIds` parameter selects which APIs receive it, and defaults to all APIs.
+- Apply the provided policy XML yourself in the APIM policy editor, replacing the placeholder host with the hostname of your deployed callout service.
+
+For the policy contents, the scopes you can attach it to, and how a block decision becomes a client response, see [Azure API Management policies for App and API Protection][2].
+
+## Validate the deployment
+
+Send a normal request, then a simulated attack:
+
+```shell
+# Normal request: passes through to your backend
+curl -v https://<apim-gateway-host>/<api-path>
+
+# Simulated attack: returns 403
+curl -v -A dd-test-scanner-log-block "https://<apim-gateway-host>/<api-path>"
+```
+
+The first request succeeds. The second returns `403`.
+
+Then confirm the data reached Datadog:
+
+1. Open [Security > App and API Protection][6]. The simulated attack appears as a signal.
+2. Open [APM > Service Catalog][7] and look for the `dd-apim-callout` service. Its spans carry the tag `component:apim-callout`.
+
+To check the callout service itself, request its health endpoint on port `8081`:
+
+```shell
+curl -s http://<callout-host>:8081/
+# {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
+```
+
+## Performance
+
+Measured on a 0.5 vCPU, 1 GiB Azure Container Apps deployment:
+
+| Phase                                                          | Processing time |
+|----------------------------------------------------------------|-----------------|
+| Request headers                                                | ~2.4 ms         |
+| Response headers                                               | ~2.4 ms         |
+| Full APIM pipeline, including both callouts and the backend    | ~9.7 ms         |
+
+Body phases run only when body inspection is enabled and the previous phase asked for the body. The dominant cost is network round-trip time, so deploy the callout service in the same Azure region as your APIM instance.
+
+## Compatibility
+
+For the capabilities this integration supports and the versions that introduced them, see the [App and API Protection compatibility requirements][8].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://learn.microsoft.com/en-us/azure/api-management/send-request-policy
+[2]: /security/application_security/setup/azure/api-management/policies
+[3]: https://app.datadoghq.com/organization-settings/api-keys
+[4]: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fdd-trace-go%2Fmain%2Fcontrib%2Fazure%2Fapim-callout%2Fdeploy%2Fazure%2Fazuredeploy.json
+[5]: /security/application_security/setup/azure/api-management/configuration
+[6]: https://app.datadoghq.com/security/appsec
+[7]: https://app.datadoghq.com/services
+[8]: /security/application_security/setup/compatibility/

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -61,7 +61,9 @@ For the policy internals, see [Azure API Management policies for App and API Pro
 
 ## Deploy the callout service
 
-[Deploy to Azure][4]
+Click the button below and fill in the form in the Azure portal:
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)][4]
 
 Two parameters are required:
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -105,6 +105,10 @@ You have two options:
 - Set `deployPolicy` to `true` and let the deployment inject the policy. The `targetApiIds` parameter selects which APIs receive the policy and defaults to all APIs.
 - Apply the provided policy XML yourself in the APIM policy editor. Replace every occurrence of the placeholder URL `https://<dd-apim-callout-host>:8080` with the `calloutBaseUrl` output of the deployment, not the hostname alone. The output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it does not include a port. Leaving the `https` scheme or `:8080` suffix in place causes the policy to miss the service and fail open.
 
+<div class="alert alert-warning">
+Setting <code>deployPolicy</code> to <code>true</code> <strong>replaces</strong> the policy at each selected scope. It does not merge with what is already there, so any existing rules at that scope are lost. Apply the policy yourself when the APIs you are protecting already have policy content, and merge the Datadog inbound and outbound fragments into your existing sections.
+</div>
+
 For the policy contents, attachment scopes, and how a block becomes a client response, see [Azure API Management policies for App and API Protection][2].
 
 ## Validate the deployment

--- a/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Enabling App and API Protection for Azure API Management
+description: Add threat detection and blocking to your Azure API Management gateway with the App and API Protection callout service.
 further_reading:
     - link: "/security/application_security/setup/azure/api-management/configuration"
       tag: "Documentation"
@@ -28,13 +29,13 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
 {{< /callout >}}
 
-App and API Protection for Azure API Management adds threat detection and blocking to your APIM gateway without any change to your backend code. Azure API Management is a managed service, so it cannot run an in-process tracer. Instead, Datadog provides an HTTP callout service that the gateway calls from an APIM policy. On each call, the service runs the Datadog Web Application Firewall (WAF) and returns a decision: continue or block.
+App and API Protection for Azure API Management (APIM) adds threat detection and blocking to your APIM gateway without requiring changes to your backend code. APIM is a managed service, so it cannot run an in-process tracer. Instead, Datadog provides an HTTP callout service that the gateway invokes from an APIM policy. For each request, the service runs the Datadog Web Application Firewall (WAF) and returns a decision: continue or block.
 
-Protection applies at the gateway, so it covers every API behind it in any language. That includes third-party and legacy APIs you do not own.
+Protection applies at the gateway, so it covers every API behind the gateway, regardless of language. This includes third-party and legacy APIs you do not own.
 
 ## How it works
 
-Azure API Management evaluates policies on the way in and on the way out. The Datadog policy adds a [`send-request`][1] callout to the Datadog callout service at each stage, then reads the decision back from a policy variable.
+Azure API Management evaluates policies on the way in and on the way out. The Datadog policy adds a [`send-request`][1] callout to the Datadog callout service at each stage, then reads the decision from a policy variable.
 
 The exchange uses four calls:
 
@@ -55,11 +56,12 @@ For the policy internals, see [Azure API Management policies for App and API Pro
 - An existing Azure API Management instance on the **Developer**, **Standard v2**, or **Premium** tier. This integration places the callout service inside a virtual network and requires APIM virtual network integration, so the **Consumption** tier is not supported.
 - A [Datadog API key][3].
 - Permission to deploy ARM or Bicep templates into the target resource group, and to edit APIM policies.
+- `Microsoft.Authorization/roleAssignments/write` on the APIM resource. The template grants the **API Management Service Contributor** role to a managed identity so it can configure virtual network integration. This role assignment is created on every deployment, including when `deployPolicy` is `false`.
 - Optional: an existing Log Analytics workspace to collect Container Apps logs.
 
 ## Deploy the callout service
 
-Click the button below and fill in the form in the Azure portal:
+Click **Deploy to Azure** and fill in the form in the Azure portal:
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)][4]
 
@@ -67,18 +69,18 @@ Two parameters are required:
 
 | Parameter         | Value                                                                                                                                       |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `datadogApiKey`   | Your Datadog API key. In the Azure portal, select **Reference a Key Vault secret** to use an existing Key Vault secret instead of the value. |
+| `datadogApiKey`   | Your Datadog API key. In the Azure portal, select **Reference a Key Vault secret** to use an existing Key Vault secret.|
 | `apimServiceName` | The name of the existing APIM instance to protect.                                                                                          |
 
-Every other parameter has a default. The template provisions:
+The template provisions:
 
-- A virtual network with separate subnets for APIM, the callout service, and the Datadog Agent. It also creates network security groups and a NAT gateway for egress.
+- A virtual network with separate subnets for APIM, the callout service, and the Datadog Agent. The template also creates network security groups and a NAT gateway for egress.
 - The callout service on Azure Container Apps with KEDA HTTP autoscaling. Ingress is on port `8080`, the health probe on port `8081`, and the service scales from 1 to 10 replicas at 20 concurrent requests per replica.
-- The Datadog Agent on Azure Container Instances in a private subnet. The callout service sends traces and security events to it.
-- A private DNS zone and virtual network link so APIM resolves the internal Container Apps hostname.
-- Virtual network integration on the existing APIM instance, and optionally the Datadog policy itself.
+- The Datadog Agent on Azure Container Instances in a private subnet. The callout service sends traces and security events to the Agent.
+- A private DNS zone and virtual network link so APIM can resolve the internal Container Apps hostname.
+- Virtual network integration on the existing APIM instance and, optionally, the Datadog policy itself.
 
-Useful defaults:
+Every other parameter has a default. Useful defaults include:
 
 | Parameter                     | Default                                              |
 |-------------------------------|------------------------------------------------------|
@@ -90,18 +92,18 @@ Useful defaults:
 | `vnetAddressPrefix`           | `10.0.0.0/16`                                        |
 | `minReplicas` / `maxReplicas` | `1` / `10`                                           |
 | `concurrentRequestsThreshold` | `20`                                                 |
-| `targetApiIds`                | empty, which applies to all APIs                     |
+| `targetApiIds`                | Empty, which applies to all APIs                     |
 
 To deploy from the command line or from your own infrastructure-as-code instead, see [Configuring the Azure API Management callout][5].
 
 ## Apply the Datadog policy
 
-The callout service only inspects traffic the gateway sends to it, so attach the Datadog policy to the APIs you want to protect.
+The callout service only inspects traffic that the gateway sends to it, so attach the Datadog policy to the APIs you want to protect.
 
 You have two options:
 
-- Set `deployPolicy` to `true` and let the deployment inject the policy for you. The `targetApiIds` parameter selects which APIs receive it, and defaults to all APIs.
-- Apply the provided policy XML yourself in the APIM policy editor. Replace every occurrence of the whole placeholder URL `https://<dd-apim-callout-host>:8080` with the `calloutBaseUrl` output of the deployment, not the hostname alone. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it carries no port. Leaving the `https` scheme or the `:8080` suffix in place makes the policy miss the service and fail open.
+- Set `deployPolicy` to `true` and let the deployment inject the policy. The `targetApiIds` parameter selects which APIs receive the policy and defaults to all APIs.
+- Apply the provided policy XML yourself in the APIM policy editor. Replace every occurrence of the placeholder URL `https://<dd-apim-callout-host>:8080` with the `calloutBaseUrl` output of the deployment, not the hostname alone. The output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it does not include a port. Leaving the `https` scheme or `:8080` suffix in place causes the policy to miss the service and fail open.
 
 For the policy contents, attachment scopes, and how a block becomes a client response, see [Azure API Management policies for App and API Protection][2].
 
@@ -117,12 +119,12 @@ curl -v https://<apim-gateway-host>/<api-path>
 curl -v -A dd-test-scanner-log-block "https://<apim-gateway-host>/<api-path>"
 ```
 
-Then confirm the data reached Datadog:
+Verify the results in Datadog:
 
-1. Open [Security > App and API Protection][6]. The simulated attack appears as a signal.
-2. Open [APM > Service Catalog][7] and look for the `apim-callout` service. Its spans carry the tag `component:apim-callout`. To publish it under a different name, set `DD_SERVICE` on the callout container.
+1. Open [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App and API Protection{{< /ui >}}][6] and confirm that the simulated attack appears as a signal.
+2. Open the [App and API Protection Service Inventory][7] and confirm that the `apim-callout` service appears. Its spans have the tag `component:apim-callout`. To use a different service name, set `DD_SERVICE` on the callout container.
 
-The callout service also exposes a health endpoint on port `8081`. The Container Apps ingress publishes only port `8080`, so that endpoint is reachable from inside the container alone. Azure Container Apps uses it for the liveness and readiness probes. To check it, review replica health in the Azure portal.
+The callout service also exposes a health endpoint on port `8081`. Container Apps ingress publishes only port `8080`, so the health endpoint is reachable only from within the container. Azure Container Apps uses it for liveness and readiness probes. To check its status, review replica health in the Azure portal.
 
 ## Performance
 
@@ -134,13 +136,13 @@ Measured on a 0.5 vCPU, 1 GiB Azure Container Apps deployment:
 | Response headers                                               | ~2.4 ms         |
 | Full APIM pipeline, including both callouts and the backend    | ~9.7 ms         |
 
-Body phases run only when body inspection is enabled and the previous phase asked for the body. The dominant cost is network round-trip time, so deploy the callout service in the same Azure region as your APIM instance.
+Body phases run only when body inspection is enabled and the previous phase requested the body. To minimize network round-trip time, deploy the callout service in the same Azure region as your APIM instance.
 
 ## Compatibility
 
 For the capabilities this integration supports and the versions that introduced them, see the [App and API Protection compatibility requirements][8].
 
-## Further Reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
@@ -150,5 +152,5 @@ For the capabilities this integration supports and the versions that introduced 
 [4]: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fdd-trace-go%2Fmain%2Fcontrib%2Fazure%2Fapim-callout%2Fdeploy%2Fazure%2Fazuredeploy.json
 [5]: /security/application_security/setup/azure/api-management/configuration
 [6]: https://app.datadoghq.com/security/appsec
-[7]: https://app.datadoghq.com/services
+[7]: https://app.datadoghq.com/security/appsec/inventory/services
 [8]: /security/application_security/setup/compatibility/

--- a/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
@@ -37,9 +37,9 @@ The callout service ships as the container image `ghcr.io/datadog/dd-trace-go/ap
 {{< tabs >}}
 {{% tab "Azure CLI" %}}
 
-The `deploy/azure/deploy.sh` script wraps `az deployment group create` for repeatable rollouts.
+The `deploy/azure/deploy.sh` script wraps `az deployment group create`.
 
-Before deploying, it verifies four things: the Azure CLI is installed and authenticated, Bicep is available, the resource group exists, and the APIM tier is not Consumption. It then runs `az deployment group what-if` so you can preview the changes before they are applied.
+It first checks that the Azure CLI is installed and authenticated, Bicep is available, the resource group exists, and the APIM tier is not Consumption. It then runs `az deployment group what-if` so you can preview the changes before they are applied.
 
 ```shell
 DD_API_KEY=<your-datadog-api-key> \
@@ -166,7 +166,7 @@ If the following variables are unset, the service assigns them at startup:
 | `DD_APPSEC_WAF_TIMEOUT`       | `10ms`    | Per-request WAF evaluation budget.                             |
 | `DD_TRACE_PROPAGATION_STYLE`  | `datadog` | Format of the trace-context headers injected into requests.    |
 
-APM tracing of the callout service is off by default. The value of this integration is the security signal, not a trace of the gateway hop. If a single WAF evaluation exceeds its budget, the request is allowed rather than delayed.
+If a single WAF evaluation exceeds its budget, the request is allowed rather than delayed.
 
 ## Datadog Agent connection
 
@@ -188,7 +188,7 @@ When TLS is enabled, the APIM policy must call the service over `https://`.
 
 ## Health check
 
-The health endpoint answers on its own port so that a gateway or orchestrator probe never competes with callout traffic:
+The health endpoint answers on its own port:
 
 ```shell
 curl -s http://localhost:8081/
@@ -199,7 +199,7 @@ The health endpoint returns `200` whenever the service is running, whatever the 
 
 ## Sizing and performance
 
-Measured on a 0.5 vCPU, 1 GiB Azure Container Apps deployment: the request-headers phase and the response-headers phase each take about 2.4 ms. The full APIM pipeline, including both callouts and the backend, takes about 9.7 ms.
+On a 0.5 vCPU, 1 GiB Azure Container Apps deployment, the request-headers and response-headers phases each take about 2.4 ms. The full APIM pipeline, including both callouts and the backend, takes about 9.7 ms.
 
 Body phases run only when body inspection is enabled and the previous phase asked for the body. The gateway maintains a connection pool to the callout service, so production figures can come in below these numbers.
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
@@ -170,13 +170,22 @@ If a single WAF evaluation exceeds its budget, the request is allowed rather tha
 
 ## Datadog Agent connection
 
-Configure the container to reach your Datadog Agent with the following variables:
+The callout service does not talk to Datadog directly. It sends traces and security events to a Datadog Agent, and the Agent forwards them. These are two separate containers, and each takes its own variables.
 
-| Environment variable | Default value   | Description                           |
-|----------------------|-----------------|---------------------------------------|
-| `DD_AGENT_HOST`      | `localhost`     | Hostname or IP of your Datadog Agent. |
-| `DD_API_KEY`         | (required)      | Your Datadog API key.                 |
-| `DD_SITE`            | `datadoghq.com` | Your Datadog site.                    |
+On the **callout container**:
+
+| Environment variable | Default value | Description                           |
+|----------------------|---------------|---------------------------------------|
+| `DD_AGENT_HOST`      | `localhost`   | Hostname or IP of your Datadog Agent. |
+
+On the **Datadog Agent container**:
+
+| Environment variable | Default value   | Description                          |
+|----------------------|-----------------|--------------------------------------|
+| `DD_API_KEY`         | (required)      | Your Datadog API key.                |
+| `DD_SITE`            | `datadoghq.com` | Your Datadog site.                   |
+
+Do not set `DD_API_KEY` on the callout container. The one-click deployment applies this split for you. The callout container receives `DD_AGENT_HOST`, and the Agent container receives `DD_API_KEY` and `DD_SITE` from the `datadogApiKey` and `datadogSite` parameters.
 
 Your site is {{< region-param key="dd_site" code="true" >}}.
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
@@ -1,0 +1,212 @@
+---
+title: Configuring the Azure API Management callout
+further_reading:
+    - link: "/security/application_security/setup/azure/api-management"
+      tag: "Documentation"
+      text: "Enabling App and API Protection for Azure API Management"
+    - link: "/security/application_security/setup/azure/api-management/policies"
+      tag: "Documentation"
+      text: "Azure API Management policies for App and API Protection"
+    - link: 'https://github.com/DataDog/dd-trace-go/tree/main/contrib/azure/apim-callout'
+      tag: "Source Code"
+      text: "App and API Protection Azure API Management callout source code"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
+{{< callout url="#" btn_hidden="true" header="App and API Protection for Azure API Management is in Preview" >}}
+To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
+{{< /callout >}}
+
+This page covers deploying the App and API Protection callout service outside the one-click template, and every setting the service accepts. If you have not deployed the integration yet, start with [Enabling App and API Protection for Azure API Management][1].
+
+The callout service ships as the container image `ghcr.io/datadog/dd-trace-go/apim-callout:latest`. It listens on two ports:
+
+- `8080` serves the callout endpoint, a single `POST /` that handles all request and response phases.
+- `8081` serves the health endpoint, `GET /`.
+
+## Deployment options
+
+{{< tabs >}}
+{{% tab "Azure CLI" %}}
+
+The `deploy/azure/deploy.sh` script wraps `az deployment group create` for repeatable rollouts.
+
+Before deploying, it verifies four things: the Azure CLI is installed and authenticated, Bicep is available, the resource group exists, and the APIM tier is not Consumption. It then runs `az deployment group what-if` so you can preview the changes before they are applied.
+
+```shell
+DD_API_KEY=<your-datadog-api-key> \
+  ./deploy/azure/deploy.sh \
+  --resource-group <rg-name> \
+  --apim-name <apim-service-name>
+```
+
+On success, the script prints the callout URL, the Container Apps hostname, the Datadog Agent IP address, and whether the policy was deployed.
+
+Available flags:
+
+| Flag                            | Description                                                     |
+|---------------------------------|-----------------------------------------------------------------|
+| `--resource-group`, `-g`        | Target resource group.                                          |
+| `--apim-name`                   | Name of the APIM instance to protect.                           |
+| `--apim-resource-group`         | Resource group of the APIM instance, when it differs.           |
+| `--api-ids`                     | Restrict the policy to specific API IDs.                        |
+| `--deploy-policy`               | Inject the Datadog policy.                                      |
+| `--no-deploy-policy`            | Skip policy injection.                                          |
+| `--what-if`                     | Preview the deployment without applying it.                     |
+| `--name-prefix`                 | Prefix for created resource names.                              |
+| `--container-image`             | Override the callout container image.                           |
+| `--dd-site`                     | Datadog site.                                                   |
+| `--log-analytics-workspace-id`  | Existing Log Analytics workspace for logs.                      |
+| `--vnet-address-prefix`         | Address prefix for the created virtual network.                 |
+| `--existing-vnet-id`            | Use an existing virtual network.                                |
+| `--existing-aca-subnet-id`      | Use an existing subnet for the callout service.                 |
+| `--existing-aci-subnet-id`      | Use an existing subnet for the Datadog Agent.                   |
+| `--enable-https`                | Serve the callout endpoint over HTTPS.                          |
+| `--no-locks`                    | Skip resource locks.                                            |
+| `--min-replicas`                | Minimum callout replicas.                                       |
+| `--max-replicas`                | Maximum callout replicas.                                       |
+| `--concurrent-requests`         | Concurrent requests per replica before scaling out.             |
+
+The script reads `DD_API_KEY` and `DD_SITE` from the environment.
+
+{{% /tab %}}
+
+{{% tab "Bicep module" %}}
+
+Reference the Bicep module directly from your own infrastructure-as-code:
+
+```bicep
+module apimCallout 'path/to/contrib/azure/apim-callout/deploy/azure/main.bicep' = {
+  name: 'dd-apim-callout'
+  params: {
+    datadogApiKey: keyVault.getSecret('dd-api-key')
+    apimServiceName: 'my-apim'
+    logAnalyticsWorkspaceId: logAnalytics.id
+    // every other parameter has a default
+  }
+}
+```
+
+`datadogApiKey` and `apimServiceName` are required. The remaining parameters are optional: `apimResourceGroup`, `targetApiIds`, `logAnalyticsWorkspaceId`, `namePrefix`, `location`, `datadogSite`, `deployPolicy`, `enableHttps`, `containerImage`, `vnetAddressPrefix`, `existingVnetId`, `existingAcaSubnetId`, `existingAciSubnetId`, `enableLocks`, `minReplicas`, `maxReplicas`, `concurrentRequestsThreshold`, and `customTags`.
+
+Defaults:
+
+| Parameter                     | Default                                           |
+|-------------------------------|---------------------------------------------------|
+| `namePrefix`                  | `dd-apim`                                         |
+| `datadogSite`                 | `datadoghq.com`                                   |
+| `deployPolicy`                | `false`                                           |
+| `enableHttps`                 | `false`                                           |
+| `containerImage`              | `ghcr.io/datadog/dd-trace-go/apim-callout:latest` |
+| `vnetAddressPrefix`           | `10.0.0.0/16`                                     |
+| `minReplicas` / `maxReplicas` | `1` / `10`                                        |
+| `concurrentRequestsThreshold` | `20`                                              |
+| `targetApiIds`                | empty, which applies to all APIs                  |
+
+Accepted `datadogSite` values are `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `datadoghq.eu`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, and `ddog-gov.com`. Your site is {{< region-param key="dd_site" code="true" >}}.
+
+{{% /tab %}}
+
+{{% tab "Docker" %}}
+
+For local testing or for hosting outside Azure, run the image directly:
+
+```shell
+docker run -d \
+  -p 8080:8080 \
+  -p 8081:8081 \
+  -e DD_APPSEC_ENABLED=true \
+  -e DD_AGENT_HOST=datadog-agent \
+  ghcr.io/datadog/dd-trace-go/apim-callout:latest
+```
+
+Confirm the service is up:
+
+```shell
+curl -s http://localhost:8081/
+# {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
+```
+
+A container hosted this way still needs network reachability from the APIM gateway, and a Datadog Agent to receive traces and security events.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Configuration
+
+The callout service supports the following settings:
+
+| Environment variable               | Default value | Description                                                                                                                         |
+|------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_APIM_CALLOUT_HOST`             | `0.0.0.0`     | Address the callout service listens on.                                                                                             |
+| `DD_APIM_CALLOUT_PORT`             | `8080`        | Port for the callout endpoint (`POST /`).                                                                                           |
+| `DD_APIM_CALLOUT_HEALTHCHECK_PORT` | `8081`        | Port for the health endpoint (`GET /`).                                                                                             |
+| `DD_APPSEC_ENABLED`                | `true`        | Enable the Datadog WAF.                                                                                                             |
+| `DD_APPSEC_BODY_PARSING_SIZE_LIMIT`| `10485760`    | Maximum number of body bytes analyzed, in bytes (10 MB). Set to `0` to skip body analysis, which reduces the exchange to two calls.  |
+| `DD_APIM_CALLOUT_REQUEST_TIMEOUT`  | `30s`         | Time-to-live for cached per-request state. Orphaned state is released after this duration.                                           |
+| `DD_APIM_CALLOUT_TLS`              | `false`       | Serve HTTPS instead of HTTP.                                                                                                        |
+| `DD_APIM_CALLOUT_TLS_CERT_FILE`    | (empty)       | Path to the TLS certificate. Required when TLS is enabled.                                                                          |
+| `DD_APIM_CALLOUT_TLS_KEY_FILE`     | (empty)       | Path to the TLS private key. Required when TLS is enabled.                                                                          |
+
+## Automatic defaults
+
+If the following variables are unset, the service assigns them at startup:
+
+| Environment variable          | Value     | Description                                                    |
+|-------------------------------|-----------|----------------------------------------------------------------|
+| `DD_APM_TRACING_ENABLED`      | `false`   | Send APM traces for the callout service itself.                |
+| `DD_APPSEC_WAF_TIMEOUT`       | `10ms`    | Per-request WAF evaluation budget.                             |
+| `DD_TRACE_PROPAGATION_STYLE`  | `datadog` | Format of the trace-context headers injected into requests.    |
+
+APM tracing of the callout service is off by default. The value of this integration is the security signal, not a trace of the gateway hop. If a single WAF evaluation exceeds its budget, the request is allowed rather than delayed.
+
+## Datadog Agent connection
+
+Configure the container to reach your Datadog Agent with the following variables:
+
+| Environment variable | Default value   | Description                           |
+|----------------------|-----------------|---------------------------------------|
+| `DD_AGENT_HOST`      | `localhost`     | Hostname or IP of your Datadog Agent. |
+| `DD_API_KEY`         | (required)      | Your Datadog API key.                 |
+| `DD_SITE`            | `datadoghq.com` | Your Datadog site.                    |
+
+Your site is {{< region-param key="dd_site" code="true" >}}.
+
+## Encrypting the callout endpoint
+
+To serve the callout endpoint over HTTPS, set `DD_APIM_CALLOUT_TLS` to `true` and provide both `DD_APIM_CALLOUT_TLS_CERT_FILE` and `DD_APIM_CALLOUT_TLS_KEY_FILE`. If TLS is enabled and either file is missing, the service does not start. The minimum accepted TLS version is 1.2.
+
+When TLS is enabled, the APIM policy must call the service over `https://`.
+
+## Health check
+
+The health endpoint answers on its own port so that a gateway or orchestrator probe never competes with callout traffic:
+
+```shell
+curl -s http://localhost:8081/
+# {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
+```
+
+The health endpoint returns `200` whenever the service is running, whatever the state of the WAF. Use the Datadog UI checks described in [Enabling App and API Protection for Azure API Management][1] to confirm that security data is arriving.
+
+## Sizing and performance
+
+Measured on a 0.5 vCPU, 1 GiB Azure Container Apps deployment: the request-headers phase and the response-headers phase each take about 2.4 ms. The full APIM pipeline, including both callouts and the backend, takes about 9.7 ms.
+
+Body phases run only when body inspection is enabled and the previous phase asked for the body. The gateway maintains a connection pool to the callout service, so production figures can come in below these numbers.
+
+The dominant cost is network round-trip time, not WAF evaluation. Deploy the callout service in the same Azure region as your APIM instance, and keep APIM close to your API consumers. The default autoscaling range is 1 to 10 replicas, scaling out at 20 concurrent requests per replica.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /security/application_security/setup/azure/api-management

--- a/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
@@ -51,13 +51,20 @@ DD_API_KEY=<your-datadog-api-key> \
 
 On success, the script prints the callout URL, the Container Apps hostname, the Datadog Agent IP address, and whether the policy was deployed.
 
+This example omits both `--deploy-policy` and `--no-deploy-policy`, which makes the script choose for you. It reads the existing policy at the target scope and then:
+
+- Deploys the policy when the scope has no policy, or only the default skeleton.
+- Skips deployment when it finds the Datadog callout already in place, or any custom policy content.
+
+This differs from the Bicep module, where `deployPolicy` defaults to `false`. The command above can therefore write an APIM policy. To guarantee that no policy is written, pass `--no-deploy-policy`.
+
 Available flags:
 
 | Flag                            | Description                                                     |
 |---------------------------------|-----------------------------------------------------------------|
 | `--resource-group`, `-g`        | Resource group for the deployment.                                          |
 | `--apim-name`                   | Name of the APIM instance to protect.                           |
-| `--apim-resource-group`         | Resource group containing the APIM instance, if different from the deployment resource group.           |
+| `--apim-resource-group`         | Resource group containing the APIM instance, if different from the deployment resource group. You also need permission to create resources in that resource group. The deployment creates a managed identity, a role assignment, and a deployment script there. |
 | `--api-ids`                     | Restrict the policy to specific API IDs.                        |
 | `--deploy-policy`               | Inject the Datadog policy.                                      |
 | `--no-deploy-policy`            | Skip policy injection.                                          |
@@ -66,10 +73,10 @@ Available flags:
 | `--container-image`             | Override the callout container image.                           |
 | `--dd-site`                     | Datadog site.                                                   |
 | `--log-analytics-workspace-id`  | ID of an existing Log Analytics workspace for logs.                      |
-| `--vnet-address-prefix`         | Address prefix for the created virtual network.                 |
-| `--existing-vnet-id`            | ID of an existing virtual network to use. Requires `--existing-aca-subnet-id` and `--existing-aci-subnet-id`, and the APIM instance must already be integrated with the same virtual network. |
-| `--existing-aca-subnet-id`      | ID of an existing subnet for the callout service.               |
-| `--existing-aci-subnet-id`      | ID of an existing subnet for the Datadog Agent.      |
+| `--vnet-address-prefix`         | Address space for the created virtual network. The subnet prefixes are fixed, so this value must contain them. See [Address ranges](#address-ranges). |
+| `--existing-vnet-id`            | ID of an existing virtual network to use. See [Using an existing virtual network](#using-an-existing-virtual-network) for the required subnets and their prerequisites. |
+| `--existing-aca-subnet-id`      | ID of an existing subnet for the callout service. Required with `--existing-vnet-id`. |
+| `--existing-aci-subnet-id`      | ID of an existing subnet for the Datadog Agent. Required with `--existing-vnet-id`. |
 | `--enable-https`                | Serve the callout endpoint over HTTPS.                          |
 | `--no-locks`                    | Skip resource locks.                                            |
 | `--min-replicas`                | Minimum number of callout replicas.                                       |
@@ -98,7 +105,7 @@ module apimCallout 'path/to/contrib/azure/apim-callout/deploy/azure/main.bicep' 
 
 `datadogApiKey` and `apimServiceName` are required. The remaining parameters are optional: `apimResourceGroup`, `targetApiIds`, `logAnalyticsWorkspaceId`, `namePrefix`, `location`, `datadogSite`, `deployPolicy`, `enableHttps`, `containerImage`, `vnetAddressPrefix`, `existingVnetId`, `existingAcaSubnetId`, `existingAciSubnetId`, `enableLocks`, `minReplicas`, `maxReplicas`, `concurrentRequestsThreshold`, and `customTags`.
 
-Setting `existingVnetId` changes those requirements. In that mode, `existingAcaSubnetId` and `existingAciSubnetId` become required, and the module does not create an APIM subnet. The APIM instance must therefore already be integrated with the same virtual network. Otherwise the APIM configuration step can fail, or APIM cannot resolve the callout service.
+Setting `existingVnetId` makes `existingAcaSubnetId` and `existingAciSubnetId` required, and adds prerequisites on those subnets. Setting `vnetAddressPrefix` does not move the subnets. For both, see [Networking](#networking).
 
 Defaults:
 
@@ -142,6 +149,32 @@ A container hosted this way still needs network reachability from the APIM gatew
 {{% /tab %}}
 {{< /tabs >}}
 
+## Networking
+
+### Address ranges
+
+`vnetAddressPrefix` and `--vnet-address-prefix` set the address space of the virtual network, but the subnet prefixes inside it are fixed:
+
+| Subnet             | Prefix         |
+|--------------------|----------------|
+| Callout service    | `10.0.1.0/27`  |
+| Datadog Agent      | `10.0.2.0/24`  |
+| APIM               | `10.0.3.0/27`  |
+
+Because the deployment does not derive the subnets from the address space, any value you set must contain these three prefixes. The default `10.0.0.0/16` does. A value such as `10.1.0.0/16` leaves the subnets outside the virtual network, and the deployment fails.
+
+To place the callout service in a different address range, supply your own network with `existingVnetId` instead.
+
+### Using an existing virtual network
+
+Setting `existingVnetId` makes the deployment skip the virtual network, subnets, network security groups, and NAT gateway. You supply those instead, so `existingAcaSubnetId` and `existingAciSubnetId` become required, and each subnet must meet the requirements the deployment would otherwise have set up:
+
+- The callout subnet needs a `Microsoft.App/environments` delegation, and enough addresses for the Container Apps environment.
+- The Agent subnet needs a `Microsoft.ContainerInstance/containerGroups` delegation, and outbound connectivity so the Agent can reach Datadog.
+- The callout service must reach the Agent on port `8126`.
+
+The deployment also creates no APIM subnet in this mode, so the APIM instance must already be integrated with the same virtual network. Otherwise the APIM configuration step can fail, or APIM cannot resolve the callout service.
+
 ## Configuration
 
 The callout service enables the Datadog Web Application Firewall (WAF) itself at startup, so you do not need to set `DD_APPSEC_ENABLED`.
@@ -183,10 +216,15 @@ On the **callout container**:
 
 On the **Datadog Agent container**:
 
-| Environment variable | Default value   | Description                          |
-|----------------------|-----------------|--------------------------------------|
-| `DD_API_KEY`         | (required)      | Your Datadog API key.                |
-| `DD_SITE`            | `datadoghq.com` | Your Datadog site.                   |
+| Environment variable      | Default value   | Description                                                                                       |
+|---------------------------|-----------------|---------------------------------------------------------------------------------------------------|
+| `DD_API_KEY`              | (required)      | Your Datadog API key.                                                                             |
+| `DD_SITE`                 | `datadoghq.com` | Your Datadog site.                                                                                |
+| `DD_APM_ENABLED`          | `false`         | Set to `true`. The Agent does not accept traces otherwise.                                        |
+| `DD_APM_NON_LOCAL_TRAFFIC`| `false`         | Set to `true`. The callout runs in a separate container, so its traffic is not local to the Agent. |
+| `DD_APM_RECEIVER_PORT`    | `8126`          | Port the Agent accepts traces on. The callout must be able to reach it.                           |
+
+Because the callout runs in its own container, `DD_APM_ENABLED` and `DD_APM_NON_LOCAL_TRAFFIC` are both required. Without them the Agent drops the spans and security events this integration produces. The one-click deployment sets all of these on the Agent container for you.
 
 Do not set `DD_API_KEY` on the callout container. The one-click deployment sets `DD_AGENT_HOST` on the callout container and maps `datadogApiKey` and `datadogSite` to `DD_API_KEY` and `DD_SITE` on the Agent container.
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Azure API Management callout
+description: Deploy the App and API Protection callout service with the Azure CLI, Bicep, or Docker, and configure its environment variables.
 further_reading:
     - link: "/security/application_security/setup/azure/api-management"
       tag: "Documentation"
@@ -25,11 +26,11 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
 {{< /callout >}}
 
-This page covers deploying the App and API Protection callout service outside the one-click template, and every setting the service accepts. If you have not deployed the integration yet, start with [Enabling App and API Protection for Azure API Management][1].
+This page describes how to deploy and configure the App and API Protection callout service for Azure API Management (APIM) without using the one-click template. If you have not deployed the integration yet, start with [Enabling App and API Protection for Azure API Management][1].
 
 The callout service ships as the container image `ghcr.io/datadog/dd-trace-go/apim-callout:latest`. It listens on two ports:
 
-- `8080` serves the callout endpoint, a single `POST /` that handles all request and response phases.
+- `8080` serves the callout endpoint, `POST /`, which handles all request and response phases.
 - `8081` serves the health endpoint, `GET /`.
 
 ## Deployment options
@@ -39,7 +40,7 @@ The callout service ships as the container image `ghcr.io/datadog/dd-trace-go/ap
 
 The `deploy/azure/deploy.sh` script wraps `az deployment group create`.
 
-It first checks that the Azure CLI is installed and authenticated, Bicep is available, the resource group exists, and the APIM tier is not Consumption. It then runs `az deployment group what-if` so you can preview the changes before they are applied.
+It first verifies that the Azure CLI is installed and authenticated, Bicep is available, the resource group exists, and the APIM tier is not Consumption. It then runs `az deployment group what-if` so you can preview the changes before applying them.
 
 ```shell
 DD_API_KEY=<your-datadog-api-key> \
@@ -54,9 +55,9 @@ Available flags:
 
 | Flag                            | Description                                                     |
 |---------------------------------|-----------------------------------------------------------------|
-| `--resource-group`, `-g`        | Target resource group.                                          |
+| `--resource-group`, `-g`        | Resource group for the deployment.                                          |
 | `--apim-name`                   | Name of the APIM instance to protect.                           |
-| `--apim-resource-group`         | Resource group of the APIM instance, when it differs.           |
+| `--apim-resource-group`         | Resource group containing the APIM instance, if different from the deployment resource group.           |
 | `--api-ids`                     | Restrict the policy to specific API IDs.                        |
 | `--deploy-policy`               | Inject the Datadog policy.                                      |
 | `--no-deploy-policy`            | Skip policy injection.                                          |
@@ -64,15 +65,15 @@ Available flags:
 | `--name-prefix`                 | Prefix for created resource names.                              |
 | `--container-image`             | Override the callout container image.                           |
 | `--dd-site`                     | Datadog site.                                                   |
-| `--log-analytics-workspace-id`  | Existing Log Analytics workspace for logs.                      |
+| `--log-analytics-workspace-id`  | ID of an existing Log Analytics workspace for logs.                      |
 | `--vnet-address-prefix`         | Address prefix for the created virtual network.                 |
-| `--existing-vnet-id`            | Use an existing virtual network.                                |
-| `--existing-aca-subnet-id`      | Use an existing subnet for the callout service.                 |
-| `--existing-aci-subnet-id`      | Use an existing subnet for the Datadog Agent.                   |
+| `--existing-vnet-id`            | ID of an existing virtual network to use. Requires `--existing-aca-subnet-id` and `--existing-aci-subnet-id`, and the APIM instance must already be integrated with the same virtual network. |
+| `--existing-aca-subnet-id`      | ID of an existing subnet for the callout service.               |
+| `--existing-aci-subnet-id`      | ID of an existing subnet for the Datadog Agent.      |
 | `--enable-https`                | Serve the callout endpoint over HTTPS.                          |
 | `--no-locks`                    | Skip resource locks.                                            |
-| `--min-replicas`                | Minimum callout replicas.                                       |
-| `--max-replicas`                | Maximum callout replicas.                                       |
+| `--min-replicas`                | Minimum number of callout replicas.                                       |
+| `--max-replicas`                | Maximum number of callout replicas.                                       |
 | `--concurrent-requests`         | Concurrent requests per replica before scaling out.             |
 
 The script reads `DD_API_KEY` and `DD_SITE` from the environment.
@@ -96,6 +97,8 @@ module apimCallout 'path/to/contrib/azure/apim-callout/deploy/azure/main.bicep' 
 ```
 
 `datadogApiKey` and `apimServiceName` are required. The remaining parameters are optional: `apimResourceGroup`, `targetApiIds`, `logAnalyticsWorkspaceId`, `namePrefix`, `location`, `datadogSite`, `deployPolicy`, `enableHttps`, `containerImage`, `vnetAddressPrefix`, `existingVnetId`, `existingAcaSubnetId`, `existingAciSubnetId`, `enableLocks`, `minReplicas`, `maxReplicas`, `concurrentRequestsThreshold`, and `customTags`.
+
+Setting `existingVnetId` changes those requirements. In that mode, `existingAcaSubnetId` and `existingAciSubnetId` become required, and the module does not create an APIM subnet. The APIM instance must therefore already be integrated with the same virtual network. Otherwise the APIM configuration step can fail, or APIM cannot resolve the callout service.
 
 Defaults:
 
@@ -123,33 +126,33 @@ For local testing or for hosting outside Azure, run the image directly:
 docker run -d \
   -p 8080:8080 \
   -p 8081:8081 \
-  -e DD_APPSEC_ENABLED=true \
   -e DD_AGENT_HOST=datadog-agent \
   ghcr.io/datadog/dd-trace-go/apim-callout:latest
 ```
 
-Confirm the service is up:
+Confirm the service is running:
 
 ```shell
 curl -s http://localhost:8081/
 # {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
 ```
 
-A container hosted this way still needs network reachability from the APIM gateway, and a Datadog Agent to receive traces and security events.
+A container hosted this way still needs network reachability from the APIM gateway and a Datadog Agent to receive traces and security events.
 
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Configuration
 
-The callout service supports the following settings:
+The callout service enables the Datadog Web Application Firewall (WAF) itself at startup, so you do not need to set `DD_APPSEC_ENABLED`.
+
+The service supports the following settings:
 
 | Environment variable               | Default value | Description                                                                                                                         |
 |------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APIM_CALLOUT_HOST`             | `0.0.0.0`     | Address the callout service listens on.                                                                                             |
+| `DD_APIM_CALLOUT_HOST`             | `0.0.0.0`     | Address on which the callout service listens.                                                                                            |
 | `DD_APIM_CALLOUT_PORT`             | `8080`        | Port for the callout endpoint (`POST /`).                                                                                           |
 | `DD_APIM_CALLOUT_HEALTHCHECK_PORT` | `8081`        | Port for the health endpoint (`GET /`).                                                                                             |
-| `DD_APPSEC_ENABLED`                | `true`        | Enable the Datadog WAF.                                                                                                             |
 | `DD_APPSEC_BODY_PARSING_SIZE_LIMIT`| `10485760`    | Maximum number of body bytes analyzed, in bytes (10 MB). Set to `0` to skip body analysis, which reduces the exchange to two calls.  |
 | `DD_APIM_CALLOUT_REQUEST_TIMEOUT`  | `30s`         | Time-to-live for cached per-request state. Orphaned state is released after this duration.                                           |
 | `DD_APIM_CALLOUT_TLS`              | `false`       | Serve HTTPS instead of HTTP.                                                                                                        |
@@ -162,7 +165,7 @@ If the following variables are unset, the service assigns them at startup:
 
 | Environment variable          | Value     | Description                                                    |
 |-------------------------------|-----------|----------------------------------------------------------------|
-| `DD_APM_TRACING_ENABLED`      | `false`   | Send APM traces for the callout service itself.                |
+| `DD_APM_TRACING_ENABLED`      | `false`   | Whether to send APM traces for the callout service itself.                |
 | `DD_APPSEC_WAF_TIMEOUT`       | `10ms`    | Per-request WAF evaluation budget.                             |
 | `DD_TRACE_PROPAGATION_STYLE`  | `datadog` | Format of the trace-context headers injected into requests.    |
 
@@ -170,7 +173,7 @@ If a single WAF evaluation exceeds its budget, the request is allowed rather tha
 
 ## Datadog Agent connection
 
-The callout service does not talk to Datadog directly. It sends traces and security events to a Datadog Agent, and the Agent forwards them. These are two separate containers, and each takes its own variables.
+The callout service does not send data directly to Datadog. It sends traces and security events to a Datadog Agent, which forwards them to Datadog. The callout service and Agent run in separate containers, and each has its own environment variables.
 
 On the **callout container**:
 
@@ -185,7 +188,7 @@ On the **Datadog Agent container**:
 | `DD_API_KEY`         | (required)      | Your Datadog API key.                |
 | `DD_SITE`            | `datadoghq.com` | Your Datadog site.                   |
 
-Do not set `DD_API_KEY` on the callout container. The one-click deployment applies this split for you. The callout container receives `DD_AGENT_HOST`, and the Agent container receives `DD_API_KEY` and `DD_SITE` from the `datadogApiKey` and `datadogSite` parameters.
+Do not set `DD_API_KEY` on the callout container. The one-click deployment sets `DD_AGENT_HOST` on the callout container and maps `datadogApiKey` and `datadogSite` to `DD_API_KEY` and `DD_SITE` on the Agent container.
 
 Your site is {{< region-param key="dd_site" code="true" >}}.
 
@@ -197,24 +200,24 @@ When TLS is enabled, the APIM policy must call the service over `https://`.
 
 ## Health check
 
-The health endpoint answers on its own port:
+Check the health endpoint on port `8081`:
 
 ```shell
 curl -s http://localhost:8081/
 # {"status":"ok","library":{"language":"golang","version":"2.x.x"}}
 ```
 
-The health endpoint returns `200` whenever the service is running, whatever the state of the WAF. Use the Datadog UI checks described in [Enabling App and API Protection for Azure API Management][1] to confirm that security data is arriving.
+A `200` response indicates that the service is running, but does not indicate the state of the WAF. To confirm that security data is arriving, use the Datadog UI checks described in [Enabling App and API Protection for Azure API Management][1].
 
 ## Sizing and performance
 
 On a 0.5 vCPU, 1 GiB Azure Container Apps deployment, the request-headers and response-headers phases each take about 2.4 ms. The full APIM pipeline, including both callouts and the backend, takes about 9.7 ms.
 
-Body phases run only when body inspection is enabled and the previous phase asked for the body. The gateway maintains a connection pool to the callout service, so production figures can come in below these numbers.
+Body phases run only when body inspection is enabled and the previous phase requested the body. The gateway maintains a connection pool to the callout service, which can reduce latency in production.
 
-The dominant cost is network round-trip time, not WAF evaluation. Deploy the callout service in the same Azure region as your APIM instance, and keep APIM close to your API consumers. The default autoscaling range is 1 to 10 replicas, scaling out at 20 concurrent requests per replica.
+To minimize network round-trip time, deploy the callout service in the same Azure region as your APIM instance, and keep APIM close to your API consumers. By default, the service scales from 1 to 10 replicas and scales out at 20 concurrent requests per replica.
 
-## Further Reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
@@ -41,7 +41,7 @@ Use the full document for a new policy. Use the two fragments when you already h
 
 Azure API Management evaluates policies at global, workspace, product, API, and operation scope, and `<base />` controls both inheritance and ordering between those scopes. Attach the Datadog policy at the scope you want to protect: all APIs, a single product, one API, or one operation.
 
-Before applying the policy, replace the placeholder host `<dd-apim-callout-host>` with the hostname of your deployed callout service. The policy calls `https://<dd-apim-callout-host>:8080/`. The deployment performs this substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
+The policy ships with the placeholder URL `https://<dd-apim-callout-host>:8080`. Before applying it, replace every occurrence of that whole URL with the `calloutBaseUrl` output of the deployment. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it carries no port, so replace the entire URL rather than the hostname alone. The deployment performs the same substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
 
 The policy has this shape:
 
@@ -130,7 +130,7 @@ The presence of these headers on the backend request confirms that the inbound p
 
 ## Identifying the integration in Datadog
 
-The callout service appears in APM as the `dd-apim-callout` service, and its spans carry the tag `component:apim-callout`.
+The callout service appears in APM as the `apim-callout` service, and its spans carry the tag `component:apim-callout`. To publish it under a different name, set `DD_SERVICE` on the callout container.
 
 When the WAF matches a request, the span also carries App and API Protection tags, including `appsec.event`, `appsec.blocked`, and `http.client_ip`.
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
@@ -1,0 +1,144 @@
+---
+title: Azure API Management policies for App and API Protection
+further_reading:
+    - link: "/security/application_security/setup/azure/api-management"
+      tag: "Documentation"
+      text: "Enabling App and API Protection for Azure API Management"
+    - link: "/security/application_security/setup/azure/api-management/configuration"
+      tag: "Documentation"
+      text: "Configuring the Azure API Management callout"
+    - link: 'https://learn.microsoft.com/en-us/azure/api-management/send-request-policy'
+      tag: "Documentation"
+      text: "Azure API Management send-request policy"
+    - link: 'https://github.com/DataDog/dd-trace-go/tree/main/contrib/azure/apim-callout'
+      tag: "Source Code"
+      text: "App and API Protection Azure API Management callout source code"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">
+App and API Protection is in Preview on Datadog Government site US1-FED.
+</div>
+{{< /site-region >}}
+
+{{< callout url="#" btn_hidden="true" header="App and API Protection for Azure API Management is in Preview" >}}
+To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
+{{< /callout >}}
+
+Azure API Management drives this integration entirely through policy. The policy calls the Datadog callout service with the native [`send-request`][1] policy, reads the decision from a policy variable, and either forwards the request or returns a block response.
+
+Three policy documents are provided in [`deploy/azure/policies`][2]:
+
+| File                       | Contents                                              |
+|----------------------------|-------------------------------------------------------|
+| `azure-apim-full.xml`      | The complete policy document, with both sections.     |
+| `azure-apim-inbound.xml`   | The inbound section only.                             |
+| `azure-apim-outbound.xml`  | The outbound section only.                            |
+
+Use the full document for a new policy. Use the two fragments when you already have policy content in one section and want to merge the Datadog stages into it.
+
+## Applying the policy
+
+Azure API Management evaluates policies at global, workspace, product, API, and operation scope, and `<base />` controls both inheritance and ordering between those scopes. Attach the Datadog policy at the scope you want to protect: all APIs, a single product, one API, or one operation.
+
+Before applying the policy, replace the placeholder host `<dd-apim-callout-host>` with the hostname of your deployed callout service. The policy calls `https://<dd-apim-callout-host>:8080/`. The deployment performs this substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
+
+The policy has this shape:
+
+```xml
+<policies>
+  <inbound>
+    <base />
+    <!-- Phase 1: serialize request headers, call the service, read the decision -->
+    <!-- Phase 2 (conditional): send the request body when the service asks for it -->
+    <!-- If blocked: return-response. Otherwise: inject x-datadog-* headers -->
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+    <!-- Phase 3: serialize response headers, call the service, read the decision -->
+    <!-- Phase 4 (conditional): send the response body when the service asks for it -->
+    <!-- If blocked: return-response -->
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>
+```
+
+## How the callout works
+
+Every callout is a `send-request` with `mode="new"`, `timeout="3"`, and `ignore-error="true"`, posting `application/json` to the callout service. The policy stores each response in a variable named `ddPhase1Response` through `ddPhase4Response`, and the parsed JSON body in `ddPhase1` through `ddPhase4`.
+
+The exchange has four phases:
+
+1. **Request headers.** The policy serializes the request method, scheme, authority, path with query string, client IP address, and headers, then posts them. The service replies with a request ID, trace propagation headers, and, when body inspection applies, an accepted body size. The policy stores the request ID in the variable `ddRequestId`.
+2. **Request body.** Runs only when phase 1 returned an accepted body size. The policy base64-encodes the request body, truncating it to that size, and posts it together with the request ID.
+3. **Response headers.** The policy posts the response status code and headers together with the request ID.
+4. **Response body.** Runs only when phase 3 returned an accepted body size, and handles the body the same way as phase 2.
+
+The request ID ties all four phases to a single WAF evaluation context. The callout service holds that context in an in-memory cache whose time-to-live defaults to 30 seconds, set by `DD_APIM_CALLOUT_REQUEST_TIMEOUT`. The context is created in phase 1, kept between phases, and released after the final phase or after a block.
+
+## Blocking
+
+When the WAF decides to block, the callout service answers with a `block` object:
+
+```json
+{
+  "block": {
+    "status": 403,
+    "headers": { "Content-Type": ["application/json"] },
+    "content": "<base64-encoded body>"
+  }
+}
+```
+
+The policy detects `block` and calls `return-response` to send that status code, set `Content-Type` from `block.headers` (defaulting to `application/json` when absent), and write the body by base64-decoding `block.content`.
+
+Because `return-response` cancels the rest of the pipeline, a block during an inbound phase means your backend is never called.
+
+## Fail-open behavior
+
+The callout service is never a hard dependency. Every failure path allows traffic through:
+
+| Scenario                                                     | Result                                                                                              |
+|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| The callout service is unreachable, or the call times out    | `ignore-error="true"` leaves the response variable unset, the policy skips the check, traffic continues |
+| The callout answers with a status other than `200`           | The policy treats the result as allow, and traffic continues                                        |
+| The callout receives invalid JSON                            | It answers `400` with `{}`, and the policy treats the result as allow                               |
+| The request ID is unknown in a later phase                   | The service answers `200` with `{}`, and no block is applied                                        |
+| The WAF times out, or the processor reports an error         | The service answers `200` with `{}`, and no block is applied                                        |
+| Cached request state passed its time-to-live                 | The orphaned state is released, and traffic continues                                               |
+
+Because every failure path allows traffic, a misconfiguration surfaces as missing security data rather than as broken traffic. When signals are missing, check that the WAF is enabled and that the policy is attached to the API before looking anywhere else.
+
+Policy overhead on the gateway is small. Building the JSON body with `set-body` and parsing the response variable each stay under 0.1 ms, and the conditional evaluation stays under 0.01 ms. The dominant cost is network round-trip time to the callout service.
+
+## Trace context propagation
+
+When the request is allowed, phase 1 returns propagation headers and the policy injects them into the request before forwarding it to the backend:
+
+- `x-datadog-trace-id`
+- `x-datadog-parent-id`
+- `x-datadog-sampling-priority`
+- `x-datadog-origin`
+- `x-datadog-tags`
+
+The presence of these headers on the backend request confirms that the inbound policy ran and allowed the call.
+
+## Identifying the integration in Datadog
+
+The callout service appears in APM as the `dd-apim-callout` service, and its spans carry the tag `component:apim-callout`.
+
+When the WAF matches a request, the span also carries App and API Protection tags, including `appsec.event`, `appsec.blocked`, and `http.client_ip`.
+
+The client IP address comes from the value the policy sends in phase 1. If another proxy sits in front of APIM, that value determines `http.client_ip`.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://learn.microsoft.com/en-us/azure/api-management/send-request-policy
+[2]: https://github.com/DataDog/dd-trace-go/tree/main/contrib/azure/apim-callout/deploy/azure/policies

--- a/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
@@ -25,7 +25,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
 {{< /callout >}}
 
-Azure API Management drives this integration entirely through policy. The policy calls the Datadog callout service with the native [`send-request`][1] policy, reads the decision from a policy variable, and either forwards the request or returns a block response.
+This integration runs entirely in Azure API Management policy. The policy calls the Datadog callout service with the native [`send-request`][1] policy and reads the decision from a policy variable. It then forwards the request or returns a block response.
 
 Three policy documents are provided in [`deploy/azure/policies`][2]:
 
@@ -101,7 +101,7 @@ Because `return-response` cancels the rest of the pipeline, a block during an in
 
 ## Fail-open behavior
 
-The callout service is never a hard dependency. Every failure path allows traffic through:
+Every failure path allows traffic through:
 
 | Scenario                                                     | Result                                                                                              |
 |--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -112,9 +112,9 @@ The callout service is never a hard dependency. Every failure path allows traffi
 | The WAF times out, or the processor reports an error         | The service answers `200` with `{}`, and no block is applied                                        |
 | Cached request state passed its time-to-live                 | The orphaned state is released, and traffic continues                                               |
 
-Because every failure path allows traffic, a misconfiguration surfaces as missing security data rather than as broken traffic. When signals are missing, check that the WAF is enabled and that the policy is attached to the API before looking anywhere else.
+When signals are missing, check that the WAF is enabled and that the policy is attached to the API before looking anywhere else.
 
-Policy overhead on the gateway is small. Building the JSON body with `set-body` and parsing the response variable each stay under 0.1 ms, and the conditional evaluation stays under 0.01 ms. The dominant cost is network round-trip time to the callout service.
+Building the JSON body with `set-body` and parsing the response variable each stay under 0.1 ms, and the conditional evaluation stays under 0.01 ms. The dominant cost is network round-trip time to the callout service.
 
 ## Trace context propagation
 
@@ -134,7 +134,7 @@ The callout service appears in APM as the `dd-apim-callout` service, and its spa
 
 When the WAF matches a request, the span also carries App and API Protection tags, including `appsec.event`, `appsec.blocked`, and `http.client_ip`.
 
-The client IP address comes from the value the policy sends in phase 1. If another proxy sits in front of APIM, that value determines `http.client_ip`.
+The client IP address comes from the value the policy sends in phase 1. That value sets `http.client_ip`, even when another proxy sits in front of APIM.
 
 ## Further Reading
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
@@ -1,5 +1,6 @@
 ---
 title: Azure API Management policies for App and API Protection
+description: Understand how the Azure API Management policy calls the App and API Protection callout service, applies block decisions, and propagates trace context.
 further_reading:
     - link: "/security/application_security/setup/azure/api-management"
       tag: "Documentation"
@@ -25,7 +26,7 @@ App and API Protection is in Preview on Datadog Government site US1-FED.
 To try the preview of App and API Protection for Azure API Management, use the following setup instructions.
 {{< /callout >}}
 
-This integration runs entirely in Azure API Management policy. The policy calls the Datadog callout service with the native [`send-request`][1] policy and reads the decision from a policy variable. It then forwards the request or returns a block response.
+The App and API Protection for Azure API Management (APIM) integration uses the native APIM [`send-request`][1] policy to call the Datadog callout service and reads the decision from a policy variable.
 
 Three policy documents are provided in [`deploy/azure/policies`][2]:
 
@@ -35,13 +36,13 @@ Three policy documents are provided in [`deploy/azure/policies`][2]:
 | `azure-apim-inbound.xml`   | The inbound section only.                             |
 | `azure-apim-outbound.xml`  | The outbound section only.                            |
 
-Use the full document for a new policy. Use the two fragments when you already have policy content in one section and want to merge the Datadog stages into it.
+Use the full document for a new policy. If you already have policy content, use the inbound and outbound fragments to merge the Datadog stages into the corresponding sections.
 
 ## Applying the policy
 
 Azure API Management evaluates policies at global, workspace, product, API, and operation scope, and `<base />` controls both inheritance and ordering between those scopes. Attach the Datadog policy at the scope you want to protect: all APIs, a single product, one API, or one operation.
 
-The policy ships with the placeholder URL `https://<dd-apim-callout-host>:8080`. Before applying it, replace every occurrence of that whole URL with the `calloutBaseUrl` output of the deployment. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it carries no port, so replace the entire URL rather than the hostname alone. The deployment performs the same substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
+The policy ships with the placeholder URL `https://<dd-apim-callout-host>:8080`. Before applying it, replace every occurrence of that entire URL with the `calloutBaseUrl` output of the deployment. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it does not include a port, so replace the entire URL rather than the hostname alone. The deployment performs the same substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
 
 The policy has this shape:
 
@@ -70,16 +71,16 @@ The policy has this shape:
 
 ## How the callout works
 
-Every callout is a `send-request` with `mode="new"`, `timeout="3"`, and `ignore-error="true"`, posting `application/json` to the callout service. The policy stores each response in a variable named `ddPhase1Response` through `ddPhase4Response`, and the parsed JSON body in `ddPhase1` through `ddPhase4`.
+Every callout is a `send-request` with `mode="new"`, `timeout="3"`, and `ignore-error="true"`. Each callout posts `application/json` to the callout service. The policy stores each response in `ddPhase1Response` through `ddPhase4Response` and the corresponding parsed JSON body in `ddPhase1` through `ddPhase4`.
 
 The exchange has four phases:
 
 1. **Request headers.** The policy serializes the request method, scheme, authority, path with query string, client IP address, and headers, then posts them. The service replies with a request ID, trace propagation headers, and, when body inspection applies, an accepted body size. The policy stores the request ID in the variable `ddRequestId`.
-2. **Request body.** Runs only when phase 1 returned an accepted body size. The policy base64-encodes the request body, truncating it to that size, and posts it together with the request ID.
+2. **Request body.** Runs only when phase 1 returns an accepted body size. The policy base64-encodes the request body, truncating it to that size, and posts it together with the request ID.
 3. **Response headers.** The policy posts the response status code and headers together with the request ID.
 4. **Response body.** Runs only when phase 3 returned an accepted body size, and handles the body the same way as phase 2.
 
-The request ID ties all four phases to a single WAF evaluation context. The callout service holds that context in an in-memory cache whose time-to-live defaults to 30 seconds, set by `DD_APIM_CALLOUT_REQUEST_TIMEOUT`. The context is created in phase 1, kept between phases, and released after the final phase or after a block.
+The request ID ties all four phases to a single Datadog Web Application Firewall (WAF) evaluation context. The callout service holds that context in an in-memory cache whose time-to-live defaults to 30 seconds, set by `DD_APIM_CALLOUT_REQUEST_TIMEOUT`. The context is created in phase 1, kept between phases, and released after the final phase or after a block.
 
 ## Blocking
 
@@ -95,7 +96,7 @@ When the WAF decides to block, the callout service answers with a `block` object
 }
 ```
 
-The policy detects `block` and calls `return-response` to send that status code, set `Content-Type` from `block.headers` (defaulting to `application/json` when absent), and write the body by base64-decoding `block.content`.
+The policy detects `block` and calls `return-response` to send the status code, set `Content-Type` from `block.headers` (defaulting to `application/json` when absent), and write the body by base64-decoding `block.content`.
 
 Because `return-response` cancels the rest of the pipeline, a block during an inbound phase means your backend is never called.
 
@@ -105,16 +106,16 @@ Every failure path allows traffic through:
 
 | Scenario                                                     | Result                                                                                              |
 |--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| The callout service is unreachable, or the call times out    | `ignore-error="true"` leaves the response variable unset, the policy skips the check, traffic continues |
-| The callout answers with a status other than `200`           | The policy treats the result as allow, and traffic continues                                        |
-| The callout receives invalid JSON                            | It answers `400` with `{}`, and the policy treats the result as allow                               |
-| The request ID is unknown in a later phase                   | The service answers `200` with `{}`, and no block is applied                                        |
-| The WAF times out, or the processor reports an error         | The service answers `200` with `{}`, and no block is applied                                        |
-| Cached request state passed its time-to-live                 | The orphaned state is released, and traffic continues                                               |
+| The callout service is unreachable, or the call times out    | `ignore-error="true"` leaves the response variable unset. The policy skips the check, and traffic continues. |
+| The callout answers with a status other than `200`           | The policy treats the result as allow, and traffic continues.                                        |
+| The callout receives invalid JSON                            | It returns `400` with `{}`, and the policy treats the result as allow.                               |
+| The request ID is unknown in a later phase                   | The service answers `200` with `{}`, and no block is applied.                                        |
+| The WAF times out, or the processor reports an error         | The service returns `200` with `{}`, and no block is applied.                                        |
+| Cached request state passed its time-to-live                 | The orphaned state is released, and traffic continues.                                               |
 
-When signals are missing, check that the WAF is enabled and that the policy is attached to the API before looking anywhere else.
+When signals are missing, first check that the WAF is enabled and that the policy is attached to the API.
 
-Building the JSON body with `set-body` and parsing the response variable each stay under 0.1 ms, and the conditional evaluation stays under 0.01 ms. The dominant cost is network round-trip time to the callout service.
+Building the JSON body with `set-body` and parsing the response variable each take less than 0.1 ms, and conditional evaluation takes less than 0.01 ms. The dominant cost is network round-trip time to the callout service.
 
 ## Trace context propagation
 
@@ -126,17 +127,17 @@ When the request is allowed, phase 1 returns propagation headers and the policy 
 - `x-datadog-origin`
 - `x-datadog-tags`
 
-The presence of these headers on the backend request confirms that the inbound policy ran and allowed the call.
+The presence of these headers on the backend request confirms that the inbound policy ran and allowed the request.
 
 ## Identifying the integration in Datadog
 
-The callout service appears in APM as the `apim-callout` service, and its spans carry the tag `component:apim-callout`. To publish it under a different name, set `DD_SERVICE` on the callout container.
+The callout service appears in APM as the `apim-callout` service, and its spans carry the tag `component:apim-callout`. To use a different service name, set `DD_SERVICE` on the callout container.
 
 When the WAF matches a request, the span also carries App and API Protection tags, including `appsec.event`, `appsec.blocked`, and `http.client_ip`.
 
 The client IP address comes from the value the policy sends in phase 1. That value sets `http.client_ip`, even when another proxy sits in front of APIM.
 
-## Further Reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
+++ b/hugo/content/en/security/application_security/setup/azure/api-management/policies.md
@@ -44,6 +44,8 @@ Azure API Management evaluates policies at global, workspace, product, API, and 
 
 The policy ships with the placeholder URL `https://<dd-apim-callout-host>:8080`. Before applying it, replace every occurrence of that entire URL with the `calloutBaseUrl` output of the deployment. That output is `http://<ACA-FQDN>` unless you set `enableHttps` to `true`, and it does not include a port, so replace the entire URL rather than the hostname alone. The deployment performs the same substitution for you when you set `deployPolicy` to `true`, and its `targetApiIds` parameter selects which APIs receive the policy.
 
+`azure-apim-full.xml` contains a `<base />` element in each of its four sections. APIM rejects those at global scope, so if you apply the file to all APIs, remove every `<base />` element first. Keep them when you apply the policy to a product, an API, or an operation, because they control inheritance from the enclosing scope. The deployment applies the same rule for you: it strips the elements for all-APIs deployments and keeps them when `targetApiIds` names specific APIs.
+
 The policy has this shape:
 
 ```xml
@@ -113,7 +115,13 @@ Every failure path allows traffic through:
 | The WAF times out, or the processor reports an error         | The service returns `200` with `{}`, and no block is applied.                                        |
 | Cached request state passed its time-to-live                 | The orphaned state is released, and traffic continues.                                               |
 
-When signals are missing, first check that the WAF is enabled and that the policy is attached to the API.
+Because every failure path allows traffic, a misconfiguration shows up as missing security data rather than as broken traffic. When signals are missing, check the following:
+
+1. The policy is attached to the API you are sending traffic to, at a scope that applies to it.
+2. The policy calls the right URL. Compare the `set-url` value against the `calloutBaseUrl` output of the deployment, including scheme and port.
+3. The gateway can reach the callout service on that URL. A callout that never arrives leaves no trace in the policy, because `ignore-error="true"` hides it.
+4. The callout service logs show incoming requests. If they do not, the gateway is not reaching it.
+5. The callout service can reach the Datadog Agent on port `8126`, and the Agent has `DD_APM_ENABLED` and `DD_APM_NON_LOCAL_TRAFFIC` set to `true`. Without those, the service evaluates traffic but nothing arrives in Datadog.
 
 Building the JSON body with `set-body` and parsing the response variable each take less than 0.1 ms, and conditional evaluation takes less than 0.01 ms. The dominant cost is network round-trip time to the callout service.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes APPSEC-68968

Adds setup documentation for the Azure API Management (APIM) integration for App and API Protection, which reaches APIM gateways through an HTTP callout invoked from an APIM policy. There was no documentation for this integration before this PR.

Three new pages under `security/application_security/setup/azure/api-management/`:

- **`_index.md`** — getting started. Centered on the one-click **Deploy to Azure** template: prerequisites, what the template provisions, the two required parameters, and how to validate the deployment.
- **`configuration.md`** — deploying the callout container yourself (Azure CLI, Bicep module, Docker) and the full environment variable reference.
- **`policies.md`** — the APIM policy: the four-call protocol, how a block decision becomes a client response, fail-open behavior, and trace context propagation.

Also adds an Azure API Management card to the **Microsoft Azure** group on the setup index.

Notes for reviewers:

- The integration is in Preview, so each page carries the Preview callout and the gov site-region alert, matching `setup/gcp/service-extensions.md`.
- The new card uses `src=` with the local `integrations_logos/azure_api_management.png` asset rather than `avatar=`, because there is no `azure-api-management_avatar.svg` on the logo CDN (it returns 403).
- No compatibility page is added here. Compatibility content for this integration is generated from the feature manifest repository and already lists APIM at the shared `setup/compatibility/` page, so these pages link there rather than duplicating it.
- Availability is stated as v2.8.0, which is the first released version of the `contrib/azure/apim-callout` module.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code. Every factual claim was verified against the `contrib/azure/apim-callout` source in dd-trace-go rather than its README, which corrected two errors that would otherwise have shipped: the body-parsing size limit default is `10485760` (10 MB), not `104857600`, and the variable that disables APM tracing is `DD_APM_TRACING_ENABLED`, not `DD_AGENT_APM_ENABLED`. Vale reports 0 errors and 0 warnings on the three new files. Rendering has not been checked locally; please see the branch preview.

### Additional notes

