### PR TITLE
Restore DSM end-to-end latency troubleshooting content

### DIFF
--- a/hugo/content/en/data_streams/_index.md
+++ b/hugo/content/en/data_streams/_index.md
@@ -149,6 +149,14 @@ Datadog automatically links the infrastructure powering your services and relate
 
 Datadog can automatically detect your managed [Confluent Cloud][8] connectors and visualize them in the Data Streams Monitoring topology map. Install and configure the [Confluent Cloud integration][9] to collect information from your Confluent Cloud connectors—including throughput, status, and topic dependencies.
 
+## Troubleshooting
+
+### End-to-end latency metric doesn't look accurate
+
+Latency calculations for a pathway require single-threaded message processing. If messages in your pipeline use multiple threads, add manual instrumentation. Manual instrumentation is available for [Go][12] and [Java][13] applications. For other languages, see the [manual instrumentation guide][14]. For .NET manual instrumentation, contact [Support][15].
+
+In the Pathways tab, the message **latency values may be approximate for these pathways** appears for pathways that need manual instrumentation for accurate latency values.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -164,3 +172,7 @@ Datadog can automatically detect your managed [Confluent Cloud][8] connectors an
 [9]: /integrations/confluent_cloud/
 [10]: https://app.datadoghq.com/data-streams/map
 [11]: /opentelemetry/compatibility
+[12]: /data_streams/go#manual-instrumentation
+[13]: /data_streams/java#manual-instrumentation
+[14]: /data_streams/manual_instrumentation/
+[15]: /help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The in-app APPROXIMATION badge on the DSM "Top latency contributors" widget links to `/data_streams/#end-to-end-latency-metric-doesnt-look-accurate`, a section deleted in March 2025 without migrating its content. This PR restores it on the Data Streams Monitoring index page and fixes its instrumentation link to point at the Go/Java manual instrumentation docs instead of circularly back to Setup.

https://linear.app/datadoghq/issue/DSM2-254/approximation-tooltip-troubleshooting-link-is-a-dead-anchor-in-dsm

### Merge readiness

- [X] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

