### PR TITLE
[DOCS-15525] Expand Log Findings page for GA

### DIFF
--- a/hugo/content/en/logs/explorer/findings.md
+++ b/hugo/content/en/logs/explorer/findings.md
@@ -33,13 +33,19 @@ Use Findings to collect possible evidence, compare results, and build context as
 
 ## Findings panel
 
-The Findings canvas lives in the side panel on the left of Log Explorer, next to your saved views. To open it:
+Findings lives in the side panel on the left of Log Explorer, next to your saved views. To open it:
 
 1. Navigate to [Log Explorer][1].
 2. Click {{< ui >}}Views{{< /ui >}} in the upper left corner to open the side panel.
-3. Click the **Findings** tab. The tab shows how many findings are on the canvas.
+3. Click the **Findings** tab. The tab shows how many findings you have.
+
+The panel contains the canvas, the workspace where each finding appears as a card. The canvas is where you work with findings: arrange them, reopen them in Log Explorer, and select them to send elsewhere. It keeps its contents and layout across page reloads and browser sessions.
 
 To dock the panel next to your log results, click {{< ui >}}Pin{{< /ui >}}. To collapse it, click {{< ui >}}Hide{{< /ui >}}.
+
+Findings includes a walkthrough of the canvas that you can reopen at any time.
+<!-- Which control opens the walkthrough, and where does it live? Naming it here would make this step actionable. -->
+
 
 ## Capture a finding
 
@@ -53,43 +59,49 @@ The finding stores your search query, time range, and [visualization][4], includ
 
 ### Individual log events
 
-1. Click a log event in your results to open the [log side panel][5].
-2. Hover over the **Log Message** section and click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
+Click a log event in your results to open the [log side panel][5]. Hover over the **Log Message** section and click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
 
 ### Specific text in a log message
 
-To capture part of a log message, such as an error string or an identifier, select the text in the **Log Message** section and press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. The finding stores the text you selected.
+To capture part of a log message, such as an error string or an identifier, select the text in the **Log Message** section and press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. The finding stores the text you selected instead of the whole event.
+<!-- Is the keyboard shortcut the only way to capture selected text, or does a button appear on selection? -->
+
 
 ## Organize the canvas
 
 Hover over a finding to rename it, and drag it to move or resize it. Datadog saves the layout you build, so the canvas looks the same the next time you open the panel.
 
 To group findings by the query they came from, click the auto-organize icon on the left of the canvas. Moving, resizing, or deleting a finding resets the grouping.
+<!-- A screenshot of the canvas controls would make the auto-organize icon findable. Add one alongside the GA video. -->
 
-Use the remaining canvas controls to zoom in and out, fit the canvas to your findings, and open a full-screen view. On the full-screen canvas, you can pan, zoom, rename, and delete findings the same way.
+The controls on the left of the canvas also zoom in and out, fit the canvas to your findings, and open a full-screen view. The full-screen view gives you the same controls with more room, and you can drag the background to pan across it.
 
 ## Delete findings
 
-To delete a single finding, hover over it and click the {{< ui >}}Delete{{< /ui >}} icon. To delete several findings at once, select each and press <kbd>Delete</kbd>. To select every finding on the canvas, press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd>.
+To delete one finding, hover over it and use the delete control on the card. To delete several at once, select them and press <kbd>Delete</kbd>. To select every finding first, press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd>.
+<!-- Does a finding card have a delete control? Hovering a card shows Open in Explorer and rename only. Confirm how to delete one finding with the mouse. -->
 
-The clear icon in the Findings panel removes the findings you have selected, or every finding on the canvas when nothing is selected.
+The clear icon in the Findings panel deletes findings; it does not clear your selection. It removes the findings you have selected, or every finding when nothing is selected.
+<!-- Confirm the clear icon deletes rather than deselects, and whether it warns before emptying a full canvas. -->
 
-Deleting is not permanent. A toast appears with an {{< ui >}}Undo{{< /ui >}} option, and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> restores what you removed.
+Deleting is not permanent. A toast appears with an {{< ui >}}Undo{{< /ui >}} option, and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> restores what you removed. Undo covers your last ten actions on the canvas.
+<!-- How long does a deleted finding stay recoverable? Confirm whether undo history survives a page reload or ends with the browser session. -->
+
 
 ## Return to a finding
 
 Double-click a finding, or hover over it and click the {{< ui >}}Open in Explorer{{< /ui >}} icon. Log Explorer reloads the query, time range, and visualization that the finding was captured with. The rest of your findings stay on the canvas.
 
-This makes Findings useful as a set of checkpoints. When you land on a query that scopes an investigation well, capture it before you pivot. If a pivot leads nowhere, reopen that finding to get back to where you started instead of rebuilding the query.
+Each finding keeps its own query and time range. You can change your search as often as you need, then come back to an earlier result in one click with no query to rebuild.
 
 ## Use findings as context
 
 Select one or more findings on the canvas to act on them together:
 
-- To ask about findings, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. [Bits AI][2] opens with the selected findings attached as context.
-- To keep findings, click {{< ui >}}Open in Notebooks{{< /ui >}} and choose a new or existing [Notebook][3].
+- To ask [Bits AI][2] about them, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. Bits AI chat opens with the selected findings attached as context.
+- To copy them into a [Notebook][3], click {{< ui >}}Open in Notebooks{{< /ui >}} and choose a new or existing notebook. The findings you send stay on the canvas.
 
-Select only the findings that matter for the question you're asking. A postmortem might need two of the five findings you captured, and a narrow selection gives Bits AI a narrower problem to reason about.
+Send only the findings that relate to your question. If three of the eight findings on your canvas cover the error you're asking about, select those three.
 
 ## Keyboard shortcuts
 
@@ -101,7 +113,7 @@ Select only the findings that matter for the question you're asking. A postmorte
 | Undo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> |
 | Redo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> |
 
-Findings also includes a tutorial you can reopen at any time to walk through the canvas.
+<!-- Undo and redo bindings are unconfirmed. Confirm these, and add any shortcuts missing from this table. -->
 
 ## Further Reading
 

--- a/hugo/content/en/logs/explorer/findings.md
+++ b/hugo/content/en/logs/explorer/findings.md
@@ -47,7 +47,7 @@ Add a finding from anywhere in Log Explorer that shows results. Datadog names ea
 
 ### A query and its visualization
 
-In the toolbar above your results, click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
+In the toolbar above your results, click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. You can also click {{< ui >}}Add current page as finding{{< /ui >}} in the Findings panel.
 
 The finding stores your search query, time range, and [visualization][4], including any group-by and aggregation you configured. Capture the same query as a list and as a timeseries to keep both views side by side.
 
@@ -68,7 +68,13 @@ To group findings by the query they came from, click the auto-organize icon on t
 
 Use the remaining canvas controls to zoom in and out, fit the canvas to your findings, and open a full-screen view. On the full-screen canvas, you can pan, zoom, rename, and delete findings the same way.
 
-**Note**: Undo and redo cover your last ten actions on the canvas, including deletions.
+## Delete findings
+
+To delete a single finding, hover over it and click the {{< ui >}}Delete{{< /ui >}} icon. To delete several at once, select them and press <kbd>Delete</kbd>. Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd> first to select everything on the canvas.
+
+The clear icon in the Findings panel removes the findings you have selected, or every finding on the canvas when nothing is selected.
+
+Deleting is not permanent right away. A toast appears with an {{< ui >}}Undo{{< /ui >}} option, and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> restores what you removed.
 
 ## Return to a finding
 
@@ -90,6 +96,8 @@ Select only the findings that matter for the question you're asking. A postmorte
 | Action | Shortcut |
 | ------ | -------- |
 | Add a finding | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd> |
+| Select all findings | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd> |
+| Delete selected findings | <kbd>Delete</kbd> |
 | Undo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> |
 | Redo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> |
 

--- a/hugo/content/en/logs/explorer/findings.md
+++ b/hugo/content/en/logs/explorer/findings.md
@@ -2,6 +2,19 @@
 title: Log Findings
 description: 'Capture, organize, and reuse important context during log investigations in Log Explorer.'
 private: true
+further_reading:
+    - link: 'logs/explorer/'
+      tag: 'Documentation'
+      text: 'Search and analyze your logs in Log Explorer'
+    - link: 'logs/explorer/saved_views/'
+      tag: 'Documentation'
+      text: 'Automatically configure your Log Explorer'
+    - link: 'bits_ai/bits_chat/'
+      tag: 'Documentation'
+      text: 'Ask questions about your data with Bits AI chat'
+    - link: 'notebooks/'
+      tag: 'Documentation'
+      text: 'Build and share investigations with Notebooks'
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/findings" btn_hidden="false" header="Join the Preview!" >}}
@@ -12,10 +25,82 @@ Findings for Log Explorer is in Preview. Use this form to submit your request.
 
 Findings helps you capture, organize, and reuse important context during log investigations in [Log Explorer][1].
 
-With Findings, you can save log lines, visualizations, and queries to a canvas with the **Add Finding** button or keyboard shortcuts while investigating. This allows you to return to them or branch into new questions without losing track of earlier observations or investigative paths.
+With Findings, you can save log events, visualizations, and queries to a canvas with the **Add a finding** button or a keyboard shortcut while investigating. Each finding stores the context it was captured in. You can return to it or branch into new questions without losing track of earlier observations or investigative paths. Findings persist across page reloads and browser sessions until you delete them.
 
-Use Findings to collect possible evidence, compare results, and build context as your investigation evolves. Select findings to use as context to Ask Bits questions, or save them to a Notebook to share with others.
+Use Findings to collect possible evidence, compare results, and build context as your investigation evolves. Select findings to use as context for [Bits AI][2] questions, or send them to a [Notebook][3] to share with others.
 
 {{< img src="logs/explorer/findings_demo.mp4" alt="Findings demo in Log Explorer" video=true style="width:100%;" >}}
 
+## Findings panel
+
+The Findings canvas lives in the side panel on the left of Log Explorer, next to your saved views. To open it:
+
+1. Navigate to [Log Explorer][1].
+2. Click {{< ui >}}Views{{< /ui >}} in the upper left corner to open the side panel.
+3. Click the **Findings** tab. The tab shows how many findings are on the canvas.
+
+Click {{< ui >}}Pin{{< /ui >}} to dock the panel next to your log results, or {{< ui >}}Hide{{< /ui >}} to collapse it.
+
+## Capture a finding
+
+Add a finding from anywhere in Log Explorer that shows results. Datadog names each finding after what you captured, and records the query and time range it came from.
+
+### A query and its visualization
+
+In the toolbar above your results, click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
+
+The finding stores your search query, time range, and [visualization][4], including any group-by and aggregation you configured. Capture the same query as a list and as a timeseries to keep both views side by side.
+
+### An individual log event
+
+1. Click a log event in your results to open the [log side panel][5].
+2. Hover over the **Log Message** section and click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
+
+### Specific text in a log message
+
+To capture part of a log message, such as an error string or an identifier, select the text in the **Log Message** section and press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. The finding stores the text you selected.
+
+## Organize the canvas
+
+Hover over a finding to rename it, and drag it to move or resize it. Datadog saves the layout you build, so the canvas looks the same the next time you open the panel.
+
+To group findings by the query they came from, click the auto-organize icon on the left of the canvas. Moving, resizing, or deleting a finding resets the grouping.
+
+Use the remaining canvas controls to zoom in and out, fit the canvas to your findings, and open a full-screen view. On the full-screen canvas, you can pan, zoom, rename, and delete findings the same way.
+
+**Note**: Undo and redo cover your last ten actions on the canvas, including deletions.
+
+## Return to a finding
+
+Double-click a finding, or hover over it and click the {{< ui >}}Open in Explorer{{< /ui >}} icon. Log Explorer reloads the query, time range, and visualization that the finding was captured with. The rest of your findings stay on the canvas.
+
+This makes Findings useful as a set of checkpoints. When you land on a query that scopes an investigation well, capture it before you pivot. If a pivot leads nowhere, reopen that finding to get back to where you started instead of rebuilding the query.
+
+## Use findings as context
+
+Select one or more findings on the canvas to act on them together:
+
+- To ask about them, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. [Bits AI][2] opens with the selected findings attached as context.
+- To keep them, click {{< ui >}}Open in Notebooks{{< /ui >}} and choose a new or existing [Notebook][3].
+
+Select only the findings that matter for the question you're asking. A postmortem might need two of the five findings you captured, and a narrow selection gives Bits AI a narrower problem to reason about.
+
+## Keyboard shortcuts
+
+| Action | Shortcut |
+| ------ | -------- |
+| Add a finding | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd> |
+| Undo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> |
+| Redo | <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> |
+
+Findings also includes a tutorial you can reopen at any time to walk through the canvas.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 [1]: /logs/explorer/
+[2]: /bits_ai/bits_chat/
+[3]: /notebooks/
+[4]: /logs/explorer/visualize/
+[5]: /logs/explorer/side_panel/

--- a/hugo/content/en/logs/explorer/findings.md
+++ b/hugo/content/en/logs/explorer/findings.md
@@ -39,19 +39,19 @@ The Findings canvas lives in the side panel on the left of Log Explorer, next to
 2. Click {{< ui >}}Views{{< /ui >}} in the upper left corner to open the side panel.
 3. Click the **Findings** tab. The tab shows how many findings are on the canvas.
 
-Click {{< ui >}}Pin{{< /ui >}} to dock the panel next to your log results, or {{< ui >}}Hide{{< /ui >}} to collapse it.
+To dock the panel next to your log results, click {{< ui >}}Pin{{< /ui >}}. To collapse it, click {{< ui >}}Hide{{< /ui >}}.
 
 ## Capture a finding
 
 Add a finding from anywhere in Log Explorer that shows results. Datadog names each finding after what you captured, and records the query and time range it came from.
 
-### A query and its visualization
+### Queries and visualizations
 
 In the toolbar above your results, click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. You can also click {{< ui >}}Add current page as finding{{< /ui >}} in the Findings panel.
 
 The finding stores your search query, time range, and [visualization][4], including any group-by and aggregation you configured. Capture the same query as a list and as a timeseries to keep both views side by side.
 
-### An individual log event
+### Individual log events
 
 1. Click a log event in your results to open the [log side panel][5].
 2. Hover over the **Log Message** section and click the {{< ui >}}Add a finding{{< /ui >}} icon, or press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>.
@@ -70,11 +70,11 @@ Use the remaining canvas controls to zoom in and out, fit the canvas to your fin
 
 ## Delete findings
 
-To delete a single finding, hover over it and click the {{< ui >}}Delete{{< /ui >}} icon. To delete several at once, select them and press <kbd>Delete</kbd>. Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd> first to select everything on the canvas.
+To delete a single finding, hover over it and click the {{< ui >}}Delete{{< /ui >}} icon. To delete several findings at once, select each and press <kbd>Delete</kbd>. To select every finding on the canvas, press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd>.
 
 The clear icon in the Findings panel removes the findings you have selected, or every finding on the canvas when nothing is selected.
 
-Deleting is not permanent right away. A toast appears with an {{< ui >}}Undo{{< /ui >}} option, and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> restores what you removed.
+Deleting is not permanent. A toast appears with an {{< ui >}}Undo{{< /ui >}} option, and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Z</kbd> restores what you removed.
 
 ## Return to a finding
 
@@ -86,8 +86,8 @@ This makes Findings useful as a set of checkpoints. When you land on a query tha
 
 Select one or more findings on the canvas to act on them together:
 
-- To ask about them, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. [Bits AI][2] opens with the selected findings attached as context.
-- To keep them, click {{< ui >}}Open in Notebooks{{< /ui >}} and choose a new or existing [Notebook][3].
+- To ask about findings, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. [Bits AI][2] opens with the selected findings attached as context.
+- To keep findings, click {{< ui >}}Open in Notebooks{{< /ui >}} and choose a new or existing [Notebook][3].
 
 Select only the findings that matter for the question you're asking. A postmortem might need two of the five findings you captured, and a narrow selection gives Bits AI a narrower problem to reason about.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Addresses DOCS-15525

Expands the hidden Log Findings page ahead of the GA rollout. The page previously carried an overview and a demo video only.

- Adds a **Findings panel** section covering where the canvas lives and how to pin or hide it
- Adds a **Capture a finding** section with three entry points: a query and its visualization, an individual log event, and selected text in a log message
- Adds an **Organize the canvas** section covering rename, drag, resize, auto-organize by query, zoom, and full-screen view
- Adds a **Delete findings** section covering single and multi-select deletion, the clear icon in the panel, and undo
- Adds a **Return to a finding** section covering double-click and **Open in Explorer**, plus using findings as investigation checkpoints
- Adds a **Use findings as context** section for **Ask Bits** and **Open in Notebooks**
- Adds a **Keyboard shortcuts** table
- Adds `further_reading` entries for Log Explorer, Saved Views, Bits AI chat, and Notebooks

### Merge readiness

- [ ] Ready for merge

Open questions:

- **Clear icon and "Add current page as finding".** Both are documented based on the finalized design, and the implementation was still in review when this was written. Confirm they shipped, and confirm the final button labels and tooltip wording.
- **Auto-organize.** Documented as grouping by query, with a note that moving, resizing, or deleting a finding resets the grouping. Confirm that is still accurate at GA.
- Notes on findings and copying a canvas link are left out — both are out of GA scope.
- Finding limits are deliberately omitted, per our conversation.

GA-day follow-ups, tracked separately from this PR:

- Remove the Preview callout
- Replace `findings_demo.mp4` with a re-recorded video that has no Preview label and shows current button locations
- Remove `private: true` and add the page to the left nav

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to draft the expanded sections from the demo video, the GA plan, and the bug bash script, then reviewed and edited manually.

### Additional notes

UI details were derived from the existing demo video, so they reflect the Preview build. Anything that moved between Preview and GA needs a second pass.

### Vale

`vale hugo/content/en/logs/explorer/findings.md` — 0 errors, 0 warnings, 0 suggestions.
