### PR TITLE
llm_observability: document prompt_uuid for OTel Prompt Tracking

### DIFF
--- a/hugo/content/en/llm_observability/instrument/api.md
+++ b/hugo/content/en/llm_observability/instrument/api.md
@@ -255,6 +255,8 @@ An image on a message. Provide either `content` or `attachment_key`.
 | query_variable_keys | [string] | Variable keys that contain the user query. Used for hallucination detection. |
 | context_variable_keys | [string] | Variable keys that contain ground-truth or context content. Used for hallucination detection. |
 | tags | Dict[key (string), string] | Tags to attach to the prompt run. |
+| prompt_uuid | string | No, unless linking to Prompt Management. The prompt's UUID from [Prompt Management][6]. Required for the span to link back to its Prompt Management registry entry. |
+| prompt_version_uuid | string | The specific prompt version's UUID from [Prompt Management][6]. |
 
 {{% /tab %}}
 {{% tab "Example" %}}
@@ -278,6 +280,8 @@ An image on a message. Provide either `content` or `attachment_key`.
 {{< /code-block >}}
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: If your prompt comes from the [Prompt Management][6] registry (for example, fetched through the Prompt Management REST API in a language without a native Agent Observability SDK), include the `prompt_uuid` (and `prompt_version_uuid`, if available) returned by the API alongside `id` and `version`. Without `prompt_uuid`, the span's prompt metadata is tracked but does not link back to the registry entry in the Prompts view.
 
 #### Meta
 | Field       | Type              | Description  |
@@ -704,3 +708,4 @@ For feedback events, provide exactly one of `span_id`, `trace_id`, `session_id`,
 [3]: /getting_started/tagging/
 [4]: /llm_observability/investigate/evaluations/end_user_feedback
 [5]: /llm_observability/instrument/sdk/?tab=python#enriching-spans
+[6]: /llm_observability/configure/prompt_management

--- a/hugo/content/en/llm_observability/instrument/prompt_tracking.md
+++ b/hugo/content/en/llm_observability/instrument/prompt_tracking.md
@@ -89,9 +89,13 @@ The following fields are supported in the prompt tracking JSON:
 | `id` | string | No | Unique identifier for the prompt. Defaults to `{ml_app}_unnamed-prompt` if omitted |
 | `name` | string | No | Prompt name. Used as a fallback for `id` if `id` is omitted |
 | `version` | string | No | User-supplied version tag |
+| `prompt_uuid` | string | No, unless linking to Prompt Management | The prompt's UUID from [Prompt Management][8]. Required for the span to link back to its Prompt Management registry entry |
+| `prompt_version_uuid` | string | No | The specific prompt version's UUID from [Prompt Management][8] |
 | `variables` | object | No | Template variable substitutions |
 | `rag_context_variables` | array of strings | No | Names of variables in `variables` that contain RAG context (ground truth). Used by RAG evaluators |
 | `rag_query_variables` | array of strings | No | Names of variables in `variables` that contain the user query. Used by RAG evaluators |
+
+**Note**: If your prompt comes from the [Prompt Management][8] registry (for example, fetched through the Prompt Management REST API in a language without a native Agent Observability SDK), include the `prompt_uuid` (and `prompt_version_uuid`, if available) returned by the API alongside `id` and `version`. Without `prompt_uuid`, the span's prompt metadata is tracked but does not link back to the registry entry in the Prompts view.
 
 <div class="alert alert-info">If you are using prompt templates, Agent Observability can automatically attach version information based on prompt content.</div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds `prompt_uuid` and `prompt_version_uuid` to the field tables for:
- OpenTelemetry Prompt Tracking (the `_dd.ml_obs.prompt_tracking` span attribute)
- The Agent Observability HTTP API's `Prompt` object

Both tables previously documented only `id`/`name`/`version` (plus template, variables, and RAG fields). If a prompt is fetched from the Prompt Management registry (for example, through the Prompt Management REST API, in a language without a native Agent Observability SDK) and then tagged onto a span through OTel or the raw HTTP API, `id`/`version` alone aren't enough for that span to link back to its Prompt Management registry entry in the Prompts view. This PR adds the two missing fields to both tables and a short note explaining when they're needed.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used to draft the field-table wording and confirm field usage before proposing this docs change.

### Additional notes

