### PR TITLE
Document BYOC Logs cluster IDs and renaming

### DIFF
--- a/hugo/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/hugo/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -54,7 +54,7 @@ To find your BYOC Logs index name:
 
 1. Navigate to the [Datadog Log Explorer][2].
 2. Look for the {{< ui >}}BYOC INDEXES{{< /ui >}} section in the left facet panel.
-3. Your BYOC Logs indexes are listed there, in the format `byoc--<CLUSTER_ID>--<INDEX_NAME>`.
+3. Your BYOC Logs indexes are listed there, in the format `byoc--<cluster_id>--<index_name>`.
 
 You can also find your index names in the [BYOC Logs console][3] by selecting a cluster and clicking {{< ui >}}View Indexes{{< /ui >}}.
 
@@ -106,7 +106,7 @@ When using AI-powered tools with `search_datadog_logs`, you can ask questions in
 
 ## Important notes
 
-- The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<CLUSTER_ID>--<INDEX_NAME>`).
+- The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<cluster_id>--<index_name>`).
 - When using natural language queries, explicitly mention your BYOC Logs index name in your prompt.
 - BYOC Logs data is queryable in real-time as soon as it is indexed.
 - Query syntax follows standard [Datadog log search syntax][4].

--- a/hugo/content/en/byoc-logs/guides/query_logs_with_mcp.md
+++ b/hugo/content/en/byoc-logs/guides/query_logs_with_mcp.md
@@ -54,7 +54,7 @@ To find your BYOC Logs index name:
 
 1. Navigate to the [Datadog Log Explorer][2].
 2. Look for the {{< ui >}}BYOC INDEXES{{< /ui >}} section in the left facet panel.
-3. Your BYOC Logs indexes are listed there, in the format `byoc--<cluster_name>--<index_name>`.
+3. Your BYOC Logs indexes are listed there, in the format `byoc--<CLUSTER_ID>--<INDEX_NAME>`.
 
 You can also find your index names in the [BYOC Logs console][3] by selecting a cluster and clicking {{< ui >}}View Indexes{{< /ui >}}.
 
@@ -106,7 +106,7 @@ When using AI-powered tools with `search_datadog_logs`, you can ask questions in
 
 ## Important notes
 
-- The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<cluster_name>--<index_name>`).
+- The `indexes` parameter must contain valid BYOC Logs index names (in the format `byoc--<CLUSTER_ID>--<INDEX_NAME>`).
 - When using natural language queries, explicitly mention your BYOC Logs index name in your prompt.
 - BYOC Logs data is queryable in real-time as soon as it is indexed.
 - Query syntax follows standard [Datadog log search syntax][4].

--- a/hugo/content/en/byoc-logs/install/_index.md
+++ b/hugo/content/en/byoc-logs/install/_index.md
@@ -19,6 +19,17 @@ BYOC (Bring Your Own Cloud) Logs requires **Kubernetes** for production deployme
 If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog account team to activate BYOC Logs on your account.
 </div>
 
+### Cluster ID
+
+Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog:
+
+```yaml
+config:
+  cluster_id: <CLUSTER_ID>
+```
+
+If you omit this value, the Helm chart generates a cluster ID from the Kubernetes namespace and Helm release name. Changing the cluster ID after installation can interrupt ingestion and search. To change it, follow [Rename a BYOC Logs cluster][3].
+
 ### Kubernetes cluster requirements
 
 | Requirement            | Details                                                                                  |
@@ -44,3 +55,4 @@ BYOC Logs supports the following object storage types:
 {{< /whatsnext >}}
 
 [2]: /byoc-logs/install/docker/
+[3]: /byoc-logs/operate/rename_cluster/

--- a/hugo/content/en/byoc-logs/install/_index.md
+++ b/hugo/content/en/byoc-logs/install/_index.md
@@ -21,10 +21,13 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 
 ### Cluster ID
 
-Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog. Datadog uses the cluster ID in the following places:
+Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog. The cluster ID forms the cluster name segment of each BYOC Logs index name:
 
-- The `byoc--<CLUSTER_ID>` index name, which is used in Log Explorer and in monitor and dashboard queries
-- The `cluster_id` tag on telemetry emitted by the cluster, including metrics, logs, and traces
+```
+byoc--<CLUSTER_NAME>--<INDEX_NAME>
+```
+
+These index names appear under {{< ui >}}BYOC INDEXES{{< /ui >}} in Log Explorer and can be used in monitor and dashboard queries.
 
 Configure the cluster ID in the Helm values:
 
@@ -33,7 +36,7 @@ config:
   cluster_id: <CLUSTER_ID>
 ```
 
-If you omit this value, the Helm chart generates a cluster ID from the Kubernetes namespace and Helm release name. Changing the cluster ID after installation can interrupt ingestion and search. To change it, follow [Rename a BYOC Logs cluster][3].
+Changing the cluster ID after installation changes the BYOC Logs index names and can interrupt ingestion and search. To change it, follow [Rename a BYOC Logs cluster][3].
 
 ### Kubernetes cluster requirements
 

--- a/hugo/content/en/byoc-logs/install/_index.md
+++ b/hugo/content/en/byoc-logs/install/_index.md
@@ -24,7 +24,7 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable identifier for the cluster. The cluster ID forms part of each BYOC Logs index name:
 
 ```
-byoc--<CLUSTER_ID>--<INDEX_NAME>
+byoc--<cluster_id>--<index_name>
 ```
 
 These index names appear under {{< ui >}}BYOC INDEXES{{< /ui >}} in Log Explorer and can be used in monitor and dashboard queries.

--- a/hugo/content/en/byoc-logs/install/_index.md
+++ b/hugo/content/en/byoc-logs/install/_index.md
@@ -21,10 +21,10 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 
 ### Cluster ID
 
-Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog. The cluster ID forms the cluster name segment of each BYOC Logs index name:
+Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable identifier for the cluster. The cluster ID forms part of each BYOC Logs index name:
 
 ```
-byoc--<CLUSTER_NAME>--<INDEX_NAME>
+byoc--<CLUSTER_ID>--<INDEX_NAME>
 ```
 
 These index names appear under {{< ui >}}BYOC INDEXES{{< /ui >}} in Log Explorer and can be used in monitor and dashboard queries.

--- a/hugo/content/en/byoc-logs/install/_index.md
+++ b/hugo/content/en/byoc-logs/install/_index.md
@@ -21,7 +21,12 @@ If you don't see the BYOC Logs entry in the Logs menu, contact your Datadog acco
 
 ### Cluster ID
 
-Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog:
+Set `config.cluster_id` in the BYOC Logs Helm values to a meaningful, stable name that identifies the cluster in Datadog. Datadog uses the cluster ID in the following places:
+
+- The `byoc--<CLUSTER_ID>` index name, which is used in Log Explorer and in monitor and dashboard queries
+- The `cluster_id` tag on telemetry emitted by the cluster, including metrics, logs, and traces
+
+Configure the cluster ID in the Helm values:
 
 ```yaml
 config:

--- a/hugo/content/en/byoc-logs/install/aws_eks.md
+++ b/hugo/content/en/byoc-logs/install/aws_eks.md
@@ -251,6 +251,8 @@ echo ""
 
    # BYOC Logs node configuration
    config:
+     # A meaningful, stable name that identifies the cluster in Datadog.
+     cluster_id: <CLUSTER_ID>
      # The root URI where index data is stored. This should be an S3 path.
      # All indexes created in BYOC Logs are stored under this location.
      default_index_root_uri: s3://<BUCKET_NAME>/indexes

--- a/hugo/content/en/byoc-logs/install/azure_aks.md
+++ b/hugo/content/en/byoc-logs/install/azure_aks.md
@@ -301,6 +301,8 @@ azure:
 
 # BYOC Logs node configuration
 config:
+  # A meaningful, stable name that identifies the cluster in Datadog.
+  cluster_id: <CLUSTER_ID>
   # The root URI where index data is stored. This should be an Azure path.
   # All indexes created in BYOC Logs are stored under this location.
   default_index_root_uri: azure://<CONTAINER_NAME>/indexes

--- a/hugo/content/en/byoc-logs/install/custom_k8s.md
+++ b/hugo/content/en/byoc-logs/install/custom_k8s.md
@@ -172,6 +172,8 @@ serviceAccount:
 
 # BYOC Logs node configuration
 config:
+  # A meaningful, stable name that identifies the cluster in Datadog.
+  cluster_id: <CLUSTER_ID>
   # The root URI where index data is stored. This should be an S3-compatible path pointing to your MinIO bucket.
   # All indexes created in BYOC Logs are stored under this location.
   default_index_root_uri: s3://<BUCKET_NAME>/indexes

--- a/hugo/content/en/byoc-logs/install/gcp_gke.md
+++ b/hugo/content/en/byoc-logs/install/gcp_gke.md
@@ -276,6 +276,8 @@ serviceAccount:
 
 # BYOC Logs node configuration
 config:
+  # A meaningful, stable name that identifies the cluster in Datadog.
+  cluster_id: <CLUSTER_ID>
   # The root URI where index data is stored. This should be an gs path.
   # All indexes created in BYOC Logs are stored under this location.
   default_index_root_uri: gs://${BUCKET_NAME}/indexes

--- a/hugo/content/en/byoc-logs/operate/_index.md
+++ b/hugo/content/en/byoc-logs/operate/_index.md
@@ -16,6 +16,7 @@ Manage your BYOC (Bring Your Own Cloud) Logs deployment with guides on sizing, a
   {{< nextlink href="/byoc-logs/operate/search_logs/" >}}Search Logs{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/best_practices/" >}}Production Best Practices{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/disk_buffer_durability/" >}}Configure Disk Buffer Durability{{< /nextlink >}}
+  {{< nextlink href="/byoc-logs/operate/rename_cluster/" >}}Rename a Cluster{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/updates/" >}}Releases and Updates{{< /nextlink >}}
   {{< nextlink href="/byoc-logs/operate/troubleshooting/" >}}Troubleshooting{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -14,7 +14,7 @@ further_reading:
 
 The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
 
-Renaming a cluster changes the cluster name segment in each BYOC Logs index name from `byoc--<OLD_CLUSTER_ID>--<INDEX_NAME>` to `byoc--<NEW_CLUSTER_ID>--<INDEX_NAME>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
+Renaming a cluster changes the cluster ID segment in each BYOC Logs index name from `byoc--<OLD_CLUSTER_ID>--<INDEX_NAME>` to `byoc--<NEW_CLUSTER_ID>--<INDEX_NAME>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
 
 ## Rename with downtime
 

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -12,9 +12,9 @@ further_reading:
 
 ## Overview
 
-The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
+The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes.
 
-Renaming a cluster changes the cluster ID segment in each BYOC Logs index name from `byoc--<old_cluster_id>--<index_name>` to `byoc--<new_cluster_id>--<index_name>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
+Renaming a cluster changes its BYOC Logs index names from `byoc--<old_cluster_id>--<index_name>` to `byoc--<new_cluster_id>--<index_name>`. Update monitors and dashboards that use the old index names.
 
 ## Rename with downtime
 
@@ -40,7 +40,7 @@ Use this procedure when temporary ingestion and search failures are acceptable.
 
 ## Rename gracefully
 
-Use `config.additional_acceptable_cluster_ids` to allow nodes with the old and new cluster IDs to communicate during the rename. This maintains communication between nodes across the three rollouts, but pods restart during each rollout. Complete each rollout before starting the next one.
+Use `config.additional_acceptable_cluster_ids` to allow nodes with the old and new cluster IDs to communicate during the rename. Complete each rollout before starting the next one.
 
 After each change to the Helm values, upgrade the release with the following command:
 

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -14,6 +14,8 @@ further_reading:
 
 The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
 
+Renaming a cluster changes its Datadog index name from `byoc--<OLD_CLUSTER_ID>` to `byoc--<NEW_CLUSTER_ID>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index name or tag value.
+
 ## Rename with downtime
 
 Use this procedure when temporary ingestion and search failures are acceptable.

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -1,0 +1,83 @@
+---
+title: Rename a BYOC Logs Cluster
+description: Change the cluster ID of a BYOC Logs deployment directly or with a rolling migration.
+further_reading:
+- link: "/byoc-logs/install/"
+  tag: "Documentation"
+  text: "Install BYOC Logs"
+- link: "/byoc-logs/operate/monitoring/"
+  tag: "Documentation"
+  text: "Monitor BYOC Logs"
+---
+
+## Overview
+
+The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
+
+## Rename with downtime
+
+Use this procedure when temporary ingestion and search failures are acceptable.
+
+1. Change `config.cluster_id` in the Helm values file:
+
+   ```yaml
+   config:
+     cluster_id: <NEW_CLUSTER_ID>
+   ```
+
+2. Upgrade the Helm release:
+
+   ```shell
+   helm upgrade <RELEASE_NAME> datadog/cloudprem \
+     --namespace <NAMESPACE_NAME> \
+     --values datadog-values.yaml
+   ```
+
+3. Wait for the rollout to finish. During the rollout, nodes with different cluster IDs cannot communicate, which can interrupt ingestion and search.
+4. Verify that all pods are ready and that ingestion and search have recovered.
+
+## Rename gracefully
+
+Use `config.additional_acceptable_cluster_ids` to allow nodes with the old and new cluster IDs to communicate during the rename. This maintains communication between nodes across the three rollouts, but pods restart during each rollout. Complete each rollout before starting the next one.
+
+After each change to the Helm values, upgrade the release with the following command:
+
+```shell
+helm upgrade <RELEASE_NAME> datadog/cloudprem \
+  --namespace <NAMESPACE_NAME> \
+  --values datadog-values.yaml
+```
+
+1. Configure nodes with the old cluster ID to accept the new cluster ID:
+
+   ```yaml
+   config:
+     cluster_id: <OLD_CLUSTER_ID>
+     additional_acceptable_cluster_ids:
+       - <NEW_CLUSTER_ID>
+   ```
+
+2. Upgrade the Helm release and wait for the rollout to finish.
+3. Change the cluster ID while retaining compatibility with the old cluster ID:
+
+   ```yaml
+   config:
+     cluster_id: <NEW_CLUSTER_ID>
+     additional_acceptable_cluster_ids:
+       - <OLD_CLUSTER_ID>
+   ```
+
+4. Upgrade the Helm release and wait for the rollout to finish.
+5. Remove `additional_acceptable_cluster_ids`:
+
+   ```yaml
+   config:
+     cluster_id: <NEW_CLUSTER_ID>
+   ```
+
+6. Upgrade the Helm release and wait for the rollout to finish.
+7. Verify that all pods are ready and that ingestion and search remain available.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -14,7 +14,7 @@ further_reading:
 
 The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
 
-Renaming a cluster changes its Datadog index name from `byoc--<OLD_CLUSTER_ID>` to `byoc--<NEW_CLUSTER_ID>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index name or tag value.
+Renaming a cluster changes the cluster name segment in each BYOC Logs index name from `byoc--<OLD_CLUSTER_ID>--<INDEX_NAME>` to `byoc--<NEW_CLUSTER_ID>--<INDEX_NAME>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
 
 ## Rename with downtime
 

--- a/hugo/content/en/byoc-logs/operate/rename_cluster.md
+++ b/hugo/content/en/byoc-logs/operate/rename_cluster.md
@@ -14,7 +14,7 @@ further_reading:
 
 The `config.cluster_id` Helm value identifies a BYOC Logs cluster in Datadog. Changing this value restarts the cluster nodes. Choose a rename procedure based on the deployment's availability requirements.
 
-Renaming a cluster changes the cluster ID segment in each BYOC Logs index name from `byoc--<OLD_CLUSTER_ID>--<INDEX_NAME>` to `byoc--<NEW_CLUSTER_ID>--<INDEX_NAME>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
+Renaming a cluster changes the cluster ID segment in each BYOC Logs index name from `byoc--<old_cluster_id>--<index_name>` to `byoc--<new_cluster_id>--<index_name>`. It also changes the `cluster_id` tag on metrics, logs, and traces emitted by the cluster. Update Log Explorer views, monitors, dashboards, and telemetry queries that reference the old index names or tag value.
 
 ## Rename with downtime
 

--- a/hugo/content/en/byoc-logs/operate/search_logs.md
+++ b/hugo/content/en/byoc-logs/operate/search_logs.md
@@ -25,7 +25,7 @@ You can select a specific index to narrow your search, or select all indexes in 
 BYOC (Bring Your Own Cloud) Logs index names follow this format:
 
 ```
-byoc--<CLUSTER_ID>--<INDEX_NAME>
+byoc--<cluster_id>--<index_name>
 ```
 
 ## Search limitations

--- a/hugo/content/en/byoc-logs/operate/search_logs.md
+++ b/hugo/content/en/byoc-logs/operate/search_logs.md
@@ -25,7 +25,7 @@ You can select a specific index to narrow your search, or select all indexes in 
 BYOC (Bring Your Own Cloud) Logs index names follow this format:
 
 ```
-byoc--<CLUSTER_NAME>--<INDEX_NAME>
+byoc--<CLUSTER_ID>--<INDEX_NAME>
 ```
 
 ## Search limitations

--- a/hugo/content/en/byoc-logs/quickstart.md
+++ b/hugo/content/en/byoc-logs/quickstart.md
@@ -47,8 +47,6 @@ docker run -d \
 
 In Datadog, go to the [BYOC Logs console][4] and check that your cluster is connected. You should see the `connected` status.
 
-In the BYOC Logs console, you can edit the cluster metadata and rename your cluster to `demo`.
-
 {{< img src="/cloudprem/quickstart/clouprem_console.png" alt="Screenshot of the BYOC Logs console showing the cluster connected status" style="width:100%;" >}}
 
 ## Step 3: Send a log


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents why `config.cluster_id` should be meaningful and stable, adds it to installation examples, and provides direct and graceful rename procedures.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you have already created your PR with an incorrect branch name, rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Codex to inspect the Helm chart and draft the documentation.

### Additional notes

Keep this PR in draft until `additional_acceptable_cluster_ids` is available in a BYOC Logs release.