### PR TITLE
[SDCT-1023] Point Usage Attribution to CI billing enrichment

### DIFF
--- a/hugo/content/en/account_management/billing/usage_attribution.md
+++ b/hugo/content/en/account_management/billing/usage_attribution.md
@@ -22,7 +22,9 @@ Administrators or users with the Usage Read permission can access the Usage Attr
 - Summarizes usage at the end of each month and visualizes usage over time broken out by tags.
 - Generates month-to-date and hourly CSV files.
 
-This feature does not support product usage that cannot be tagged during instrumentation. For example, Incident Management Users, CI Pipeline and Test Users, Parallel Testing Slots, and Audit Trail. 
+This feature does not support product usage that cannot be tagged during instrumentation. For example, Incident Management Users, Parallel Testing Slots, and Audit Trail.
+
+**Note**: To break down CI Pipeline and Test Optimization billing by team or other organizational tags, see [Billing enrichment][5] in the CI Visibility Billing documentation.
 
 ## Getting started
 
@@ -109,3 +111,4 @@ For direct billing customers, month-end cost attribution reports are generated a
 [2]: https://docs.datadoghq.com/api/v1/usage-metering/#get-hourly-usage-attribution
 [3]: https://docs.datadoghq.com/getting_started/tagging/#define-tags
 [4]: https://docs.datadoghq.com/api/latest/usage-metering/#get-monthly-cost-attribution
+[5]: /account_management/billing/ci_visibility/#billing-enrichment


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

CI Pipeline and Test Users was listed as an unsupported product in the generic Usage Attribution documentation, but CI/Test Optimization billing can now be broken down by team or other organizational tags through Billing enrichment. This PR removes that item from the "not supported" list and adds a note pointing readers to the Billing enrichment documentation.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Change drafted and applied with Claude Code, based on the corresponding web-ui change (ddoghq/web-ui#8981) that removed CI Pipeline & Test Users from the same unsupported list in the product UI.

### Additional notes