### PR TITLE
docs(reference-tables): document 200-column limit [DOCS-15563]

### DIFF
--- a/hugo/content/en/reference_tables/_index.md
+++ b/hugo/content/en/reference_tables/_index.md
@@ -267,7 +267,7 @@ To be alerted on errors encountered during imports, use [Event Monitors][4] for 
 You can create monitors from the {{< ui >}}Monitors{{< /ui >}} tab, or click on the Settings icon next to {{< ui >}}New Reference Table +{{< /ui >}} to generate a pre-filled monitor.
 
 ## Reference Table limits
-- A reference table can have up to 50 columns
+- A reference table can have up to 200 columns
 - A single row cannot be larger than 500KiB
 - The size of a reference table file uploaded through the UI can be up to 200 MB
 - The size of a reference table file uploaded through a cloud bucket file can be up to 200 MB


### PR DESCRIPTION
### What does this PR do? What is the motivation?

#### Motivation

The Reference Tables limits section lists an outdated maximum of 50 columns, which can cause users to plan around a lower limit than the product supports.

#### Changes

Updates the documented maximum to 200 columns per reference table.

#### QA Instructions

Confirm that the Reference Table limits section states that a reference table can have up to 200 columns.

#### Blast Radius

Documentation only. No product behavior or other Reference Tables limits change.

#### Documentation

DOCS-15563

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, rename your branch and open a fresh PR.
- 🤖 Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews the PR.

### AI assistance

Used Codex to locate the source text, update the limit, run validation, and prepare the PR.

### Additional notes

None.
