### PR TITLE
[SEC-37122][k9] Document http.url_details.host BYOTI source

### DIFF
--- a/hugo/content/en/security/cloud_siem/ingest_and_enrich/threat_intelligence.md
+++ b/hugo/content/en/security/cloud_siem/ingest_and_enrich/threat_intelligence.md
@@ -38,6 +38,7 @@ When Cloud SIEM processes a log, the log's IP, domain, hash, AWS account ID, con
       - `DNS_ANSWER_NAME`
       - `HTTP_URL`
       - `HTTP_URL_DETAILS_DOMAIN`
+      - `HTTP_URL_DETAILS_HOST`
       - `HOSTNAME`
     - **File hashes**: SHA1, SHA256, and ssdeep hashes found in file- and process-related log attributes.
     - **AWS account IDs**: Values from AWS-related log attributes (for example, `userIdentity.accountId`).


### PR DESCRIPTION
## Changes
Related to [SEC-37122](https://datadoghq.atlassian.net/browse/SEC-37122).

Cloud SIEM now enriches domain indicators from `http.url_details.host`, the default output of the URL Parser processor. This adds the attribute to the BYOTI domain and hostname source list on the Bring Your Own Threat Intelligence page.


[SEC-37122]: https://datadoghq.atlassian.net/browse/SEC-37122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ