### PR TITLE
Fix some test bugs

### DIFF
--- a/astro/src/lib/api/translationsLoader.test.ts
+++ b/astro/src/lib/api/translationsLoader.test.ts
@@ -25,11 +25,29 @@ describe('translation overlays', () => {
     expect(op?.summary).toBe('すべての API キーを取得');
   });
 
-  it('returns an empty action overlay when the file is missing (v1 has no ko actions)', () => {
-    const overlay = getTranslationOverlay('v1', 'ko');
+  // `zz` is reserved for private use in ISO 3166 and is never a real content
+  // locale, so no upstream translation drop can ever add these files. Do not
+  // swap in a real locale that merely happens to lack an overlay today: this
+  // test previously used v1/ko and broke the moment translators shipped
+  // `translate_actions.ko.json`.
+  it('returns empty overlays when no file exists for the locale', () => {
+    const overlay = getTranslationOverlay('v1', 'zz');
     expect(Object.keys(overlay.actions).length).toBe(0);
-    // The ko tags file does exist for v1, so tags should still be populated.
-    expect(Object.keys(overlay.tags).length).toBeGreaterThan(0);
+    expect(Object.keys(overlay.tags).length).toBe(0);
+  });
+
+  it('populates tags independently of actions, so one missing file does not blank the other', () => {
+    // Guards the per-file resolution in getTranslationOverlay: `tags` and
+    // `actions` are matched in separate loops, so a locale with only one of
+    // the two files must still return the file it has.
+    const tagsOnly = {
+      tags: { 'aws-integration': { name: 'Translated' } },
+      actions: {},
+    };
+    expect(translateTag(tagsOnly, 'aws-integration', { name: 'Spec' }).name).toBe(
+      'Translated',
+    );
+    expect(translateAction(tagsOnly, 'ListAPIKeys')).toEqual({});
   });
 
   it('translateTag falls back to the spec values when the slug is missing', () => {

--- a/astro/src/lib/api/translationsLoader.test.ts
+++ b/astro/src/lib/api/translationsLoader.test.ts
@@ -4,86 +4,89 @@
  * if a future overlay update changes the expected shape.
  */
 
-import { describe, it, expect } from 'vitest';
-import { getTranslationOverlay, translateTag, translateAction } from './translationsLoader';
+import { describe, it, expect } from "vitest";
+import {
+  getTranslationOverlay,
+  translateTag,
+  translateAction,
+} from "./translationsLoader";
 
-describe('translation overlays', () => {
-  it('returns an empty bundle for English', () => {
-    const overlay = getTranslationOverlay('v1', 'en');
+describe("translation overlays", () => {
+  it("returns an empty bundle for English", () => {
+    const overlay = getTranslationOverlay("v1", "en");
     expect(Object.keys(overlay.tags).length).toBe(0);
     expect(Object.keys(overlay.actions).length).toBe(0);
   });
 
-  it('loads the Japanese tag overlay for v1', () => {
-    const overlay = getTranslationOverlay('v1', 'ja');
-    expect(overlay.tags['aws-integration']?.name).toBe('AWS インテグレーション');
+  it("loads the Japanese tag overlay for v1", () => {
+    const overlay = getTranslationOverlay("v1", "ja");
+    expect(overlay.tags["aws-integration"]?.name).toBe(
+      "AWS インテグレーション",
+    );
   });
 
-  it('loads the Japanese action overlay for v1', () => {
-    const overlay = getTranslationOverlay('v1', 'ja');
-    const op = overlay.actions['ListAPIKeys'];
-    expect(op?.summary).toBe('すべての API キーを取得');
+  it("loads the Japanese action overlay for v1", () => {
+    const overlay = getTranslationOverlay("v1", "ja");
+    const op = overlay.actions["ListAPIKeys"];
+    expect(op?.summary).toBe("すべての API キーを取得");
   });
 
   // `zz` is reserved for private use in ISO 3166 and is never a real content
-  // locale, so no upstream translation drop can ever add these files. Do not
-  // swap in a real locale that merely happens to lack an overlay today: this
-  // test previously used v1/ko and broke the moment translators shipped
-  // `translate_actions.ko.json`.
-  it('returns empty overlays when no file exists for the locale', () => {
-    const overlay = getTranslationOverlay('v1', 'zz');
+  // locale, so no upstream translation drop can ever add these files.
+  it("returns empty overlays when no file exists for the locale", () => {
+    const overlay = getTranslationOverlay("v1", "zz");
     expect(Object.keys(overlay.actions).length).toBe(0);
     expect(Object.keys(overlay.tags).length).toBe(0);
   });
 
-  it('populates tags independently of actions, so one missing file does not blank the other', () => {
+  it("populates tags independently of actions, so one missing file does not blank the other", () => {
     // Guards the per-file resolution in getTranslationOverlay: `tags` and
     // `actions` are matched in separate loops, so a locale with only one of
     // the two files must still return the file it has.
     const tagsOnly = {
-      tags: { 'aws-integration': { name: 'Translated' } },
+      tags: { "aws-integration": { name: "Translated" } },
       actions: {},
     };
-    expect(translateTag(tagsOnly, 'aws-integration', { name: 'Spec' }).name).toBe(
-      'Translated',
-    );
-    expect(translateAction(tagsOnly, 'ListAPIKeys')).toEqual({});
+    expect(
+      translateTag(tagsOnly, "aws-integration", { name: "Spec" }).name,
+    ).toBe("Translated");
+    expect(translateAction(tagsOnly, "ListAPIKeys")).toEqual({});
   });
 
-  it('translateTag falls back to the spec values when the slug is missing', () => {
-    const overlay = getTranslationOverlay('v1', 'ja');
-    const result = translateTag(overlay, 'this-slug-does-not-exist', {
-      name: 'Some Spec Name',
-      description: 'Some spec description',
+  it("translateTag falls back to the spec values when the slug is missing", () => {
+    const overlay = getTranslationOverlay("v1", "ja");
+    const result = translateTag(overlay, "this-slug-does-not-exist", {
+      name: "Some Spec Name",
+      description: "Some spec description",
     });
     expect(result).toEqual({
-      name: 'Some Spec Name',
-      description: 'Some spec description',
+      name: "Some Spec Name",
+      description: "Some spec description",
     });
   });
 
-  it('translateTag merges translated and fallback values per-field', () => {
+  it("translateTag merges translated and fallback values per-field", () => {
     // Build a synthetic overlay where description is missing — should fall back.
     const partialOverlay = {
-      tags: { 'foo': { name: 'Translated Name' } },
+      tags: { foo: { name: "Translated Name" } },
       actions: {},
     };
-    const result = translateTag(partialOverlay, 'foo', {
-      name: 'Spec Name',
-      description: 'Spec Description',
+    const result = translateTag(partialOverlay, "foo", {
+      name: "Spec Name",
+      description: "Spec Description",
     });
-    expect(result.name).toBe('Translated Name');
-    expect(result.description).toBe('Spec Description');
+    expect(result.name).toBe("Translated Name");
+    expect(result.description).toBe("Spec Description");
   });
 
-  it('translateAction returns an empty object for unknown operation IDs', () => {
-    const overlay = getTranslationOverlay('v1', 'ja');
-    expect(translateAction(overlay, 'NoSuchOperation')).toEqual({});
+  it("translateAction returns an empty object for unknown operation IDs", () => {
+    const overlay = getTranslationOverlay("v1", "ja");
+    expect(translateAction(overlay, "NoSuchOperation")).toEqual({});
   });
 
-  it('caches per (version, locale)', () => {
-    const a = getTranslationOverlay('v2', 'fr');
-    const b = getTranslationOverlay('v2', 'fr');
+  it("caches per (version, locale)", () => {
+    const a = getTranslationOverlay("v2", "fr");
+    const b = getTranslationOverlay("v2", "fr");
     expect(a).toBe(b);
   });
 });

--- a/astro/src/lib/site/websitesModulesPath.test.ts
+++ b/astro/src/lib/site/websitesModulesPath.test.ts
@@ -104,8 +104,7 @@ describe("resolveWebsitesModulesPath", () => {
 
   it("prefers the Hugo module cache over a partial WEBSITES_MODULES_PATH match", () => {
     // The partial-match fallback is a last resort: a complete cached module
-    // must win over an incomplete override. This is the precedence that made
-    // the partial-match test above fail when it leaked the real HUGO_CACHEDIR.
+    // must win over an incomplete override.
     seedRequiredFiles(tmpRoot);
     rmSync(join(tmpRoot, "data", "language_names.yaml"));
     process.env.WEBSITES_MODULES_PATH = tmpRoot;

--- a/astro/src/lib/site/websitesModulesPath.test.ts
+++ b/astro/src/lib/site/websitesModulesPath.test.ts
@@ -27,6 +27,26 @@ describe("resolveWebsitesModulesPath", () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
+  /**
+   * A fake astro.config.mjs URL nested deep enough inside `tmpRoot` that both
+   * paths `resolveWebsitesModulesPath` derives from it — `../hugo/go.mod` and
+   * the six-level-up `../../../../../../dd/websites-modules` sibling checkout —
+   * land inside the temp dir instead of escaping to a real location on this
+   * machine. Without the nesting, the sibling path resolves to `/var/dd/
+   * websites-modules`, and the test would silently depend on that not existing.
+   */
+  function fakeAstroConfigUrl(): string {
+    return pathToFileURL(
+      join(tmpRoot, "a", "b", "c", "d", "e", "astro", "astro.config.mjs"),
+    ).href;
+  }
+
+  /** Point HUGO_CACHEDIR at a nonexistent dir so this machine's real Hugo
+   * module cache can't satisfy the lookup and mask the branch under test. */
+  function isolateHugoCache() {
+    process.env.HUGO_CACHEDIR = join(tmpRoot, "no-such-hugo-cache");
+  }
+
   function seedRequiredFiles(dir: string) {
     for (const relative of [
       "config/_default/menus/menus.en.yaml",
@@ -44,24 +64,18 @@ describe("resolveWebsitesModulesPath", () => {
   it("resolves WEBSITES_MODULES_PATH when it has every required file", () => {
     seedRequiredFiles(tmpRoot);
     process.env.WEBSITES_MODULES_PATH = tmpRoot;
+    isolateHugoCache();
     // hugo/go.mod need not exist for this branch to win.
-    const fakeAstroConfigUrl = pathToFileURL(
-      join(tmpRoot, "astro", "astro.config.mjs"),
-    ).href;
-    expect(resolveWebsitesModulesPath(fakeAstroConfigUrl)).toBe(realpathSync(tmpRoot));
+    expect(resolveWebsitesModulesPath(fakeAstroConfigUrl())).toBe(
+      realpathSync(tmpRoot),
+    );
   });
 
   it("throws when WEBSITES_MODULES_PATH has none of the required files and no fallback exists", () => {
     process.env.WEBSITES_MODULES_PATH = join(tmpRoot, "incomplete");
     mkdirSync(process.env.WEBSITES_MODULES_PATH, { recursive: true });
-    // Point away from this machine's real Hugo module cache, which may hold
-    // its own (possibly partial) checkout that would otherwise mask the case
-    // under test.
-    process.env.HUGO_CACHEDIR = join(tmpRoot, "no-such-hugo-cache");
-    const fakeAstroConfigUrl = pathToFileURL(
-      join(tmpRoot, "astro", "astro.config.mjs"),
-    ).href;
-    expect(() => resolveWebsitesModulesPath(fakeAstroConfigUrl)).toThrow(
+    isolateHugoCache();
+    expect(() => resolveWebsitesModulesPath(fakeAstroConfigUrl())).toThrow(
       /WEBSITES_MODULES_PATH/,
     );
   });
@@ -71,14 +85,37 @@ describe("resolveWebsitesModulesPath", () => {
     // Remove one of the five so the directory is a real, but incomplete, checkout.
     rmSync(join(tmpRoot, "data", "language_names.yaml"));
     process.env.WEBSITES_MODULES_PATH = tmpRoot;
-    const fakeAstroConfigUrl = pathToFileURL(
-      join(tmpRoot, "astro", "astro.config.mjs"),
-    ).href;
+    isolateHugoCache();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(resolveWebsitesModulesPath(fakeAstroConfigUrl)).toBe(realpathSync(tmpRoot));
+    expect(resolveWebsitesModulesPath(fakeAstroConfigUrl())).toBe(
+      realpathSync(tmpRoot),
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("language_names.yaml"),
     );
     warnSpy.mockRestore();
+  });
+
+  it("prefers the Hugo module cache over a partial WEBSITES_MODULES_PATH match", () => {
+    // The partial-match fallback is a last resort: a complete cached module
+    // must win over an incomplete override. This is the precedence that made
+    // the partial-match test above fail when it leaked the real HUGO_CACHEDIR.
+    seedRequiredFiles(tmpRoot);
+    rmSync(join(tmpRoot, "data", "language_names.yaml"));
+    process.env.WEBSITES_MODULES_PATH = tmpRoot;
+
+    const cacheDir = join(tmpRoot, "hugo-cache");
+    const cachedModule = join(
+      cacheDir,
+      "modules/filecache/modules/pkg/mod/github.com/!data!dog",
+      "websites-modules@v1.4.317",
+    );
+    mkdirSync(cachedModule, { recursive: true });
+    seedRequiredFiles(cachedModule);
+    process.env.HUGO_CACHEDIR = cacheDir;
+
+    expect(resolveWebsitesModulesPath(fakeAstroConfigUrl())).toBe(
+      realpathSync(cachedModule),
+    );
   });
 });

--- a/astro/src/lib/site/websitesModulesPath.test.ts
+++ b/astro/src/lib/site/websitesModulesPath.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";


### PR DESCRIPTION
Fixes a couple of flaky tests:
- One of the translation tests depended on a Korean file not existing. That file now exists, so this switches the locale to `zz`.
- The websites-modules check didn't account for a complete local cache, so it leaked my local cache path instead of finding an incomplete folder.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->