### PR TITLE
Document WebAssembly browser symbolication

### DIFF
--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -164,7 +164,7 @@ window.DD_RUM.init({
 
 Deploy the changes to your application. After your deployment is live, Datadog collects events from your users' browsers.
 
-### Step 5 - Upload source maps and WASM symbols (optional but recommended)
+### Step 5 - Upload source maps and WebAssembly symbols (optional but recommended)
 
 Upload your JavaScript source maps to access unminified stack traces. See the [source map upload guide][17].
 

--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -234,5 +234,5 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [17]: /real_user_monitoring/guide/upload-javascript-source-maps
 [18]: /getting_started/tagging/unified_service_tagging/
 [19]: /getting_started/tagging/
-[20]: /real_user_monitoring/guide/upload-webassembly-symbols/#instrument-your-browser-application
+[20]: /error_tracking/frontend/collecting_browser_errors/#enable-webassembly-symbolication
 [21]: /real_user_monitoring/guide/upload-webassembly-symbols/#upload-your-symbols

--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -164,11 +164,11 @@ window.DD_RUM.init({
 
 Deploy the changes to your application. After your deployment is live, Datadog collects events from your users' browsers.
 
-### Step 5 - Upload source maps and WASM symbols (optional but recommended)
+### Step 5 - Upload debug symbols (optional but recommended)
 
 Upload your JavaScript source maps to access unminified stack traces. See the [source map upload guide][17].
 
-If your browser application uses WebAssembly, configure the Browser SDK WASM plugin and upload the module's debug symbols. See the [WebAssembly symbol upload guide][20].
+If your browser application uses WebAssembly, [configure the Browser SDK WASM plugin][20] and [upload the module's debug symbols][21].
 
 ### Step 6 - Visualize your data
 
@@ -234,4 +234,5 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [17]: /real_user_monitoring/guide/upload-javascript-source-maps
 [18]: /getting_started/tagging/unified_service_tagging/
 [19]: /getting_started/tagging/
-[20]: /real_user_monitoring/guide/upload-webassembly-symbols/
+[20]: /real_user_monitoring/guide/upload-webassembly-symbols/#instrument-your-browser-application
+[21]: /real_user_monitoring/guide/upload-webassembly-symbols/#upload-your-symbols

--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -13,6 +13,9 @@ further_reading:
 - link: "/real_user_monitoring/guide/upload-javascript-source-maps"
   tag: "Documentation"
   text: "Upload JavaScript source maps"
+- link: "/real_user_monitoring/guide/upload-webassembly-symbols"
+  tag: "Documentation"
+  text: "Upload WebAssembly symbols"
 - link: "/error_tracking/explorer"
   tag: "Documentation"
   text: "Learn about the Error Tracking Explorer"
@@ -161,9 +164,11 @@ window.DD_RUM.init({
 
 Deploy the changes to your application. After your deployment is live, Datadog collects events from your users' browsers.
 
-### Step 5 - Upload source maps (optional but recommended)
+### Step 5 - Upload source maps and WASM symbols (optional but recommended)
 
 Upload your JavaScript source maps to access unminified stack traces. See the [source map upload guide][17].
+
+If your browser application uses WebAssembly, configure the Browser SDK WASM plugin and upload the module's debug symbols. See the [WebAssembly symbol upload guide][20].
 
 ### Step 6 - Visualize your data
 
@@ -229,3 +234,4 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [17]: /real_user_monitoring/guide/upload-javascript-source-maps
 [18]: /getting_started/tagging/unified_service_tagging/
 [19]: /getting_started/tagging/
+[20]: /real_user_monitoring/guide/upload-webassembly-symbols/

--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -234,5 +234,5 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [17]: /real_user_monitoring/guide/upload-javascript-source-maps
 [18]: /getting_started/tagging/unified_service_tagging/
 [19]: /getting_started/tagging/
-[20]: /error_tracking/frontend/collecting_browser_errors/#enable-webassembly-symbolication
+[20]: /error_tracking/frontend/collecting_browser_errors/#configure-webassembly-error-tracking
 [21]: /real_user_monitoring/guide/upload-webassembly-symbols/#upload-your-symbols

--- a/hugo/content/en/error_tracking/frontend/browser.md
+++ b/hugo/content/en/error_tracking/frontend/browser.md
@@ -164,7 +164,7 @@ window.DD_RUM.init({
 
 Deploy the changes to your application. After your deployment is live, Datadog collects events from your users' browsers.
 
-### Step 5 - Upload debug symbols (optional but recommended)
+### Step 5 - Upload source maps and WASM symbols (optional but recommended)
 
 Upload your JavaScript source maps to access unminified stack traces. See the [source map upload guide][17].
 

--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -519,7 +519,9 @@ datadogLogs.init({
 
 Initialize Browser Logs before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames.
 
-Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the logger's third argument, as shown in the examples above. Then, [upload the module's WebAssembly symbols][14].
+Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the logger's third argument, as shown in the examples above.
+
+Then, [upload WebAssembly symbols][14] to symbolicate the errors.
 
 ### Generic logger function
 

--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -519,7 +519,7 @@ datadogLogs.init({
 
 Initialize Browser Logs before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames.
 
-Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the logger's third argument, as shown in the examples above.
+Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the third argument to `logger.error()`, as shown in [Error tracking](#error-tracking).
 
 Then, [upload WebAssembly symbols][14] to symbolicate the errors.
 

--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -517,7 +517,7 @@ datadogLogs.init({
 });
 ```
 
-Initialize Browser Logs before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. For a module instantiated directly from bytes, the plugin records a synthetic module URL.
+Initialize Browser Logs before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames.
 
 Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the logger's third argument, as shown in the examples above. Then, [upload the module's WebAssembly symbols][14].
 

--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -22,7 +22,7 @@ With the browser logs SDK, you can send logs directly to Datadog from web browse
 
 - **Independent of the RUM SDK**: The Browser Logs SDK can be used without the RUM SDK.
 - **Worker environments**: The Browser Logs SDK works in Worker and Service Worker environments using the same setup methods. However, logs sent from Worker environments do not automatically include session information.
-- **WebAssembly errors**: To symbolicate WASM frames in browser logs, configure the Browser SDK WASM plugin and upload the module's debug symbols. See [Upload WebAssembly Symbols][14].
+- **WebAssembly errors**: To symbolicate WASM frames in browser logs, [configure the Browser SDK WASM plugin](#webassembly-errors) and [upload the module's debug symbols][14].
 
 ## Setup
 
@@ -493,6 +493,33 @@ The results are the same when using NPM, CDN async, or CDN sync:
   ...
 }
 ```
+
+#### WebAssembly errors
+
+To symbolicate WebAssembly (WASM) stack frames, install the Browser SDK WASM plugin. Use the same version for the plugin and the Browser Logs SDK:
+
+```shell
+npm install --save-exact \
+  @datadog/browser-logs@<VERSION> \
+  @datadog/browser-plugin-wasm@<VERSION>
+```
+
+Register the plugin when you initialize Browser Logs:
+
+```javascript
+import { datadogLogs } from '@datadog/browser-logs';
+import { makeWasmPlugin } from '@datadog/browser-plugin-wasm';
+
+datadogLogs.init({
+  // ...
+  forwardErrorsToLogs: true,
+  plugins: [makeWasmPlugin()],
+});
+```
+
+Initialize Browser Logs before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. For a module instantiated directly from bytes, the plugin records a synthetic module URL.
+
+Set `forwardErrorsToLogs` to `true` to forward unhandled WASM errors automatically. When logging a handled WASM error, pass its `Error` object as the logger's third argument, as shown in the examples above. Then, [upload the module's WebAssembly symbols][14].
 
 ### Generic logger function
 

--- a/hugo/content/en/logs/log_collection/javascript.md
+++ b/hugo/content/en/logs/log_collection/javascript.md
@@ -22,6 +22,7 @@ With the browser logs SDK, you can send logs directly to Datadog from web browse
 
 - **Independent of the RUM SDK**: The Browser Logs SDK can be used without the RUM SDK.
 - **Worker environments**: The Browser Logs SDK works in Worker and Service Worker environments using the same setup methods. However, logs sent from Worker environments do not automatically include session information.
+- **WebAssembly errors**: To symbolicate WASM frames in browser logs, configure the Browser SDK WASM plugin and upload the module's debug symbols. See [Upload WebAssembly Symbols][14].
 
 ## Setup
 
@@ -1365,3 +1366,4 @@ window.DD_LOGS && window.DD_LOGS.getInternalContext() // { session_id: "xxxx-xxx
 [9]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [11]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#enrich-and-control-rum-data
 [12]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#discard-a-rum-event
+[14]: /real_user_monitoring/guide/upload-webassembly-symbols/

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
@@ -58,9 +58,9 @@ Source errors include code-level information about the error. More information a
 |-----------------|--------|-------------------------------------------------------------------|
 | `error.type`    | string | The error type (or error code in some cases).                     |
 
-## Enable WebAssembly symbolication
+## Configure WebAssembly error tracking
 
-To symbolicate WebAssembly (WASM) stack frames, install the Browser SDK WASM plugin. Use the same version for the plugin and the RUM Browser SDK:
+To track WebAssembly (WASM) errors, install the Browser SDK WASM plugin. Use the same version for the plugin and the RUM Browser SDK:
 
 ```shell
 npm install --save-exact \
@@ -82,7 +82,9 @@ datadogRum.init({
 
 Initialize RUM before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. This lets Datadog select the correct build ID when an application loads multiple modules.
 
-Unhandled errors are collected automatically. To report a handled WASM error, pass the `Error` object to [`addError()`](#collect-errors-manually). Then, [upload the module's WebAssembly symbols][20].
+Unhandled errors are collected automatically. To report a handled WASM error, pass the `Error` object to [`addError()`](#collect-errors-manually).
+
+Then, [upload WebAssembly symbols][20] to symbolicate the errors.
 
 ## Collect errors manually
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
@@ -80,7 +80,7 @@ datadogRum.init({
 });
 ```
 
-Initialize RUM before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. This lets Datadog select the correct build ID when an application loads multiple modules. For a module instantiated directly from bytes, the plugin records a synthetic module URL.
+Initialize RUM before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. This lets Datadog select the correct build ID when an application loads multiple modules.
 
 Unhandled errors are collected automatically. To report a handled WASM error, pass the `Error` object to [`addError()`](#collect-errors-manually). Then, [upload the module's WebAssembly symbols][20].
 

--- a/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
+++ b/hugo/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
@@ -58,6 +58,32 @@ Source errors include code-level information about the error. More information a
 |-----------------|--------|-------------------------------------------------------------------|
 | `error.type`    | string | The error type (or error code in some cases).                     |
 
+## Enable WebAssembly symbolication
+
+To symbolicate WebAssembly (WASM) stack frames, install the Browser SDK WASM plugin. Use the same version for the plugin and the RUM Browser SDK:
+
+```shell
+npm install --save-exact \
+  @datadog/browser-rum@<VERSION> \
+  @datadog/browser-plugin-wasm@<VERSION>
+```
+
+Register the plugin when you initialize RUM:
+
+```javascript
+import { makeWasmPlugin } from '@datadog/browser-plugin-wasm';
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+  // ...
+  plugins: [makeWasmPlugin()],
+});
+```
+
+Initialize RUM before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to errors that contain WASM stack frames. This lets Datadog select the correct build ID when an application loads multiple modules. For a module instantiated directly from bytes, the plugin records a synthetic module URL.
+
+Unhandled errors are collected automatically. To report a handled WASM error, pass the `Error` object to [`addError()`](#collect-errors-manually). Then, [upload the module's WebAssembly symbols][20].
+
 ## Collect errors manually
 
 Monitor handled exceptions, handled promise rejections, and other errors not tracked automatically by the Browser SDK with the `addError()` API:
@@ -276,3 +302,4 @@ Get visibility into cross-origin scripts by following these two steps:
 [17]: /error_tracking/manage_data_collection
 [18]: /error_tracking/issue_states#excluding-an-issue
 [19]: /real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#discard-a-frontend-error
+[20]: /real_user_monitoring/guide/upload-webassembly-symbols/

--- a/hugo/content/en/real_user_monitoring/guide/_index.md
+++ b/hugo/content/en/real_user_monitoring/guide/_index.md
@@ -35,6 +35,7 @@ cascade:
     {{< nextlink href="real_user_monitoring/guide/send-custom-user-actions" >}}Send custom user actions{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/identify-bots-in-the-ui" >}}Identify bots in the RUM Explorer{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/upload-javascript-source-maps" >}}Upload JavaScript source maps{{< /nextlink >}}
+    {{< nextlink href="real_user_monitoring/guide/upload-webassembly-symbols" >}}Upload WebAssembly symbols{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/sampling-browser-plans" >}}Control session volume using sampling configuration for Browser RUM and Browser RUM & Session Replay{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/enrich-and-control-rum-data" >}}Enrich and control your browser RUM data{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/browser-sdk-upgrade" >}}Upgrade the RUM Browser SDK{{< /nextlink >}}

--- a/hugo/content/en/real_user_monitoring/guide/debug-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/debug-symbols.md
@@ -21,7 +21,7 @@ You can ignore this warning. The stack trace is already readable.
 
 ### No debug symbols uploaded for this version
 
-Use the [RUM Debug Symbols page][1] to see if there are debug symbols for your application. This page is filtered by {{< ui >}}type{{< /ui >}} (JavaScript, Android, iOS, React Native, Flutter). Use the filter to find the debug symbols you are looking for.
+Use the [RUM Debug Symbols page][1] to see if there are debug symbols for your application. This page is filtered by {{< ui >}}type{{< /ui >}} (JavaScript, WebAssembly, Android, iOS, React Native, Flutter). Use the filter to find the debug symbols you are looking for.
 
 If there are no debug symbols for your application, [upload them][2].
 
@@ -37,14 +37,16 @@ Datadog relies on different tags to match debug symbols with stack traces. These
 | Application type | Tag combination used for matching |
 | ---- | ---- |
 | JavaScript | `service`, `version`, `path`|
+| WebAssembly | `build_id` |
 | Android | v1.13.0+: `build_id`<br/> Older versions: `service`, `version`, `variant`|
 | iOS | `uuid` |
 | React Native | `service`, `version`, `bundle_name`, `platform`; if multiple source maps match on these fields, the one with the highest `build_number` is selected |
 | Flutter | `service`, `version`, `variant`, `architecture` |
 
-The [RUM Debug Symbols page][1] displays the values of these tags. If you find a mismatch, [upload the debug symbols][2] again with a corrected set of tags.
+The [RUM Debug Symbols page][1] displays the values of these tags. If you find a mismatch, upload the debug symbols again with a corrected set of tags. For WebAssembly, see [Upload WebAssembly Symbols][3].
 
 
 
 [1]: https://app.datadoghq.com/source-code/setup/rum
 [2]: /real_user_monitoring/error_tracking/mobile/android/?tab=us#upload-your-mapping-file
+[3]: /real_user_monitoring/guide/upload-webassembly-symbols/

--- a/hugo/content/en/real_user_monitoring/guide/debug-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/debug-symbols.md
@@ -43,10 +43,9 @@ Datadog relies on different tags to match debug symbols with stack traces. These
 | React Native | `service`, `version`, `bundle_name`, `platform`; if multiple source maps match on these fields, the one with the highest `build_number` is selected |
 | Flutter | `service`, `version`, `variant`, `architecture` |
 
-The [RUM Debug Symbols page][1] displays the values of these tags. If you find a mismatch, upload the debug symbols again with a corrected set of tags. For WebAssembly, see [Upload WebAssembly Symbols][3].
+The [RUM Debug Symbols page][1] displays the values of these tags. If you find a mismatch, upload the debug symbols again with a corrected set of tags.
 
 
 
 [1]: https://app.datadoghq.com/source-code/setup/rum
 [2]: /real_user_monitoring/error_tracking/mobile/android/?tab=us#upload-your-mapping-file
-[3]: /real_user_monitoring/guide/upload-webassembly-symbols/

--- a/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
@@ -91,6 +91,6 @@ You can view uploaded files on the [RUM Debug Symbols page][4].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/guide/upload-javascript-source-maps/
-[2]: /real_user_monitoring/application_monitoring/browser/collecting_browser_errors/#enable-webassembly-symbolication
+[2]: /real_user_monitoring/application_monitoring/browser/collecting_browser_errors/#configure-webassembly-error-tracking
 [3]: /logs/log_collection/javascript/#webassembly-errors
 [4]: https://app.datadoghq.com/source-code/setup/rum

--- a/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
@@ -1,0 +1,151 @@
+---
+title: Upload WebAssembly Symbols
+description: "Upload WebAssembly debug symbols to make WASM stack traces collected from browser applications readable."
+further_reading:
+- link: '/error_tracking/frontend/browser'
+  tag: 'Documentation'
+  text: 'Set up Browser Error Tracking'
+- link: '/real_user_monitoring/guide/upload-javascript-source-maps'
+  tag: 'Documentation'
+  text: 'Upload JavaScript source maps'
+- link: '/real_user_monitoring/guide/debug-symbols'
+  tag: 'Documentation'
+  text: 'Investigate obfuscated stack traces with RUM Debug Symbols'
+- link: 'https://github.com/DataDog/datadog-ci/tree/master/packages/base/src/commands/wasm-symbols'
+  tag: 'Source Code'
+  text: 'WebAssembly symbols command reference'
+---
+
+## Overview
+
+WebAssembly (WASM) runs as part of a browser application. It is not a separate Datadog application type. The Datadog Browser SDK collects WASM errors with the surrounding browser context, and Datadog Error Tracking can symbolicate their WASM stack frames with uploaded DWARF debug information.
+
+A single error can contain both JavaScript and WASM frames. Upload [JavaScript source maps][1] for the JavaScript frames and WASM symbols for the WASM frames.
+
+<div class="alert alert-warning">WebAssembly symbolication is in beta. The Browser SDK plugin and the <code>datadog-ci wasm-symbols upload</code> command are experimental and may change.</div>
+
+## Prerequisites
+
+You need:
+
+- A browser application configured for [RUM][2], [Browser Logs][3], or both.
+- Matching versions of `@datadog/browser-plugin-wasm` and the Browser RUM or Logs SDK package where you register it.
+- A `.wasm` symbol file with embedded DWARF debug sections and a `build_id` custom section.
+- `@datadog/datadog-ci` version 5.23.0 or later.
+
+## Instrument your browser application
+
+Install the WASM plugin alongside the Browser SDK packages that your application uses. Keep all Browser SDK packages on the same version:
+
+```shell
+npm install --save-exact \
+  @datadog/browser-rum@<VERSION> \
+  @datadog/browser-logs@<VERSION> \
+  @datadog/browser-plugin-wasm@<VERSION>
+```
+
+Register a plugin instance when you initialize RUM, Browser Logs, or both:
+
+```javascript
+import { datadogLogs } from '@datadog/browser-logs';
+import { makeWasmPlugin } from '@datadog/browser-plugin-wasm';
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+  applicationId: '<APPLICATION_ID>',
+  clientToken: '<CLIENT_TOKEN>',
+  site: '<DATADOG_SITE>',
+  service: '<SERVICE>',
+  env: '<ENV>',
+  version: '<VERSION>',
+  plugins: [makeWasmPlugin()],
+});
+
+datadogLogs.init({
+  clientToken: '<CLIENT_TOKEN>',
+  site: '<DATADOG_SITE>',
+  service: '<SERVICE>',
+  env: '<ENV>',
+  version: '<VERSION>',
+  forwardErrorsToLogs: true,
+  plugins: [makeWasmPlugin()],
+});
+```
+
+Initialize the Browser SDK before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to WASM error events. Modules loaded before the plugin is initialized cannot be associated with their build IDs.
+
+The plugin enriches errors that have a WASM frame in their stack trace. When you report a handled error manually, pass the `Error` object to RUM or as the third argument to the Logs logger:
+
+```javascript
+try {
+  callWasmFunction();
+} catch (error) {
+  datadogRum.addError(error);
+  datadogLogs.logger.error('WASM operation failed', {}, error);
+}
+```
+
+## Generate debug symbols
+
+Configure your WASM toolchain to generate:
+
+- Embedded DWARF sections such as `.debug_info` and `.debug_line`.
+- A `build_id` custom section. The build ID in the uploaded symbol file must match the build ID in the module loaded by the browser.
+
+For example, with Emscripten:
+
+```shell
+emcc -g -Wl,--build-id <SOURCES> -o <OUTPUT>.js
+```
+
+You can inspect the generated module with `wasm-objdump`:
+
+```shell
+wasm-objdump -h <OUTPUT>.wasm
+wasm-objdump -j build_id -x <OUTPUT>.wasm
+```
+
+Keep the symbol file as a build artifact so you can upload it from your CI pipeline.
+
+## Upload your symbols
+
+Install the Datadog CLI and configure your Datadog API key and site:
+
+```shell
+npm install --save-dev @datadog/datadog-ci@latest
+export DATADOG_API_KEY=<DATADOG_API_KEY>
+export DATADOG_SITE={{< region-param key="dd_site" >}}
+```
+
+Enable beta commands and upload either one `.wasm` file or a directory. When given a directory, the CLI searches it recursively for `.wasm` files:
+
+```shell
+DD_BETA_COMMANDS_ENABLED=1 datadog-ci wasm-symbols upload /path/to/build
+```
+
+The command skips files that do not contain both embedded DWARF information and a `build_id` custom section. Use `--dry-run` to validate symbol files without uploading them:
+
+```shell
+DD_BETA_COMMANDS_ENABLED=1 datadog-ci wasm-symbols upload /path/to/build --dry-run
+```
+
+By default, Datadog keeps the first symbol file uploaded for a build ID. Use `--replace-existing` when you intentionally need to replace it.
+
+<div class="alert alert-info">The uploader does not resolve an <code>external_debug_info</code> reference. A runtime module that contains only this reference is skipped. Upload a symbol file that contains embedded DWARF sections and the same <code>build_id</code> as the runtime module.</div>
+
+## How symbols are matched
+
+Datadog uses the module URL metadata to associate each WASM stack frame with a module, then matches the module to its uploaded symbols by `build_id`. Unlike JavaScript source maps, `service` and `version` are not part of the WASM symbol lookup.
+
+The Browser SDK plugin records metadata for WASM modules loaded after initialization. This lets Datadog select the correct build ID when a page loads multiple modules. For a module instantiated directly from bytes, the plugin records a synthetic module URL so its build ID remains available for symbolication.
+
+You can view uploaded files on the [RUM Debug Symbols page][4].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /real_user_monitoring/guide/upload-javascript-source-maps/
+[2]: /real_user_monitoring/application_monitoring/browser/setup/
+[3]: /logs/log_collection/javascript/
+[4]: https://app.datadoghq.com/source-code/setup/rum

--- a/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
@@ -28,62 +28,9 @@ A single error can contain both JavaScript and WASM frames. Upload [JavaScript s
 
 You need:
 
-- A browser application configured for [RUM][2], [Browser Logs][3], or both.
-- Matching versions of `@datadog/browser-plugin-wasm` and the Browser RUM or Logs SDK package where you register it.
+- A browser application configured to collect WASM module metadata with [RUM][2], [Browser Logs][3], or both.
 - A `.wasm` symbol file with embedded DWARF debug sections and a `build_id` custom section.
 - `@datadog/datadog-ci` version 5.23.0 or later.
-
-## Instrument your browser application
-
-Install the WASM plugin alongside the Browser SDK packages that your application uses. Keep all Browser SDK packages on the same version:
-
-```shell
-npm install --save-exact \
-  @datadog/browser-rum@<VERSION> \
-  @datadog/browser-logs@<VERSION> \
-  @datadog/browser-plugin-wasm@<VERSION>
-```
-
-Register a plugin instance when you initialize RUM, Browser Logs, or both:
-
-```javascript
-import { datadogLogs } from '@datadog/browser-logs';
-import { makeWasmPlugin } from '@datadog/browser-plugin-wasm';
-import { datadogRum } from '@datadog/browser-rum';
-
-datadogRum.init({
-  applicationId: '<APPLICATION_ID>',
-  clientToken: '<CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
-  service: '<SERVICE>',
-  env: '<ENV>',
-  version: '<VERSION>',
-  plugins: [makeWasmPlugin()],
-});
-
-datadogLogs.init({
-  clientToken: '<CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
-  service: '<SERVICE>',
-  env: '<ENV>',
-  version: '<VERSION>',
-  forwardErrorsToLogs: true,
-  plugins: [makeWasmPlugin()],
-});
-```
-
-Initialize the Browser SDK before loading any WASM modules. The plugin observes modules created with the browser's `WebAssembly` APIs and adds their URLs and build IDs to WASM error events. Modules loaded before the plugin is initialized cannot be associated with their build IDs.
-
-The plugin enriches errors that have a WASM frame in their stack trace. When you report a handled error manually, pass the `Error` object to RUM or as the third argument to the Logs logger:
-
-```javascript
-try {
-  callWasmFunction();
-} catch (error) {
-  datadogRum.addError(error);
-  datadogLogs.logger.error('WASM operation failed', {}, error);
-}
-```
 
 ## Generate debug symbols
 
@@ -137,8 +84,6 @@ By default, Datadog keeps the first symbol file uploaded for a build ID. Use `--
 
 Datadog uses the module URL metadata to associate each WASM stack frame with a module, then matches the module to its uploaded symbols by `build_id`. Unlike JavaScript source maps, `service` and `version` are not part of the WASM symbol lookup.
 
-The Browser SDK plugin records metadata for WASM modules loaded after initialization. This lets Datadog select the correct build ID when a page loads multiple modules. For a module instantiated directly from bytes, the plugin records a synthetic module URL so its build ID remains available for symbolication.
-
 You can view uploaded files on the [RUM Debug Symbols page][4].
 
 ## Further reading
@@ -146,6 +91,6 @@ You can view uploaded files on the [RUM Debug Symbols page][4].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/guide/upload-javascript-source-maps/
-[2]: /real_user_monitoring/application_monitoring/browser/setup/
-[3]: /logs/log_collection/javascript/
+[2]: /real_user_monitoring/application_monitoring/browser/collecting_browser_errors/#enable-webassembly-symbolication
+[3]: /logs/log_collection/javascript/#webassembly-errors
 [4]: https://app.datadoghq.com/source-code/setup/rum

--- a/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
+++ b/hugo/content/en/real_user_monitoring/guide/upload-webassembly-symbols.md
@@ -26,7 +26,7 @@ A single error can contain both JavaScript and WASM frames. Upload [JavaScript s
 
 ## Prerequisites
 
-You need:
+Before uploading symbols, make sure you have:
 
 - A browser application configured to collect WASM module metadata with [RUM][2], [Browser Logs][3], or both.
 - A `.wasm` symbol file with embedded DWARF debug sections and a `build_id` custom section.
@@ -45,6 +45,8 @@ For example, with Emscripten:
 emcc -g -Wl,--build-id <SOURCES> -o <OUTPUT>.js
 ```
 
+This command produces `<OUTPUT>.js`, the JavaScript loader, and `<OUTPUT>.wasm`, the WebAssembly binary containing the embedded DWARF information and `build_id` custom section.
+
 You can inspect the generated module with `wasm-objdump`:
 
 ```shell
@@ -59,7 +61,7 @@ Keep the symbol file as a build artifact so you can upload it from your CI pipel
 Install the Datadog CLI and configure your Datadog API key and site:
 
 ```shell
-npm install --save-dev @datadog/datadog-ci@latest
+npm install --save-dev @datadog/datadog-ci
 export DATADOG_API_KEY=<DATADOG_API_KEY>
 export DATADOG_SITE={{< region-param key="dd_site" >}}
 ```


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the WebAssembly symbolication workflow for browser applications.

- Positions WebAssembly as part of the Browser platform rather than an independent application type.
- Documents Browser RUM and Logs plugin setup, including initialization order and handled Logs error reporting.
- Documents embedded DWARF and `build_id` requirements.
- Documents the beta `datadog-ci wasm-symbols upload` workflow and current `external_debug_info` limitation.
- Explains mixed JavaScript/WASM stacks and build ID matching.
- Links the guide from Browser Error Tracking, Browser Logs, and RUM Debug Symbols.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

### AI assistance

Used Codex to inspect the Browser SDK and datadog-ci implementations, draft the documentation, and validate the rendered page.

### Additional notes

The new page rendered successfully in a local Hugo preview. `git diff --check` and the documentation pre-commit checks pass.

Jira: https://datadoghq.atlassian.net/browse/RUM-18422