### PR TITLE
Document optional BigQuery Location field

### DIFF
--- a/hugo/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
+++ b/hugo/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md
@@ -674,6 +674,7 @@ After you set up your Google Cloud resources and IAM roles, configure the experi
 1. Under {% ui %}Dataset and GCS Bucket{% /ui %}, enter:
    - {% ui %}Dataset{% /ui %}: The dataset you created in [Step 1](#create-a-bigquery-dataset) (for example, `datadog_experiments_output`).
    - {% ui %}GCS Bucket{% /ui %}: The Cloud Storage bucket you created in [Step 1](#create-a-cloud-storage-bucket).
+   - {% ui %}Location{% /ui %} (optional): The location of the dataset you created in [Step 1](#create-a-bigquery-dataset) (for example, `europe-west2`). Datadog submits experiment queries in this location. If you leave this blank, BigQuery infers the location.
 1. Click {% ui %}Save{% /ui %}.
 
 {% img src="/product_analytics/experiment/guide/bigquery_experiment_setup_dd.png" alt="The Edit Data Warehouse modal with BigQuery selected, showing two sections: Select BigQuery Account with fields for GCP service account and Project, and Dataset and GCS Bucket with fields for Dataset and GCS Bucket." style="width:90%;" /%}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fbbc8f37-24f8-4168-958c-86c34e355e4f","source":"chat","resourceId":"e3d7373c-af57-43fa-b58a-0b0aad949e56","workflowId":"de920208-4471-4359-aaae-248646855a17","codeChangeId":"de920208-4471-4359-aaae-248646855a17","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the new optional **Location** field in the BigQuery warehouse connection settings for Datadog Experiments, added in https://github.com/ddoghq/dd-source/pull/78991.

Customers whose BigQuery dataset lives in a non-default region need a way to tell Datadog where to submit experiment queries. This adds that field to the existing setup steps.

**Changes:**

- Added a **Location** (optional) bullet to the **Dataset and GCS Bucket** field list in the BigQuery branch of `## Step 3: Configure experiment settings` in `hugo/content/en/experiments/guide/connecting_a_data_warehouse.mdoc.md`.
- The entry explains what to enter (the location of the dataset created in Step 1, for example `europe-west2`), that Datadog submits experiment queries in that location, and that leaving it blank lets BigQuery infer the location.

**Testing:**

- Verified the new bullet matches the surrounding field-list format, including the page's existing `Field (optional):` convention used by the **Copy IAM role ARN** field in the Redshift branch, and the `[Step 1](#create-a-bigquery-dataset)` anchor already used by the sibling **Dataset** field.
- Checked the copy against the substitution and temporal-word tables in `CLAUDE.md` (no `ensure`, `via`, `just`, `will`, `currently`, and so on). Vale is not installed in this environment, so this check was manual.
- Confirmed the change is scoped to the BigQuery `{% if equals($database, "bigquery") %}` block and does not affect the Databricks, Redshift, or Snowflake branches.
- Left the screenshot alt text unchanged, since the existing image does not show the new field.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code, then reviewed against the page's existing field-list conventions and the repo style guide.

### Additional notes

The field label is documented as **Location**, matching the short labels used by the sibling **Dataset** and **GCS Bucket** fields. Please confirm this matches the label shipped in the UI.

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e3d7373c-af57-43fa-b58a-0b0aad949e56)

Comment @datadog to request changes