### PR TITLE
Add Nepal to On-Call supported countries list

### DIFF
--- a/hugo/content/en/incident_response/on-call/notification_preferences/supported_countries.md
+++ b/hugo/content/en/incident_response/on-call/notification_preferences/supported_countries.md
@@ -86,6 +86,7 @@ For the best experience, download the Datadog <a href="https://docs.datadoghq.co
 | Monaco | +377 |
 | Montenegro | +382 |
 | Morocco | +212 |
+| Nepal | +977 |
 | Netherlands | +31 |
 | New Zealand | +64 |
 | Nigeria*, ** | +234 |


### PR DESCRIPTION
### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### Additional notes

On-Call phone notifications now support Nepal.