### PR TITLE
Mark Data Observability model configuration settings as Preview

### DIFF
--- a/hugo/content/en/monitors/types/data_observability.md
+++ b/hugo/content/en/monitors/types/data_observability.md
@@ -205,7 +205,15 @@ You can add a {{< ui >}}Group by{{< /ui >}} clause to split a single monitor int
 
 The default limit is 500 groups per monitor. To increase this limit, [contact Support][9].
 
+### Missing data
+
+In the {{< ui >}}If data is missing to evaluate{{< /ui >}} dropdown menu, select what the monitor reports when no data is available for an evaluation.
+
 ### Model configuration
+
+{{< callout url="#" btn_hidden="true" header="Preview" >}}
+The following model configuration settings are in Preview. Contact your Datadog representative to enable them for your organization.
+{{< /callout >}}
 
 For monitors using the {{< ui >}}Anomalies{{< /ui >}} detection method, expand {{< ui >}}Model configuration{{< /ui >}} to refine how the model behaves:
 
@@ -214,8 +222,6 @@ For monitors using the {{< ui >}}Anomalies{{< /ui >}} detection method, expand {
 | {{< ui >}}Alert after N consecutive anomalies{{< /ui >}} | The number of consecutive failed evaluations before the monitor alerts. Configure this setting to suppress isolated spikes. |
 | {{< ui >}}Minimum upper bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the upper end. |
 | {{< ui >}}Minimum lower bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the lower end. |
-
-In the {{< ui >}}If data is missing to evaluate{{< /ui >}} dropdown menu, select what the monitor reports when no data is available for an evaluation.
 
 ### Monitor schedule
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a Preview callout to the **model configuration** settings on the Data Observability monitor page. These three settings are gated per organization and are not generally available:

- Alert after N consecutive anomalies
- Minimum upper bound size
- Minimum lower bound size

The page currently documents them with no indication that access has to be requested, so a reader following the docs would look for controls they cannot see.

The callout uses the same `{{< callout >}}` pattern already used for Preview in this product area (`data_observability/quality_monitoring/transactional_databases/postgres.md`) and on `monitors/types/netflow.md`.

**One small structural change was needed to scope the callout correctly.** The `Model configuration` section also contained the `If data is missing to evaluate` setting, which is *not* gated. In the product UI that dropdown sits outside the collapsible Model configuration panel, as a sibling, so the docs were also misrepresenting the UI structure. It now has its own `Missing data` section above, which keeps the Preview callout scoped to only the three gated settings.

### Merge readiness

- [ ] Ready for merge

Opening as draft. Two things to confirm before merging:

1. Whether "Contact your Datadog representative" is the right instruction, or whether it should say account team. I used the phrasing already established by the two existing Preview callouts in the repo.
2. Whether the gating is exactly these three settings. If the Anomalies detection method as a whole is gated, the callout should move up to `Configure monitor` instead.

### AI assistance

Drafted with Claude Code. The callout placement and wording follow existing precedent in this repo rather than being invented; the scoping fix was checked against a screenshot of the monitor creation UI.

### Additional notes

Related and not in this PR: the Terraform provider exposes model configuration through `monitor_options.model_type_override` on the `datadog_monitor` resource with no Preview marking. If these settings are gated, that attribute description should say so too. That is a change in `DataDog/terraform-provider-datadog`, not here.
