### PR TITLE
[ACTP] Clarify HTTP token authentication setup

### DIFF
--- a/hugo/content/en/actions/connections/http.md
+++ b/hugo/content/en/actions/connections/http.md
@@ -64,8 +64,9 @@ The Token Auth connection uses a bearer token to authenticate the HTTP request.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for authentication.
 1. From the {{< ui >}}Authentication Type{{< /ui >}} dropdown, select {{< ui >}}Token Auth{{< /ui >}}.
-1. Enter a {{< ui >}}Token Name{{< /ui >}} and {{< ui >}}Token Value{{< /ui >}}. You can enter multiple tokens. To reference your token in a header, parameter, or the request body, use the syntax `{{ secretTokenName }}`.
-1. Optionally, add additional {{< ui >}}Request Headers{{< /ui >}}, {{< ui >}}URL parameters{{< /ui >}} and a {{< ui >}}Body{{< /ui >}} to your request.
+1. Enter a {{< ui >}}Token Name{{< /ui >}} and {{< ui >}}Token Value{{< /ui >}}. You can enter multiple tokens.
+1. Configure how HTTP requests that use the connection include the token. The connection does not add the token to requests automatically. In {{< ui >}}Request Headers{{< /ui >}}, {{< ui >}}URL parameters{{< /ui >}}, or the {{< ui >}}Body{{< /ui >}}, reference the token with the syntax `{{ secretTokenName }}`, replacing `secretTokenName` with the {{< ui >}}Token Name{{< /ui >}} from the previous step. For example, if the token name is `apiToken`, add an `Authorization` header with the value `Bearer {{ apiToken }}`.
+1. Optionally, add other {{< ui >}}Request Headers{{< /ui >}}, {{< ui >}}URL parameters{{< /ui >}}, or a {{< ui >}}Body{{< /ui >}} to your request.
 1. Click {{< ui >}}Create{{< /ui >}}.
 
 ### Create an HTTP basic authentication connection


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Improve and clarify how to use secrets in templates. Clarifies how HTTP token authentication connections work:

- States that the connection does not add tokens to requests automatically.
- Explains where to reference a token and how the token name maps to the template syntax.
- Adds a concrete bearer-token authorization header example.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Codex to draft and validate the documentation update.
