### PR TITLE
[Fleet Automation] Document Kubernetes config-editing prerequisites (keys, cluster name, Helm install)

### DIFF
--- a/hugo/content/en/agent/fleet_automation/fleet_view.md
+++ b/hugo/content/en/agent/fleet_automation/fleet_view.md
@@ -122,10 +122,28 @@ Most Kubernetes view features are available without version requirements. Specif
 | View `DatadogAgent` configuration | Datadog Operator v1.24 or later |
 | View Helm Chart values | Datadog Helm Chart v3.157.0 or later |
 | Edit configuration | [Remote Configuration][6] enabled and Datadog Operator v1.27 or later |
+| Edit configuration without setting a cluster name | Datadog Operator v1.30.0 or later |
 | View integrations on a Cluster Agent | Agent v7.72.0 or later |
 | View integration status on a Cluster Agent | Agent v7.79.0 or later |
 
-To edit configuration from Fleet View, also set the following flags in your [Operator configuration][7]: `remoteConfigEnabled`, `remoteUpdatesEnabled`, and `createControllerRevisions`. Editing Helm Chart values from Fleet View is not supported.
+To edit configuration from Fleet View, set the following flags in your [Operator configuration][7]: `remoteConfigEnabled`, `remoteUpdatesEnabled`, and `createControllerRevisions`. Editing also requires a Datadog API key and application key to be configured. Editing Helm Chart values from Fleet View is not supported.
+
+On Datadog Operator versions earlier than v1.30.0, you must also set a cluster name (`clusterName`), otherwise the {{< ui >}}Edit{{< /ui >}} button remains disabled. As of Datadog Operator v1.30.0, a cluster name is optional.
+
+If you install the Datadog Operator with its Helm chart, you can enable the required flags together using the `previewFleetRollouts` value:
+
+{{< code-block lang="shell" >}}
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm upgrade --install datadog-operator datadog/datadog-operator \
+  --set previewFleetRollouts=true \
+  --set apiKeyExistingSecret=datadog-secret \
+  --set appKeyExistingSecret=datadog-secret \
+  --devel
+{{< /code-block >}}
+
+Replace `datadog-secret` with the name of the Kubernetes Secret that holds your Datadog API and application keys. The `--devel` flag installs the latest development release of the chart.
 
 ### View Kubernetes clusters
 


### PR DESCRIPTION
### What does this PR do?
Completes the **Prerequisites for Kubernetes view** section for editing `DatadogAgent` configuration from Fleet View:
- Adds the Datadog **API key + application key** requirement for editing.
- Documents the **cluster name** behavior: required on Datadog Operator versions earlier than v1.30.0 (otherwise the **Edit** button is silently disabled), optional as of v1.30.0.
- Adds a **copyable Helm install snippet** for enabling the required Operator flags.

### Motivation
Preview customers (most recently during a Grainger setup) hit a silent failure where the **Edit** button stays disabled with no obvious cause. The missing prerequisites were a cluster name (Remote Config previously tagged on `cluster_name`) and API + application keys. Datadog Operator v1.30.0 switches to `cluster_id`, making the cluster name optional. None of this was documented, so support and SAs were debugging it live.

### Open questions for reviewers (why this is a draft)
1. **`previewFleetRollouts` is marked unstable** in the operator Helm chart `values.yaml` (`# @ignore previewFleetRollouts could be removed without notice`). It's currently the only Helm value that sets all three flags (`remoteConfigEnabled`, `remoteUpdatesEnabled`, `createControllerRevisions`) together. Keep it in the public doc, or document the manual flag path instead?
2. **Confirm the "cluster name optional as of v1.30.0" line.** The chart's stable `remoteConfiguration.enabled` value still reads "Requires clusterName, API and App keys" at appVersion `1.30.0-rc.2`. That likely covers operator-level RC (a different mechanism), but please confirm against the Fleet-editing path.
3. **Pre-release pin.** `--devel` pulls the dev chart (`2.26.0-dev.4` / operator `1.30.0-rc.2`). Once the chart GAs, drop `--devel` and revisit the version numbers. Consider whether this section needs a Preview/Beta callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
