### PR TITLE
Update unsupported characters for Feature Flag Tracking

### DIFF
--- a/hugo/content/en/real_user_monitoring/feature_flag_tracking/setup.md
+++ b/hugo/content/en/real_user_monitoring/feature_flag_tracking/setup.md
@@ -118,7 +118,7 @@ You can start collecting feature flag data with [custom feature flag management 
 
 <div class="alert alert-danger">
 
-**Note**: The following special characters are not supported for Feature Flag Tracking: `.`, `:`, `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `“`, `”`, `~`, `*`, `?`, `\`. Datadog recommends avoiding these characters when possible in your feature flag names. If you are required to use one of these characters, replace the character before sending the data to Datadog. For example:
+**Note**: The following special characters are not supported for Feature Flag Tracking: `.`, `:`, `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `“`, `”`, `~`, `*`, `?`, `\`, and spaces. Datadog recommends avoiding these characters when possible in your feature flag names. If you are required to use one of these characters, replace the character before sending the data to Datadog. For example:
 
   ```javascript
   datadogRum.addFeatureFlagEvaluation(key.replaceAll(':', '_'), value);


### PR DESCRIPTION
Added spaces to the list of unsupported special characters for Feature Flag Tracking in the documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds spaces to the list of unsupported characters for Feature Flag Tracking because spaces cause feature flags to appear in the tracking view with no variants, but were not documented as unsupported alongside the other special characters.

### Merge readiness

- [ x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

N/A

### AI assistance

### Additional notes

Fixes #[36300](https://github.com/DataDog/documentation/issues/36300)
