### PR TITLE
Document the notebooks MCP toolset

### DIFF
--- a/hugo/content/en/mcp_server/setup.md
+++ b/hugo/content/en/mcp_server/setup.md
@@ -690,6 +690,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `kubernetes`: Tools for searching and describing [Kubernetes][51] resources and retrieving manifests across all clusters
 - `llmobs`: Tools for searching and analyzing [Agent Observability][36] spans and experiments
 - `networks`: Tools for [Cloud Network Monitoring][37] analysis and [Network Device Monitoring][38]
+- `notebooks`: Extended tools for [notebooks][54], beyond the notebook tools included in the `core` toolset
 - `onboarding`: Agentic onboarding tools for guided Datadog setup and configuration
 - `product-analytics`: Tools for interacting with [Product Analytics][41] queries
 - `profiling`: Tools for discovering, exploring, and analyzing [Continuous Profiler][58] data


### PR DESCRIPTION
### What does this PR do?

Adds `notebooks` to the **Available toolsets** list on the MCP Server setup page. One bullet, placed alphabetically between `networks` and `onboarding`.

### Motivation

The `notebooks` toolset is not currently listed, so there is no public reference for it — a customer has no way to know the toolset name to pass in `?toolsets=`.

The notebook tools that will serve it are moving off the `experimental` toolset, which Agent Experiences is retiring org-wide at the end of Q3.

### Additional Notes

Listed under **Available toolsets** rather than **Preview toolsets** because DataDog/dd-source#76032 marks the toolset `isGA`, which puts it in the `all` alias. That PR needs to merge and deploy before this one — the list is introduced as "These toolsets are generally available", so listing it earlier would describe a toolset customers cannot yet enable.

Deliberately scoped to the toolset. This PR does not document individual tools; the tool entries on the tools page can follow once the tools have moved and their per-org gating is settled.
