### PR TITLE
Add C++ support to AI-native SAST docs

### DIFF
--- a/hugo/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/hugo/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -98,6 +98,7 @@ AI-native SAST uses a two-phase approach:
 | Elixir     | Available   |
 | Swift      | Available   |
 | Dart       | Available   |
+| C++        | Available   |
 
 ### Detected vulnerability types
 

--- a/hugo/content/en/security/code_security/static_analysis/configuration.md
+++ b/hugo/content/en/security/code_security/static_analysis/configuration.md
@@ -26,6 +26,7 @@ When AI-native SAST is enabled, its default rulesets run for the supported langu
 | Language | Ruleset |
 | --- | --- |
 | C# | `csharp-ai_sast` |
+| C++ | `cpp-ai_sast` |
 | Dart | `dart-ai_sast` |
 | Elixir | `elixir-ai_sast` |
 | Go | `go-ai_sast` |
@@ -38,6 +39,8 @@ When AI-native SAST is enabled, its default rulesets run for the supported langu
 | Rust | `rust-ai_sast` |
 | Swift | `swift-ai_sast` |
 | TypeScript | `typescript-ai_sast` |
+
+AI-native SAST rule IDs use the `datadog/<rule-name>` format (for example, `datadog/typescript-promptinjection`). To target a specific AI-native SAST rule in `rule-configs` or a `no-dd-sa` comment, use the full rule ID, including the `datadog/` prefix.
 
 The `use-default-rulesets` setting applies to both traditional SAST and AI-native SAST rulesets. If you set `use-default-rulesets: false`, include every traditional and AI-native SAST ruleset that you want to run. For example, the following configuration runs the Ruby security and AI-native SAST rulesets:
 

--- a/hugo/content/en/security/code_security/static_analysis/configuration.md
+++ b/hugo/content/en/security/code_security/static_analysis/configuration.md
@@ -40,7 +40,7 @@ When AI-native SAST is enabled, its default rulesets run for the supported langu
 | Swift | `swift-ai_sast` |
 | TypeScript | `typescript-ai_sast` |
 
-AI-native SAST rule IDs use the `datadog/<rule-name>` format (for example, `datadog/typescript-promptinjection`). To target a specific AI-native SAST rule in `rule-configs` or a `no-dd-sa` comment, use the full rule ID, including the `datadog/` prefix.
+AI-native SAST rule IDs use the format `datadog/<rule-name>` (for example, `datadog/typescript-promptinjection`). To target a specific AI-native SAST rule in `rule-configs` or a `no-dd-sa` comment, use the full rule ID, including the `datadog/` prefix.
 
 The `use-default-rulesets` setting applies to both traditional SAST and AI-native SAST rulesets. If you set `use-default-rulesets: false`, include every traditional and AI-native SAST ruleset that you want to run. For example, the following configuration runs the Ruby security and AI-native SAST rulesets:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds C++ to the AI-native SAST supported languages table and its corresponding `cpp-ai_sast` ruleset entry in the SAST configuration reference, so the docs reflect current AI-native SAST language coverage.

Also documents that AI-native SAST rule IDs use the `datadog/<rule-name>` format for rule-level configuration (`rule-configs`) and `no-dd-sa` suppression, which wasn't previously called out.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to verify C++ AI-native SAST support against the datadog-saist engine repo (language model, tree-sitter parsing, rule matching) before updating the docs, and to draft the docs edits.

### Additional notes