### PR TITLE
[DOCS-15327] Make App and API Protection naming consistent

### DIFF
--- a/hugo/content/en/security/application_security/_index.md
+++ b/hugo/content/en/security/application_security/_index.md
@@ -36,7 +36,7 @@ further_reading:
   text: "Mitigate account takeovers with Datadog App and API Protection"
 - link: "https://learn.datadoghq.com/courses/app-protection-block-attacks"
   tag: "Learning Center"
-  text: "Block Application Attacks with Application & API Protection"
+  text: "Block Application Attacks with App and API Protection"
 algolia:
   tags: ["asm", "App and API Protection"]
 site_support_id: application_security_override
@@ -60,7 +60,7 @@ AI Guard is in Preview. Get real-time security guardrails for your AI apps and a
 
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 
-**App & API Protection (AAP)** provides unified visibility and security for your applications and APIs, helping you detect, investigate, and prevent threats across modern workloads.
+**App and API Protection (AAP)** provides unified visibility and security for your applications and APIs, helping you detect, investigate, and prevent threats across modern workloads.
 
 Whether you're defending public-facing APIs, internal services, or user-facing applications, AAP equips your teams with realtime OOTB threat detection, posture assessment, and in-app protections.
 

--- a/hugo/content/en/security/application_security/api_posture/api_findings.md
+++ b/hugo/content/en/security/application_security/api_posture/api_findings.md
@@ -40,7 +40,7 @@ Click a finding to view its details and perform a workflow such as Validate > In
 
 Datadog API Posture uses [Bits Code][3] to generate code fixes for vulnerabilities.
 
-1. In Datadog, navigate to [**Security** > **App & API Protection** > **Findings**][1].
+1. In Datadog, navigate to [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Findings{{< /ui >}}][1].
 2. Select a finding to open a side panel with details about the finding and the affected endpoint.
 3. In the **Next Steps** > **Remediation** section, click **Fix with Bits**.
 

--- a/hugo/content/en/security/application_security/api_posture/compliance.md
+++ b/hugo/content/en/security/application_security/api_posture/compliance.md
@@ -51,7 +51,7 @@ The OWASP API Security Top 10 identifies the most critical security risks for AP
 
 ## View your compliance posture
 
-Navigate to [**Security > App & API Protection > Compliance**][4] to open the Compliance Frameworks page. You can:
+Navigate to [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Compliance{{< /ui >}}][4] to open the Compliance Frameworks page. You can:
 - Select a framework (for example, OWASP API Security Top 10) to see per-control pass/fail status.
 - Click a failing control to view the list of API security findings that caused it to fail.
 - Open a finding's side panel to see the affected endpoint, severity, and recommended remediation steps.

--- a/hugo/content/en/security/application_security/guide/manage_account_theft_appsec.md
+++ b/hugo/content/en/security/application_security/guide/manage_account_theft_appsec.md
@@ -171,7 +171,7 @@ The actions covered in the next sections help you to identify and leverage detec
 
 1. Open [Create a new rule][18].  
 2. Enter a name for the rule.
-3. Select {{< ui >}}Signal{{< /ui >}} and remove all entries except {{< ui >}}App and API Protection{{< /ui >}}.
+3. Select {{< ui >}}Signal{{< /ui >}} and remove all entries except {{< ui >}}App & API Protection{{< /ui >}}.
 4. Restrict the rule to `category:account_takeover`, and expand the severities to include `Medium`.
 5. Add notification recipients (Slack, Teams, PagerDuty).
    To learn more, see [Notification channels][19].  

--- a/hugo/content/en/security/application_security/setup/aws/fargate/_index.md
+++ b/hugo/content/en/security/application_security/setup/aws/fargate/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/aws/waf/_index.md
+++ b/hugo/content/en/security/application_security/setup/aws/waf/_index.md
@@ -123,7 +123,7 @@ Ensure the AWS role attached to the [Connection][3] has the following permission
 {{% /tab %}}
 {{< /tabs >}}
 
-After setup is complete, click **Block New Attackers** on the App & API Protection [denylist page][6]. Select the web ACL and associated AWS connection to block IP addresses.
+After setup is complete, click **Block New Attackers** on the [denylist page][6]. Select the web ACL and associated AWS connection to block IP addresses.
 
 [1]: /integrations/amazon-web-services/
 [2]: /integrations/amazon_waf/

--- a/hugo/content/en/security/application_security/setup/docker/_index.md
+++ b/hugo/content/en/security/application_security/setup/docker/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/dotnet/dotnet.md
+++ b/hugo/content/en/security/application_security/setup/dotnet/dotnet.md
@@ -201,7 +201,7 @@ ENV DD_APPSEC_ENABLED=true
 
 ## Using AAP without APM tracing
 
-If you want to use Application & API Protection without APM tracing functionality, you can deploy with tracing disabled:
+If you want to use App and API Protection without APM tracing functionality, you can deploy with tracing disabled:
 
 1. Configure your SDK with the `DD_APM_TRACING_ENABLED=false` environment variable in addition to the `DD_APPSEC_ENABLED=true` environment variable.
 2. This configuration will reduce the amount of APM data sent to Datadog to the minimum required by App and API Protection products.

--- a/hugo/content/en/security/application_security/setup/gcp/cloud-run/_index.md
+++ b/hugo/content/en/security/application_security/setup/gcp/cloud-run/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/go/setup.md
+++ b/hugo/content/en/security/application_security/setup/go/setup.md
@@ -8,7 +8,7 @@ aliases:
 further_reading:
 - link: "/security/application_security/setup/go/sdk"
   tag: "Documentation"
-  text: "App & API Protection SDK for Go"
+  text: "App and API Protection SDK for Go"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Adding user information to traces"
@@ -90,7 +90,7 @@ Add the following environment variable value to your application container's Doc
 ENV DD_APPSEC_ENABLED=true
 ```
 
-For more information on how to create a fitting docker image, See <a href="/security/application_security/setup/go/dockerfile">Creating a Dockerfile for App & API Protection for Go</a>.
+For more information on how to create a fitting docker image, See <a href="/security/application_security/setup/go/dockerfile">Creating a Dockerfile for App and API Protection for Go</a>.
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}

--- a/hugo/content/en/security/application_security/setup/kubernetes/_index.md
+++ b/hugo/content/en/security/application_security/setup/kubernetes/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/kubernetes/gateway-api.md
+++ b/hugo/content/en/security/application_security/setup/kubernetes/gateway-api.md
@@ -162,7 +162,7 @@ The Gateway API integration uses the [Datadog Go Tracer][6] and inherits all env
 
 ## Enabling APM tracing
 
-By default, the request mirror traces won't enable Datadog's APM product. If you want to use Application & API Protection without APM tracing functionality, this is the default behavior. 
+By default, the request mirror traces won't enable Datadog's APM product. If you want to use App and API Protection without APM tracing functionality, this is the default behavior. 
 
 To enable APM tracing, set the environment variable `DD_APM_TRACING_ENABLED=true` in the request mirror deployment.
 

--- a/hugo/content/en/security/application_security/setup/linux/_index.md
+++ b/hugo/content/en/security/application_security/setup/linux/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/macos/_index.md
+++ b/hugo/content/en/security/application_security/setup/macos/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/setup/php/troubleshooting.md
+++ b/hugo/content/en/security/application_security/setup/php/troubleshooting.md
@@ -168,21 +168,21 @@ If your service is a PHP service, explicitly set the environment variable to `DD
 ### Remote Configuration
 
 If AAP was activated using [Remote Configuration][16], do the following: 
-  1. Go to [Services][15].
-  2. Select **App & API Protection in Monitoring Mode**.
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. Select {{< ui >}}App & API Protection in Monitoring Mode{{< /ui >}}.
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   4. Click on a service.
-  5. In **Capabilities** > **App & API Protection** > **Threat Detection**, click **Deactivate**.
+  5. In {{< ui >}}Capabilities{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Threat Detection{{< /ui >}}, click {{< ui >}}Deactivate{{< /ui >}}.
 
 <div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">Remote Configuration</a>, you can use a <strong>Deactivate</strong> button. If AAP was activated using local configuration, the <strong>Deactivate</strong> button is not an option.</div>
 
 ### Bulk disable
 
 To disable AAP on your services in bulk, do the following: 
-  1. Go to [Services][15].
-  2. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   3. Select the checkboxes for the services where you want to disable threat detection.
-  4. In **Bulk Actions**, select **Deactivate threat detection on (number of) services**.
+  4. In {{< ui >}}Bulk Actions{{< /ui >}}, select {{< ui >}}Deactivate threat detection on (number of) services{{< /ui >}}.
 
 
 

--- a/hugo/content/en/security/application_security/setup/windows/_index.md
+++ b/hugo/content/en/security/application_security/setup/windows/_index.md
@@ -4,19 +4,19 @@ disable_sidebar: true
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
-  text: "Protect against Threats with Datadog Application & API Protection"
+  text: "Protect against Threats with Datadog App and API Protection"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Tracking user activity"
 - link: "/security/default_rules/?category=cat-application-security"
   tag: "Documentation"
-  text: "OOTB Application & API Protection Rules"
+  text: "OOTB App and API Protection Rules"
 - link: "/security/application_security/troubleshooting"
   tag: "Documentation"
-  text: "Troubleshooting Application & API Protection"
+  text: "Troubleshooting App and API Protection"
 - link: "/security/application_security/how-it-works/"
   tag: "Documentation"
-  text: "How Application & API Protection Works in Datadog"
+  text: "How App and API Protection Works in Datadog"
 ---
 
 {{< site-region region="gov" >}}

--- a/hugo/content/en/security/application_security/threat_protection/policies/_index.md
+++ b/hugo/content/en/security/application_security/threat_protection/policies/_index.md
@@ -36,7 +36,7 @@ From there, all AAP-protected services block incoming requests performed by the 
 
 In addition to manually blocking attackers, you can configure automation rules to have AAP automatically block attackers that are flagged in Security Signals.
 
-To get started, navigate to **Security > App and API Protection > Protection > [Detection Rules][14]**. You can create a new rule or edit an existing rule with type _App and API Protection_. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
+To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > [{{< ui >}}Detection Rules{{< /ui >}}][14]. You can create a rule or edit an existing rule. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
 
 **Note**: You must instrument your services to be able to block authenticated attackers. See [User Monitoring and Protection][15] for more details.
 
@@ -71,7 +71,7 @@ For fine-grained control, you can clone a Datadog managed policy or create a cus
 
 As In-App WAF rules are toggled between modes, the changes are reflected in near real-time for services with [Remote Configuration enabled][2]. For other services, you can update the policy on the [In-App WAF page][9] and then [define In-App WAF rules][10] for the change in behavior to be applied.
 
-Manage In-App WAF by navigating to Security --> App and API Protection --> Configuration --> [In-App WAF][9].
+Manage In-App WAF by navigating to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][9].
 
 View blocked security traces in the [Trace Explorer][11] by filtering on the facet `Blocked:true`.
 
@@ -81,7 +81,7 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 1. [**Enable Remote Configuration**][2] so that your AAP-enabled services show up under In-App WAF. This is required to securely push In-App WAF configuration from your Datadog backend to the SDK in your infrastructure.
 
-2. **Associate your AAP/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to **Security > App and API Protection > Protection > [In-App WAF][9]**. The service appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
+2. **Associate your AAP/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][9]. The service appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
 
    If you need granular control, clone one of the available policies to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
 
@@ -93,7 +93,7 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 {{% asm-protection-page-configuration %}}
 
-The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to **Security > App and API Protection > Protection > In-App Waf > [Custom Responses][16]**.
+The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App Waf{{< /ui >}} > [{{< ui >}}Custom Responses{{< /ui >}}][16].
 
 You can optionally mask the fact that the attacker has been detected and blocked by overriding the response code to be `200 OK` or `404 NOT FOUND` when the deny page is served.
 
@@ -103,7 +103,7 @@ You can also optionally redirect attackers to a custom deny page and away from y
 
 Protection mode is **on** by default and is a toggle available to quickly disable blocking across **all** your services. Requests can be blocked from two sections in Datadog: all attacker requests from Security Signals, and security traces from In-App WAF.
 
-As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to **Security > App and API Protection > Protection > [In-App WAF][9]** and toggle **Allow Request Blocking** to off.
+As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > [{{< ui >}}In-App WAF{{< /ui >}}][9] and toggle **Allow Request Blocking** to off.
 
 [1]: /security/application_security/setup/
 [2]: /tracing/guide/remote_config

--- a/hugo/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
+++ b/hugo/content/en/security/application_security/threat_protection/policies/inapp_waf_rules.md
@@ -52,7 +52,7 @@ An input represents which part of the request the operator is applied to. The fo
 
 ## Custom In-App WAF rules
 
-Custom In-App WAF rules enable users to log or block specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App and API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App WAF{{< /ui >}} > [{{< ui >}}Custom Rules{{< /ui >}}][4].
+Custom In-App WAF rules enable users to log or block specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to {{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App WAF{{< /ui >}} > [{{< ui >}}Custom Rules{{< /ui >}}][4].
 
 **Note:** Default rules in In-App WAF are read-only. To refine your In-App WAF behavior, modify the In-App WAF rules. Default rules cannot be modified, however, you can create a custom rule based on one of the default rules, and modify the match conditions to your needs. Be sure to disable the default rule so that you don't have two similar rules evaluating the same requests.
 
@@ -93,7 +93,7 @@ Blocking on a service is defined through the policy rules. Three Datadog default
 
 Services using a policy are visible directly in the policy management page.
 
-1. In Datadog, navigate to [Security > App and API Protection > Policies > In-App WAF][2].
+1. In Datadog, navigate to [{{< ui >}}Security{{< /ui >}} > {{< ui >}}App & API Protection{{< /ui >}} > {{< ui >}}Policies{{< /ui >}} > {{< ui >}}In-App WAF{{< /ui >}}][2].
 
    {{< img src="security/application_security/threats/waf/in-app-waf.png" alt="In-App WAF configuration page, showing two default policies." style="width:100%;" >}}
 

--- a/hugo/content/en/security/application_security/troubleshooting.md
+++ b/hugo/content/en/security/application_security/troubleshooting.md
@@ -556,21 +556,21 @@ If your service is a PHP service, explicitly set the environment variable to `DD
 ### Remote Configuration
 
 If AAP was activated using [Remote Configuration][16], do the following: 
-  1. Go to [Services][15].
-  2. Select **App & API Protection in Monitoring Mode**.
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  2. Select {{< ui >}}App & API Protection in Monitoring Mode{{< /ui >}}.
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   4. Click on a service.
-  5. In the service details, in **App & API Protection**, click **Deactivate**.
+  5. In the service details, in {{< ui >}}App & API Protection{{< /ui >}}, click {{< ui >}}Deactivate{{< /ui >}}.
 
 <div class="alert alert-info">If AAP was activated using <a href="https://app.datadoghq.com/organization-settings/remote-config">Remote Configuration</a>, you can use a <strong>Deactivate</strong> button. If AAP was activated using local configuration, the <strong>Deactivate</strong> button is not an option.</div>
 
 ### Bulk disable
 
 To disable AAP on your services in bulk, do the following: 
-  1. Go to [Services][15].
-  3. In the **App & API Protection** facet, enable **Monitoring Only**, **No data**, and **Ready to block**.
+  1. Go to [{{< ui >}}Services{{< /ui >}}][15].
+  3. In the {{< ui >}}App & API Protection{{< /ui >}} facet, enable {{< ui >}}Monitoring Only{{< /ui >}}, {{< ui >}}No data{{< /ui >}}, and {{< ui >}}Ready to block{{< /ui >}}.
   3. Select the check boxes for the services where you want to disable threat detection.
-  4. In **Bulk Actions**, select **Deactivate Threat detection on (number of) services**.
+  4. In {{< ui >}}Bulk Actions{{< /ui >}}, select {{< ui >}}Deactivate Threat detection on (number of) services{{< /ui >}}.
 
   
 ## Need more help?


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15327

Normalizes "App and API Protection" naming across `security/application_security/`:
- Product name in prose, titles, and further_reading entries uses "App and API Protection"
- Literal UI elements use "App & API Protection" wrapped in `{{< ui >}}` tags
- Fixes stale breadcrumbs in `threat_protection/policies/_index.md` that referenced a non-existent "Protection" navigation segment; corrected to "Policies", matching the actual product navigation and the pattern already used in `inapp_waf_rules.md`
- Removes an inaccurate reference to filtering detection rules by "type App & API Protection"

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to audit naming consistency across the section, apply UI-tag formatting, and cross-reference documentation to verify navigation paths before correcting breadcrumbs.

### Additional notes