### PR TITLE
Create Skills Library documentation

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -1610,6 +1610,11 @@ menu:
       identifier: bits_data_analysis
       parent: bits_ai
       weight: 8
+    - name: Skills Library
+      url: bits_ai/skills_library
+      identifier: bits_ai_skills_library
+      parent: bits_ai
+      weight: 9
     - name: Dashboards
       url: dashboards/
       pre: dashboard

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -23,7 +23,7 @@ Skills work with [Bits Chat][1], [Bits Agent Builder][2], the Datadog app for Sl
 
 ## Create a skill
 
-Create a skill in the Skills Library or by asking Bits Chat.
+Create a skill directly in the Skills Library, or ask Bits Chat to create one for you.
 
 ### Create a skill in the Skills Library
 

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -89,7 +89,7 @@ For more information about creating and testing agents, see [Bits Agent Builder]
 
 ## Use a skill in Slack
 
-After you connect the Datadog app to Slack, mention `@Datadog` and add the skill's slash command:
+After you connect the Datadog app for Slack, mention `@Datadog` and add the skill's slash command:
 
 ```text
 @Datadog /my-skill

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -103,7 +103,7 @@ External AI agents that connect to the Datadog MCP Server can discover and load 
 
 The Datadog MCP Server provides the following tools:
 
-- `list_datadog_skills()`: Lists the skills available to the agent. Agents can also discover available skills through MCP Resources.
+- `list_datadog_skills()`: Lists the skills available to the agent.
 - `load_datadog_skill()`: Loads a selected skill into the agent's context.
 
 A typical external-agent workflow is:

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -1,0 +1,105 @@
+---
+title: Skills Library
+description: Create reusable skills that provide Bits AI and external AI agents with organization-specific domain knowledge and instructions.
+further_reading:
+- link: "/bits_ai/bits_chat/"
+  tag: "Documentation"
+  text: "Bits Chat"
+- link: "/actions/agents/"
+  tag: "Documentation"
+  text: "Bits Agent Builder"
+- link: "/bits_ai/mcp_server/"
+  tag: "Documentation"
+  text: "Datadog MCP Server"
+---
+
+## Overview
+
+Use the Skills Library to define reusable domain knowledge and instructions for AI agents. Skills give agents task-specific context without requiring you to repeat the same information in each prompt.
+
+For example, create a skill that describes an organization's incident response process, service ownership conventions, or requirements for summarizing an investigation.
+
+Skills work with [Bits Chat][1], [Bits Agent Builder][2], the Datadog app for Slack, and external agents such as Claude Code, Codex, and Cursor that connect through the [Datadog MCP Server][3].
+
+## Create a skill
+
+1. Open the [**Skills Library**][4] in Datadog.
+2. Create a skill or import an existing `SKILLS.md` file.
+3. Add the domain knowledge and instructions that the agent should follow.
+4. Select the skill's visibility:
+   - **Private**: Keep the skill private.
+   - **Public**: Share the skill with the Datadog organization.
+5. Save the skill.
+
+Use focused instructions and give the skill a descriptive name. A clear name makes the skill easier to discover and invoke with a slash command.
+
+## Use a skill in Bits Chat
+
+To make a skill available to Bits Chat:
+
+1. Open **Settings** in Bits Chat.
+2. Select **Skills**.
+3. Enable the skill.
+
+After you enable a skill, Bits Chat uses it automatically when the skill is relevant to a request.
+
+Invoke a skill explicitly by entering its slash command in the conversation:
+
+```text
+/my-skill
+```
+
+You can include additional context in the same message or continue the conversation after invoking the skill.
+
+## Use a skill in Bits Agent Builder
+
+In the agent instructions, add each skill that the agent needs. Choose only skills that apply to the agent's intended tasks so that the instructions remain focused.
+
+During a test conversation, invoke a skill explicitly with its slash command:
+
+```text
+/my-skill
+```
+
+For more information about creating and testing agents, see [Bits Agent Builder][2].
+
+## Use a skill in Slack
+
+After you connect the Datadog app to Slack, mention `@Datadog` and add the skill's slash command:
+
+```text
+@Datadog /my-skill
+```
+
+Add any task-specific details after the command.
+
+## Use skills with an external agent
+
+External AI agents that connect to the Datadog MCP Server can discover and load skills from the Skills Library.
+
+The Datadog MCP Server provides the following tools:
+
+- `list_datadog_skills()`: Lists the skills available to the agent. Agents can also discover available skills through MCP Resources.
+- `load_datadog_skill()`: Loads a selected skill into the agent's context.
+
+A typical external-agent workflow is:
+
+1. Connect the agent to the Datadog MCP Server.
+2. Discover available skills with `list_datadog_skills()` or MCP Resources.
+3. Load the skill needed for the task with `load_datadog_skill()`.
+4. Ask the agent to complete the task using the loaded instructions and knowledge.
+
+For connection instructions, see the [Datadog MCP Server][3] documentation.
+
+## Availability
+
+The Skills Library supports Bits Chat, Bits Agent Builder, Slack, and external agents that connect through the Datadog MCP Server. Bits Investigation does not support skills.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /bits_ai/bits_chat/
+[2]: /actions/agents/
+[3]: /bits_ai/mcp_server/
+[4]: https://app.datadoghq.com/actions/skills

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -2,15 +2,15 @@
 title: Skills Library
 description: Create reusable skills that provide Bits AI and external AI agents with organization-specific domain knowledge and instructions.
 further_reading:
-- link: "/bits_ai/bits_chat/"
-  tag: "Documentation"
-  text: "Bits Chat"
-- link: "/actions/agents/"
-  tag: "Documentation"
-  text: "Bits Agent Builder"
-- link: "/mcp_server/"
-  tag: "Documentation"
-  text: "Datadog MCP Server"
+    - link: '/bits_ai/bits_chat/'
+      tag: 'Documentation'
+      text: 'Bits Chat'
+    - link: '/actions/agents/'
+      tag: 'Documentation'
+      text: 'Bits Agent Builder'
+    - link: '/mcp_server/'
+      tag: 'Documentation'
+      text: 'Datadog MCP Server'
 ---
 
 ## Overview
@@ -31,8 +31,8 @@ Create a skill in the Skills Library or by asking Bits Chat.
 2. Create a skill or import an existing `SKILLS.md` file.
 3. Add the domain knowledge and instructions that the agent should follow.
 4. Select the skill's visibility:
-   - **Private**: Keep the skill private.
-   - **Public**: Share the skill with the Datadog organization.
+    - **Private**: Keep the skill private.
+    - **Public**: Share the skill with the Datadog organization.
 5. Save the skill.
 
 Use focused instructions and give the skill a descriptive name. A clear name makes the skill easier to discover and invoke with a slash command.
@@ -117,7 +117,7 @@ For connection instructions, see the [Datadog MCP Server][3] documentation.
 
 ## Availability
 
-The Skills Library supports Bits Chat, Bits Agent Builder, Slack, and external agents that connect through the Datadog MCP Server. Bits Investigation does not support skills.
+The Skills Library is supported Bits Chat, Bits Agent Builder, Slack, and external agents that connect through the Datadog MCP Server.
 
 ## Further reading
 

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -117,7 +117,7 @@ For connection instructions, see the [Datadog MCP Server][3] documentation.
 
 ## Availability
 
-The Skills Library is supported Bits Chat, Bits Agent Builder, Slack, and external agents that connect through the Datadog MCP Server.
+The Skills Library is available in Bits Chat, Bits Agent Builder, Slack, and external agents that connect through the Datadog MCP Server.
 
 ## Further reading
 

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -23,6 +23,10 @@ Skills work with [Bits Chat][1], [Bits Agent Builder][2], the Datadog app for Sl
 
 ## Create a skill
 
+Create a skill in the Skills Library or by asking Bits Chat.
+
+### Create a skill in the Skills Library
+
 1. Open the [**Skills Library**][4] in Datadog.
 2. Create a skill or import an existing `SKILLS.md` file.
 3. Add the domain knowledge and instructions that the agent should follow.
@@ -32,6 +36,26 @@ Skills work with [Bits Chat][1], [Bits Agent Builder][2], the Datadog app for Sl
 5. Save the skill.
 
 Use focused instructions and give the skill a descriptive name. A clear name makes the skill easier to discover and invoke with a slash command.
+
+### Create a skill with Bits Chat
+
+Ask Bits Chat to create a skill:
+
+```text
+Create a new Skills Library skill
+```
+
+To create a skill from the context in an existing Bits Chat conversation, enter:
+
+```text
+Turn this conversation into a skill
+```
+
+You can also create a skill from an existing Slack thread. In the thread, enter:
+
+```text
+@Datadog turn this conversation into a skill
+```
 
 ## Use a skill in Bits Chat
 

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -53,9 +53,9 @@ You can include additional context in the same message or continue the conversat
 
 ## Use a skill in Bits Agent Builder
 
-In the agent instructions, add each skill that the agent needs. Choose only skills that apply to the agent's intended tasks so that the instructions remain focused.
+In the agent configuration, select each skill that the agent needs. The agent automatically loads selected skills.
 
-During a test conversation, invoke a skill explicitly with its slash command:
+To invoke a skill explicitly during a conversation, enter its slash command:
 
 ```text
 /my-skill

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "/actions/agents/"
   tag: "Documentation"
   text: "Bits Agent Builder"
-- link: "/bits_ai/mcp_server/"
+- link: "/mcp_server/"
   tag: "Documentation"
   text: "Datadog MCP Server"
 ---
@@ -125,5 +125,5 @@ The Skills Library supports Bits Chat, Bits Agent Builder, Slack, and external a
 
 [1]: /bits_ai/bits_chat/
 [2]: /actions/agents/
-[3]: /bits_ai/mcp_server/
+[3]: /mcp_server/
 [4]: https://app.datadoghq.com/actions/skills

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -27,7 +27,7 @@ Create a skill directly in the Skills Library, or ask Bits Chat to create one fo
 
 ### Create a skill in the Skills Library
 
-1. Open the [**Skills Library**][4] in Datadog.
+1. Open the [{{< ui >}}Skills Library{{< /ui >}}][4] in Datadog.
 2. Create a skill or import an existing `SKILLS.md` file.
 3. Add the domain knowledge and instructions that the agent should follow.
 4. Select the skill's visibility:

--- a/hugo/content/en/bits_ai/skills_library.md
+++ b/hugo/content/en/bits_ai/skills_library.md
@@ -28,7 +28,7 @@ Create a skill directly in the Skills Library, or ask Bits Chat to create one fo
 ### Create a skill in the Skills Library
 
 1. Open the [{{< ui >}}Skills Library{{< /ui >}}][4] in Datadog.
-2. Create a skill or import an existing `SKILLS.md` file.
+2. Create a skill or import an existing `SKILL.md` file.
 3. Add the domain knowledge and instructions that the agent should follow.
 4. Select the skill's visibility:
     - **Private**: Keep the skill private.


### PR DESCRIPTION
Added a new Skills Library documentation page outlining how to create and use reusable skills for AI agents in Datadog.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds Skills Library page in public documentation.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Used Codex to generate the page, based off of the dogfooding announcement [email](https://docs.google.com/document/d/10xY4uUweeZ0uLdBGL9mh3OJzxLasO5-DNbXzveum3pI/edit?tab=t.0), additional instructions and contribution guidelines
