### PR TITLE
Document the notebooks MCP toolset

### DIFF
--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -1260,6 +1260,30 @@ Retrieves all network interfaces for a specific device.
 - Show me all interfaces on device `device:abc123`.
 - List the interface statuses for my core router.
 
+## Notebooks
+
+<div class="alert alert-info">The <code>notebooks</code> toolset is not enabled by default. See <a href="/mcp_server/setup">Set Up the Datadog MCP Server</a> for instructions on enabling toolsets.</div>
+
+Extended tools for [notebooks][57], beyond the notebook tools included in the `core` toolset.
+
+### `create_notebook_comments`
+*Toolset: **notebooks***\
+*Permissions Required: `Notebooks Read` and `Notebooks Write`*\
+Creates one or more comments on a notebook in a single call. Supports comment threads anchored to markdown text, threads attached to a widget cell, and replies to an existing comment.
+
+- Comment on the conclusion in this notebook asking for more detail.
+- Leave a comment on the latency graph in notebook abc-123-def.
+- Reply to the open comment thread in this notebook.
+
+### `add_notebooks_to_collection`
+*Toolset: **notebooks***\
+*Permissions Required: `Notebooks Read` and `Notebooks Write`*\
+Adds one or more notebooks to an existing notebook collection.
+
+- Add this notebook to the incident review collection.
+- Put notebooks abc-123-def and ghi-456-jkl into the onboarding collection.
+- Add the notebooks I created today to the weekly report collection.
+
 ## Onboarding
 
 Agentic onboarding tools for guided Datadog setup and configuration.


### PR DESCRIPTION
### What does this PR do?

Adds a `## Notebooks` section to the MCP Server tools page documenting the `notebooks` toolset and the two tools that will serve it: `create_notebook_comments` and `add_notebooks_to_collection`.

Placed between Networks and Onboarding to keep the toolset sections alphabetical.

### Motivation

Neither tool is documented today. Both currently sit on the `experimental` toolset, which is not disclosed anywhere on this page, so this is their first public documentation rather than a relabelling.

Agent Experiences is retiring `experimental` org-wide at the end of Q3. The `notebooks` toolset is where the notebook tools move, so it needs a public entry before that move is customer-visible.

### Additional Notes

The section uses the existing non-default-toolset alert, matching `cases`, `experiments`, and `product-analytics`, since `core` is the only default toolset.

Depends on two dd-source changes, and should not merge before the first has deployed:

- DataDog/dd-source#76032 marks the `notebooks` toolset GA and client-visible. Until that ships the toolset is absent from the public endpoint, so a customer following these docs could not enable it.
- DataDog/dd-source#76035 moves the two tools onto the toolset.

Open question for reviewers, and the reason this is a draft: both tools are additionally gated per org by feature flag (`notebook-collections` and `notebooks-comments-mcp`). The alert box covers the toolset not being enabled by default, but nothing on this page documents per-tool flags, so a customer who enables `?toolsets=notebooks` may still see no tools. If that is not acceptable, the alternative is the stronger Preview alert used by `apm`, `code-exec`, and `remote-actions`, which would need a product-preview signup URL.

Internal review from the notebooks team first, then the Documentation team, following the same path as #39583.
