### PR TITLE
Fixed Typo: 'Ringstone' to 'Ringtone' in mobile guide

### DIFF
--- a/hugo/content/en/mobile/guide/configure-mobile-device-for-on-call.md
+++ b/hugo/content/en/mobile/guide/configure-mobile-device-for-on-call.md
@@ -127,7 +127,7 @@ For reliability, Datadog uses a rotating set of phone numbers to contact you. To
 
 4. Under {{< ui >}}People{{< /ui >}}, allow notifications from the Datadog On-Call contact. If you enabled critical alerts for Datadog push applications, then the Datadog mobile app also appears under **Apps**.
 
-5. To bypass silent mode, navigate to the Datadog On-Call contact >> tap {{< ui >}}Ringstone{{< /ui >}} >> activate {{< ui >}}Emergency Bypass{{< /ui >}}.
+5. To bypass silent mode, navigate to the Datadog On-Call contact >> tap {{< ui >}}Ringtone{{< /ui >}} >> activate {{< ui >}}Emergency Bypass{{< /ui >}}.
 {{% /tab %}}
 
 {{% tab "Android" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes a typo in the telephony channels iOS section of the On-Call mobile device setup guide: "Ringstone" → "Ringtone".

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:


### AI assistance

Claude Code was used to find the type. Edits and review was done manually.

### Additional notes

None
