### PR TITLE
[DOCS-15513] Update Flutter RUM documentation for Actions and Resources association

### DIFF
--- a/hugo/layouts/shortcodes/mdoc/en/sdk/setup/flutter.mdoc.md
+++ b/hugo/layouts/shortcodes/mdoc/en/sdk/setup/flutter.mdoc.md
@@ -28,7 +28,6 @@ Datadog supports Flutter Monitoring for iOS, Android, and Web for Flutter 3.27+.
 Datadog supports Flutter Web starting with v3 of the SDK, with a few known limitations.
 
 * Long running actions (`startAction` and `stopAction`) are not supported
-* Actions (`addAction`) and manually reported Resources (`startResource` and `stopResource`) do not properly associate with Errors or Actions.
 * Event mappers are not supported.
 
 #### iOS


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15513

Removes an outdated Flutter Web limitation stating that Actions (`addAction`) and manually reported Resources (`startResource`/`stopResource`) don't properly associate with Errors or Actions. This is no longer accurate in the latest SDK versions.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the outdated limitation and update the docs.

### Additional notes