### PR TITLE
Clarify reserved service attribute behavior

### DIFF
--- a/hugo/content/en/events/explorer/attributes.md
+++ b/hugo/content/en/events/explorer/attributes.md
@@ -28,6 +28,12 @@ This list describes automatically ingested reserved attributes with events.
 | `service` | The name of the application or service generating the events. |
 | `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. |   
 
+### Events with multiple service tags
+
+The reserved `service` attribute has a single value. If an event contains multiple `service:<value>` tags, Datadog uses one of them to populate the reserved attribute. Do not rely on which value is selected, because tag processing order can vary.
+
+Send only one `service` tag per event. Use a different tag key for additional dimensions, such as `application:<value>`. Additional `service` tags remain in the raw tag list and can be found with a query such as `tags:("service:<value>")`. A `service:<value>` query matches only the value assigned to the reserved attribute.
+
 To search a tag that has the same key as a reserved attribute, use the `tags` search syntax. 
 Example: `tags:("status:<status>")`
 

--- a/hugo/content/en/events/explorer/attributes.md
+++ b/hugo/content/en/events/explorer/attributes.md
@@ -30,12 +30,14 @@ This list describes automatically ingested reserved attributes with events.
 
 ### Events with multiple service tags
 
-The reserved `service` attribute has a single value. If an event contains multiple `service:<value>` tags, the event processing version determines which tag populates the reserved attribute:
+The reserved `service` attribute accepts one value. If an event has multiple `service` tags:
 
-- V1 uses the first `service` tag it encounters. Because V1 does not sort tags before processing them, the selected value is not deterministic.
-- V2 sorts tags alphabetically and uses the first `service` tag. For example, if an event has `service:bcd` and `service:ace`, V2 assigns `service:ace` to the reserved attribute.
+- V1 selects the first `service` tag it processes. Because tags are not sorted, the result is not deterministic.
+- V2 sorts the tags alphabetically and selects the first `service` tag.
 
-Send only one `service` tag per event. Use a different tag key for additional dimensions, such as `application:<value>`. Additional `service` tags remain in the raw tag list and can be found with a query such as `tags:("service:<value>")`. A `service:<value>` query matches only the value assigned to the reserved attribute.
+For example, consider an event with `env:prod`, `service:payments`, `team:store`, and `service:checkout`. V1 can assign either service value. V2 assigns `checkout`, because `service:checkout` comes before `service:payments` alphabetically.
+
+Send only one `service` tag per event and use another tag key for additional dimensions. A `service:<value>` query matches the reserved attribute; use `tags:("service:<value>")` to find any value in the raw tag list.
 
 To search a tag that has the same key as a reserved attribute, use the `tags` search syntax. 
 Example: `tags:("status:<status>")`

--- a/hugo/content/en/events/explorer/attributes.md
+++ b/hugo/content/en/events/explorer/attributes.md
@@ -30,7 +30,10 @@ This list describes automatically ingested reserved attributes with events.
 
 ### Events with multiple service tags
 
-The reserved `service` attribute has a single value. If an event contains multiple `service:<value>` tags, Datadog uses one of them to populate the reserved attribute. Do not rely on which value is selected, because tag processing order can vary.
+The reserved `service` attribute has a single value. If an event contains multiple `service:<value>` tags, the event processing version determines which tag populates the reserved attribute:
+
+- V1 uses the first `service` tag it encounters. Because V1 does not sort tags before processing them, the selected value is not deterministic.
+- V2 sorts tags alphabetically and uses the first `service` tag. For example, if an event has `service:bcd` and `service:ace`, V2 assigns `service:ace` to the reserved attribute.
 
 Send only one `service` tag per event. Use a different tag key for additional dimensions, such as `application:<value>`. Additional `service` tags remain in the raw tag list and can be found with a query such as `tags:("service:<value>")`. A `service:<value>` query matches only the value assigned to the reserved attribute.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Clarifies how the reserved `service` attribute behaves when an event contains multiple `service` tags. Recommends sending one `service` tag per event, explains how to represent additional dimensions, and distinguishes reserved-attribute searches from raw-tag searches.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI assistance was used to identify the documentation gap and draft the clarification.

### Additional notes
