### PR TITLE
[FRCC-9] Document per-file breakdown in Code Coverage PR comments

### DIFF
--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -45,6 +45,7 @@ gates:
       threshold: 95
 comments:
   enabled: true
+  file_breakdown: true
 ```
 
 ## Services configuration
@@ -295,15 +296,39 @@ gates:
 
 ## PR Comments
 
-By default, Datadog posts a code coverage summary comment on every pull request. You can suppress it on a per-repository basis with the `comments.enabled` field.
+By default, Datadog posts a code coverage summary comment on every pull request. The summary reports the total and patch coverage for the pull request and links to the Code Coverage page in Datadog.
 
-PR Gate checks are not affected by this setting.
+The `comments` block accepts the following fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | Boolean | `true` | Whether Datadog posts a code coverage comment on pull requests. |
+| `file_breakdown` | Boolean | `false` | Whether the comment includes a per-file table of total and patch coverage. |
+
+PR Gate checks are not affected by these settings.
+
+### Disabling PR comments
+
+You can suppress the comment on a per-repository basis with the `comments.enabled` field:
 
 {{< code-block lang="yaml" filename="code-coverage.datadog.yml" >}}
 schema-version: v1
 comments:
   enabled: false
 {{< /code-block >}}
+
+### Per-file breakdown
+
+Set `comments.file_breakdown` to `true` to add a table to the comment listing the files changed in the pull request, along with their total coverage and patch coverage:
+
+{{< code-block lang="yaml" filename="code-coverage.datadog.yml" >}}
+schema-version: v1
+comments:
+  enabled: true
+  file_breakdown: true
+{{< /code-block >}}
+
+The breakdown is off by default to keep the comment concise. It has no effect when `comments.enabled` is `false`.
 
 ## Carryforward
 

--- a/hugo/content/en/code_coverage/configuration.md
+++ b/hugo/content/en/code_coverage/configuration.md
@@ -328,7 +328,7 @@ comments:
   file_breakdown: true
 {{< /code-block >}}
 
-The breakdown is off by default to keep the comment concise. It has no effect when `comments.enabled` is `false`.
+The breakdown has no effect when `comments.enabled` is `false`.
 
 ## Carryforward
 

--- a/hugo/content/en/code_coverage/setup.md
+++ b/hugo/content/en/code_coverage/setup.md
@@ -446,7 +446,7 @@ test:
 The command recursively searches the specified directories for supported coverage report files, so specifying the current directory (`.`) is usually sufficient.
 See the [`datadog-ci` documentation][14] for more details on the `datadog-ci coverage upload` command.
 
-Shortly after the code coverage report upload is finished, Datadog adds a PR comment with code coverage percentage values.
+Shortly after the code coverage report upload is finished, Datadog adds a PR comment with code coverage percentage values. To add a per-file breakdown of total and patch coverage to the comment, see [PR Comments][21].
 You can also view your coverage data aggregated by pull request in the [Code Coverage page][15] in Datadog, with the ability to examine individual files and lines of code.
 
 {{< img src="/code_coverage/pr_details.png" text="Code Coverage PR details page in Datadog" style="width:100%" >}}
@@ -555,3 +555,4 @@ For a description of how reports are merged and how each line status is counted,
 [18]: /code_coverage/setup/#integrate-with-source-code-provider
 [19]: https://app.datadoghq.com/organization-settings/data-access-controls
 [20]: /code_coverage/coverage_calculation
+[21]: /code_coverage/configuration#pr-comments


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes FRCC-9

Documents the new `comments.file_breakdown` option for Code Coverage PR comments, which adds a per-file table of total and patch coverage to the comment.

- Expands the **PR Comments** section in `code_coverage/configuration.md` with a field reference table for the `comments` block and separate subsections for disabling comments and enabling the per-file breakdown.
- Adds `file_breakdown` to the example configuration file.
- Links to the section from `code_coverage/setup.md`.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- :warning: Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- :robot: **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code was used to draft the documentation changes from the ticket requirements.

### Additional notes

