### PR TITLE
[DOCS-13920] GA Bits investigations on Synthetic tests

### DIFF
--- a/hugo/content/en/getting_started/synthetics/api_test.md
+++ b/hugo/content/en/getting_started/synthetics/api_test.md
@@ -229,6 +229,10 @@ To troubleshoot a failed test, review the failures on the **Activity** tab or th
 
 With Datadog's [APM integration with Synthetic Monitoring][14], access the root cause of a failed test run by looking at the trace generated from the test run in the {{< ui >}}Traces{{< /ui >}} tab.
 
+### Launch a Bits Investigation
+
+To identify the root cause of a failing Synthetic API test, launch a [Bits Investigation][16]. Bits Investigation analyzes test results, traces, logs, and metrics to surface a root cause and flag if the failure is a regression or a misconfiguration.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -248,3 +252,4 @@ With Datadog's [APM integration with Synthetic Monitoring][14], access the root 
 [13]: /monitors/types/synthetic_monitoring/
 [14]: /synthetics/apm/
 [15]: /synthetics/api_tests/grpc_tests
+[16]: /bits_ai/bits_investigation/investigate_issues/#from-the-synthetic-test-details-page

--- a/hugo/content/en/getting_started/synthetics/browser_test.md
+++ b/hugo/content/en/getting_started/synthetics/browser_test.md
@@ -145,6 +145,10 @@ To troubleshoot a [failed test][10], review the failures on the **Activity** tab
 
 Use Datadog's [APM integration with Synthetic Monitoring][14] to view traces generated from your backend by the test runs from the {{< ui >}}Traces{{< /ui >}} tab.
 
+### Launch a Bits Investigation
+
+To identify the root cause of a failing Synthetic browser test, launch a [Bits Investigation][15]. Bits Investigation analyzes test results, traces, logs, and metrics to surface a root cause and flag if the failure is a regression or a misconfiguration.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -164,3 +168,4 @@ Use Datadog's [APM integration with Synthetic Monitoring][14] to view traces gen
 [12]: /synthetics/browser_tests/test_results#resources
 [13]: /synthetics/browser_tests/test_results#test-performance
 [14]: /synthetics/apm/
+[15]: /bits_ai/bits_investigation/investigate_issues/#from-the-synthetic-test-details-page

--- a/hugo/content/en/monitors/types/synthetic_monitoring.md
+++ b/hugo/content/en/monitors/types/synthetic_monitoring.md
@@ -84,6 +84,10 @@ Conditional alerting
 
 For more information, see [Synthetic Monitoring notifications][6].
 
+## Launch a Bits Investigation
+
+When a Synthetic Browser or API test monitor enters an alert state, you can launch a [Bits Investigation][8] to identify the root cause. Bits Investigation analyzes test results, traces, logs, and metrics to surface a root cause and flag if the failure is a regression or a misconfiguration. You can also toggle {{< ui >}}Auto-Investigate{{< /ui >}} on a Synthetic monitor to start investigations automatically when it alerts.
+
 ## Best practices
 
 - Always include a default `@notification` (outside any conditions) to prevent dropped messages.
@@ -101,3 +105,4 @@ For more information, see [Synthetic Monitoring notifications][6].
 [5]: /monitors/notify/#renotify
 [6]: /synthetics/notifications
 [7]: /synthetics/guide/how-synthetics-monitors-trigger-alerts/
+[8]: /bits_ai/bits_investigation/investigate_issues/

--- a/hugo/content/en/synthetics/api_tests/http_tests.md
+++ b/hugo/content/en/synthetics/api_tests/http_tests.md
@@ -366,6 +366,10 @@ The {{< ui >}}Summary{{< /ui >}} panel identifies unique issues causing failures
 
 For a complete list of HTTP and SSL error codes, see [API Testing Errors][12].
 
+## Launch a Bits Investigation
+
+To identify the root cause of a failing Synthetic HTTP test, launch a [Bits Investigation][18]. Bits Investigation analyzes test results, traces, logs, and metrics to surface a root cause and flag if the failure is a regression or a misconfiguration.
+
 ## Permissions
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][13] can create, edit, and delete Synthetic HTTP tests. To get create, edit, and delete access to Synthetic HTTP tests, upgrade your user to one of those two [default roles][13].
@@ -394,3 +398,4 @@ If you are using the [custom role feature][14], add your user to any custom role
 [15]: /account_management/rbac/#create-a-custom-role
 [16]: /synthetics/api_tests/errors/#http-errors
 [17]: /api_catalog
+[18]: /bits_ai/bits_investigation/investigate_issues/#from-the-synthetic-test-details-page


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-13920

Adds a "Launch a Bits Investigation" section to four Synthetic Monitoring pages, linking to the current Bits Investigation documentation:

- Getting Started with API Tests
- Getting Started with Browser Tests
- Synthetic Monitors
- HTTP Tests

This supersedes #36720, which predates the Aug 2026 monorepo reorg and could not be cleanly merged. The rest of that PR's content has already shipped via other merged PRs; this PR carries forward only the still-novel additions, updated to the current Bits Investigation naming and paths.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to resolve merge conflicts from PR #36720 by reconciling changes against current master and re-drafting the still-novel content on a fresh branch.

### Additional notes