### PR TITLE
Fix unescaped quote in callout code snippet

### DIFF
--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -91,7 +91,7 @@
         "scope": "markdown",
         "prefix": ";;callout",
         "body": [
-            "{{< callout url="#" btn_hidden=\"false\" header=\"Join the Preview!\">}}",
+            "{{< callout url=\"#\" btn_hidden=\"false\" header=\"Join the Preview!\">}}",
             "<Product name> is in Preview. Use this form to submit your request today.",
             "{{< /callout >}}"
         ],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes an unescaped double quote in the `;;callout` VS Code snippet (`.vscode/markdown.code-snippets`). The `url` attribute was missing escaping (`url="#"` instead of `url=\"#\"`), which broke the JSON snippet body compared to the other attributes on the same line.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify and apply the fix.

### Additional notes