### PR TITLE
[DOCS-15447] De-duplicate remaining BI integration docs

### DIFF
--- a/hugo/content/en/data_observability/quality_monitoring/business_intelligence/looker.md
+++ b/hugo/content/en/data_observability/quality_monitoring/business_intelligence/looker.md
@@ -1,61 +1,21 @@
 ---
 title: Looker
-description: Connect Looker to Datadog Data Observability to view field-level lineage from warehouse tables to Looker explore fields, dashboards, and Looks.
+description: Looker integration for Data Observability lineage. See the integration documentation for setup.
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
 ---
 
-## Overview
+Datadog's Looker integration helps data teams make changes to their data platform without breaking dashboards and Looks, and identify unused content to remove.
 
-Datadog's Looker integration helps data teams make changes to their data platform without breaking dashboards and Looks, and identify unused content to remove. The integration collects metadata and field-level lineage for objects in your Looker account. When Datadog connects, it:
+Lineage is derived from your data warehouse, so you also need at least one [supported data warehouse destination][2] connected to Datadog.
 
-- Pulls metadata from your Looker instance, including projects, models, explores, views, dashboards, Looks, and folders
-- Generates field-level lineage between warehouse tables and columns and downstream Looker views and derived tables, and between Looker views and other Looker objects such as dashboards and explores
-- Parses LookML files directly from your linked Git repositories to extract richer lineage and metadata, including derived tables, view extensions, and refinements
-
-## Setup
-
-### Create a Looker API key
-
-1. Go to your Looker dashboard (for example, at `https://<your_company>.cloud.looker.com`).
-2. Navigate to {{< ui >}}Admin{{< /ui >}} > {{< ui >}}Users{{< /ui >}}.
-3. Select the user you want to create an API key for.
-4. Next to {{< ui >}}API Keys{{< /ui >}}, click {{< ui >}}Edit Keys{{< /ui >}}.
-5. Click {{< ui >}}New API Key{{< /ui >}}.
-6. Copy the client ID and secret.
-
-### Add the API credentials to Datadog
-
-1. Navigate to the [Looker integration tile][2].
-2. Click {{< ui >}}Configure{{< /ui >}} > {{< ui >}}+ Add New Account{{< /ui >}}.
-3. Fill out the form with the following:
-   - {{< ui >}}Account name{{< /ui >}}: A label to identify this Looker instance
-   - {{< ui >}}Instance URL{{< /ui >}}: The URL of your Looker instance (for example, `https://company.cloud.looker.com`)
-   - {{< ui >}}Client ID{{< /ui >}}: The client ID from the previous step
-   - {{< ui >}}API Secret{{< /ui >}}: The client secret from the previous step
-4. Click {{< ui >}}Save{{< /ui >}}.
-
-### Connect LookML repositories
-
-Datadog parses LookML files to collect lineage and metadata for Looker views and derived tables.
-
-Connect each LookML Git repository to Datadog using the [Source Code Integration][4]. The next time the Looker integration runs on its hourly schedule, it automatically detects the repositories and parses the LookML files.
-
-If your Git repositories already appear on the Datadog [repositories page][5], no additional steps are required.
-
-## What's next
-
-It can take up to 60 minutes for data to appear after the initial setup.
-
-After syncing, you can explore your Looker assets and their upstream dependencies in the [Data Observability Catalog][3].
+See the [Looker integration][1] documentation for setup and configuration.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[2]: https://app.datadoghq.com/integrations/looker
-[3]: https://app.datadoghq.com/data-obs/catalog
-[4]: https://app.datadoghq.com/integrations/github
-[5]: https://app.datadoghq.com/source-code/repositories
+[1]: /integrations/looker/
+[2]: /data_observability/quality_monitoring/data_warehouses/

--- a/hugo/content/en/data_observability/quality_monitoring/business_intelligence/metabase.md
+++ b/hugo/content/en/data_observability/quality_monitoring/business_intelligence/metabase.md
@@ -1,78 +1,21 @@
 ---
 title: Metabase
-description: Connect Metabase to Datadog Data Observability to view end-to-end lineage from warehouse tables to dashboards.
+description: Metabase integration for Data Observability lineage. See the integration documentation for setup.
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
 ---
 
-## Overview
+Datadog's Metabase integration helps data teams make changes to their data platform without breaking Metabase dashboards, and identify unused cards or dashboards. The integration also collects Metabase activity, view, and query logs.
 
-Datadog's Metabase integration helps data teams make changes to their data platform without breaking Metabase dashboards, and identify unused cards or dashboards. When Datadog connects, it:
+Lineage is derived from your data warehouse, so you also need at least one [supported data warehouse destination][2] connected to Datadog. Log collection has no such requirement.
 
-- Pulls metadata from your Metabase environment, including cards and dashboards.
-- Automatically generates lineage from warehouse tables and columns to downstream Metabase cards, as well as from those cards to downstream dashboards.
-
-## Connect Metabase
-
-### Prerequisites
-
-This integration requires a Metabase Pro or Enterprise plan.
-
-### Generate an API key
-
-Follow [Metabase's API documentation][1] to generate an API key.
-
-### Get DNS alias (required for cloud instances only)
-
-1. Log into your Metabase cloud instance as an administrator.
-1. Click on the gear icon in the upper right corner.
-1. Select {{< ui >}}Admin settings{{< /ui >}}.
-1. Go to the {{< ui >}}Settings{{< /ui >}} tab.
-1. Click on the {{< ui >}}Cloud{{< /ui >}} tab from the left menu.
-1. Click on {{< ui >}}Go to the Metabase Store{{< /ui >}}.
-1. Log into your Metabase Store using Metabase credentials.
-1. Go to the {{< ui >}}Instances{{< /ui >}} tab.
-1. Click on the DNS alias section to get the DNS alias value.
-
-### Get self-hosted instance domain (required for self-hosted instances only)
-
-**Note**: Your self-hosted Metabase instance must be accessible from the internet through HTTPS only.
-
-1. Log in to your Metabase instance as an administrator.
-1. Click on the gear icon in the upper right corner.
-1. Select {{< ui >}}Admin settings{{< /ui >}}.
-1. Go to the {{< ui >}}Settings{{< /ui >}} tab.
-1. Click on the {{< ui >}}General{{< /ui >}} tab from the left menu.
-1. Under {{< ui >}}SITE URL{{< /ui >}}, copy the domain portion of the URL. For example, if the URL is `https://example.com`, copy `example.com`.
-
-### Add the Metabase integration
-
-1. Navigate to the [Metabase integration tile][2] and enter the following information:
-
-   | Parameter | Description |
-   |-----------|-------------|
-   | Account name | Datadog-only account name associated with these credentials. |
-   | Instance type | The hosting type of your Metabase instance. Valid values are `cloud` or `self-hosted`. Default is `cloud`. |
-   | DNS alias | The DNS alias of your Metabase cloud instance (required for cloud instances only). Must be at least three characters long and contain only lowercase letters, dashes, and numbers. |
-   | Self-hosted instance domain | The domain of your self-hosted Metabase instance (required for self-hosted instances only). Must be publicly accessible through HTTPS only (for example, `example.com`). |
-   | Metabase API key | The API key used to authenticate the API requests. |
-
-2. After you've entered these credentials, click {{< ui >}}Save{{< /ui >}}.
-
-## What's next
-
-When your Metabase account is successfully connected, Datadog syncs and automatically derives lineage from warehouse tables/columns to Metabase cards and dashboards.
-
-Initial syncs may take up to several hours depending on the size of your Metabase deployment.
-
-After syncing, you can explore your Metabase assets and their upstream dependencies in the [Data Observability Catalog][3].
+See the [Metabase integration][1] documentation for setup and configuration.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://www.metabase.com/docs/latest/people-and-groups/api-keys#create-an-api-key
-[2]: https://app.datadoghq.com/integrations/metabase
-[3]: https://app.datadoghq.com/data-obs/catalog
+[1]: /integrations/metabase/
+[2]: /data_observability/quality_monitoring/data_warehouses/

--- a/hugo/content/en/data_observability/quality_monitoring/business_intelligence/powerbi.md
+++ b/hugo/content/en/data_observability/quality_monitoring/business_intelligence/powerbi.md
@@ -1,78 +1,21 @@
 ---
 title: Power BI
-description: Connect Power BI to Datadog Data Observability to view end-to-end lineage from warehouse tables to dashboards.
+description: Power BI integration for Data Observability lineage. See the integration documentation for setup.
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
 ---
 
-## Overview
+Datadog's Power BI integration helps data teams make changes to their data platform without breaking dashboards, and identify unused reports and dashboards to remove.
 
-Datadog's Power BI integration helps data teams make changes to their data platform without breaking dashboards, and identify unused reports and dashboards to remove. When Datadog connects, it:
+Lineage is derived from your data warehouse, so you also need at least one [supported data warehouse destination][2] connected to Datadog.
 
-- Pulls metadata from your Power BI account like datasets, reports, and dashboards.
-- Automatically generates lineage between warehouse tables with downstream datasets, reports, and dashboards.
-
-## Connect Power BI
-
-### Create an app registration and security group
-
-#### App registration
-
-1. Sign into Microsoft Azure.
-2. Search for {{< ui >}}App registrations{{< /ui >}}.
-3. Click {{< ui >}}New registration{{< /ui >}}.
-4. Fill in the required fields and register an application for Datadog.
-5. Copy the Application (client) ID somewhere safe.
-6. Go to {{< ui >}}Certificates & secrets{{< /ui >}} in sidebar and click {{< ui >}}New client secret{{< /ui >}}.
-7. Add a secret for Datadog.
-8. Copy the secret value somewhere safe.
-
-#### Security group
-
-1. Search for {{< ui >}}Azure Active Directory{{< /ui >}}.
-2. Go to {{< ui >}}Groups{{< /ui >}} in the sidebar and click {{< ui >}}New group{{< /ui >}}.
-3. Create a group for the app registration.
-4. Click into the newly created group. You may need to refresh the page for it to show up.
-5. Go to {{< ui >}}Members{{< /ui >}} in the sidebar and click {{< ui >}}Add members{{< /ui >}}.
-6. Find the app registration created earlier and add it as a member.
-
-### Grant access in Power BI
-
-#### Enable API and admin API access for security group in Power BI Admin
-
-1. Go to the Power BI Admin portal.
-2. In Tenant settings, enable {{< ui >}}Service principals can call Fabric APIs{{< /ui >}} for your security group.
-3. In Tenant settings, find {{< ui >}}Admin API settings{{< /ui >}}.
-4. Enable the following for your security group:
-   - {{< ui >}}Allow service principals to use read-only admin APIs{{< /ui >}}
-   - {{< ui >}}Enhance admin APIs responses with detailed metadata{{< /ui >}}
-   - {{< ui >}}Enhance admin APIs responses with DAX and mashup expressions{{< /ui >}}
-
-#### Grant access to workspaces
-
-From the Power BI Admin portal:
-
-1. From the sidebar, click {{< ui >}}Workspaces{{< /ui >}} to open the Workspaces pane.
-2. Grant Viewer permissions to the service principal in each workspace you want Datadog to have access to.
-
-### Add the Power BI integration
-
-1. Navigate to the [Power BI integration tile][1] and enter your tenant ID, and the client ID and secret from earlier.
-2. After you've entered these credentials, click {{< ui >}}Save{{< /ui >}}.
-
-## What's next
-
-When your Power BI account is successfully connected, Datadog syncs and automatically derives lineage from warehouse tables/columns to Power BI datasets, reports, and dashboards.
-
-Initial syncs may take up to several hours depending on the size of your Power BI deployment.
-
-After syncing, you can explore your Power BI assets and their upstream dependencies in the [Data Observability Catalog][2].
+See the [Power BI integration][1] documentation for setup and configuration.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/integrations/power-bi
-[2]: https://app.datadoghq.com/data-obs/catalog
+[1]: /integrations/power-bi/
+[2]: /data_observability/quality_monitoring/data_warehouses/

--- a/hugo/content/en/data_observability/quality_monitoring/business_intelligence/sigma.md
+++ b/hugo/content/en/data_observability/quality_monitoring/business_intelligence/sigma.md
@@ -1,49 +1,21 @@
 ---
 title: Sigma
-description: Connect Sigma to Datadog Data Observability to view end-to-end lineage from warehouse tables to workbooks.
+description: Sigma integration for Data Observability lineage. See the integration documentation for setup.
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
 ---
 
-## Overview
+Datadog's Sigma integration helps data teams make changes to their data platform without breaking Sigma workbooks, and identify unused workbooks or datasets.
 
-Datadog's Sigma integration helps data teams make changes to their data platform without breaking Sigma workbooks, and identify unused workbooks or datasets. When Datadog connects, it:
+Lineage is derived from your data warehouse, so you also need at least one [supported data warehouse destination][2] connected to Datadog.
 
-- Pulls metadata from your Sigma site, including workbooks and queries.
-- Automatically generates lineage between warehouse tables and columns and downstream Sigma datasets and workbooks.
-
-## Connect Sigma
-
-### Retrieve API keys
-
-Follow [Sigma's API client instructions][1] to retrieve a Client ID and Client Secret (also called an API token).
-
-### Add the Sigma integration
-
-1. Navigate to the [Sigma integration tile][2] and enter the following information:
-
-   - Account name
-   - Client ID
-   - Client secret
-   - Cloud provider. If you don't know your cloud provider, you can find it using Sigma's [Supported cloud platforms and regions documentation][3].
-
-2. After you've entered these credentials, click {{< ui >}}Save{{< /ui >}}.
-
-## What's next
-
-When your Sigma account is successfully connected, Datadog syncs and automatically derives lineage from warehouse tables/columns to Sigma workbooks.
-
-Initial syncs may take up to several hours depending on the size of your Sigma deployment.
-
-After syncing, you can explore your Sigma assets and their upstream dependencies in the [Data Observability Catalog][4].
+See the [Sigma integration][1] documentation for setup and configuration.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://help.sigmacomputing.com/reference/generate-client-credentials
-[2]: https://app.datadoghq.com/integrations/sigma-computing
-[3]: https://help.sigmacomputing.com/docs/region-warehouse-and-feature-support#supported-cloud-platforms-and-regions
-[4]: https://app.datadoghq.com/data-obs/catalog
+[1]: /integrations/sigma-computing/
+[2]: /data_observability/quality_monitoring/data_warehouses/

--- a/hugo/content/en/data_observability/quality_monitoring/business_intelligence/tableau.md
+++ b/hugo/content/en/data_observability/quality_monitoring/business_intelligence/tableau.md
@@ -1,62 +1,21 @@
 ---
 title: Tableau
-description: Connect Tableau to Datadog Data Observability to view end-to-end lineage from warehouse tables to dashboards.
+description: Tableau integration for Data Observability lineage. See the integration documentation for setup.
 further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
 ---
 
-## Overview
+Datadog's Tableau integration helps data teams make changes to their data platform without breaking dashboards, and identify unused workbooks and data sources to remove.
 
-Datadog's Tableau integration helps data teams make changes to their data platform without breaking dashboards, and identify unused workbooks and data sources to remove. When Datadog connects, it:
+Lineage is derived from your data warehouse, so you also need at least one [supported data warehouse destination][2] connected to Datadog.
 
-- Pulls metadata from your Tableau site like fields, worksheets, dashboards, workbooks, and data sources
-- Automatically generates lineage between warehouse tables/columns with downstream Tableau fields, worksheets, dashboards, and workbooks.
-
-## Connect Tableau
-
-### Tableau requirements
-
-In order for Datadog to extract your metadata from Tableau, you must meet all of the [Tableau Metadata GraphQL][1] requirements:
-
-- Tableau Cloud/Server v2019.3+
-- Tableau REST API must be enabled
-- The Metadata API must be [enabled][2]
-
-### Create a personal access token
-
-For details on how to create a Personal Access Token (PAT), see the [Tableau Documentation][3]. Scope the PAT to the target site if needed.
-
-### Add the Tableau integration
-
-To connect Tableau to Datadog:
-
-1. Navigate to the [Tableau integration tile][4] and enter the following information:
-
-   - Account name (for use within Datadog only)
-   - Site name (optional, leave blank to use the default site)
-   - Server version (example: 2025.2.0). Find this in your Tableau Server or Cloud admin settings.
-   - Server endpoint (example: https://prod-useast-b.online.tableau.com)
-   - Token name
-   - Token value
-
-2. After you've entered these credentials, click {{< ui >}}Save{{< /ui >}}.
-
-## What's next
-
-When your Tableau account is successfully connected, Datadog syncs and automatically derives lineage from warehouse tables/columns to Tableau fields, worksheets, dashboards, workbooks, and data sources.
-
-Initial syncs may take up to several hours depending on the size of your Tableau deployment.
-
-After syncing, you can explore your Tableau assets and their upstream dependencies in the [Data Observability Catalog][5].
+See the [Tableau integration][1] documentation for setup and configuration.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://help.tableau.com/current/api/metadata_api/en-us/index.html#metadata-api-and-graphql
-[2]: https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_start.html#enable-the-tableau-metadata-api-for-tableau-server
-[3]: https://help.tableau.com/current/pro/desktop/en-us/useracct.htm#create-and-revoke-personal-access-tokens
-[4]: https://app.datadoghq.com/integrations/tableau
-[5]: https://app.datadoghq.com/data-obs/catalog
+[1]: /integrations/tableau/
+[2]: /data_observability/quality_monitoring/data_warehouses/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15447

Followup to my [Hex proof-of-concept](https://github.com/DataDog/documentation/pull/39211) de-duplicating those docs, applied to the remaining five BI integrations: Looker, Tableau, Sigma, Power BI, and Metabase.

Each of these integrations has two copies of its docs — one under `integrations/` generated from the integration README, and one under `data_observability/`. The two have drifted. This PR keeps the `integrations/` version as the single source of truth and reduces each `data_observability/` page to a stub: what the integration is for, the data warehouse prerequisite, and a link to the integration docs for setup.

I went with the same stub format as Hex: title, description, one-line value proposition, warehouse prerequisite, link out to the integrations docs. (The wording on the Metabase page is slightly different because that one also does log collection.)

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Claude Code to diff each pair of docs, identify what content existed only in the Data Observability copy, and draft the stubs.

### Additional notes

Companion PRs move the content that only existed in the Data Observability copies into the integration READMEs:

- [integrations-internal-core#4165](https://github.com/DataDog/integrations-internal-core/pull/4165) — Looker, Power BI, Sigma, Tableau
- [integrations-core#25123](https://github.com/DataDog/integrations-core/pull/25123) — Metabase