### PR TITLE
Document RUM operations MCP tools

### DIFF
--- a/hugo/content/en/mcp_server/setup.md
+++ b/hugo/content/en/mcp_server/setup.md
@@ -695,7 +695,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `product-analytics`: Tools for interacting with [Product Analytics][41] queries
 - `profiling`: Tools for discovering, exploring, and analyzing [Continuous Profiler][58] data
 - `reference-tables`: Tools for managing [Reference Tables][48], including listing tables, reading rows, appending rows, and creating tables from cloud storage
-- `rum`: Tools for [Real User Monitoring][57], including resolving applications, summarizing performance, surfacing aggregated insights, exploring metrics, managing retention filters, and managing custom RUM metrics
+- `rum`: Tools for [Real User Monitoring][57], including resolving applications, summarizing performance, surfacing aggregated insights, monitoring and managing operations, exploring metrics, managing retention filters, and managing custom RUM metrics
 - `security`: Tools for code security scanning and searching [security signals][39] and [security findings][40]
 - `software-delivery`: Tools for interacting with Software Delivery ([CI Visibility][30] and [Test Optimization][31])
 - `synthetics`: Tools for interacting with Datadog [Synthetic tests][29]

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -1562,7 +1562,7 @@ Runs a read-only shell command on a specified host. Supported commands include: 
 
 ## RUM
 
-Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, exploring metrics, inspecting application configuration, managing retention filters, and managing custom RUM metrics.
+Tools for [Real User Monitoring][58], including resolving applications, summarizing performance, surfacing aggregated insights for views, monitoring and managing [operations][73], exploring metrics, inspecting application configuration, managing retention filters, and managing custom RUM metrics.
 
 ### `search_rum_applications`
 *Toolset: **rum***\
@@ -1587,6 +1587,54 @@ Returns aggregated insights for RUM Views: waterfall, long tasks, vital distribu
 
 - For the `/checkout` view in the "shop" application, show me the aggregated resource waterfall over the last hour.
 - Break down INP distribution by device type for the home page.
+
+### `search_rum_operations`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` or `Timeseries`*\
+Lists the [operations][73] in your organization, including both SDK-instrumented and UI-configured operations, and resolves an operation name to its `operation_id` and `application_id`. Operations observed only through the SDK have no ID.
+
+- List the RUM operations on the "checkout-web" application.
+- Find the operation ID for the "checkout-flow" operation.
+
+### `get_rum_operation_summary`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` or `Timeseries` or `SLOs Read` or `Monitors Read`*\
+Returns a health summary for a single operation: volume, success rate, failure breakdown by reason, latency percentiles, a per-bucket success and failure trend, and related SLOs and monitors.
+
+- Is the "checkout-flow" operation healthy over the last 24 hours?
+- Show me the p95 latency baseline and trend for the checkout operation.
+
+### `get_rum_operation_insights`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` or `Timeseries`*\
+Investigates why an operation is failing, slow, or abandoned. The `failures` mode returns top failing endpoints, custom context attributes on failed runs, and correlated crash errors. The `latency` mode compares slow and fast cohorts and returns top slow resources. The `abandonment` mode shows how often users give up instead of completing, which views and in-flight resources are involved, and where users navigate next.
+
+- Why is the "checkout-flow" operation slow over the last four hours?
+- Users are dropping out of checkout without any errors. Show me abandonment insights.
+
+### `create_rum_operation`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Write`*\
+Creates a UI-configured operation that tracks a user journey between a start event and a success, failure, or abandonment event, matched by search queries against RUM events. This tool does not create SDK-instrumented operations, which are defined in application code. Confirm the operation name, queries, and event types before applying.
+
+- Create an operation on "checkout-web" that starts on the `/checkout` view and succeeds on `/checkout/complete`.
+- Set up an operation for the signup flow that fails when a validation error occurs.
+
+### `update_rum_operation`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` and `RUM Apps Write`*\
+Updates a UI-configured operation in place. Only the fields you pass are changed, and the rest keep their current values. This tool cannot rename an operation, and does not affect SDK-instrumented operations. Confirm the change before applying.
+
+- Change the failure query on the "checkout" operation to match declined payments.
+- Add abandonment tracking to the signup operation.
+
+### `delete_rum_operation`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read` and `RUM Apps Write`*\
+Permanently deletes a UI-configured operation by ID or name. The response lists any SLOs and monitors still tagged for the operation, which are not deleted with it. Confirm the deletion before applying. This tool does not affect SDK-instrumented operations.
+
+- Delete the "legacy-checkout" operation from "checkout-web".
+- Remove the operation with ID `abc-123-def`.
 
 ### `search_rum_metrics`
 *Toolset: **rum***\
@@ -2444,6 +2492,7 @@ Cancels a running workflow execution instance. Invoke this tool only when the us
 [70]: /data_observability/
 [71]: /account_management/audit_trail/
 [72]: /actions/forms/
+[73]: /real_user_monitoring/operations_monitoring/
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents the six RUM operations tools in the MCP server tools reference, now that they are generally available:

- `search_rum_operations`
- `get_rum_operation_summary`
- `get_rum_operation_insights`
- `create_rum_operation`
- `update_rum_operation`
- `delete_rum_operation`

Each entry lists its toolset, required permissions, a description, and example prompts. Also mentions operations in the RUM section intro and in the `rum` toolset description on the setup page, and adds a reference link to the Operations Monitoring page.

Replaces #39772, which is closed in favor of this branch so that every commit is signed. Same content, rebased onto current `master` as a single commit.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- :warning: Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- :robot: **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Tool names, required permissions, and behavior were taken from the tool registrations in `rum-mcp`; the doc entries and example prompts were drafted with Claude Code.

### Additional notes

