### PR TITLE
[DOCS-15384] Add standalone Supply Chain Firewall page

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -8102,6 +8102,11 @@ menu:
       url: /security/code_security/software_composition_analysis/cve_explorer/
       parent: software_composition_analysis
       weight: 5
+    - name: Supply Chain Firewall
+      identifier: sca_supply_chain_firewall
+      url: /security/code_security/software_composition_analysis/supply_chain_firewall/
+      parent: software_composition_analysis
+      weight: 6
     - name: Secret Scanning
       identifier: sec_secret_scanning
       url: /security/code_security/secret_scanning/

--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -8092,19 +8092,19 @@ menu:
       url: /security/code_security/software_composition_analysis/configuration/
       parent: software_composition_analysis
       weight: 3
+    - name: Supply Chain Firewall (SCFW)
+      identifier: sca_supply_chain_firewall
+      url: /security/code_security/software_composition_analysis/supply_chain_firewall/
+      parent: software_composition_analysis
+      weight: 4
     - name: Library Inventory
       identifier: sca_library_inventory
       url: /security/code_security/software_composition_analysis/library_inventory/
       parent: software_composition_analysis
-      weight: 4
+      weight: 5
     - name: CVE Explorer
       identifier: sca_cve_explorer
       url: /security/code_security/software_composition_analysis/cve_explorer/
-      parent: software_composition_analysis
-      weight: 5
-    - name: Supply Chain Firewall
-      identifier: sca_supply_chain_firewall
-      url: /security/code_security/software_composition_analysis/supply_chain_firewall/
       parent: software_composition_analysis
       weight: 6
     - name: Secret Scanning

--- a/hugo/content/en/security/code_security/_index.md
+++ b/hugo/content/en/security/code_security/_index.md
@@ -43,7 +43,7 @@ Code Security scans your first-party code and open source libraries used in your
 - [Runtime Code Analysis (IAST)][3] for identifying vulnerabilities in the first-party code within your services
 - [Secret Scanning][8] for identifying and validating leaked secrets
 - [Infrastructure as Code (IaC) Security][10] for identifying security misconfigurations in IaC stored in your repositories
-- [Supply Chain Security](#supply-chain-security-preview) for preventing malicious packages from entering your development environment and code repositories
+- [Supply Chain Firewall](#supply-chain-firewall-preview) for preventing malicious packages from entering your development environment and code repositories
 
 Code Security helps teams implement DevSecOps throughout the organization:
 - **Developers:** early vulnerability detection, code quality improvements, faster development as developers spend less time debugging and patching.
@@ -102,16 +102,16 @@ IaC Security analyzes infrastructure-as-code to detect misconfigurations before 
 
 With [Cloud Security Management (CSM)][18], you can see misconfigurations in IaC Security directly from runtime findings. See [IaC Security setup][17] to get started.
 
-## Supply Chain Security (Preview)
+## Supply Chain Firewall (Preview)
 
 {{< callout url=https://docs.google.com/forms/d/1Xqh5h1n3-jC7au2t30fdTq732dkTJqt_cb7C7T-AkPc/viewform?edit_requested=true
  btn_hidden="false" header="Join the Preview!">}}
-Use this form to submit your request to join the Supply Chain Security Preview.
+Join the Supply Chain Firewall preview.
 {{< /callout >}}
 
-Supply Chain Security prevents malicious open source packages from entering your development environments at the point of installation, before they reach your repositories or CI/CD pipelines.
+Supply Chain Firewall (SCFW) prevents malicious open source packages from entering your development environments at the point of installation, before they reach your repositories or CI/CD pipelines.
 
-Unlike SCA, which scans dependencies already in your codebase, the Datadog Supply Chain Firewall (SCFW) intercepts package manager commands (`npm`, `pip`, `poetry`) in real time and blocks malicious or recently published packages before they are installed. See [Supply Chain Firewall][22] to get started.
+Unlike SCA, which scans dependencies already in your codebase, SCFW intercepts package manager commands (`npm`, `pip`, `poetry`) in real time and blocks malicious or recently published packages before they're installed. See [Supply Chain Firewall][22] to get started.
 
 ## Code Security MCP Server (Preview)
 The [Code Security MCP Server][19] is a local Model Context Protocol (MCP) server that brings SAST, secrets detection, SCA, IaC scanning, and SBOM generation directly into AI coding assistants such as Cursor, Claude Desktop, and VS Code. Read the [MCP Server documentation][17] to get started.

--- a/hugo/content/en/security/code_security/_index.md
+++ b/hugo/content/en/security/code_security/_index.md
@@ -111,11 +111,7 @@ Use this form to submit your request to join the Supply Chain Security Preview.
 
 Supply Chain Security prevents malicious open source packages from entering your development environments at the point of installation, before they reach your repositories or CI/CD pipelines.
 
-Unlike SCA, which scans dependencies already in your codebase, the Datadog Supply Chain Firewall (SCFW) intercepts package manager commands (`npm`, `pip`, `poetry`) in real time and blocks malicious or recently published packages before they are installed.
-
-Supply Chain Security evaluates every package install against Datadog's malicious package feed (powered by [GuardDog][21]), known vulnerability advisories, and configurable recency thresholds. If a package matches one of these checks, SCFW immediately blocks the installation and displays a clear, actionable message on developer laptops and [CI runners][20].
-
-In addition to protecting individual developer machines or CI pipelines, SCFW provides event observability to search, filter, and audit ALLOW, WARN, and BLOCK events across developer machines and CI systems in a unified event feed.
+Unlike SCA, which scans dependencies already in your codebase, the Datadog Supply Chain Firewall (SCFW) intercepts package manager commands (`npm`, `pip`, `poetry`) in real time and blocks malicious or recently published packages before they are installed. See [Supply Chain Firewall][22] to get started.
 
 ## Code Security MCP Server (Preview)
 The [Code Security MCP Server][19] is a local Model Context Protocol (MCP) server that brings SAST, secrets detection, SCA, IaC scanning, and SBOM generation directly into AI coding assistants such as Cursor, Claude Desktop, and VS Code. Read the [MCP Server documentation][17] to get started.
@@ -142,5 +138,4 @@ The [Code Security MCP Server][19] is a local Model Context Protocol (MCP) serve
 [17]: /security/code_security/iac_security/setup/?tab=github
 [18]: /security/cloud_security_management/
 [19]: /security/code_security/dev_tool_int/mcp_server/
-[20]: /security/code_security/dev_tool_int/scfw_github_action/
-[21]: https://github.com/DataDog/guarddog
+[22]: /security/code_security/software_composition_analysis/supply_chain_firewall/

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Supply Chain Firewall
 description: Block malicious and recently published open source packages at install time with Datadog's Supply Chain Firewall.
-is_beta: true
 disable_toc: false
 further_reading:
 - link: "https://securitylabs.datadoghq.com/articles/introducing-supply-chain-firewall/"

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -4,12 +4,6 @@ description: Block malicious and recently published open source packages at inst
 is_beta: true
 disable_toc: false
 further_reading:
-- link: "/security/code_security/dev_tool_int/scfw_github_action/"
-  tag: "Documentation"
-  text: "Supply Chain Firewall GitHub Action"
-- link: "/integrations/supply-chain-firewall/"
-  tag: "Documentation"
-  text: "Supply Chain Firewall Integration"
 - link: "https://securitylabs.datadoghq.com/articles/introducing-supply-chain-firewall/"
   tag: "Blog"
   text: "Introducing Supply-Chain Firewall: Protecting Developers from Malicious Open Source Packages"
@@ -17,19 +11,15 @@ further_reading:
 
 {{< callout url=https://docs.google.com/forms/d/1Xqh5h1n3-jC7au2t30fdTq732dkTJqt_cb7C7T-AkPc/viewform?edit_requested=true
  btn_hidden="false" header="Join the Preview!">}}
-Use this form to submit your request to join the Supply Chain Security Preview.
+Supply Chain Firewall is in preview.
 {{< /callout >}}
 
-Supply Chain Firewall (SCFW) prevents malicious open source packages from entering your development environments at the point of installation, before they reach your repositories or CI/CD pipelines.
+Supply Chain Firewall (SCFW) prevents malicious open source packages from entering your development environments at the point of installation, before they reach repositories or CI/CD pipelines.
 
-[Software Composition Analysis (SCA)][1]'s static and runtime modes scan dependencies already present in your codebase or running services. SCFW instead intercepts package manager commands as developers and CI systems run them, blocking malicious or recently published packages before they are installed.
+SCFW wraps supported package manager commands (`npm`, `pip`, and `poetry`). When install commands are run through SCFW, packages are verified against:
 
-## How it works
-
-SCFW wraps supported package manager commands (`npm`, `pip`, and `poetry`). When someone runs an installation command through SCFW, it collects every package that the command would install and verifies each one against:
-
-- Datadog Security Research's public [malicious packages dataset][2]
-- [OSV.dev][3] advisories for known malicious packages and vulnerabilities
+- Datadog Security Research's public [malicious packages dataset][1]
+- [OSV.dev][2] advisories for known malicious packages and vulnerabilities
 - Package registry metadata, to flag packages published within a configurable recency threshold
 
 Based on these checks, SCFW produces one of three outcomes for the command:
@@ -40,23 +30,45 @@ Based on these checks, SCFW produces one of three outcomes for the command:
 
 ## Install and use the CLI
 
-Install Supply Chain Firewall with [`pipx`][4]:
+Install the SCFW CLI locally so package manager commands can be inspected before packages are installed.
+
+The recommended method to install SCFW is with `pipx`, which installs `scfw` in its own isolated Python environment, separate from your project dependencies, while still putting the SCFW command on your system `PATH`:
 
 ```bash
 pipx install scfw
 ```
 
-You can also install it with `pip install scfw` directly into an active Python environment. Confirm the installation succeeded:
+Alternatively, you can install SCFW with `pip install scfw` directly in an active Python environment.
+
+Either way, confirm the installation succeeded:
 
 ```bash
 scfw --version
 ```
 
-After installation, run `scfw configure` to set up your environment so that supported package manager commands are automatically routed through SCFW, and to enable Datadog logging.
+To inspect package manager commands in CI instead of locally, see the [Supply Chain Firewall GitHub Action][3].
 
-### Inspect a package manager command
+### Configure your environment
 
-Prepend `scfw run` to any supported package manager command to inspect it before it runs:
+Set up shell aliases so that supported package manager commands are automatically routed through SCFW without having to prepend `scfw run`. `scfw configure` also enables log forwarding to Datadog; see [Supply Chain Firewall integration][4] for details.
+
+Run `scfw configure` with no arguments for an interactive walkthrough of available options:
+
+```bash
+scfw configure
+```
+
+Alternatively, you can set options by passing them directly. For example, to alias `npm` and `pip`:
+
+```bash
+scfw configure --alias-npm --alias-pip
+```
+
+Configuration writes settings to a clearly delimited, SCFW-managed block in your `~/.bashrc` and `~/.zshrc`. Don't edit this block by hand, because SCFW needs to be able to maintain it. You can rerun `scfw configure` at any time to update your settings, or run `scfw configure --remove` to remove all SCFW-managed configuration, for example before uninstalling.
+
+### Inspect a package during install
+
+Route `npm`, `pip`, or `poetry` installs through SCFW so they're checked against threat data before installation. 
 
 ```bash
 scfw run npm install react
@@ -65,7 +77,7 @@ scfw run pip install -r requirements.txt
 
 ### Audit installed packages
 
-Use `scfw audit` to run SCFW's verifiers against packages that are already installed:
+Check previously installed packages, or packages installed outside of `scfw run`, against SCFW threat data.
 
 ```bash
 scfw audit npm
@@ -74,28 +86,26 @@ scfw audit --executable venv/bin/pip pip
 
 ### Compatibility
 
+SCFW runs on macOS and common Linux distributions. Windows is not supported.
+
+SCFW supports these package manager versions and subcommands:
+
 | Package manager | Supported versions | Inspected subcommands |
 |------------------|--------------------|-------------------------|
 | npm | 7.0 and later | `install` (including aliases) |
 | pip | 22.2 and later | `install` |
 | poetry | 1.7 and later | `add`, `install`, `sync`, `update` |
 
-Any other subcommands for these package managers always run without inspection. By default, SCFW refuses to run inspected subcommands with an unsupported version of a supported package manager.
+Subcommands other than those specified always run without inspection. 
 
-<div class="alert alert-info">SCFW runs on macOS and common Linux distributions. Windows is not supported.</div>
+If a package manager version is below its minimum supported version, SCFW refuses to run inspected subcommands for it, rather than allowing them to run uninspected. This fail-closed behavior aligns with SCFW's goal of blocking 100% of known-malicious installs. Upgrade to a supported version to inspect commands normally, or pass `--allow-unsupported` to `scfw run` to skip verification and allow the command to run anyway.
 
-## Related setup
-
-- To inspect package manager commands in CI, see the [Supply Chain Firewall GitHub Action][5].
-- To forward SCFW logs to Datadog, see the [Supply Chain Firewall integration][6].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /security/code_security/software_composition_analysis/
-[2]: https://github.com/DataDog/malicious-software-packages-dataset
-[3]: https://osv.dev
-[4]: https://pipx.pypa.io/
-[5]: /security/code_security/dev_tool_int/scfw_github_action/
-[6]: /integrations/supply-chain-firewall/
+[1]: https://github.com/DataDog/malicious-software-packages-dataset
+[2]: https://osv.dev
+[3]: /security/code_security/dev_tool_int/scfw_github_action/
+[4]: /integrations/supply-chain-firewall/

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -49,7 +49,7 @@ To inspect package manager commands in CI instead of locally, see the [Supply Ch
 
 ### Configure your environment
 
-Set up shell aliases so that supported package manager commands are automatically routed through SCFW without having to prepend `scfw run`. `scfw configure` also enables log forwarding to Datadog; see [Supply Chain Firewall integration][4] for details.
+Set up shell aliases so that supported package manager commands are automatically routed through SCFW without having to prepend `scfw run`. Configuration also enables log forwarding to Datadog; see [Supply Chain Firewall integration][4] for details.
 
 Run `scfw configure` with no arguments for an interactive walkthrough of available options:
 

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -1,0 +1,101 @@
+---
+title: Supply Chain Firewall
+description: Block malicious and recently published open source packages at install time with Datadog's Supply Chain Firewall.
+is_beta: true
+disable_toc: false
+further_reading:
+- link: "/security/code_security/dev_tool_int/scfw_github_action/"
+  tag: "Documentation"
+  text: "Supply Chain Firewall GitHub Action"
+- link: "/integrations/supply-chain-firewall/"
+  tag: "Documentation"
+  text: "Supply Chain Firewall Integration"
+- link: "https://securitylabs.datadoghq.com/articles/introducing-supply-chain-firewall/"
+  tag: "Blog"
+  text: "Introducing Supply-Chain Firewall: Protecting Developers from Malicious Open Source Packages"
+---
+
+{{< callout url=https://docs.google.com/forms/d/1Xqh5h1n3-jC7au2t30fdTq732dkTJqt_cb7C7T-AkPc/viewform?edit_requested=true
+ btn_hidden="false" header="Join the Preview!">}}
+Use this form to submit your request to join the Supply Chain Security Preview.
+{{< /callout >}}
+
+Supply Chain Firewall (SCFW) prevents malicious open source packages from entering your development environments at the point of installation, before they reach your repositories or CI/CD pipelines.
+
+[Software Composition Analysis (SCA)][1]'s static and runtime modes scan dependencies already present in your codebase or running services. SCFW instead intercepts package manager commands as developers and CI systems run them, blocking malicious or recently published packages before they are installed.
+
+## How it works
+
+SCFW wraps supported package manager commands (`npm`, `pip`, and `poetry`). When someone runs an installation command through SCFW, it collects every package that the command would install and verifies each one against:
+
+- Datadog Security Research's public [malicious packages dataset][2]
+- [OSV.dev][3] advisories for known malicious packages and vulnerabilities
+- Package registry metadata, to flag packages published within a configurable recency threshold
+
+Based on these checks, SCFW produces one of three outcomes for the command:
+
+- **Allow**: No issues are found, and the installation proceeds normally.
+- **Warn**: A verifier reports non-critical findings. SCFW displays the findings and prompts the user to confirm whether to proceed.
+- **Block**: A verifier reports a critical finding, generally indicating that a package is known to be malicious. SCFW blocks the installation and displays an actionable message explaining why.
+
+## Install and use the CLI
+
+Install Supply Chain Firewall with [`pipx`][4]:
+
+```bash
+pipx install scfw
+```
+
+You can also install it with `pip install scfw` directly into an active Python environment. Confirm the installation succeeded:
+
+```bash
+scfw --version
+```
+
+After installation, run `scfw configure` to set up your environment so that supported package manager commands are automatically routed through SCFW, and to enable Datadog logging.
+
+### Inspect a package manager command
+
+Prepend `scfw run` to any supported package manager command to inspect it before it runs:
+
+```bash
+scfw run npm install react
+scfw run pip install -r requirements.txt
+```
+
+### Audit installed packages
+
+Use `scfw audit` to run SCFW's verifiers against packages that are already installed:
+
+```bash
+scfw audit npm
+scfw audit --executable venv/bin/pip pip
+```
+
+### Compatibility
+
+| Package manager | Supported versions | Inspected subcommands |
+|------------------|--------------------|-------------------------|
+| npm | 7.0 and later | `install` (including aliases) |
+| pip | 22.2 and later | `install` |
+| poetry | 1.7 and later | `add`, `install`, `sync`, `update` |
+
+Any other subcommands for these package managers always run without inspection. By default, SCFW refuses to run inspected subcommands with an unsupported version of a supported package manager.
+
+<div class="alert alert-info">SCFW runs on macOS and common Linux distributions. Windows is not supported.</div>
+
+## Related setup
+
+- To inspect package manager commands in CI, see the [Supply Chain Firewall GitHub Action][5].
+- To forward SCFW logs to Datadog, see the [Supply Chain Firewall integration][6].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /security/code_security/software_composition_analysis/
+[2]: https://github.com/DataDog/malicious-software-packages-dataset
+[3]: https://osv.dev
+[4]: https://pipx.pypa.io/
+[5]: /security/code_security/dev_tool_int/scfw_github_action/
+[6]: /integrations/supply-chain-firewall/

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -15,77 +15,145 @@ Supply Chain Firewall is in preview.
 
 Supply Chain Firewall (SCFW) prevents malicious open source packages from entering your development environments at the point of installation, before they reach repositories or CI/CD pipelines.
 
-SCFW wraps supported package manager commands (`npm`, `pip`, and `poetry`). When install commands are run through SCFW, packages are verified against:
-
-- Datadog Security Research's public [malicious packages dataset][1]
-- [OSV.dev][2] advisories for known malicious packages and vulnerabilities
-- Package registry metadata, to flag packages published within a configurable recency threshold
+SCFW wraps supported package manager commands (`npm`, `pip`, and `poetry`). When you run an installation command through SCFW, it evaluates the package against Datadog Security Research's [threat intelligence feed][1] of known-malicious and compromised open source packages as well as custom allow and block policies you configure for your organization.
 
 Based on these checks, SCFW produces one of three outcomes for the command:
 
 - **Allow**: No issues are found, and the installation proceeds normally.
-- **Warn**: A verifier reports non-critical findings. SCFW displays the findings and prompts the user to confirm whether to proceed.
-- **Block**: A verifier reports a critical finding, generally indicating that a package is known to be malicious. SCFW blocks the installation and displays an actionable message explaining why.
+- **Warn**: Reports non-critical findings and prompts you to confirm whether to proceed.
+- **Block**: Reports a critical finding, generally indicating that a package is known to be malicious, and blocks the installation with an actionable message explaining why.
 
-## Install and use the CLI
+## Install the CLI
 
-Install the SCFW CLI locally so package manager commands can be inspected before packages are installed.
+Install the SCFW CLI locally so package manager commands can be inspected before packages are installed. 
 
-The recommended method to install SCFW is with `pipx`, which installs `scfw` in its own isolated Python environment, separate from your project dependencies, while still putting the SCFW command on your system `PATH`:
+SCFW is distributed as a single Go binary with no runtime dependencies, and runs on macOS and common Linux distributions. Windows is not supported.
 
-```bash
-pipx install scfw
-```
-
-Alternatively, you can install SCFW with `pip install scfw` directly in an active Python environment.
-
-Either way, confirm the installation succeeded:
-
-```bash
-scfw --version
-```
+You can install SCFW with Go or with a GitHub release. 
 
 To inspect package manager commands in CI instead of locally, see the [Supply Chain Firewall GitHub Action][3].
 
-### Configure your environment
+### Install with Go
 
-Set up shell aliases so that supported package manager commands are automatically routed through SCFW without having to prepend `scfw run`. Configuration also enables log forwarding to Datadog; see [Supply Chain Firewall integration][4] for details.
-
-Run `scfw configure` with no arguments for an interactive walkthrough of available options:
+Use `go install` if you have Go 1.26 and you want the fastest path to a working CLI.
 
 ```bash
-scfw configure
+go install github.com/DataDog/supply-chain-firewall/scfw@latest
 ```
 
-Alternatively, you can set options by passing them directly. For example, to alias `npm` and `pip`:
+This installs the `scfw` binary to `$(go env GOPATH)/bin`. Add that directory to your `PATH` if it isn't already there.
+
+### Install with a GitHub release
+
+Install with a GitHub release if you don't have Go installed, or if you want to pin and verify a specific release.
+
+Download the binary for your operating system and architecture from the [latest GitHub release][2]. Before running these commands, replace the value of `scfw_expected_checksum` with the checksum published for that binary on the release page.
 
 ```bash
-scfw configure --alias-npm --alias-pip
+# Replace this placeholder with the checksum from the release page.
+scfw_expected_checksum="<expected-sha256-checksum>"
+
+# Detect the operating system used in the release artifact name.
+case "$(uname -s)" in
+    Darwin) scfw_os=darwin ;;
+    Linux)  scfw_os=linux ;;
+    *) echo "Unsupported operating system: $(uname -s)" >&2; exit 1 ;;
+esac
+
+# Detect the CPU architecture used in the release artifact name.
+case "$(uname -m)" in
+    x86_64)        scfw_arch=amd64 ;;
+    arm64|aarch64) scfw_arch=arm64 ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Download the binary for the detected platform.
+scfw_binary="scfw-${scfw_os}-${scfw_arch}"
+curl -fLO "https://github.com/DataDog/supply-chain-firewall/releases/latest/download/${scfw_binary}"
+
+# Calculate the downloaded binary's checksum and compare it against the published value.
+scfw_actual_checksum=$(sha256sum "${scfw_binary}" | awk '{print $1}')
+if [ "${scfw_actual_checksum}" != "${scfw_expected_checksum}" ]; then
+    echo "Checksum verification failed" >&2
+    exit 1
+fi
+
+# Install the verified binary in a directory on PATH.
+chmod +x "${scfw_binary}"
+sudo install "${scfw_binary}" /usr/local/bin/scfw
 ```
 
-Configuration writes settings to a clearly delimited, SCFW-managed block in your `~/.bashrc` and `~/.zshrc`. Don't edit this block by hand, because SCFW needs to be able to maintain it. You can rerun `scfw configure` at any time to update your settings, or run `scfw configure --remove` to remove all SCFW-managed configuration, for example before uninstalling.
+## Configure your environment
 
-### Inspect a package during install
-
-Route `npm`, `pip`, or `poetry` installs through SCFW so they're checked against threat data before installation. 
+Configure SCFW to store your Datadog credentials and set up shell aliases so that supported package manager commands are automatically routed through SCFW.
 
 ```bash
-scfw run npm install react
-scfw run pip install -r requirements.txt
+scfw configure \
+    --dd-api-key=<DD_API_KEY> \
+    --dd-app-key=<DD_APP_KEY> \
+    --dd-site=<DD_SITE> \
+    --alias-npm \
+    --alias-pip \
+    --alias-poetry
 ```
 
-### Audit installed packages
+The configuration command performs several distinct steps:
 
-Check previously installed packages, or packages installed outside of `scfw run`, against SCFW threat data.
+- Stores your API and application keys securely in your system's keychain.
+
+   <div class="alert alert-tip">You can provide your Datadog credentials and site with the `DD_API_KEY`, `DD_APP_KEY`, and `DD_SITE` environment variables instead of passing them as flags. Environment variables take precedence over credentials stored in the system keychain.</div>
+
+- Adds SCFW's alias configuration to your shell's rc files (whichever of `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` already exist). Restart your shell, or source the relevant rc file, for the aliases to take effect.
+
+   <div class="alert alert-tip">Alias options are additive: aliases added by an earlier run remain in place unless you pass the corresponding `--remove-alias-*` option. The command manages a clearly delimited, SCFW-managed block in your shell rc files, and doesn't touch anything else in those files.</div>
+
+- Enables log forwarding to Datadog. See [Supply Chain Firewall integration][4] for details.
+
+The configuration command accepts these options:
+
+| Option | Description |
+| --- | --- |
+| `--dd-api-key` | Datadog API key used for policy evaluation and reporting. |
+| `--dd-app-key` | Datadog application key used for policy evaluation and reporting. |
+| `--dd-site` | Datadog site parameter used for policy evaluation and reporting (default: `datadoghq.com`). |
+| `--alias-npm` | Add a shell alias to run all npm commands through SCFW. |
+| `--remove-alias-npm` | Remove the npm shell alias managed by SCFW. |
+| `--alias-pip` | Add shell aliases to run all pip/pip3 commands through SCFW. |
+| `--remove-alias-pip` | Remove the pip/pip3 shell aliases managed by SCFW. |
+| `--alias-poetry` | Add a shell alias to run all poetry commands through SCFW. |
+| `--remove-alias-poetry` | Remove the poetry shell alias managed by SCFW. |
+| `--scfw-home` | Directory SCFW can use as a local cache. |
+| `--remove` | Remove all SCFW-managed configuration. |
+
+To check whether your credentials and aliases are configured correctly, run:
 
 ```bash
-scfw audit npm
-scfw audit --executable venv/bin/pip pip
+scfw doctor
 ```
 
-### Compatibility
+## Inspect a package during install
 
-SCFW runs on macOS and common Linux distributions. Windows is not supported.
+After you install and configure SCFW, `npm`, `pip`, and `poetry` commands are automatically routed through SCFW. 
+
+To inspect a command manually instead, prepend `scfw run --`:
+
+```bash
+scfw run -- npm install react
+scfw run -- pip install -r requirements.txt
+```
+
+The `scfw run` command supports these options:
+
+| Option | Description |
+| --- | --- |
+| `--executable` | Package manager executable to use for running commands (default: environmentally determined). |
+| `--error-on-block` | Treats blocked commands as errors, meaning exit non-zero. Useful for scripting and CI. |
+| `--allow-on-warning` | Non-interactively allows commands with only warning-level findings. |
+| `--block-on-warning` | Non-interactively blocks commands with only warning-level findings. |
+
+The `SCFW_ON_WARNING` environment variable (`allow` or `block`) has the same effect as `--allow-on-warning` or `--block-on-warning`, and takes precedence when set. An environment variable is useful for enforcing a consistent policy across a CI environment without changing every invocation. In non-interactive contexts with no terminal, SCFW can't prompt for confirmation, so it blocks warning-level results by default unless `--allow-on-warning`, `--block-on-warning`, or `SCFW_ON_WARNING` is set.
+
+## Compatibility
 
 SCFW supports these package manager versions and subcommands:
 
@@ -95,16 +163,27 @@ SCFW supports these package manager versions and subcommands:
 | pip | 22.2 and later | `install` |
 | poetry | 1.7 and later | `add`, `install`, `sync`, `update` |
 
-Subcommands other than those specified always run without inspection. 
+Subcommands other than those specified always run without inspection.
 
-If a package manager version is below its minimum supported version, SCFW refuses to run inspected subcommands for it, rather than allowing them to run uninspected. This fail-closed behavior aligns with SCFW's goal of blocking 100% of known-malicious installs. Upgrade to a supported version to inspect commands normally, or pass `--allow-unsupported` to `scfw run` to skip verification and allow the command to run anyway.
+If a package manager version is below its minimum supported version, SCFW refuses to run inspected subcommands for it, rather than allowing them to run uninspected. This fail-closed behavior is intended to block known-malicious installs. Upgrade to a supported version to inspect commands normally.
 
+## Uninstall SCFW
+
+Uninstalling SCFW removes the CLI and the configuration it manages from your environment.
+
+Before removing the binary, run `scfw configure --remove` to remove SCFW-managed configuration from your environment:
+
+```bash
+scfw configure --remove
+```
+
+Then remove the `scfw` binary, for example by deleting it from `/usr/local/bin`, or from `$(go env GOPATH)/bin` if you installed it with `go install`.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/malicious-software-packages-dataset
-[2]: https://osv.dev
+[2]: https://github.com/DataDog/supply-chain-firewall/releases/latest
 [3]: /security/code_security/dev_tool_int/scfw_github_action/
 [4]: /integrations/supply-chain-firewall/

--- a/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
+++ b/hugo/content/en/security/code_security/software_composition_analysis/supply_chain_firewall/_index.md
@@ -29,7 +29,7 @@ Install the SCFW CLI locally so package manager commands can be inspected before
 
 SCFW is distributed as a single Go binary with no runtime dependencies, and runs on macOS and common Linux distributions. Windows is not supported.
 
-You can install SCFW with Go or with a GitHub release. 
+You can install SCFW 4.0.0 and later with Go or with a GitHub release. 
 
 To inspect package manager commands in CI instead of locally, see the [Supply Chain Firewall GitHub Action][3].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15384

Adds a standalone Supply Chain Firewall (SCFW) page under the Software Composition Analysis section covering:
- An overview of SCFW and how it fits alongside SCA's static and runtime modes
- How it works: the checks it runs and the allow/warn/block outcomes
- Installing and using the CLI (`scfw run`, `scfw audit`), including compatibility details and unsupported platforms
- Cross-references to the GitHub Action page and the Supply Chain Firewall integration for log forwarding

Also trims the Supply Chain Security summary on the Code Security overview page so it links to the new standalone page instead of duplicating its content.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code, based on ticket requirements and the public SCFW GitHub repository README.

### Additional notes