### PR TITLE
Add Peer Benchmarks section to Track Application Startups

### DIFF
--- a/hugo/content/en/real_user_monitoring/setup/enable_rum/track_application_startups.mdoc.md
+++ b/hugo/content/en/real_user_monitoring/setup/enable_rum/track_application_startups.mdoc.md
@@ -20,12 +20,14 @@ RUM measures how fast your mobile app becomes usable after launch. Time to initi
 
 {% if equals($platform, "android") %}
 {% partial file="sdk/track_app_startups/android.mdoc.md" /%}
+{% partial file="sdk/track_app_startups/peer_benchmarks.mdoc.md" /%}
 {% /if %}
 
 <!-- iOS -->
 
 {% if equals($platform, "ios") %}
 {% partial file="sdk/track_app_startups/ios.mdoc.md" /%}
+{% partial file="sdk/track_app_startups/peer_benchmarks.mdoc.md" /%}
 {% /if %}
 
 <!-- Flutter -->

--- a/hugo/layouts/shortcodes/mdoc/en/sdk/track_app_startups/peer_benchmarks.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/track_app_startups/peer_benchmarks.mdoc.md
@@ -1,0 +1,23 @@
+## Peer Benchmarks
+
+Peer Benchmarks compare your application's TTID to the performance of comparable applications monitored by Datadog. Get visibility into your relative performance against other organizations using Datadog.
+
+### Use Peer Benchmarks
+
+{% alert level="info" %}
+To use this feature, your organization must use [RUM without Limits](/real_user_monitoring/rum_without_limits/).
+{% /alert %}
+
+Peer Benchmarks are displayed on the Explore Vitals page.
+
+Benchmarks adapt to the filters you apply on metric dimensions in the UI, letting you compare your performance for a specific end-user base. Filtering on `env`, `service`, or `version` has no effect.
+
+### How it works
+
+Peer applications are selected to share a similar audience base, combining development platform and user session traffic.
+
+### Data privacy
+
+Peer Benchmarks data is fully anonymized: only aggregated indicators are displayed, so no individual application can be isolated.
+
+Benchmarks are only shown when the number of peer applications is large enough to ensure statistical significance and strict anonymity.


### PR DESCRIPTION
## What does this PR do?

Documents Peer Benchmarks for TTID on the **Track Application Startups** page (Setup RUM > Enable the DD RUM Module).

The section covers what the comparison is, the RUM without Limits prerequisite, where it appears in the UI, filtering behavior on metric dimensions, how peer applications are selected, and the data privacy guarantees.

## Implementation

Added as a shared partial (`sdk/track_app_startups/peer_benchmarks.mdoc.md`) included from the `android` and `ios` blocks, since the content is identical for both and application startup tracking is not available on the other SDKs.

## Notes for reviewers

- The **Explore Vitals page** is currently unlinked — target path TBC.
- The RUM without Limits link is inline rather than reference-style, to avoid colliding with the `[1]`/`[2]` definitions already used by the `android` and `ios` partials that render on the same page. Happy to switch if reference definitions are scoped per partial.
- Please check both `?platform=android` and `?platform=ios` on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)