### PR TITLE
Clarify DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE defaults by extension version

### DIFF
--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -19,13 +19,13 @@ Datadog provides full visibility into the metrics, logs, and traces for AWS Lamb
     - Datadog Node.js Lambda layer: v142+
     - Datadog Python Lambda layer: v127+
 
-2. Set the following environment variable on your Lambda function:
+2. If you use Datadog Lambda Extension v99, set the following environment variable on your Lambda function. For v100+, the default value is `5`, so you don't need to set it explicitly.
 
     ```text
     DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE=5
     ```
 
-    This environment variable configures the Datadog Lambda Extension to buffer logs and enrich them with the durable execution context sent by the Datadog Lambda Library. Set its value to a non-negative integer specifying the maximum number of invocations whose logs are buffered. The default, `0`, disables enrichment, so durable executions do not appear in Datadog.
+    This environment variable configures the Datadog Lambda Extension to buffer logs and enrich them with the durable execution context sent by the Datadog Lambda Library. Set its value to a non-negative integer specifying the maximum number of invocations whose logs are buffered. A value of `0` disables enrichment, so durable executions do not appear in Datadog. In v99, the default is `0`; in v100+, the default is `5`.
 
 ### Forward durable execution events
 

--- a/hugo/content/en/serverless/aws_lambda/durable_functions.md
+++ b/hugo/content/en/serverless/aws_lambda/durable_functions.md
@@ -19,7 +19,7 @@ Datadog provides full visibility into the metrics, logs, and traces for AWS Lamb
     - Datadog Node.js Lambda layer: v142+
     - Datadog Python Lambda layer: v127+
 
-2. If you use Datadog Lambda Extension v99, set the following environment variable on your Lambda function. For v100+, the default value is `5`, so you don't need to set it explicitly.
+2. If you use Datadog Lambda Extension v99, set the following environment variable on your Lambda function. For v100+, the default value is already `5`, so you don't need to set it explicitly.
 
     ```text
     DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE=5


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Lambda durable functions setup page instructed all users to set `DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE=5`, and described the default as `0`. That holds only for Lambda extension v99; in v100+ the default is `5`, so the step is unnecessary there.

This PR scopes the step to v99 and states the default per extension version.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code made the wording edit and opened this PR.

### Additional notes