### PR TITLE
[DOCS-15510] Add Windows private location upgrade steps

### DIFF
--- a/hugo/content/en/synthetics/platform/private_locations/_index.md
+++ b/hugo/content/en/synthetics/platform/private_locations/_index.md
@@ -920,8 +920,8 @@ Then, run the [configuration command based on your environment](#install-your-pr
 #### Upgrade a Windows private location
 
 1. Back up your configuration file (`C:\ProgramData\Datadog Synthetics Private Location\config.json`) before upgrading or changing it.
-2. Download and run the latest [worker installer][34] (`datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi`), then follow the prompts.
-3. If the installer prompts you to modify or update your configuration, select your existing file. Leaving the field blank or generating a new configuration replaces your current one.
+2. Download the latest [MSI installer][34], run it, and follow the prompts. If prompted to modify or update your configuration, always use your backed-up file.
+3. If you use the installer's **Modify** option, select your existing configuration file. Leaving the field blank or generating a new configuration replaces your current one.
 4. Confirm that the private location worker service is running and references the correct configuration file.
 
 ### Test your internal endpoint

--- a/hugo/content/en/synthetics/platform/private_locations/_index.md
+++ b/hugo/content/en/synthetics/platform/private_locations/_index.md
@@ -917,6 +917,13 @@ Then, run the [configuration command based on your environment](#install-your-pr
 
 **Note**: If you're using `docker run` to launch your Private Location image and you've previously installed the Private Location image using the `latest` tag, make sure to add `--pull=always` to the `docker run` command to make sure the newest version is pulled rather than relying on the cached version of the image that may exist locally with the same `latest` tag.
 
+#### Upgrade a Windows private location
+
+1. Back up your configuration file (`C:\ProgramData\Datadog Synthetics Private Location\config.json`) before upgrading or changing it.
+2. Download and run the latest [worker installer][34] (`datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi`), then follow the prompts.
+3. If the installer prompts you to modify or update your configuration, select your existing file. Leaving the field blank or generating a new configuration replaces your current one.
+4. Confirm that the private location worker service is running and references the correct configuration file.
+
 ### Test your internal endpoint
 
 Once at least one private location worker starts reporting to Datadog, the private location status displays green.
@@ -1021,4 +1028,5 @@ Restricting a Private Location may limit other users from adding it to a test or
 [31]: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html
 [32]: /synthetics/platform/private_locations/configuration
 [33]: /synthetics/guide/kerberos-authentication/
+[34]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15510

Adds a "Upgrade a Windows private location" section to the private locations page. It covers backing up the configuration file, downloading and running the MSI installer, and correctly using the installer's Modify option so an existing configuration isn't accidentally replaced.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

[If AI tools were used, briefly note how. Leave blank if not applicable.]

### Additional notes