### PR TITLE
docs(rum): document debug ID source map uploads

### DIFF
--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle that associates stack traces with a debug ID or with `service` and `version` metadata.
+When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle. This snippet associates stack traces with a debug ID or with `service` and `version` metadata.
 
 At build time, the plugin injects a snippet that writes metadata to `window.DD_SOURCE_CODE_CONTEXT`. At runtime, the RUM SDK reads this metadata to associate stack frames with [uploaded source maps][2].
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -32,19 +32,16 @@ At build time, the plugin injects a snippet that writes metadata to `window.DD_S
 
 ## Configuration
 
-Configure the `rum.sourceCodeContext` object in your build plugin options:
+Configure `rum.sourceCodeContext` using one of the following methods. The two configurations are mutually exclusive.
 
-Choose either debug ID matching or service and version matching. The two configurations are mutually exclusive.
+{{< tabs >}}
+{{% tab "Debug ID (Recommended)" %}}
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `rum.sourceCodeContext.debugId` | Boolean | No | `false` | Inject a deterministic debug ID into each JavaScript bundle. |
-| `rum.sourceCodeContext.service` | String | Yes, unless `debugId` is enabled | None | Service name. Must match the RUM SDK `service` initialization parameter. |
-| `rum.sourceCodeContext.version` | String | No | None | Release version. If omitted, source code context is not associated with a specific version. If set, must match the RUM SDK `version` initialization parameter. |
+Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
-## Example
+Set `debugId` to `true` in `rum.sourceCodeContext` to inject a debug ID into each JavaScript bundle.
 
-The following example injects debug IDs and uploads source maps directly from the build plugin:
+The following example also configures `errorTracking.sourcemaps.debugId` so that the build plugin uploads the source maps:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -69,6 +66,40 @@ module.exports = {
   ],
 };
 ```
+
+If you upload source maps with another tool, such as `datadog-ci`, omit `auth` and `errorTracking.sourcemaps` from this configuration.
+
+{{% /tab %}}
+{{% tab "Service and version" %}}
+
+Service and version matching associates stack frames with source maps using metadata from the RUM SDK and the uploaded source maps.
+
+Configure the following options in `rum.sourceCodeContext`:
+
+- `service` (String, required): The service name. It must match the RUM SDK `service` initialization parameter.
+- `version` (String, optional): The release version. If set, it must match the RUM SDK `version` initialization parameter. If omitted, source code context is not associated with a specific version.
+
+```javascript
+const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
+
+module.exports = {
+  plugins: [
+    datadogWebpackPlugin({
+      rum: {
+        sourceCodeContext: {
+          service: 'my-application',
+          version: '1.0.0',
+        },
+      },
+    }),
+  ],
+};
+```
+
+The `service` and `version` values must match the metadata used when uploading the source maps.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 <div class="alert alert-info">This example uses webpack. The configuration object is identical across all supported bundlers. See <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/">Build Plugins</a> for installation instructions for your bundler.</div>
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -32,14 +32,14 @@ At build time, the plugin injects a snippet that writes metadata to `window.DD_S
 
 ## Configuration
 
-Configure `rum.sourceCodeContext` using one of the following methods. The two configurations are mutually exclusive.
+Choose one of the following source code context methods. The two configurations are mutually exclusive.
 
 {{< tabs >}}
 {{% tab "Debug ID (Recommended)" %}}
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
-Set `debugId` to `true` in `rum.sourceCodeContext` to inject a debug ID into each JavaScript bundle.
+Set `debugId` to `true` in `sourcemaps` to inject a debug ID into each JavaScript bundle.
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -47,10 +47,8 @@ const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
 module.exports = {
   plugins: [
     datadogWebpackPlugin({
-      rum: {
-        sourceCodeContext: {
-          debugId: true,
-        },
+      sourcemaps: {
+        debugId: true,
       },
     }),
   ],

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -1,6 +1,6 @@
 ---
 title: Source Code Context
-description: "Display source code inline in Error Tracking stack traces by injecting service and version metadata at build time."
+description: "Display source code inline in Error Tracking stack traces by injecting debug ID or service and version metadata at build time."
 algolia:
   tags: ['source code context', 'build plugins', 'error tracking', 'stack traces']
 further_reading:
@@ -20,14 +20,14 @@ further_reading:
 
 ## Overview
 
-When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle that associates stack traces with your `service` and `version` metadata.
+When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle that associates stack traces with a debug ID or with `service` and `version` metadata.
 
-At build time, the plugin injects a snippet that writes metadata to `window.DD_SOURCE_CODE_CONTEXT`. At runtime, the RUM SDK reads `window.DD_SOURCE_CODE_CONTEXT` to tag errors with the correct service and version for source code resolution. This works in conjunction with [uploaded source maps][2] — source maps provide the file mapping, and `window.DD_SOURCE_CODE_CONTEXT` provides the service and version association.
+At build time, the plugin injects a snippet that writes metadata to `window.DD_SOURCE_CODE_CONTEXT`. At runtime, the RUM SDK reads this metadata to associate stack frames with [uploaded source maps][2].
 
 ## Prerequisites
 
 - Source maps uploaded to Datadog, either through the [Source Maps build plugin][3] or [manually][2].
-- The RUM SDK initialized with matching `service` and `version` parameters.
+- For service and version matching, initialize the RUM SDK with matching `service` and `version` parameters.
 - The Datadog build plugin installed and registered with your bundler. See [Build Plugins][4] for installation instructions.
 
 ## Configuration
@@ -36,12 +36,14 @@ Configure the `rum.sourceCodeContext` object in your build plugin options:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `rum.sourceCodeContext.service` | String | Yes | None | Service name. Must match the RUM SDK `service` initialization parameter. |
+| `rum.sourceCodeContext.debugId` | Boolean | No | `false` | Inject a deterministic debug ID into each JavaScript bundle. |
+| `rum.sourceCodeContext.upload` | Boolean | No | `false` | Upload source maps by debug ID during the build. Requires `debugId: true` and a Datadog API key. |
+| `rum.sourceCodeContext.service` | String | Yes, unless `debugId` is enabled | None | Service name. Must match the RUM SDK `service` initialization parameter. |
 | `rum.sourceCodeContext.version` | String | No | None | Release version. If omitted, source code context is not associated with a specific version. If set, must match the RUM SDK `version` initialization parameter. |
 
 ## Example
 
-The following example shows source code context combined with source maps, a common pairing:
+The following example injects debug IDs and uploads source maps directly from the build plugin:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -52,17 +54,10 @@ module.exports = {
       auth: {
         apiKey: process.env.DATADOG_API_KEY,
       },
-      errorTracking: {
-        sourcemaps: {
-          service: 'my-application',
-          releaseVersion: '1.0.0',
-          minifiedPathPrefix: 'https://example.com/static/',
-        },
-      },
       rum: {
         sourceCodeContext: {
-          service: 'my-application',
-          version: '1.0.0',
+          debugId: true,
+          upload: true,
         },
       },
     }),

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -34,10 +34,11 @@ At build time, the plugin injects a snippet that writes metadata to `window.DD_S
 
 Configure the `rum.sourceCodeContext` object in your build plugin options:
 
+Choose either debug ID matching or service and version matching. The two configurations are mutually exclusive.
+
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `rum.sourceCodeContext.debugId` | Boolean | No | `false` | Inject a deterministic debug ID into each JavaScript bundle. |
-| `rum.sourceCodeContext.upload` | Boolean | No | `false` | Upload source maps by debug ID during the build. Requires `debugId: true` and a Datadog API key. |
 | `rum.sourceCodeContext.service` | String | Yes, unless `debugId` is enabled | None | Service name. Must match the RUM SDK `service` initialization parameter. |
 | `rum.sourceCodeContext.version` | String | No | None | Release version. If omitted, source code context is not associated with a specific version. If set, must match the RUM SDK `version` initialization parameter. |
 
@@ -54,10 +55,14 @@ module.exports = {
       auth: {
         apiKey: process.env.DATADOG_API_KEY,
       },
+      errorTracking: {
+        sourcemaps: {
+          debugId: true,
+        },
+      },
       rum: {
         sourceCodeContext: {
           debugId: true,
-          upload: true,
         },
       },
     }),

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -41,22 +41,12 @@ Debug IDs associate each JavaScript bundle with its source map without relying o
 
 Set `debugId` to `true` in `rum.sourceCodeContext` to inject a debug ID into each JavaScript bundle.
 
-The following example also configures `errorTracking.sourcemaps.debugId` so that the build plugin uploads the source maps:
-
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
 
 module.exports = {
   plugins: [
     datadogWebpackPlugin({
-      auth: {
-        apiKey: process.env.DATADOG_API_KEY,
-      },
-      errorTracking: {
-        sourcemaps: {
-          debugId: true,
-        },
-      },
       rum: {
         sourceCodeContext: {
           debugId: true,
@@ -66,8 +56,6 @@ module.exports = {
   ],
 };
 ```
-
-If you upload source maps with another tool, such as `datadog-ci`, omit `auth` and `errorTracking.sourcemaps` from this configuration.
 
 {{% /tab %}}
 {{% tab "Service and version" %}}

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -1,6 +1,6 @@
 ---
 title: Source Code Context
-description: "Display source code inline in Error Tracking stack traces by injecting debug ID or service and version metadata at build time."
+description: "Display source code inline in Error Tracking stack traces by injecting service and version metadata at build time."
 algolia:
   tags: ['source code context', 'build plugins', 'error tracking', 'stack traces']
 further_reading:
@@ -20,30 +20,28 @@ further_reading:
 
 ## Overview
 
-When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle. This snippet associates stack traces with a debug ID or with `service` and `version` metadata.
+When viewing errors in [Error Tracking][1], Datadog can display the source code lines surrounding each frame in the stack trace. The Source Code Context build plugin enables this feature by injecting a small runtime snippet into your bundle that associates stack traces with your `service` and `version` metadata.
 
-At build time, the plugin injects a snippet that writes metadata to `window.DD_SOURCE_CODE_CONTEXT`. At runtime, the RUM SDK reads this metadata to associate stack frames with [uploaded source maps][2].
+At build time, the plugin injects a snippet that writes metadata to `window.DD_SOURCE_CODE_CONTEXT`. At runtime, the RUM SDK reads `window.DD_SOURCE_CODE_CONTEXT` to tag errors with the correct service and version for source code resolution. This works in conjunction with [uploaded source maps][2] — source maps provide the file mapping, and `window.DD_SOURCE_CODE_CONTEXT` provides the service and version association.
 
 ## Prerequisites
 
 - Source maps uploaded to Datadog, either through the [Source Maps build plugin][3] or [manually][2].
-- For service and version matching, initialize the RUM SDK with matching `service` and `version` parameters.
+- The RUM SDK initialized with matching `service` and `version` parameters.
 - The Datadog build plugin installed and registered with your bundler. See [Build Plugins][4] for installation instructions.
 
 ## Configuration
 
-Use a debug ID for new configurations. You can also provide `service` and `version` alongside a debug ID to identify and filter events from a specific application or micro-frontend. This metadata is independent of the debug ID used to associate stack frames with source maps.
+Configure the `rum.sourceCodeContext` object in your build plugin options:
 
-The service and version configuration below documents the legacy matching method without debug IDs.
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rum.sourceCodeContext.service` | String | Yes | None | Service name. Must match the RUM SDK `service` initialization parameter. |
+| `rum.sourceCodeContext.version` | String | No | None | Release version. If omitted, source code context is not associated with a specific version. If set, must match the RUM SDK `version` initialization parameter. |
 
-{{< tabs >}}
-{{% tab "Debug ID (Recommended)" %}}
+## Example
 
-Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
-
-Debug ID support requires [Datadog Build Plugins version 3.3.0](https://github.com/DataDog/build-plugins/releases/tag/v3.3.0) or later.
-
-Set `debugId` to `true` in `sourcemaps` to inject a debug ID into each JavaScript bundle.
+The following example shows source code context combined with source maps, a common pairing:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -51,30 +49,16 @@ const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
 module.exports = {
   plugins: [
     datadogWebpackPlugin({
-      sourcemaps: {
-        debugId: true,
+      auth: {
+        apiKey: process.env.DATADOG_API_KEY,
       },
-    }),
-  ],
-};
-```
-
-{{% /tab %}}
-{{% tab "Service and version" %}}
-
-Service and version matching associates stack frames with source maps using metadata from the RUM SDK and the uploaded source maps.
-
-Configure the following options in `rum.sourceCodeContext`:
-
-- `service` (String, required): The service name. It must match the RUM SDK `service` initialization parameter.
-- `version` (String, optional): The release version. If set, it must match the RUM SDK `version` initialization parameter. If omitted, source code context is not associated with a specific version.
-
-```javascript
-const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
-
-module.exports = {
-  plugins: [
-    datadogWebpackPlugin({
+      errorTracking: {
+        sourcemaps: {
+          service: 'my-application',
+          releaseVersion: '1.0.0',
+          minifiedPathPrefix: 'https://example.com/static/',
+        },
+      },
       rum: {
         sourceCodeContext: {
           service: 'my-application',
@@ -85,11 +69,6 @@ module.exports = {
   ],
 };
 ```
-
-The `service` and `version` values must match the metadata used when uploading the source maps.
-
-{{% /tab %}}
-{{< /tabs >}}
 
 <div class="alert alert-info">This example uses webpack. The configuration object is identical across all supported bundlers. See <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/">Build Plugins</a> for installation instructions for your bundler.</div>
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -41,7 +41,7 @@ The service and version configuration below documents the legacy matching method
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
-Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+Debug ID support requires [Datadog Build Plugins version 3.3.0](https://github.com/DataDog/build-plugins/releases/tag/v3.3.0) or later.
 
 Set `debugId` to `true` in `sourcemaps` to inject a debug ID into each JavaScript bundle.
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -32,7 +32,9 @@ At build time, the plugin injects a snippet that writes metadata to `window.DD_S
 
 ## Configuration
 
-Choose one of the following source code context methods. The two configurations are mutually exclusive.
+Use a debug ID for new configurations. You can also provide `service` and `version` alongside a debug ID to identify and filter events from a specific application or micro-frontend. This metadata is independent of the debug ID used to associate stack frames with source maps.
+
+The service and version configuration below documents the legacy matching method without debug IDs.
 
 {{< tabs >}}
 {{% tab "Debug ID (Recommended)" %}}

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_code_context.md
@@ -41,6 +41,8 @@ The service and version configuration below documents the legacy matching method
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
+Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+
 Set `debugId` to `true` in `sourcemaps` to inject a debug ID into each JavaScript bundle.
 
 ```javascript

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -36,9 +36,11 @@ The following environment variables override configuration values:
 - `DATADOG_SITE` or `DD_SITE`: Overrides `auth.site` for the intake URL.
 - `DATADOG_SOURCEMAP_INTAKE_URL`: Overrides the full intake URL directly.
 
+Choose either debug ID uploads or service and version uploads. Do not configure both upload methods in the same build.
+
 ### Debug ID
 
-Configure `rum.sourceCodeContext.debugId` and `rum.sourceCodeContext.upload` to inject debug IDs and upload source maps during the build:
+Configure `rum.sourceCodeContext.debugId` to inject debug IDs and `errorTracking.sourcemaps.debugId` to upload source maps during the build:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -50,10 +52,14 @@ module.exports = {
         apiKey: process.env.DATADOG_API_KEY,
         site: 'datadoghq.com', // Optional: defaults to datadoghq.com
       },
+      errorTracking: {
+        sourcemaps: {
+          debugId: true,
+        },
+      },
       rum: {
         sourceCodeContext: {
           debugId: true,
-          upload: true,
         },
       },
     }),
@@ -61,7 +67,7 @@ module.exports = {
 };
 ```
 
-Debug ID uploads do not require a service, release version, or minified path prefix. Set `upload` to `false` or omit it to inject debug IDs without uploading source maps from the build plugin.
+Debug ID uploads do not require a service, release version, or minified path prefix. Omit `errorTracking.sourcemaps` to inject debug IDs without uploading source maps from the build plugin.
 
 ### Service and version
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -38,9 +38,21 @@ The following environment variables override configuration values:
 
 Choose either debug ID uploads or service and version uploads. Do not configure both upload methods in the same build.
 
-### Debug ID
+{{< tabs >}}
+{{% tab "Debug ID (Recommended)" %}}
 
-Configure `rum.sourceCodeContext.debugId` to inject debug IDs and `errorTracking.sourcemaps.debugId` to upload source maps during the build:
+Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
+
+Configure the following options in `errorTracking.sourcemaps`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `debugId` | Boolean | Yes | None | Set to `true` to upload source maps using debug IDs. |
+| `bailOnError` | Boolean | No | `false` | If `true`, the build fails when a source map upload error occurs. |
+| `dryRun` | Boolean | No | `false` | If `true`, the plugin runs through the upload process without sending data to Datadog. Use this to verify your configuration. |
+| `maxConcurrency` | Number | No | `20` | Maximum number of concurrent source map uploads. |
+
+Also configure `rum.sourceCodeContext.debugId` to inject debug IDs during the build:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -67,22 +79,21 @@ module.exports = {
 };
 ```
 
-Debug ID uploads do not require a service, release version, or minified path prefix. Omit `errorTracking.sourcemaps` to inject debug IDs without uploading source maps from the build plugin.
+Debug ID uploads do not require a service, release version, or minified path prefix.
 
-### Service and version
+{{% /tab %}}
+{{% tab "Service and version" %}}
 
 Configure the `errorTracking.sourcemaps` object to upload source maps using service and version matching:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `errorTracking.sourcemaps.service` | String | Yes | None | Service name. Must match the RUM SDK `service` initialization parameter. |
-| `errorTracking.sourcemaps.releaseVersion` | String | Yes | None | Release version. Must match the RUM SDK `version` initialization parameter. |
-| `errorTracking.sourcemaps.minifiedPathPrefix` | String | Yes | None | URL or root-relative path prefix for your minified JavaScript files are served. For example, `https://example.com/static/` or `/static/`. |
-| `errorTracking.sourcemaps.bailOnError` | Boolean | No | `false` | If `true`, the build fails when a source map upload error occurs. |
-| `errorTracking.sourcemaps.dryRun` | Boolean | No | `false` | If `true`, the plugin runs through the upload process without sending data to Datadog. Use this to verify your configuration. |
-| `errorTracking.sourcemaps.maxConcurrency` | Number | No | `20` | Maximum number of concurrent source map uploads. |
-
-#### Example
+| `service` | String | Yes | None | Service name. Must match the RUM SDK `service` initialization parameter. |
+| `releaseVersion` | String | Yes, unless `metadata.version` is set | None | Release version. Must match the RUM SDK `version` initialization parameter. |
+| `minifiedPathPrefix` | String | Yes | None | URL or root-relative path prefix where your minified JavaScript files are served. For example, `https://example.com/static/` or `/static/`. |
+| `bailOnError` | Boolean | No | `false` | If `true`, the build fails when a source map upload error occurs. |
+| `dryRun` | Boolean | No | `false` | If `true`, the plugin runs through the upload process without sending data to Datadog. Use this to verify your configuration. |
+| `maxConcurrency` | Number | No | `20` | Maximum number of concurrent source map uploads. |
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -106,9 +117,12 @@ module.exports = {
 };
 ```
 
-<div class="alert alert-info">This example uses webpack. The configuration object is identical across all supported bundlers — only the import and plugin function name differ. See <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/">Build Plugins</a> for installation instructions for your bundler.</div>
-
 To also display inline source code in Error Tracking stack traces, pair service and version source map uploads with the [Source Code Context][5] plugin.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+<div class="alert alert-info">These examples use webpack. The configuration object is identical across all supported bundlers — only the import and plugin function name differ. See <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/">Build Plugins</a> for installation instructions for your bundler.</div>
 
 ## Further reading
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -43,16 +43,17 @@ Choose either debug ID uploads or service and version uploads. Do not configure 
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
-Configure the following options in `errorTracking.sourcemaps`:
+Configure the following options in `sourcemaps`:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `debugId` | Boolean | Yes | None | Set to `true` to upload source maps using debug IDs. |
+| `debugId` | Boolean | Yes | None | Set to `true` to inject a debug ID into each JavaScript bundle. |
+| `upload` | Boolean | Yes, to upload | `false` | Set to `true` to upload source maps during the build. If omitted, the plugin only injects debug IDs. |
 | `bailOnError` | Boolean | No | `false` | If `true`, the build fails when a source map upload error occurs. |
 | `dryRun` | Boolean | No | `false` | If `true`, the plugin runs through the upload process without sending data to Datadog. Use this to verify your configuration. |
 | `maxConcurrency` | Number | No | `20` | Maximum number of concurrent source map uploads. |
 
-Also configure `rum.sourceCodeContext.debugId` to inject debug IDs during the build:
+Set `debugId` and `upload` to `true` to inject debug IDs and upload source maps during the build:
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -64,22 +65,14 @@ module.exports = {
         apiKey: process.env.DATADOG_API_KEY,
         site: 'datadoghq.com', // Optional: defaults to datadoghq.com
       },
-      errorTracking: {
-        sourcemaps: {
-          debugId: true,
-        },
-      },
-      rum: {
-        sourceCodeContext: {
-          debugId: true,
-        },
+      sourcemaps: {
+        debugId: true,
+        upload: true,
       },
     }),
   ],
 };
 ```
-
-Debug ID uploads do not require a service, release version, or minified path prefix.
 
 {{% /tab %}}
 {{% tab "Service and version" %}}

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -19,7 +19,7 @@ further_reading:
 
 The Source Maps build plugin automatically uploads JavaScript source maps to Datadog during your build, enabling deobfuscated stack traces in [Error Tracking][1] and [RUM][2]. This replaces the need to manually run `datadog-ci sourcemaps upload` or configure CI/CD pipelines for source map uploads.
 
-The plugin hooks into the build process, discovers all `.js` files with corresponding `.map` source map files from the build output, and uploads them to Datadog with git metadata. Source maps can be associated with events by debug ID or by service and version.
+The plugin hooks into the build process, discovers all `.js` files with corresponding `.map` source map files from the build output, and uploads them to Datadog with git metadata. It can associate source maps with events by debug ID or by service and version.
 
 ## Prerequisites
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -19,18 +19,53 @@ further_reading:
 
 The Source Maps build plugin automatically uploads JavaScript source maps to Datadog during your build, enabling deobfuscated stack traces in [Error Tracking][1] and [RUM][2]. This replaces the need to manually run `datadog-ci sourcemaps upload` or configure CI/CD pipelines for source map uploads.
 
-The plugin hooks into the build process, discovers all `.js` files with corresponding `.map` source map files from the build output, and uploads them to Datadog with git metadata.
+The plugin hooks into the build process, discovers all `.js` files with corresponding `.map` source map files from the build output, and uploads them to Datadog with git metadata. Source maps can be associated with events by debug ID or by service and version.
 
 ## Prerequisites
 
 - A Datadog API key, set with `auth.apiKey` or the `DATADOG_API_KEY` environment variable.
 - Source maps enabled in your bundler configuration. The plugin uploads source maps but does not generate them. See [Upload JavaScript Source Maps][3] for bundler-specific source map generation setup.
-- The RUM SDK initialized with `service` and `version` parameters that match the plugin's `service` and `releaseVersion` configuration.
+- For debug ID uploads, enable debug ID injection in the build plugin.
+- For service and version uploads, initialize the RUM SDK with `service` and `version` parameters that match the plugin configuration.
 - The Datadog build plugin installed and registered with your bundler. See [Build Plugins][4] for installation instructions.
 
 ## Configuration
 
-Configure the `errorTracking.sourcemaps` object in your build plugin options:
+The following environment variables override configuration values:
+
+- `DATADOG_SITE` or `DD_SITE`: Overrides `auth.site` for the intake URL.
+- `DATADOG_SOURCEMAP_INTAKE_URL`: Overrides the full intake URL directly.
+
+### Debug ID
+
+Configure `rum.sourceCodeContext.debugId` and `rum.sourceCodeContext.upload` to inject debug IDs and upload source maps during the build:
+
+```javascript
+const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
+
+module.exports = {
+  plugins: [
+    datadogWebpackPlugin({
+      auth: {
+        apiKey: process.env.DATADOG_API_KEY,
+        site: 'datadoghq.com', // Optional: defaults to datadoghq.com
+      },
+      rum: {
+        sourceCodeContext: {
+          debugId: true,
+          upload: true,
+        },
+      },
+    }),
+  ],
+};
+```
+
+Debug ID uploads do not require a service, release version, or minified path prefix. Set `upload` to `false` or omit it to inject debug IDs without uploading source maps from the build plugin.
+
+### Service and version
+
+Configure the `errorTracking.sourcemaps` object to upload source maps using service and version matching:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -41,11 +76,7 @@ Configure the `errorTracking.sourcemaps` object in your build plugin options:
 | `errorTracking.sourcemaps.dryRun` | Boolean | No | `false` | If `true`, the plugin runs through the upload process without sending data to Datadog. Use this to verify your configuration. |
 | `errorTracking.sourcemaps.maxConcurrency` | Number | No | `20` | Maximum number of concurrent source map uploads. |
 
-The following environment variables override configuration values:
-- `DATADOG_SITE` or `DD_SITE`: Overrides `auth.site` for the intake URL.
-- `DATADOG_SOURCEMAP_INTAKE_URL`: Overrides the full intake URL directly.
-
-## Example
+#### Example
 
 ```javascript
 const { datadogWebpackPlugin } = require('@datadog/webpack-plugin');
@@ -71,7 +102,7 @@ module.exports = {
 
 <div class="alert alert-info">This example uses webpack. The configuration object is identical across all supported bundlers — only the import and plugin function name differ. See <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/">Build Plugins</a> for installation instructions for your bundler.</div>
 
-To also display inline source code in Error Tracking stack traces, pair source map uploads with the [Source Code Context][5] plugin. Source maps provide the file mapping; source code context provides the service and version association.
+To also display inline source code in Error Tracking stack traces, pair service and version source map uploads with the [Source Code Context][5] plugin.
 
 ## Further reading
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -43,6 +43,8 @@ Choose one source map upload matching method: debug ID or service and version. T
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
+Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+
 Configure the following options in `sourcemaps`:
 
 | Parameter | Type | Required | Default | Description |

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -43,7 +43,7 @@ Choose one source map upload matching method: debug ID or service and version. T
 
 Debug IDs associate each JavaScript bundle with its source map without relying on the bundle URL, service, or version. Use this method for new configurations.
 
-Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+Debug ID support requires [Datadog Build Plugins version 3.3.0](https://github.com/DataDog/build-plugins/releases/tag/v3.3.0) or later.
 
 Configure the following options in `sourcemaps`:
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/build_plugins/source_maps.md
@@ -36,7 +36,7 @@ The following environment variables override configuration values:
 - `DATADOG_SITE` or `DD_SITE`: Overrides `auth.site` for the intake URL.
 - `DATADOG_SOURCEMAP_INTAKE_URL`: Overrides the full intake URL directly.
 
-Choose either debug ID uploads or service and version uploads. Do not configure both upload methods in the same build.
+Choose one source map upload matching method: debug ID or service and version. These upload methods are mutually exclusive. RUM [source code context][5] can still include service and version metadata when you use debug ID uploads because that metadata identifies and filters events independently of source map matching.
 
 {{< tabs >}}
 {{% tab "Debug ID (Recommended)" %}}

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -118,6 +118,9 @@ If the sum of the file size for <code>javascript.364758.min.js</code> and <code>
 
 The best way to upload source maps is to add an extra step in your CI pipeline and run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and subdirectories to automatically upload source maps with relevant minified files.
 
+{{< tabs >}}
+{{% tab "Service and version" %}}
+
 {{< site-region region="us" >}}
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
 2. [Create a dedicated Datadog API key][1] and export it as an environment variable named `DD_API_KEY`.
@@ -164,6 +167,59 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 
 <div class="alert alert-info">If you are serving the same JavaScript source files from different subdomains, upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>.</div>
 
+{{% /tab %}}
+{{% tab "Debug ID" %}}
+
+Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
+
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
+2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
+3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
+4. Add debug IDs to your build output using either a Datadog Build Plugin or `datadog-ci`:
+
+   - To inject debug IDs during the build, configure the [Datadog Build Plugin][8]:
+
+     ```javascript
+     rum: {
+       sourceCodeContext: {
+         debugId: true,
+       },
+     }
+     ```
+
+   - To inject debug IDs after the build, run:
+
+     ```bash
+     datadog-ci sourcemaps inject /path/to/dist
+     ```
+
+5. Upload the source maps and corresponding JavaScript bundles:
+
+   ```bash
+   datadog-ci sourcemaps upload /path/to/dist --debug-id
+   ```
+
+If a Datadog Build Plugin already injected debug IDs, you do not need to run `datadog-ci sourcemaps inject`. Do not pass `--service`, `--release-version`, or `--minified-path-prefix` with `--debug-id`.
+
+The `inject` command modifies JavaScript bundles and source maps in place. Run it after the build and before generating byte-dependent artifacts such as SRI hashes, compressed assets, signatures, or checksum manifests. Deploy the same modified artifacts that you upload.
+
+To find the local source map for a specific debug ID, run:
+
+```bash
+datadog-ci sourcemaps find /path/to/dist --debug-id 12345678-1234-1234-1234-123456789abc
+```
+
+To find source maps that do not contain a debug ID, run:
+
+```bash
+datadog-ci sourcemaps find /path/to/dist --missing-debug-id
+```
+
+The `find` command only inspects local `*.js.map` files. It does not confirm whether Datadog received an artifact.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 See all uploaded symbols and manage your source maps on the [{{< ui >}}Explore RUM Debug Symbols{{< /ui >}}][5] page.
 
 ### Link stack frames to your source code
@@ -193,3 +249,6 @@ On the other hand, an unminified stack trace provides you with all the context y
 [3]: https://docs.datadoghq.com/logs/log_collection/javascript/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/tree/master/packages/base/src/commands/sourcemaps#link-errors-with-your-source-code
 [5]: https://app.datadoghq.com/source-code/setup/rum
+[6]: https://app.datadoghq.com/organization-settings/api-keys
+[7]: /getting_started/site/
+[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -173,11 +173,11 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
-2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
-3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
+2. [Create a dedicated Datadog API key](https://app.datadoghq.com/organization-settings/api-keys) and export it as an environment variable named `DD_API_KEY`.
+3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site](/getting_started/site/).
 4. Add debug IDs to your build output using either a Datadog Build Plugin or `datadog-ci`:
 
-   - To inject debug IDs during the build, configure the [Datadog Build Plugin][8]:
+   - To inject debug IDs during the build, configure the [Datadog Build Plugin](/real_user_monitoring/application_monitoring/browser/build_plugins/):
 
      ```javascript
      rum: {
@@ -249,6 +249,3 @@ On the other hand, an unminified stack trace provides you with all the context y
 [3]: https://docs.datadoghq.com/logs/log_collection/javascript/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/tree/master/packages/base/src/commands/sourcemaps#link-errors-with-your-source-code
 [5]: https://app.datadoghq.com/source-code/setup/rum
-[6]: https://app.datadoghq.com/organization-settings/api-keys
-[7]: /getting_started/site/
-[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -178,7 +178,7 @@ Choose one of the following upload methods.
 
 Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
 
-Configure both source map uploads and debug ID injection in your build plugin:
+Enable debug ID injection and source map uploads in your build plugin:
 
 ```javascript
 datadogWebpackPlugin({
@@ -186,20 +186,16 @@ datadogWebpackPlugin({
     apiKey: process.env.DATADOG_API_KEY,
     site: 'datadoghq.com',
   },
-  errorTracking: {
-    sourcemaps: {
-      service: 'my-application',
-      releaseVersion: '1.0.0',
-      minifiedPathPrefix: 'https://example.com/static/',
-    },
-  },
   rum: {
     sourceCodeContext: {
       debugId: true,
+      upload: true,
     },
   },
 });
 ```
+
+The plugin uploads each source map with the debug ID injected into its corresponding JavaScript bundle. You do not need to configure a service, release version, or minified path prefix.
 
 This example uses webpack. See [Datadog Build Plugins][8] for installation and configuration instructions for other supported bundlers.
 

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -119,6 +119,67 @@ If the sum of the file size for <code>javascript.364758.min.js</code> and <code>
 The best way to upload source maps is to add an extra step in your CI pipeline and run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and subdirectories to automatically upload source maps with relevant minified files.
 
 {{< tabs >}}
+{{% tab "Debug ID (Recommended)" %}}
+
+Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
+
+Choose one of the following upload methods.
+
+#### Datadog Build Plugins
+
+Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
+
+Enable debug ID injection and source map uploads in your build plugin:
+
+```javascript
+datadogWebpackPlugin({
+  auth: {
+    apiKey: process.env.DATADOG_API_KEY,
+    site: 'datadoghq.com',
+  },
+  errorTracking: {
+    sourcemaps: {
+      debugId: true,
+    },
+  },
+  rum: {
+    sourceCodeContext: {
+      debugId: true,
+    },
+  },
+});
+```
+
+The plugin uploads each source map with the debug ID injected into its corresponding JavaScript bundle.
+
+This example uses webpack. See [Datadog Build Plugins][8] for installation and configuration instructions for other supported bundlers.
+
+#### `datadog-ci`
+
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
+2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
+3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
+4. Inject debug IDs after the build:
+
+   ```bash
+   datadog-ci sourcemaps inject /path/to/dist
+   ```
+
+5. Upload the source maps and corresponding JavaScript bundles:
+
+   ```bash
+   datadog-ci sourcemaps upload /path/to/dist --debug-id
+   ```
+
+Do not pass `--service`, `--release-version`, or `--minified-path-prefix` with `--debug-id`.
+
+The `inject` command modifies JavaScript bundles and source maps in place. Run it after the build and before generating byte-dependent artifacts such as SRI hashes, compressed assets, signatures, or checksum manifests. Deploy the same modified artifacts that you upload.
+
+[6]: https://app.datadoghq.com/organization-settings/api-keys
+[7]: /getting_started/site/
+[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/source_maps/
+
+{{% /tab %}}
 {{% tab "Service and version" %}}
 
 {{< site-region region="us" >}}
@@ -168,61 +229,19 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 <div class="alert alert-info">If you are serving the same JavaScript source files from different subdomains, upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>.</div>
 
 {{% /tab %}}
-{{% tab "Debug ID" %}}
+{{< /tabs >}}
 
-Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
+See all uploaded symbols and manage your source maps on the [{{< ui >}}Explore RUM Debug Symbols{{< /ui >}}][5] page.
 
-Choose one of the following upload methods.
+### Link stack frames to your source code
 
-#### Datadog Build Plugins
+If you run `datadog-ci sourcemaps upload` within a Git working directory, Datadog collects repository metadata. The `datadog-ci` command collects the repository URL, the current commit hash, and the list of file paths in the repository that relate to your source maps. For more details about Git metadata collection, refer to the [datadog-ci documentation][4].
 
-Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
+Datadog displays links to your source code on unminified stack frames.
 
-Enable debug ID injection and source map uploads in your build plugin:
+## Troubleshooting debug ID uploads
 
-```javascript
-datadogWebpackPlugin({
-  auth: {
-    apiKey: process.env.DATADOG_API_KEY,
-    site: 'datadoghq.com',
-  },
-  errorTracking: {
-    sourcemaps: {
-      debugId: true,
-    },
-  },
-  rum: {
-    sourceCodeContext: {
-      debugId: true,
-    },
-  },
-});
-```
-
-The plugin uploads each source map with the debug ID injected into its corresponding JavaScript bundle. You do not need to configure a service, release version, or minified path prefix.
-
-This example uses webpack. See [Datadog Build Plugins][8] for installation and configuration instructions for other supported bundlers.
-
-#### `datadog-ci`
-
-1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
-2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
-3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
-4. Inject debug IDs after the build:
-
-   ```bash
-   datadog-ci sourcemaps inject /path/to/dist
-   ```
-
-5. Upload the source maps and corresponding JavaScript bundles:
-
-   ```bash
-   datadog-ci sourcemaps upload /path/to/dist --debug-id
-   ```
-
-Do not pass `--service`, `--release-version`, or `--minified-path-prefix` with `--debug-id`.
-
-The `inject` command modifies JavaScript bundles and source maps in place. Run it after the build and before generating byte-dependent artifacts such as SRI hashes, compressed assets, signatures, or checksum manifests. Deploy the same modified artifacts that you upload.
+### Inspect local source maps
 
 To find the local source map for a specific debug ID, run:
 
@@ -237,21 +256,6 @@ datadog-ci sourcemaps find /path/to/dist --missing-debug-id
 ```
 
 The `find` command only inspects local `*.js.map` files. It does not confirm whether Datadog received an artifact.
-
-[6]: https://app.datadoghq.com/organization-settings/api-keys
-[7]: /getting_started/site/
-[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/source_maps/
-
-{{% /tab %}}
-{{< /tabs >}}
-
-See all uploaded symbols and manage your source maps on the [{{< ui >}}Explore RUM Debug Symbols{{< /ui >}}][5] page.
-
-### Link stack frames to your source code
-
-If you run `datadog-ci sourcemaps upload` within a Git working directory, Datadog collects repository metadata. The `datadog-ci` command collects the repository URL, the current commit hash, and the list of file paths in the repository that relate to your source maps. For more details about Git metadata collection, refer to the [datadog-ci documentation][4].
-
-Datadog displays links to your source code on unminified stack frames.
 
 ## Troubleshoot errors with ease
 

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -137,15 +137,9 @@ datadogWebpackPlugin({
     apiKey: process.env.DATADOG_API_KEY,
     site: 'datadoghq.com',
   },
-  errorTracking: {
-    sourcemaps: {
-      debugId: true,
-    },
-  },
-  rum: {
-    sourceCodeContext: {
-      debugId: true,
-    },
+  sourcemaps: {
+    debugId: true,
+    upload: true,
   },
 });
 ```

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -222,6 +222,9 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 
 <div class="alert alert-info">If you are serving the same JavaScript source files from different subdomains, upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>.</div>
 
+[2]: /real_user_monitoring/application_monitoring/browser/setup/#initialization-parameters
+[3]: /logs/log_collection/javascript/#initialization-parameters
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -268,7 +271,5 @@ On the other hand, an unminified stack trace provides you with all the context y
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-ci/tree/master/packages/base/src/commands/sourcemaps
-[2]: https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/setup/#initialization-parameters
-[3]: https://docs.datadoghq.com/logs/log_collection/javascript/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/tree/master/packages/base/src/commands/sourcemaps#link-errors-with-your-source-code
 [5]: https://app.datadoghq.com/source-code/setup/rum

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -172,26 +172,47 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 
 Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
 
+Choose one of the following upload methods.
+
+#### Datadog Build Plugins
+
+Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
+
+Configure both source map uploads and debug ID injection in your build plugin:
+
+```javascript
+datadogWebpackPlugin({
+  auth: {
+    apiKey: process.env.DATADOG_API_KEY,
+    site: 'datadoghq.com',
+  },
+  errorTracking: {
+    sourcemaps: {
+      service: 'my-application',
+      releaseVersion: '1.0.0',
+      minifiedPathPrefix: 'https://example.com/static/',
+    },
+  },
+  rum: {
+    sourceCodeContext: {
+      debugId: true,
+    },
+  },
+});
+```
+
+This example uses webpack. See [Datadog Build Plugins][8] for installation and configuration instructions for other supported bundlers.
+
+#### `datadog-ci`
+
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
 2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
 3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
-4. Add debug IDs to your build output using either a Datadog Build Plugin or `datadog-ci`:
+4. Inject debug IDs after the build:
 
-   - To inject debug IDs during the build, configure the [Datadog Build Plugin][8]:
-
-     ```javascript
-     rum: {
-       sourceCodeContext: {
-         debugId: true,
-       },
-     }
-     ```
-
-   - To inject debug IDs after the build, run:
-
-     ```bash
-     datadog-ci sourcemaps inject /path/to/dist
-     ```
+   ```bash
+   datadog-ci sourcemaps inject /path/to/dist
+   ```
 
 5. Upload the source maps and corresponding JavaScript bundles:
 
@@ -199,7 +220,7 @@ Debug IDs associate a JavaScript bundle with its source map without relying on t
    datadog-ci sourcemaps upload /path/to/dist --debug-id
    ```
 
-If a Datadog Build Plugin already injected debug IDs, you do not need to run `datadog-ci sourcemaps inject`. Do not pass `--service`, `--release-version`, or `--minified-path-prefix` with `--debug-id`.
+Do not pass `--service`, `--release-version`, or `--minified-path-prefix` with `--debug-id`.
 
 The `inject` command modifies JavaScript bundles and source maps in place. Run it after the build and before generating byte-dependent artifacts such as SRI hashes, compressed assets, signatures, or checksum manifests. Deploy the same modified artifacts that you upload.
 
@@ -219,7 +240,7 @@ The `find` command only inspects local `*.js.map` files. It does not confirm whe
 
 [6]: https://app.datadoghq.com/organization-settings/api-keys
 [7]: /getting_started/site/
-[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/
+[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/source_maps/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -186,10 +186,14 @@ datadogWebpackPlugin({
     apiKey: process.env.DATADOG_API_KEY,
     site: 'datadoghq.com',
   },
+  errorTracking: {
+    sourcemaps: {
+      debugId: true,
+    },
+  },
   rum: {
     sourceCodeContext: {
       debugId: true,
-      upload: true,
     },
   },
 });

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -173,11 +173,11 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 Debug IDs associate a JavaScript bundle with its source map without relying on the bundle URL, service, or release version.
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
-2. [Create a dedicated Datadog API key](https://app.datadoghq.com/organization-settings/api-keys) and export it as an environment variable named `DD_API_KEY`.
-3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site](/getting_started/site/).
+2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.
+3. For sites other than US1, configure the CLI by exporting `DD_SITE` with your [Datadog site][7].
 4. Add debug IDs to your build output using either a Datadog Build Plugin or `datadog-ci`:
 
-   - To inject debug IDs during the build, configure the [Datadog Build Plugin](/real_user_monitoring/application_monitoring/browser/build_plugins/):
+   - To inject debug IDs during the build, configure the [Datadog Build Plugin][8]:
 
      ```javascript
      rum: {
@@ -216,6 +216,10 @@ datadog-ci sourcemaps find /path/to/dist --missing-debug-id
 ```
 
 The `find` command only inspects local `*.js.map` files. It does not confirm whether Datadog received an artifact.
+
+[6]: https://app.datadoghq.com/organization-settings/api-keys
+[7]: /getting_started/site/
+[8]: /real_user_monitoring/application_monitoring/browser/build_plugins/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -129,6 +129,8 @@ Choose one of the following upload methods.
 
 Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
 
+Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+
 Enable debug ID injection and source map uploads in your build plugin:
 
 ```javascript

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -116,7 +116,7 @@ If the sum of the file size for <code>javascript.364758.min.js</code> and <code>
 
 ## Upload your source maps
 
-The best way to upload source maps is to add an extra step in your CI pipeline and run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and subdirectories to automatically upload source maps with relevant minified files.
+To upload your source maps, choose one of the following matching methods: Debug ID (recommended) or service and version. Debug IDs enable source map resolution across micro frontends.
 
 {{< tabs >}}
 {{% tab "Debug ID (Recommended)" %}}
@@ -179,6 +179,8 @@ The `inject` command modifies JavaScript bundles and source maps in place. Run i
 
 {{% /tab %}}
 {{% tab "Service and version" %}}
+
+To upload source maps using a service and version, add an extra step to your CI pipeline that runs the `datadog-ci sourcemaps upload` command. It scans the `dist` directory and subdirectories to automatically upload source maps with the relevant minified files.
 
 {{< site-region region="us" >}}
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).

--- a/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -129,7 +129,7 @@ Choose one of the following upload methods.
 
 Datadog Build Plugins can inject debug IDs and upload source maps directly during the build. You do not need to install or run `datadog-ci` separately.
 
-Debug ID support requires Datadog Build Plugins version `3.3.0` or later.
+Debug ID support requires [Datadog Build Plugins version 3.3.0](https://github.com/DataDog/build-plugins/releases/tag/v3.3.0) or later.
 
 Enable debug ID injection and source map uploads in your build plugin:
 
@@ -151,6 +151,8 @@ The plugin uploads each source map with the debug ID injected into its correspon
 This example uses webpack. See [Datadog Build Plugins][8] for installation and configuration instructions for other supported bundlers.
 
 #### `datadog-ci`
+
+Debug ID support requires [`@datadog/datadog-ci` version 5.24.0](https://github.com/DataDog/datadog-ci/releases/tag/v5.24.0) or later.
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
 2. [Create a dedicated Datadog API key][6] and export it as an environment variable named `DD_API_KEY`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

RUM-18236

Updates the JavaScript source map documentation to cover debug ID workflows while preserving the existing service and version instructions.

- Presents `Debug ID (Recommended)` and `Service and version` as consistent selectable tabs.
- Documents the simplified Build Plugins configuration: `sourcemaps.debugId` injects debug IDs and `sourcemaps.upload` enables direct upload.
- Documents debug ID injection and uploads with `datadog-ci`.
- Keeps Source Code Context focused on injection and Source Maps focused on upload configuration.
- Moves the `datadog-ci sourcemaps find` commands to troubleshooting.

### Merge readiness

- [ ] Ready for merge

### Validation

- `git diff --check`
- Reviewed the generated branch preview for page structure, tab ordering, and configuration readability.
- The Build Plugins configuration was validated with focused tests and a real staging source map upload.

### AI assistance

An AI coding assistant helped restructure the pages, apply the repository style guidance, and validate the Markdown changes. The content and examples were manually reviewed.

### Additional notes

The debug ID workflow is recommended for new configurations. The service and version workflow remains available for existing configurations.

