### PR TITLE
[DOCS-15586] Escape markdown special characters inside ui shortcode

### DIFF
--- a/hugo/content/en/account_management/org_settings/cross_app_access.md
+++ b/hugo/content/en/account_management/org_settings/cross_app_access.md
@@ -187,7 +187,7 @@ A scope that is not allowed in Datadog is never granted, regardless of what the 
 
 ## Add Datadog as a connector in Claude
 
-1. In Claude, click the {{< ui >}}+{{< /ui >}} icon at the bottom of any prompt, then click {{< ui >}}Add Connector{{< /ui >}}.
+1. In Claude, click the {{< ui >}}\+{{< /ui >}} icon at the bottom of any prompt, then click {{< ui >}}Add Connector{{< /ui >}}.
 2. Find **Datadog** in the directory and enable the connector.
 3. Complete the sign-in flow when prompted.
 

--- a/hugo/content/en/actions/app_builder/components/_index.md
+++ b/hugo/content/en/actions/app_builder/components/_index.md
@@ -968,7 +968,7 @@ Tab components have the following properties.
 
 #### Tabs
 
-A list of tab views. Use the ({{< ui >}}+{{< /ui >}}) to add additional views.
+A list of tab views. Use the ({{< ui >}}\+{{< /ui >}}) to add additional views.
 
 
 #### Style

--- a/hugo/content/en/actions/app_builder/components/tables.md
+++ b/hugo/content/en/actions/app_builder/components/tables.md
@@ -44,7 +44,7 @@ One common use case is filtering a table component using the value in a text inp
 
 For example, if you want to list your dashboards in a table that you can filter using a text input component, you could do the following:
 
-1. Add a new query using the {{< ui >}}+{{< /ui >}} button.
+1. Add a new query using the {{< ui >}}\+{{< /ui >}} button.
 1. Search for "list dashboards" and click the {{< ui >}}List Dashboards{{< /ui >}} action. Name your query `listDashboards0`.
 1. Add a text input or search component to your app. Name it `searchInput`.
 1. Add a table component.
@@ -62,7 +62,7 @@ Another common use case is filtering a table using a select component.
 
 For example, if you want to list your dashboards in a table that you can filter using a select component, you could do the following:
 
-1. Add a new query using the {{< ui >}}+{{< /ui >}} button.
+1. Add a new query using the {{< ui >}}\+{{< /ui >}} button.
 1. Search for "list dashboards" and click the {{< ui >}}List Dashboards{{< /ui >}} action. Name your query `listDashboards0`.
 1. Add a select component to your app. Name it `selectInput`.
 1. Add a table component.
@@ -78,7 +78,7 @@ You can select a value from the select component and the rows of table are filte
 
 If you want to filter the results of a query itself, then use those results in your table, perform the following steps:
 
-1. Add a new query using the {{< ui >}}+{{< /ui >}} button.
+1. Add a new query using the {{< ui >}}\+{{< /ui >}} button.
 1. Search for "list dashboards" and click the {{< ui >}}List Dashboards{{< /ui >}} action. Name your query `listDashboards0`.
 1. Add a text input or search component to your app. Name it `searchInput`.
 1. Add a table component and set its {{< ui >}}data source{{< /ui >}} property to the query that you added.

--- a/hugo/content/en/actions/app_builder/queries.md
+++ b/hugo/content/en/actions/app_builder/queries.md
@@ -21,7 +21,7 @@ Queries are actions that populate your app with data from Datadog APIs or suppor
 
 The [Action Catalog][10] within the Datadog App provides actions that can be performed as queries against your infrastructure and integrations using App Builder. You can orchestrate and automate your end-to-end processes by linking together actions that perform tasks in your cloud providers, SaaS tools, and Datadog accounts.
 
-To add a query, click the Data ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the Data tab. Click the plus ({{< ui >}}+{{< /ui >}}), select {{< ui >}}Actions{{< /ui >}}, and search "query" for an action to add to your app. After you've added the query action, it appears in the {{< ui >}}Actions{{< /ui >}} List. Select a query to configure it.
+To add a query, click the Data ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the Data tab. Click the plus ({{< ui >}}\+{{< /ui >}}), select {{< ui >}}Actions{{< /ui >}}, and search "query" for an action to add to your app. After you've added the query action, it appears in the {{< ui >}}Actions{{< /ui >}} List. Select a query to configure it.
 
 You can also use Bits AI to add, configure, and trigger queries. Click the {{< ui >}}Build with AI{{< /ui >}} icon (**<i class="icon-bits-ai"></i>**) to get started. 
 
@@ -108,7 +108,7 @@ To provide mocked outputs manually, perform the following steps:
 1. Add a query and fill out the rest of your query's parameters.
 1. In the {{< ui >}}Mocked outputs{{< /ui >}} section of the query, click the {{< ui >}}GUI{{< /ui >}} tab.
 1. Fill in all required fields, which the GUI view automatically displays.
-1. Optionally, to add additional fields, click ({{< ui >}}+{{< /ui >}}). Choose a key from the dropdown and fill in a value. If you want to enter a value that is an object or an array, click the {{< ui >}}{}{{< /ui >}} or {{< ui >}}[]{{< /ui >}}, respectively, after the {{< ui >}}Enter value{{< /ui >}} field.
+1. Optionally, to add additional fields, click ({{< ui >}}\+{{< /ui >}}). Choose a key from the dropdown and fill in a value. If you want to enter a value that is an object or an array, click the {{< ui >}}{}{{< /ui >}} or {{< ui >}}[]{{< /ui >}}, respectively, after the {{< ui >}}Enter value{{< /ui >}} field.
 {{% /collapse-content %}}
 
 {{% collapse-content title="Using JSON" level="p" %}}
@@ -150,16 +150,16 @@ This app provides a button to trigger a workflow. The workflow sends a poll to a
 ##### Create workflow
 
 1. In a new workflow canvas, under {{< ui >}}Datadog Triggers{{< /ui >}}, click {{< ui >}}App{{< /ui >}}.
-1. Under the {{< ui >}}App{{< /ui >}} trigger step, click the plus ({{< ui >}}+{{< /ui >}}) icon, then search for "Make a decision" and select the {{< ui >}}Make a decision{{< /ui >}} Slack action.
+1. Under the {{< ui >}}App{{< /ui >}} trigger step, click the plus ({{< ui >}}\+{{< /ui >}}) icon, then search for "Make a decision" and select the {{< ui >}}Make a decision{{< /ui >}} Slack action.
 1. Select your workspace and choose a channel to poll.
 1. Fill in the prompt text "Cat fact or dog fact?" and change the button choices to "Cat fact" and "Dog fact".
-1. Under the {{< ui >}}Make a decision{{< /ui >}} step in the canvas, click the plus ({{< ui >}}+{{< /ui >}}) icon above {{< ui >}}Cat fact{{< /ui >}} and add the {{< ui >}}Make request{{< /ui >}} HTTP action.
+1. Under the {{< ui >}}Make a decision{{< /ui >}} step in the canvas, click the plus ({{< ui >}}\+{{< /ui >}}) icon above {{< ui >}}Cat fact{{< /ui >}} and add the {{< ui >}}Make request{{< /ui >}} HTTP action.
 1. Name the step "Get cat fact". Under {{< ui >}}Inputs{{< /ui >}}, for the {{< ui >}}URL{{< /ui >}}, keep {{< ui >}}GET{{< /ui >}} selected and enter the URL `https://catfact.ninja/fact`.
-1. Under the {{< ui >}}Make a decision{{< /ui >}} step in the canvas, click the plus ({{< ui >}}+{{< /ui >}}) icon above {{< ui >}}Dog fact{{< /ui >}}. Follow the same steps to add the {{< ui >}}Make request{{< /ui >}} HTTP action, but this time name the step "Get dog fact" and use the following parameters:
+1. Under the {{< ui >}}Make a decision{{< /ui >}} step in the canvas, click the plus ({{< ui >}}\+{{< /ui >}}) icon above {{< ui >}}Dog fact{{< /ui >}}. Follow the same steps to add the {{< ui >}}Make request{{< /ui >}} HTTP action, but this time name the step "Get dog fact" and use the following parameters:
     * {{< ui >}}URL{{< /ui >}}: `https://dogapi.dog/api/v2/facts`.
     * {{< ui >}}Request Headers{{< /ui >}}: `Content-Type` of `application/json`
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon under the cat fact step. Search for "Function" and choose the {{< ui >}}Function{{< /ui >}} data transformation step.
-1. Connect the plus ({{< ui >}}+{{< /ui >}}) icon under the dog fact step to this {{< ui >}}JS Function{{< /ui >}} step by clicking and dragging from the plus to the dot that appears above the JS Function step.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon under the cat fact step. Search for "Function" and choose the {{< ui >}}Function{{< /ui >}} data transformation step.
+1. Connect the plus ({{< ui >}}\+{{< /ui >}}) icon under the dog fact step to this {{< ui >}}JS Function{{< /ui >}} step by clicking and dragging from the plus to the dot that appears above the JS Function step.
 1. In the JS Function, under {{< ui >}}Configure{{< /ui >}}, for {{< ui >}}Script{{< /ui >}}, use the following code snippet:
     ```javascript
     const catFact = $.Steps.Get_cat_fact?.body?.fact;
@@ -183,7 +183,7 @@ This app provides a button to trigger a workflow. The workflow sends a poll to a
 
 To connect App Builder to the workflow, perform the following steps:
 
-1. In your app, click the Data ({{< ui >}}{&nbsp;}{{< /ui >}}) icon, click the plus ({{< ui >}}+{{< /ui >}}), and select {{< ui >}}Query{{< /ui >}}.
+1. In your app, click the Data ({{< ui >}}{&nbsp;}{{< /ui >}}) icon, click the plus ({{< ui >}}\+{{< /ui >}}), and select {{< ui >}}Query{{< /ui >}}.
 1. Search for "Trigger Workflow" and select the {{< ui >}}Trigger Workflow{{< /ui >}} Datadog Workflow Automation item.
 1. Set {{< ui >}}Run Settings{{< /ui >}} to Manual and name the query `triggerWorkflow0`.
 1. Under {{< ui >}}Inputs{{< /ui >}}, for {{< ui >}}App Workflow{{< /ui >}}, select {{< ui >}}My AB Workflow{{< /ui >}}.
@@ -192,7 +192,7 @@ To connect App Builder to the workflow, perform the following steps:
 1. Add a button component. Use the following values:
     * {{< ui >}}Label{{< /ui >}}: "Trigger Workflow"
     * {{< ui >}}Is Loading{{< /ui >}}: `${triggerWorkflow0.isLoading}` (click {{< ui >}}</>{{< /ui >}} to enter an expression)
-1. Under the button's {{< ui >}}Events{{< /ui >}}, click the plus ({{< ui >}}+{{< /ui >}}) to add an event. Use the following values:
+1. Under the button's {{< ui >}}Events{{< /ui >}}, click the plus ({{< ui >}}\+{{< /ui >}}) to add an event. Use the following values:
     * {{< ui >}}Event{{< /ui >}}: click
     * {{< ui >}}Reaction{{< /ui >}}: Trigger Query
     * {{< ui >}}Query{{< /ui >}}: `triggerWorkflow0`
@@ -218,11 +218,11 @@ This app provides buttons to fetch facts about two numbers from an API. It then 
 ##### Create queries
 
 1. In a new app, click the Data ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the Data tab.
-1. Click the plus ({{< ui >}}+{{< /ui >}}), then select {{< ui >}}Query{{< /ui >}}. Search for "Make request" and choose the {{< ui >}}HTTP Make request{{< /ui >}} action.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}), then select {{< ui >}}Query{{< /ui >}}. Search for "Make request" and choose the {{< ui >}}HTTP Make request{{< /ui >}} action.
 1. Use the following values:
     * {{< ui >}}Name{{< /ui >}}: `mathFact1`
     * Under {{< ui >}}Inputs{{< /ui >}}, for {{< ui >}}URL{{< /ui >}}: GET `http://numbersapi.com/random/trivia`
-1. Click the ({{< ui >}}+{{< /ui >}}) to add another {{< ui >}}HTTP Make request{{< /ui >}} query. Use the following values:
+1. Click the ({{< ui >}}\+{{< /ui >}}) to add another {{< ui >}}HTTP Make request{{< /ui >}} query. Use the following values:
     * {{< ui >}}Name{{< /ui >}}: `mathFact2`
     * Under {{< ui >}}Inputs{{< /ui >}}, for {{< ui >}}URL{{< /ui >}}: GET `http://numbersapi.com/random/trivia`
 

--- a/hugo/content/en/actions/app_builder/variables.md
+++ b/hugo/content/en/actions/app_builder/variables.md
@@ -31,7 +31,7 @@ To add a state variable with Bits AI:
 To add a state variable manually:
 
 1. In your app, click the {{< ui >}}Data{{< /ui >}} ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the Data tab.
-1. Click the plus ({{< ui >}}+{{< /ui >}}), then select {{< ui >}}Variable{{< /ui >}}.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}), then select {{< ui >}}Variable{{< /ui >}}.
 1. Optionally, click the variable name and rename it.
 1. Define the initial value for your state variable.
 
@@ -44,9 +44,9 @@ To create an app that uses a button to change a callout value component's style 
 ### Create the variables
 
 1. In your app, click the {{< ui >}}Data{{< /ui >}} ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the Data tab.
-1. Click the plus ({{< ui >}}+{{< /ui >}}), then select {{< ui >}}Variable{{< /ui >}}.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}), then select {{< ui >}}Variable{{< /ui >}}.
 1. Name the variable `callout_value` and set its {{< ui >}}Initial Value{{< /ui >}} to `Pass`.
-1. Click the plus ({{< ui >}}+{{< /ui >}}) to create another variable.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) to create another variable.
 1. Name this variable `callout_color` and set its {{< ui >}}Initial Value{{< /ui >}} to `green`.
 
 ### Create the components

--- a/hugo/content/en/actions/connections/_index.md
+++ b/hugo/content/en/actions/connections/_index.md
@@ -92,7 +92,7 @@ Alternatively, add a connection from a workflow or app page:
 1. Navigate to the [Workflow Automation list][1].
 1. Select the workflow containing the action to which you need to add a credential. The workflow builder appears.
 1. In the workflow visualization, click the action to which you need to add a credential. The right side panel populates with the action details.
-1. Under the {{< ui >}}Configure{{< /ui >}} tab, look for the {{< ui >}}Connection{{< /ui >}} dropdown and click the {{< ui >}}+{{< /ui >}} icon.
+1. Under the {{< ui >}}Configure{{< /ui >}} tab, look for the {{< ui >}}Connection{{< /ui >}} dropdown and click the {{< ui >}}\+{{< /ui >}} icon.
 1. In the {{< ui >}}New Connection{{< /ui >}} dialog box, name the connection and enter the required authentication details.
 1. Click {{< ui >}}Save{{< /ui >}}.
 
@@ -104,7 +104,7 @@ Alternatively, add a connection from a workflow or app page:
 1. Select the app containing the action you need to add a credential to. The app canvas appears.
 1. Click {{< ui >}}Edit{{< /ui >}} in the upper right.
 1. Under {{< ui >}}Data{{< /ui >}} on the left-hand side, click the action to which you need to add a credential. The left side panel populates with the action details.
-1. Look for the {{< ui >}}Connection{{< /ui >}} dropdown and click the {{< ui >}}+{{< /ui >}} icon.
+1. Look for the {{< ui >}}Connection{{< /ui >}} dropdown and click the {{< ui >}}\+{{< /ui >}} icon.
 1. In the {{< ui >}}New Connection{{< /ui >}} dialog box, name the connection and enter the required authentication details.
 1. Click {{< ui >}}Save{{< /ui >}}.
 

--- a/hugo/content/en/actions/connections/http.md
+++ b/hugo/content/en/actions/connections/http.md
@@ -19,7 +19,7 @@ To add an HTTP Request:
 {{< tabs >}}
 {{% tab "Workflow Automation" %}}
 - In a new workflow, click {{< ui >}}Add step{{< /ui >}} and search for `Make request`. Select the {{< ui >}}Make request{{< /ui >}} action to add it to your workflow.
-- In an existing workflow, click {{< ui >}}+{{< /ui >}} and search for `Make request`. Select the {{< ui >}}Make request{{< /ui >}} action to add it to your workflow.
+- In an existing workflow, click {{< ui >}}\+{{< /ui >}} and search for `Make request`. Select the {{< ui >}}Make request{{< /ui >}} action to add it to your workflow.
 
 Specify the request method and any necessary [authentication][1]. Read the sections below for further information about the available configuration options. Optionally, the request can wait on conditions that you specify in the {{< ui >}}Conditional wait{{< /ui >}} section, and retry at a given interval if the condition is not satisfied.
 
@@ -42,14 +42,14 @@ If you need to authenticate your request, use the action's {{< ui >}}Connection{
 
 ### Create an AWS connection
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}AWS{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}, {{< ui >}}Account ID{{< /ui >}}, and {{< ui >}}AWS Role Name{{< /ui >}}.
 1. Click {{< ui >}}Create{{< /ui >}}.
 
 ### Create an Azure connection
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}Azure{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}, {{< ui >}}Tenant ID{{< /ui >}}, {{< ui >}}Client ID{{< /ui >}}, and {{< ui >}}Client Secret{{< /ui >}}.
 1. Optionally, enter the {{< ui >}}Custom Scope{{< /ui >}} to be requested from Microsoft when acquiring an OAuth 2.0 access token. A resource's scope is constructed using the identifier URI for the resource and `.default`, separated by a forward slash (`/`). For example, `{identifierURI}/.default`. For more information, see [the Microsoft documentation on .default scope][3].
@@ -59,7 +59,7 @@ If you need to authenticate your request, use the action's {{< ui >}}Connection{
 
 The Token Auth connection uses a bearer token to authenticate the HTTP request.
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}HTTP{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for authentication.
@@ -73,7 +73,7 @@ The Token Auth connection uses a bearer token to authenticate the HTTP request.
 
 The Basic Auth connection uses an authorization header with a username and password to authenticate the HTTP request.
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}HTTP{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for authentication.
@@ -85,7 +85,7 @@ The Basic Auth connection uses an authorization header with a username and passw
 
 The HTTP 2 step connection allows you to make a preliminary request to retrieve an access token with which to authenticate the HTTP request. This is useful for authenticating JSON Web Token (JWT) and OAuth applications.
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}HTTP{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for authentication.
@@ -133,7 +133,7 @@ The Mutual TLS (mTLS) Auth connection allows you to use a private key and TLS ce
 
 <div class="alert alert-info">The client certificate (<code>.crt</code>, <code>.pem</code>) and private key (<code>.key</code>, <code>.pem</code>) must use the PEM format.</div>
 
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}HTTP{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for authentication.
@@ -167,7 +167,7 @@ You can use a private HTTP action to interact with services hosted on your priva
 
 To configure a private HTTP request:
 1. Add an HTTP action to your app.
-1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
+1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}\+{{< /ui >}}).
 1. Select {{< ui >}}HTTP{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
 1. Enter the {{< ui >}}Base URL{{< /ui >}} for the host in your private network.

--- a/hugo/content/en/actions/datastores/use.md
+++ b/hugo/content/en/actions/datastores/use.md
@@ -44,7 +44,7 @@ Datadog creates an app prepopulated with your datastore ID. From here, follow th
 
 To use a datastore in an existing app, add a datastore action:
 1. Click the {{< ui >}}Data{{< /ui >}} ({{< ui >}}{&nbsp;}{{< /ui >}}) icon to open the {{< ui >}}Data{{< /ui >}} tab.
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon, select {{< ui >}}Action{{< /ui >}}, and add a Datastore action to add to your app. For a list of available datastore actions, see the [Action Catalog][4].
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon, select {{< ui >}}Action{{< /ui >}}, and add a Datastore action to add to your app. For a list of available datastore actions, see the [Action Catalog][4].
 1. Choose an existing connection or [create one][10].
 1. From the {{< ui >}}Datastore ID{{< /ui >}} drop-down menu, select an existing datastore, or select {{< ui >}}New Datastore{{< /ui >}} to create one.
 
@@ -86,7 +86,7 @@ To retrieve the UUID for a datastore:
 ## Use a datastore in a workflow {#use-workflow}
 
 To use a datastore in an existing workflow, add a datastore action:
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon to add a step to your workflow.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon to add a step to your workflow.
 1. Search for `datastore` and select a Datastore action to add to your workflow. For a list of available datastore actions, see the [Action Catalog][4].
 1. Click on the step in the workflow canvas.
 1. From the {{< ui >}}Datastore ID{{< /ui >}} drop-down menu, select an existing datastore, or select {{< ui >}}New Datastore{{< /ui >}} to create one.

--- a/hugo/content/en/actions/workflows/actions/flow_control.md
+++ b/hugo/content/en/actions/workflows/actions/flow_control.md
@@ -43,10 +43,10 @@ In the example below, a for loop iterates over a list of incidents and sends a S
 {{< img src="actions/workflows/actions/flow_control/iteration2.png" alt="A workflow with a for loop. The loop iterates over a list of incidents and sends a message to a slack channel if the incident is more than a week old." style="width:100%;" >}}
 
 To add a for loop to your workflow:
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
 1. Search for and select the {{< ui >}}For loop{{< /ui >}} step.
 1. Click the loop step and enter an {{< ui >}}Input list{{< /ui >}} for the step to iterate over. You can enter a custom list or use a workflow variable.
-1. Inside the loop frame, click the ({{< ui >}}+{{< /ui >}}) icon to add a step to the loop.
+1. Inside the loop frame, click the ({{< ui >}}\+{{< /ui >}}) icon to add a step to the loop.
 1. Configure the looped action. To access the current value in the input list, use the `{{Current.Value}}` variable. To access the index of the current value, use `{{Current.Index}}`.
 1. Add and configure any additional steps you need to loop. You can use an {{< ui >}}if statement{{< /ui >}} and a {{< ui >}}break{{< /ui >}} to exit your loop early.
 1. {{< ui >}}Save{{< /ui >}} and {{< ui >}}Publish{{< /ui >}} the workflow.
@@ -62,10 +62,10 @@ The following example uses a while loop to paginate the AWS S3 List Buckets API 
 {{< img src="actions/workflows/actions/flow_control/iteration3.png" alt="A workflow with a while loop. The workflow uses a while loop to paginate the AWS S3 List Buckets API for an App." style="width:100%;" >}}
 
 To add a while loop to your workflow:
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
 1. Search for and select the {{< ui >}}While loop{{< /ui >}} step.
 1. Click the loop step and define the condition that the While loop will evaluate before each iteration. The loop continues if the condition is true, and stops when it evaluates to false.
-1. Inside the loop frame, click the plus ({{< ui >}}+{{< /ui >}}) icon to add a step to the loop.
+1. Inside the loop frame, click the plus ({{< ui >}}\+{{< /ui >}}) icon to add a step to the loop.
 1. Configure the looped action. To access the index of the current value, use `{{Current.Index}}`.
 1. Add and configure any additional steps you need to loop. You can use an {{< ui >}}if statement{{< /ui >}} and a {{< ui >}}break{{< /ui >}} action to exit your loop early.
 1. {{< ui >}}Save{{< /ui >}} and {{< ui >}}Publish{{< /ui >}} the workflow.

--- a/hugo/content/en/actions/workflows/build.md
+++ b/hugo/content/en/actions/workflows/build.md
@@ -78,7 +78,7 @@ If you're not sure about your workflow configuration, you can return to the pane
 1. Click {{< ui >}}Add Step{{< /ui >}} to start adding steps to your workflow.
 1. Search for an action using the search bar or browse through the integrations and their related actions to find the action you're looking for. Click an action to add it as a step on your workflow canvas.
 1. Click on the step in the workflow canvas to configure it or view its outputs or context variables. For more information on outputs and context variables, see [Context variables][14].
-1. After you've configured the step, click either the AI icon <i class="icon-bits-ai"></i> or the plus icon ({{< ui >}}+{{< /ui >}}) to add another step, or save the workflow if you're done.
+1. After you've configured the step, click either the AI icon <i class="icon-bits-ai"></i> or the plus icon ({{< ui >}}\+{{< /ui >}}) to add another step, or save the workflow if you're done.
 1. When you're ready to publish your workflow, click {{< ui >}}Publish{{< /ui >}}. Published workflows accrue costs based on workflow executions. For more information, see the [Datadog Pricing page][4].
 
 You can edit a step in the workflow at any time by clicking on it. Click and drag steps on your workflow to rearrange them.
@@ -134,12 +134,12 @@ You can configure your workflow to send you a notification on success or failure
 To add a notification:
 1. In the workflow configuration panel, scroll down to the {{< ui >}}Notifications{{< /ui >}} section.
 1. To add a notification if the workflow succeeds:
-   1. Click the plus ({{< ui >}}+{{< /ui >}}) icon next to {{< ui >}}Notify on success{{< /ui >}}.
+   1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon next to {{< ui >}}Notify on success{{< /ui >}}.
    1. Select the integration that you want to use for notifications.
    1. Complete the required fields for the specified integration.
    1. Click {{< ui >}}Save{{< /ui >}} to save your workflow.
 1. To add a notification if the workflow fails:
-   1. Click the plus ({{< ui >}}+{{< /ui >}}) icon next to {{< ui >}}Notify on failure{{< /ui >}}.
+   1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon next to {{< ui >}}Notify on failure{{< /ui >}}.
    1. Select the integration that you want to use for notifications.
    1. Complete the required fields for the specified integration.
    1. Click {{< ui >}}Save{{< /ui >}} to save your workflow.

--- a/hugo/content/en/actions/workflows/expressions/javascript.md
+++ b/hugo/content/en/actions/workflows/expressions/javascript.md
@@ -63,7 +63,7 @@ The function action allows for variable assignments and complex data transformat
 
 To add a function action:
 - In a new workflow, click {{< ui >}}Add step{{< /ui >}} and search for `function`. Select the {{< ui >}}Function{{< /ui >}} action to add it to your workflow.
-- In an existing workflow, click {{< ui >}}+{{< /ui >}} and search for `function`. Select the {{< ui >}}Function{{< /ui >}} action to add it to your workflow.
+- In an existing workflow, click {{< ui >}}\+{{< /ui >}} and search for `function`. Select the {{< ui >}}Function{{< /ui >}} action to add it to your workflow.
 
 #### Write function steps with AI
 
@@ -81,7 +81,7 @@ In most cases, use an inline expression instead of a dedicated expression step. 
 
 To add an expression action:
 - In a new workflow, click {{< ui >}}Add step{{< /ui >}} and search for `expression`. Select the {{< ui >}}Expression{{< /ui >}} action to add it to your workflow.
-- In an existing workflow, click {{< ui >}}+{{< /ui >}} and search for `expression`. Select the {{< ui >}}Expression{{< /ui >}} action to add it to your workflow.
+- In an existing workflow, click {{< ui >}}\+{{< /ui >}} and search for `expression`. Select the {{< ui >}}Expression{{< /ui >}} action to add it to your workflow.
 
 In an expression step, execution uses _copies_ of all available variables. Mutating a variable within a step has no effect on the variable's value outside of the step. To assign the result of an expression to a variable, see [Variables and parameters][2].
 

--- a/hugo/content/en/actions/workflows/expressions/python.md
+++ b/hugo/content/en/actions/workflows/expressions/python.md
@@ -32,7 +32,7 @@ The `ctx` object provides access to all workflow context variables, similar to t
 ## Add a Python function action
 
 In the workflow canvas: 
-1. Click {{< ui >}}+{{< /ui >}} to add a workflow step. 
+1. Click {{< ui >}}\+{{< /ui >}} to add a workflow step. 
 1. Search for `Python`. 
 1. Select the Python action to add it to your workflow.
 

--- a/hugo/content/en/actions/workflows/saved_actions.md
+++ b/hugo/content/en/actions/workflows/saved_actions.md
@@ -36,7 +36,7 @@ Use the _Saved Actions_ feature to store and reuse an action and its parameters.
 ## Use a saved action in your workflow
 
 To add a saved action as a new step in your workflow:
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon from the workflow canvas and select {{< ui >}}Saved Actions{{< /ui >}}.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon from the workflow canvas and select {{< ui >}}Saved Actions{{< /ui >}}.
 1. Use the search bar or browse through the list to find the Saved Action you're looking for.
 1. Select the Saved Action to add it as a configured step on your workflow canvas.
 

--- a/hugo/content/en/actions/workflows/trigger.md
+++ b/hugo/content/en/actions/workflows/trigger.md
@@ -65,7 +65,7 @@ To run the workflow:
 1. Add a monitor trigger to your workflow:
    - If your workflow doesn't have any triggers, click {{< ui >}}Add Trigger{{< /ui >}} > {{< ui >}}Monitor{{< /ui >}}.
    - If your workflow already has one or more triggers and you're adding the monitor as an additional trigger, click the {{< ui >}}Add Trigger{{< /ui >}} (lightning bolt) icon and select {{< ui >}}Monitor{{< /ui >}}.
-1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}+{{< /ui >}}) under the trigger.
+1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}\+{{< /ui >}}) under the trigger.
 1. Click the trigger and take note of the {{< ui >}}Mention handle{{< /ui >}}.
 1. Monitor triggers are set to trigger automatically by default. If you don't want the workflow to trigger automatically, toggle the {{< ui >}}Automatic triggering{{< /ui >}} option.
 1. Save your workflow.
@@ -119,7 +119,7 @@ To trigger a workflow from a notification rule, you must first add a security tr
 1. Add a security trigger to your workflow:
    - If your workflow doesn't have any triggers, click {{< ui >}}Add Trigger{{< /ui >}} > {{< ui >}}Security{{< /ui >}}.
    - If your workflow already has one or more triggers and you're adding the security trigger as an additional trigger, click the {{< ui >}}Add Trigger{{< /ui >}} (lightning bolt) icon and select {{< ui >}}Security{{< /ui >}}.
-1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}+{{< /ui >}}) under the trigger.
+1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}\+{{< /ui >}}) under the trigger.
 1. Click the trigger and take note of the {{< ui >}}Mention handle{{< /ui >}}.
 1. Security triggers are set to trigger automatically by default. If you don't want the workflow to trigger automatically, toggle the {{< ui >}}Automatic triggering{{< /ui >}} option.
 1. Save your workflow.
@@ -155,7 +155,7 @@ To run a workflow from a software catalog entity, you must first add a software 
 1. Add a software catalog trigger to your workflow:
    - If your workflow doesn't have any triggers, click {{< ui >}}Add Trigger{{< /ui >}} > {{< ui >}}Catalog{{< /ui >}}.
    - If your workflow already has one or more triggers and you're adding the software catalog as an additional trigger, click the {{< ui >}}Add Trigger{{< /ui >}} (lightning bolt) icon and select {{< ui >}}Catalog{{< /ui >}}.
-2. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}+{{< /ui >}}) under the trigger.
+2. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}\+{{< /ui >}}) under the trigger.
 3. Save your workflow.
 4. Click {{< ui >}}Publish{{< /ui >}} to publish your workflow. Published workflows accrue costs based on workflow executions. For more information, see the [Datadog Pricing page][11].
 
@@ -182,7 +182,7 @@ You can trigger a workflow from GitHub using the following steps.
 1. In GitHub, set the {{< ui >}}Content type{{< /ui >}} of your webhook to `application/json`.
 1. In GitHub, create a secret that is at least 16 characters long, then copy this secret to the {{< ui >}}Secret{{< /ui >}} field of your workflow trigger.
 1. In GitHub, choose which events you would like to trigger your webhook, then click {{< ui >}}Add webhook{{< /ui >}}.
-1. _Optionally_, in your workflow, click the {{< ui >}}+{{< /ui >}} to add a {{< ui >}}Rate Limit{{< /ui >}}.
+1. _Optionally_, in your workflow, click the {{< ui >}}\+{{< /ui >}} to add a {{< ui >}}Rate Limit{{< /ui >}}.
 1. Click {{< ui >}}Save{{< /ui >}} on your workflow.
 1. Click {{< ui >}}Publish{{< /ui >}} to publish the workflow. A workflow must be published before you can trigger it from GitHub. Published workflows accrue costs based on workflow executions. For more information, see the [Datadog Pricing page][11].
 
@@ -199,7 +199,7 @@ You can trigger a workflow from Slack manually with the `/datadog workflow` comm
 1. Add a Slack trigger to your workflow:
    - If your workflow doesn't have any triggers, click {{< ui >}}Add Trigger{{< /ui >}} > {{< ui >}}Slack{{< /ui >}}.
    - If your workflow already has one or more triggers and you're adding the Slack trigger as an additional trigger, click the {{< ui >}}Add Trigger{{< /ui >}} (lightning bolt) icon and select {{< ui >}}Slack{{< /ui >}}.
-1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}+{{< /ui >}}) under the trigger.
+1. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon ({{< ui >}}\+{{< /ui >}}) under the trigger.
 1. Click {{< ui >}}Save{{< /ui >}} on your workflow.
 1. Click {{< ui >}}Publish{{< /ui >}} to publish the workflow. A workflow must be published before you can trigger it from Slack. Published workflows accrue costs based on workflow executions. For more information, see the [Datadog Pricing page][11].
 1. In a Slack channel with the Datadog App, run `/datadog workflow` to select and run a workflow. You can also use the `/dd` alias to run /datadog commands.

--- a/hugo/content/en/actions/workflows/variables.md
+++ b/hugo/content/en/actions/workflows/variables.md
@@ -66,7 +66,7 @@ Input parameters are immutable key-value pairs that you can use to pass data int
 
 To add an input parameter:
 1. Click on the workflow canvas.
-1. Click the {{< ui >}}+{{< /ui >}} icon next to {{< ui >}}Input Parameters{{< /ui >}}.
+1. Click the {{< ui >}}\+{{< /ui >}} icon next to {{< ui >}}Input Parameters{{< /ui >}}.
 1. Add a parameter name, data type, and description for the parameter. The display name is generated automatically from the parameter name. Check the {{< ui >}}Use custom display name{{< /ui >}} box to customize it. The display name is a human readable name for the parameter, while the parameter name is used to reference the parameter in your workflow steps.
 1. Optionally, add a default value for the parameter. If you add a default value, the parameter is optional at runtime.
 
@@ -86,7 +86,7 @@ Output parameters allow you to access the result of a workflow. This is useful w
 
 To add an output parameter:
 1. Click on the workflow canvas.
-1. Click the {{< ui >}}+{{< /ui >}} icon next to {{< ui >}}Output Parameters{{< /ui >}}.
+1. Click the {{< ui >}}\+{{< /ui >}} icon next to {{< ui >}}Output Parameters{{< /ui >}}.
 1. Add a parameter name, value, and data type for the parameter.
 1. Optionally, add a default value for the parameter. If you add a default value, the parameter is optional at runtime.
 
@@ -106,7 +106,7 @@ To set a mutable workflow variable, use the [Set variable][1] action. You can us
 ### Set a custom variable
 
 To set a custom variable:
-1. Click the plus ({{< ui >}}+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
+1. Click the plus ({{< ui >}}\+{{< /ui >}}) icon on your workflow canvas to open the action catalog.
 1. Search for and select the {{< ui >}}Set variable{{< /ui >}} step.
 1. Click the {{< ui >}}Set variable{{< /ui >}} step and enter a {{< ui >}}Step name{{< /ui >}}.
 1. Enter a {{< ui >}}variable name{{< /ui >}}. Variable names must start with a letter and can contain only alphanumeric characters and underscores.

--- a/hugo/content/en/dashboards/template_variables.md
+++ b/hugo/content/en/dashboards/template_variables.md
@@ -69,7 +69,7 @@ If you need to see all variables at once as you scroll, click **Expand template 
 
 ## Add a template variable
 To add a template variable in a dashboard:
-1. Click {{< ui >}}Add Variable{{< /ui >}} (or {{< ui >}}+{{< /ui >}} if there are existing template variables)
+1. Click {{< ui >}}Add Variable{{< /ui >}} (or {{< ui >}}\+{{< /ui >}} if there are existing template variables)
 2. Select from a list of recommended template variables or search for the specific tag you have in mind.
 4. Select the widgets to apply this template variable to.
 6. Click {{< ui >}}Save{{< /ui >}}.

--- a/hugo/content/en/dashboards/widgets/funnel.md
+++ b/hugo/content/en/dashboards/widgets/funnel.md
@@ -26,7 +26,7 @@ Funnel analysis helps you track conversion rates across key workflows to identif
 1. Choose the data to graph:
     * RUM: See the [Search RUM Events documentation][1] to configure a RUM query.
 2. Select {{< ui >}}View{{< /ui >}} or {{< ui >}}Action{{< /ui >}} and choose a query from the dropdown menu.
-3. Click the {{< ui >}}+{{< /ui >}} button and select another query from the dropdown menu to visualize the funnel. See the [RUM Visualize documentation][2] for more information on visualizing Funnel analysis.
+3. Click the {{< ui >}}\+{{< /ui >}} button and select another query from the dropdown menu to visualize the funnel. See the [RUM Visualize documentation][2] for more information on visualizing Funnel analysis.
 
 ### Options
 

--- a/hugo/content/en/getting_started/dashboards/_index.md
+++ b/hugo/content/en/getting_started/dashboards/_index.md
@@ -105,7 +105,7 @@ See [Widgets][6] for more information and examples of setting up these graphs.
 
 Move graphs around so they create a flow for the work you do or conversations you have around the dashboard. Drag and drop widgets to place them. On screenboards, use Free Text widgets to organize sections under headings. On timeboards, add a Group widget that can contain multiple widgets, and can collapse out of the way when you're viewing the dashboard.
 
-For dashboards that grow large, use tabs to organize widgets into named sections. Click {{< ui >}}+{{< /ui >}} in the tab bar (or {{< ui >}}Add New Tab{{< /ui >}} under the dropdown next to {{< ui >}}Add Widgets{{< /ui >}}) to add a tab, then move widgets between tabs from each widget's share menu (⋮). Using tabs keeps a single dashboard focused and easy to navigate without requiring viewers to scroll through unrelated content. For more information, see [Tabs][20].
+For dashboards that grow large, use tabs to organize widgets into named sections. Click {{< ui >}}\+{{< /ui >}} in the tab bar (or {{< ui >}}Add New Tab{{< /ui >}} under the dropdown next to {{< ui >}}Add Widgets{{< /ui >}}) to add a tab, then move widgets between tabs from each widget's share menu (⋮). Using tabs keeps a single dashboard focused and easy to navigate without requiring viewers to scroll through unrelated content. For more information, see [Tabs][20].
 
 There are two ways to create links from a dashboard to any target URL:
 

--- a/hugo/content/en/getting_started/synthetics/browser_test.md
+++ b/hugo/content/en/getting_started/synthetics/browser_test.md
@@ -51,7 +51,7 @@ You may create a test using one of the following options:
 
 - **Build a test from scratch**:
 
-    1. Click the {{< ui >}}+{{< /ui >}} template to start a new Browser Test from scratch.
+    1. Click the {{< ui >}}\+{{< /ui >}} template to start a new Browser Test from scratch.
     1. Add the URL of the website you want to monitor. If you don't know what to start with, you can use `https://www.shopist.io`, a test e-commerce web application.
     2. Select {{< ui >}}Advanced Options{{< /ui >}} to set custom request options, certificates, authentication credentials, and more. 
     3. Name your test and set tags to it such as `env:prod` and `app:shopist`. Tags allow you to keep your test suite organized and quickly find tests you're interested in on the homepage.

--- a/hugo/content/en/getting_started/workflow_automation/_index.md
+++ b/hugo/content/en/getting_started/workflow_automation/_index.md
@@ -46,7 +46,7 @@ Add and configure the monitor:
 
 ### Add the Jira and Slack actions
 Add and configure the Jira step:
-1. On the workflow canvas, click the {{< ui >}}+{{< /ui >}} icon.
+1. On the workflow canvas, click the {{< ui >}}\+{{< /ui >}} icon.
 1. Search for the Jira action and select {{< ui >}}Create issue{{< /ui >}}.
 1. On the workflow canvas, click the {{< ui >}}Create issue{{< /ui >}} step.
 1. In the {{< ui >}}Configure{{< /ui >}} tab, select a {{< ui >}}Jira Account{{< /ui >}}. The account should correspond to the Jira URL found in the {{< ui >}}Accounts{{< /ui >}} section of the Jira integration tile.

--- a/hugo/content/en/gpu_monitoring/fleet.md
+++ b/hugo/content/en/gpu_monitoring/fleet.md
@@ -39,7 +39,7 @@ GPU Fleet Explorer gives you visibility from your AI workloads down to the under
 
 Use the filter dropdowns at the top of the page to filter by a specific {{< ui >}}Provider{{< /ui >}}, {{< ui >}}Device Type{{< /ui >}}, {{< ui >}}Cluster{{< /ui >}}, {{< ui >}}Region{{< /ui >}}, {{< ui >}}Service{{< /ui >}}, {{< ui >}}Data Center{{< /ui >}}, {{< ui >}}Environment{{< /ui >}}, or {{< ui >}}Team{{< /ui >}}.
 
-You can also {{< ui >}}Search{{< /ui >}} or {{< ui >}}Group{{< /ui >}} by other tags using the search and group-by fields. For example, you can group by {{< ui >}}Service{{< /ui >}} to view a row in the table for each unique service. Click the {{< ui >}}>{{< /ui >}} button next to any entry to see the devices for that service.
+You can also {{< ui >}}Search{{< /ui >}} or {{< ui >}}Group{{< /ui >}} by other tags using the search and group-by fields. For example, you can group by {{< ui >}}Service{{< /ui >}} to view a row in the table for each unique service. Click the {{< ui >}}\>{{< /ui >}} button next to any entry to see the devices for that service.
 
 {{< img src="gpu_monitoring/host_row_expansion-2.png" alt="GPU Fleet table showing services with their device types, with the row expand button highlighted" style="width:90%;" >}}
 

--- a/hugo/content/en/llm_observability/investigate/evaluations/llm_as_a_judge_evaluations/_index.md
+++ b/hugo/content/en/llm_observability/investigate/evaluations/llm_as_a_judge_evaluations/_index.md
@@ -101,7 +101,7 @@ Span Input: {{span_input}}
    You may also use the panel on the right ({{< ui >}}Filtered Spans{{< /ui >}} in span scope, {{< ui >}}Filtered Traces{{< /ui >}} in trace scope, {{< ui >}}Filtered Sessions{{< /ui >}} in session scope) to add span data as a variable:
    1. Choose an account and an application so that spans, traces, or sessions show up on the right.
    2. Select one of the spans on the right to view its JSON.
-   3. Select {{< ui >}}+{{< /ui >}} to add the JSON to your user prompt.
+   3. Select {{< ui >}}\+{{< /ui >}} to add the JSON to your user prompt.
 
 {{< img src="llm_observability/evaluations/custom_llm_judge_2-5.png" alt="The menu contents of the JSON view in the custom evaluation configuration right pane, displaying the option to Add variable to message." style="width:40%;" >}}
 

--- a/hugo/content/en/mcp_server/setup.md
+++ b/hugo/content/en/mcp_server/setup.md
@@ -49,7 +49,7 @@ Connect Datadog to ChatGPT by installing the [Datadog app][1] from ChatGPT's app
 Install the [Datadog Connector](https://claude.ai/directory/connectors/datadog) from the Claude Connectors Directory. The official connector is the recommended way to connect Datadog to Claude (including Claude Cowork) and includes MCP Apps for in-product visualizations. If you previously added Datadog as a custom connector, remove it to avoid conflicts.
 
 {{< site-region region="us,us3,us5,eu,ap1,ap2,uk1" >}}
-1. In Claude, click the {{< ui >}}+{{< /ui >}} icon at the bottom of any prompt, then click {{< ui >}}Add Connector{{< /ui >}}.
+1. In Claude, click the {{< ui >}}\+{{< /ui >}} icon at the bottom of any prompt, then click {{< ui >}}Add Connector{{< /ui >}}.
 1. Find **Datadog** in the directory and enable the connector.
 1. Complete the OAuth login flow when prompted.
 1. Verify that you have the required [permissions](#required-permissions) for the Datadog resources you want to access.

--- a/hugo/content/en/mobile/_index.md
+++ b/hugo/content/en/mobile/_index.md
@@ -128,7 +128,7 @@ On the Incidents page, you can view, search, and filter all incidents that you h
 ### Create an incident
 
 1. Navigate to the incident list by tapping on the {{< ui >}}Incidents{{< /ui >}} tab in the bottom bar.
-2. Tap the {{< ui >}}+{{< /ui >}} button in the top right corner.
+2. Tap the {{< ui >}}\+{{< /ui >}} button in the top right corner.
 3. Give your incident a title, severity, and commander.
 
 ## Notification Center

--- a/hugo/content/en/mobile/guide/configure-mobile-device-for-on-call.md
+++ b/hugo/content/en/mobile/guide/configure-mobile-device-for-on-call.md
@@ -207,7 +207,7 @@ The On-Call lock screen widget displays your On-Call status. Lock screen widgets
 5. Tap the widget on the lock screen to pull up the configuration panel.
 6. Select the organization you would like to display your On-Call status for.
 
-**Note**: You must have an empty space on your lock screen to add a new widget. You can delete lock screen widgets by tapping the {{< ui >}}-{{< /ui >}} button on the top left of the widget you would like to delete.
+**Note**: You must have an empty space on your lock screen to add a new widget. You can delete lock screen widgets by tapping the {{< ui >}}\-{{< /ui >}} button on the top left of the widget you would like to delete.
 
 ## Troubleshooting
 For help with troubleshooting, [contact Datadog support][2]. You can also send a message in the [Datadog public Slack][3] [#mobile-app][4] channel.

--- a/hugo/content/en/mobile/push_notification.md
+++ b/hugo/content/en/mobile/push_notification.md
@@ -163,7 +163,7 @@ By default if you have push notifications enabled and are assigned as a commande
 
 Create [workflow automations][3] that send mobile push notifications.
 
-1. On the workflow canvas, click the {{< ui >}}+{{< /ui >}} icon.
+1. On the workflow canvas, click the {{< ui >}}\+{{< /ui >}} icon.
 2. Search for {{< ui >}}Send mobile push notification{{< /ui >}}.
 3. Under {{< ui >}}To{{< /ui >}} select your notification recipient. The recipient must have enabled notifications in the Datadog mobile app for this option to appear.
 4. Enter the message {{< ui >}}Body{{< /ui >}}.

--- a/hugo/content/en/mobile/widgets.md
+++ b/hugo/content/en/mobile/widgets.md
@@ -369,7 +369,7 @@ Lock screen widgets for On-Call, Monitors, SLOs, Incidents, and Dashboards are s
 6. Configure the widget according to the fields specified for the selected widget.
 7. Drag, minimize, or expand the widget to customize the location and size of the widget on your lock screen.
 
-**Note**: You must have an empty space on your lock screen to add a new widget. You can delete lock screen widget by tapping the {{< ui >}}-{{< /ui >}} button on top left of the widget you would like to delete.
+**Note**: You must have an empty space on your lock screen to add a new widget. You can delete lock screen widget by tapping the {{< ui >}}\-{{< /ui >}} button on top left of the widget you would like to delete.
 
 ## Further Reading
 

--- a/hugo/content/en/monitors/notify/_index.md
+++ b/hugo/content/en/monitors/notify/_index.md
@@ -111,7 +111,7 @@ Before you add a workflow to a monitor, [add a monitor trigger to the workflow][
 After you add the monitor trigger, [add an existing workflow to your monitor][10] or create a new workflow. To create a new workflow from the monitors page:
 
 1. Click {{< ui >}}Add Workflow{{< /ui >}}.
-1. Click the {{< ui >}}+{{< /ui >}} icon and select a Blueprint, or select {{< ui >}}Start From Scratch{{< /ui >}}.
+1. Click the {{< ui >}}\+{{< /ui >}} icon and select a Blueprint, or select {{< ui >}}Start From Scratch{{< /ui >}}.
    {{< img src="/monitors/notifications/create-workflow.png" alt="Click the + button to add a new workflow" style="width:90%;">}}
 
 For more information on building a workflow, see [Build workflows][11].

--- a/hugo/content/en/real_user_monitoring/guide/alerting-with-conversion-rates.md
+++ b/hugo/content/en/real_user_monitoring/guide/alerting-with-conversion-rates.md
@@ -18,7 +18,7 @@ In Datadog, navigate to [Digital Experience > Product Analytics > Funnels][1].
 
 {{< img src="real_user_monitoring/funnel_analysis/rum-funnel-creation-2.png" alt="The funnel creation page with key actions highlighted" style="width:100%;" >}}
 
-In the {{< ui >}}Define steps for measuring conversion{{< /ui >}} section, create some steps from your views and actions. You can click on the bar graphs to see a side panel with analytics about user conversions and dropoffs. To add a subsequent view or action in the funnel, click {{< ui >}}+{{< /ui >}} and select from frequent next steps.
+In the {{< ui >}}Define steps for measuring conversion{{< /ui >}} section, create some steps from your views and actions. You can click on the bar graphs to see a side panel with analytics about user conversions and dropoffs. To add a subsequent view or action in the funnel, click {{< ui >}}\+{{< /ui >}} and select from frequent next steps.
 
 ## Export the conversion rate graph
 

--- a/hugo/content/en/real_user_monitoring/platform/dashboards/_index.md
+++ b/hugo/content/en/real_user_monitoring/platform/dashboards/_index.md
@@ -42,7 +42,7 @@ To explore individual events, click on a graph and click {{< ui >}}View RUM even
 
 ### Customize dashboards
 
-To clone your RUM dashboards, click the {{< ui >}}Settings{{< /ui >}} icon and select {{< ui >}}Clone dashboard{{< /ui >}}. To add more widgets, powerpacks, or apps, scroll down to the bottom and click the {{< ui >}}+{{< /ui >}} icon. 
+To clone your RUM dashboards, click the {{< ui >}}Settings{{< /ui >}} icon and select {{< ui >}}Clone dashboard{{< /ui >}}. To add more widgets, powerpacks, or apps, scroll down to the bottom and click the {{< ui >}}\+{{< /ui >}} icon. 
 
 You can also modify the template variables and create a [saved view][6].
 

--- a/hugo/content/en/sheets/_index.md
+++ b/hugo/content/en/sheets/_index.md
@@ -85,7 +85,7 @@ Create flexible spreadsheets: built to let you start from scratch, build models,
 
 A sheet is a flexible, blank-canvas spreadsheet with a full formula engine. Use it to build financial models, operational trackers, planning templates, or any freeform calculation that doesn't fit a query-based workflow.
 
-To add a sheet, click the {{< ui >}}+{{< /ui >}} tab at the bottom of your spreadsheet and select {{< ui >}}Add Sheet{{< /ui >}}.
+To add a sheet, click the {{< ui >}}\+{{< /ui >}} tab at the bottom of your spreadsheet and select {{< ui >}}Add Sheet{{< /ui >}}.
 
 {{< img src="/sheets/flexible_spreadsheet.png" alt="A flexible sheet showing a 2025 cloud spend by provider model, with SUMIFS and VLOOKUP formulas referencing Cloud cost and Currency conversion table tabs" style="width:90%;" >}}
 

--- a/hugo/content/en/synthetics/browser_tests/_index.md
+++ b/hugo/content/en/synthetics/browser_tests/_index.md
@@ -50,7 +50,7 @@ You may create a test using one of the following options:
 
 ### Build a test from scratch
 
-  1. Click the {{< ui >}}+{{< /ui >}} template to start a new Browser Test from scratch.
+  1. Click the {{< ui >}}\+{{< /ui >}} template to start a new Browser Test from scratch.
   1. Enter a {{< ui >}}Starting URL{{< /ui >}}: The URL from which your browser test starts the scenario.
   1. Add a {{< ui >}}name{{< /ui >}}: The name of your browser test.
   1. Select {{< ui >}}environment and additional tags{{< /ui >}}: Set the `env` and related tags attached to your browser test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>`.

--- a/hugo/content/en/synthetics/mobile_app_testing/_index.md
+++ b/hugo/content/en/synthetics/mobile_app_testing/_index.md
@@ -60,7 +60,7 @@ You may create a test using one of the following options:
 
 ### Build a test from scratch
 
-  1. Click the {{< ui >}}+{{< /ui >}} template, then select a mobile application from the dropdown menu. If you haven't created one already, create a mobile application in the [{{< ui >}}Applications List{{< /ui >}} section][2] on the [{{< ui >}}Synthetic Monitoring & Continuous Testing Settings{{< /ui >}} page][3]. 
+  1. Click the {{< ui >}}\+{{< /ui >}} template, then select a mobile application from the dropdown menu. If you haven't created one already, create a mobile application in the [{{< ui >}}Applications List{{< /ui >}} section][2] on the [{{< ui >}}Synthetic Monitoring & Continuous Testing Settings{{< /ui >}} page][3]. 
   1. Select a {{< ui >}}version{{< /ui >}} or click {{< ui >}}Always run the latest version{{< /ui >}} to use the latest version of your mobile application whenever your test is run.
   1. Add a {{< ui >}}name{{< /ui >}} for your test.
   1. Select {{< ui >}}environment and additional tags{{< /ui >}} that relate to your test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>`.

--- a/hugo/content/en/synthetics/mobile_app_testing/settings/_index.md
+++ b/hugo/content/en/synthetics/mobile_app_testing/settings/_index.md
@@ -68,7 +68,7 @@ To edit or delete a mobile application, hover over a mobile application in the {
 
 ## Manage application versions
 
-Clicking on a mobile application in the {{< ui >}}Mobile Applications List{{< /ui >}} displays existing versions of the application. Hover over a version and click the {{< ui >}}+{{< /ui >}} icon to [create a mobile app test][6] with the selected mobile application's version.
+Clicking on a mobile application in the {{< ui >}}Mobile Applications List{{< /ui >}} displays existing versions of the application. Hover over a version and click the {{< ui >}}\+{{< /ui >}} icon to [create a mobile app test][6] with the selected mobile application's version.
 
 To edit or delete a version of a mobile application, hover over a version in the mobile application and click on the respective icon.
 
@@ -76,7 +76,7 @@ To edit or delete a version of a mobile application, hover over a version in the
 
 To add a version of an existing mobile application:
 
-1. Hover over the {{< ui >}}+{{< /ui >}} icon in a mobile application in the {{< ui >}}Mobile Applications List{{< /ui >}} and click {{< ui >}}Add new version{{< /ui >}}. 
+1. Hover over the {{< ui >}}\+{{< /ui >}} icon in a mobile application in the {{< ui >}}Mobile Applications List{{< /ui >}} and click {{< ui >}}Add new version{{< /ui >}}. 
 2. Upload an [`.apk`][4] or `.ipa` file.
 3. Enter a version name. 
 4. Optionally, select {{< ui >}}Mark this version as latest{{< /ui >}}.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15586

The `ui` shortcode was recently updated to run its content through `markdownify` (#39571) so that Markdown inside `{{< ui >}}...{{< /ui >}}` renders correctly. A side effect is that a bare `+`, `-`, or `>` inside the shortcode is now interpreted as Markdown list or blockquote syntax instead of rendering as the literal character.

This PR escapes those characters (`\+`, `\-`, `\>`) wherever they appear alone inside `{{< ui >}}` tags across the English content, so they render as literal text again.

### Merge readiness

- [ ] Ready for merge