### PR TITLE
Document Least Privilege IaC rule type

### DIFF
--- a/hugo/content/en/security/code_security/iac_security/configuration.md
+++ b/hugo/content/en/security/code_security/iac_security/configuration.md
@@ -190,6 +190,7 @@ Use `ignore-categories` to ignore findings with specific rule types. Use `only-c
 - `Encryption`
 - `Insecure Configurations`
 - `Insecure Defaults`
+- `Least Privilege`
 - `Networking and Firewall`
 - `Observability`
 - `Resource Management`


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds **Least Privilege** to the list of supported IaC rule types in the IaC Security configuration docs (`ignore-categories` / `only-categories`).

Customer request: CI/CD and AI-agent findings where permissions exceed workload needs do not fit cleanly under Access Control.

Slack: https://dd.slack.com/archives/C069XJF7F4L/p1788182857176039

### Merge readiness

- [ ] Ready for merge

### AI assistance

Cursor-assisted edit.

### Additional notes

Companion PRs in dd-source, datadog-iac-scanner, schema, and web-ui.
