### PR TITLE
Update Bits Security Analyst supported sources

### DIFF
--- a/hugo/content/en/bits_ai/bits_security_analyst.md
+++ b/hugo/content/en/bits_ai/bits_security_analyst.md
@@ -52,7 +52,7 @@ Additionally, when you use Cloud SIEM notifications to send new signal alerts to
 
 ### Supported sources
 
-Bits AI can run investigations on the following Security log sources:
+Bits AI can run investigations on the following Security log sources:\*
 - Amazon GuardDuty, where supported [finding types][6] cover:
   - Anomalous and compromised IAM credentials
   - EC2 and resource credential exfiltration and misuse
@@ -63,8 +63,10 @@ Bits AI can run investigations on the following Security log sources:
   - CloudTrail or S3 defense evasion
   - Attack sequences correlating IAM credential and S3 data compromise
 - AWS CloudTrail
+- Atlassian Event Logs
 - Azure
 - Cloudflare
+- Confluence Audit Records
 - CrowdStrike
 - GCP
 - Kubernetes
@@ -75,12 +77,15 @@ Bits AI can run investigations on the following Security log sources:
 - GitLab
 - GitHub
 - JumpCloud
+- Jira Audit Records
 - Salesforce
 - Slack
 - Snowflake
 - SentinelOne
 - Windows
 - Email phishing
+
+\*In rare cases, an out-of-the-box rule for a supported source is ineligible for Bits investigations because the investigation requires additional non-SIEM telemetry. To view these rules, go to {{< ui >}}Security{{< /ui >}} > {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Bits Security Analyst{{< /ui >}} > {{< ui >}}Analyst Configuration{{< /ui >}}, then turn on {{< ui >}}Show currently ineligible rules{{< /ui >}}.
 
 ## Set up Bits Security Analyst
 
@@ -89,7 +94,8 @@ Bits AI can run investigations on the following Security log sources:
 To use Bits Security Analyst:
 - Ensure your organization is using a non-legacy version of Cloud SIEM. If you need assistance, contact [Datadog support][1].
 - To set up Bits Security Analyst, you need the **Bits Security Analyst Config Write** [permission][2].
-- To view investigations, you must have **14 days or more** of log history. If you have a shorter log history, you can still set up Bits Security Analyst, but won't see any investigations until you have that much history.
+
+<!-- The 14-day log history requirement no longer applies. -->
 
 ### Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Updates the Bits Security Analyst documentation to:

- Remove the outdated 14-day log history prerequisite.
- Add Atlassian Event Logs, Jira Audit Records, and Confluence Audit Records to the supported sources.
- Clarify that rare rule-level exceptions may require additional non-SIEM telemetry and explain how to view ineligible rules.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Codex helped draft the documentation changes and validate the diff.

### Additional notes

- Confirmed the diff changes only `hugo/content/en/bits_ai/bits_security_analyst.md`.
- `git diff --check` passes.
- Vale was not available locally; CI will run the repository's Vale checks.