### PR TITLE
Add Databricks PAR support for Microsoft Entra ID managed Service Principals

### DIFF
--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/_index.md
@@ -38,7 +38,7 @@ Follow these steps to enable Data Observability: Jobs Monitoring for Databricks.
 1. On the {{< ui >}}Identity and access{{< /ui >}} tab, click {{< ui >}}Manage{{< /ui >}} next to {{< ui >}}Service principals{{< /ui >}}.
 1. Click {{< ui >}}Add service principal{{< /ui >}}, then click {{< ui >}}Add new{{< /ui >}}.
 
-   <div class="alert alert-warning">For Azure Databricks, select the "Databricks managed" management type. Datadog does NOT support "Microsoft Entra ID managed" service principals.</div>
+   <div class="alert alert-warning">For Azure Databricks, select the "Databricks managed" management type. This OAuth setup does not support "Microsoft Entra ID managed" service principals. If your workspace uses Private Link, see the <strong>Private Link Connectivity</strong> tab, which supports Microsoft Entra ID managed service principals.</div>
 1. Enter a name and enable the following workspace entitlements for the service principal:
    - {{< ui >}}Workspace access{{< /ui >}}
    - {{< ui >}}Databricks SQL access{{< /ui >}}

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/private_link.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/private_link.md
@@ -49,6 +49,10 @@ All authentication to Datadog is handled by the underlying Private Action Runner
 
 ### Step 2: Databricks prerequisites
 
+{{< tabs >}}
+
+{{% tab "Databricks Managed Service Principal" %}}
+
 1. Create a Databricks service principal ([Databricks documentation][9]):
    1. As a workspace admin, log in to the Databricks workspace.
    1. Click your username in the top bar and select **Settings**.
@@ -56,7 +60,6 @@ All authentication to Datadog is handled by the underlying Private Action Runner
    1. Next to **Service principals**, click **Manage**.
    1. Click **Add service principal**, then click **Add new** and enter a name.
       - Alternatively, to reuse a service principal from another workspace, select an existing service principal and skip the next step.
-      <div class="alert alert-info">Datadog does not support Microsoft Entra ID managed Service Principals over Private Link.</div>
    1. Click **Add**.
 1. Generate secrets for the Databricks service principal ([Databricks documentation][10]):
    1. Select the service principal created above.
@@ -80,6 +83,49 @@ All authentication to Datadog is handled by the underlying Private Action Runner
    1. To access Databricks cost data or monitor serverless jobs, grant the service principal `CAN USE` on the SQL Warehouse and read access to [system tables][20] in Unity Catalog. See [Permissions][11] for details.
    1. To monitor serverless jobs, or to use SQL warehouse and query monitoring, add the service principal to the `databricks_pii_access` account-level group. Databricks masks SQL query text for principals outside this group. See [Query text access][21] for details.
 
+{{% /tab %}}
+
+{{% tab "Microsoft Entra ID Managed Service Principal" %}}
+
+1. Register a Microsoft Entra ID application for the service principal ([Microsoft Entra documentation][22]):
+   1. Sign in to the [Microsoft Entra admin center][23] as at least a Cloud Application Administrator.
+   1. Go to **Entra ID > App registrations**, then click **New registration**.
+   1. Enter a name and click **Register**.
+   1. On the application's **Overview** page, note the **Application (client) ID** and **Directory (tenant) ID**.
+1. Generate a client secret for the application ([Microsoft Entra documentation][22]):
+   1. On the application's page, click **Certificates & secrets**.
+   1. Click the **Client secrets** tab, then click **New client secret**.
+   1. Enter a description and lifetime, then click **Add**.
+   1. Copy the generated secret value. It is only displayed once.
+   1. Make the Databricks credentials available to the runner using **one** of the following methods:
+      - **Cloud secret storage** (AWS Secrets Manager, AWS Parameter Store, or Azure Key Vault): Store the credentials as a JSON blob:
+        ```json
+        {"client_id": "<CLIENT_ID>", "client_secret": "<CLIENT_SECRET>", "tenant_id": "<TENANT_ID>"}
+        ```
+        Make note of the secret path (AWS ARN or AKV URL). You enter this in the integration tile or set it as the `DATABRICKS_SECRET_PATH` environment variable on the runner container or pod.
+      - **Environment variables**: Set `DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET`, and `DATABRICKS_AZURE_TENANT_ID` directly on the runner container or pod. When using this method, leave the **Secret Path** field blank in the integration tile.
+1. Add the application to Databricks as a Microsoft Entra ID managed service principal ([Databricks documentation][24]):
+   1. As a workspace admin, log in to the Databricks workspace.
+   1. Click your username in the top bar and select **Settings**.
+   1. Click the **Identity and access** tab.
+   1. Next to **Service principals**, click **Manage**.
+   1. Click **Add service principal**, then click **Add new**.
+   1. Select **Microsoft Entra ID managed**, then paste the **Application (client) ID** noted above.
+   1. Enter a name and click **Add**.
+1. Provision workspace access and entitlements for the service principal. See [Permissions][11] for full details.
+   1. Grant the service principal **Workspace Admin** privileges. This allows Datadog to manage init script installations and updates automatically. Alternatively, assign more [granular permissions][11] for monitoring jobs, clusters, and queries.
+      1. Click the **Identity and access** tab.
+      1. Next to **Groups**, click **Manage**.
+      1. Select the **admins** group.
+      1. Click **Add members** and select the service principal added above.
+      1. Click **Add**.
+   1. To access Databricks cost data or monitor serverless jobs, grant the service principal `CAN USE` on the SQL Warehouse and read access to [system tables][20] in Unity Catalog. See [Permissions][11] for details.
+   1. To monitor serverless jobs, or to use SQL warehouse and query monitoring, add the service principal to the `databricks_pii_access` account-level group. Databricks masks SQL query text for principals outside this group. See [Query text access][21] for details.
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
 ### Step 3: Set up the Private Action Runner
 
 Set up your Private Action Runner using **one** of the following options.
@@ -97,7 +143,7 @@ Set up your Private Action Runner using **one** of the following options.
    1. Set `image.repository` to `gcr.io/datadoghq/dd-data-observability-par`.
    1. Set `image.tag` to `1.21.0-3`.
 1. Configure credentials on the Private Action Runner using one of the following methods:
-    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. Leave "Secret Path" in the integration tile blank.
+    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If using a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
     - Use cloud secret storage. Ensure an identity is assigned to the pod ([Azure Workload Identity][5], [AWS IAM Role][6], or [GKE Workload Identity][7]) with permissions to read the secret created in [Step 2](#step-2-databrick-prerequisites), and provide the path to the secret either via the `DATABRICKS_SECRET_PATH` environment variable, or by providing it to the "Secret Path" field in the integration tile.
 1. Restart the deployment for these changes to take effect.
 
@@ -122,7 +168,7 @@ Set up your Private Action Runner using **one** of the following options.
 
    1. The Private Action Runner should show up at the bottom as "successfully installed."
 1. Configure credentials on the Private Action Runner using one of the following methods:
-    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. Leave "Secret Path" in the integration tile blank.
+    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If using a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
     - Use cloud secret storage. Ensure an identity is assigned to the instance ([Azure Managed Identity][5], [AWS IAM Role][6], or [GCE Service Account][7]) with permissions to read the secret created in [Step 2](#step-2-databricks-prerequisites), and provide the path to the secret either through the `DATABRICKS_SECRET_PATH` environment variable, or by providing it to the "Secret Path" field in the integration tile.
 
 1. Restart the Docker container for the changes to take effect.
@@ -198,3 +244,6 @@ After completing the setup, jobs and cluster information should appear in [Data 
 [19]: /data_observability/jobs_monitoring/databricks/#install-the-datadog-agent
 [20]: https://docs.databricks.com/aws/en/admin/system-tables/
 [21]: /data_observability/jobs_monitoring/databricks/#query-text-access
+[22]: https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal
+[23]: https://entra.microsoft.com
+[24]: https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/manage-service-principals#add-service-principals-to-your-account

--- a/hugo/content/en/data_observability/jobs_monitoring/databricks/private_link.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/databricks/private_link.md
@@ -83,6 +83,12 @@ All authentication to Datadog is handled by the underlying Private Action Runner
    1. To access Databricks cost data or monitor serverless jobs, grant the service principal `CAN USE` on the SQL Warehouse and read access to [system tables][20] in Unity Catalog. See [Permissions][11] for details.
    1. To monitor serverless jobs, or to use SQL warehouse and query monitoring, add the service principal to the `databricks_pii_access` account-level group. Databricks masks SQL query text for principals outside this group. See [Query text access][21] for details.
 
+[9]: https://docs.databricks.com/aws/en/admin/users-groups/manage-service-principals?language=Workspace%C2%A0admin%C2%A0settings#-add-service-principals-to-your-account
+[10]: https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m#-step-1-create-an-oauth-secret
+[11]: /data_observability/jobs_monitoring/databricks/#permissions
+[20]: https://docs.databricks.com/aws/en/admin/system-tables/
+[21]: /data_observability/jobs_monitoring/databricks/#query-text-access
+
 {{% /tab %}}
 
 {{% tab "Microsoft Entra ID Managed Service Principal" %}}
@@ -122,6 +128,13 @@ All authentication to Datadog is handled by the underlying Private Action Runner
    1. To access Databricks cost data or monitor serverless jobs, grant the service principal `CAN USE` on the SQL Warehouse and read access to [system tables][20] in Unity Catalog. See [Permissions][11] for details.
    1. To monitor serverless jobs, or to use SQL warehouse and query monitoring, add the service principal to the `databricks_pii_access` account-level group. Databricks masks SQL query text for principals outside this group. See [Query text access][21] for details.
 
+[11]: /data_observability/jobs_monitoring/databricks/#permissions
+[20]: https://docs.databricks.com/aws/en/admin/system-tables/
+[21]: /data_observability/jobs_monitoring/databricks/#query-text-access
+[22]: https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal
+[23]: https://entra.microsoft.com
+[24]: https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/manage-service-principals#add-service-principals-to-your-account
+
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -143,7 +156,7 @@ Set up your Private Action Runner using **one** of the following options.
    1. Set `image.repository` to `gcr.io/datadoghq/dd-data-observability-par`.
    1. Set `image.tag` to `1.21.0-3`.
 1. Configure credentials on the Private Action Runner using one of the following methods:
-    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If using a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
+    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If you use a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
     - Use cloud secret storage. Ensure an identity is assigned to the pod ([Azure Workload Identity][5], [AWS IAM Role][6], or [GKE Workload Identity][7]) with permissions to read the secret created in [Step 2](#step-2-databrick-prerequisites), and provide the path to the secret either via the `DATABRICKS_SECRET_PATH` environment variable, or by providing it to the "Secret Path" field in the integration tile.
 1. Restart the deployment for these changes to take effect.
 
@@ -168,7 +181,7 @@ Set up your Private Action Runner using **one** of the following options.
 
    1. The Private Action Runner should show up at the bottom as "successfully installed."
 1. Configure credentials on the Private Action Runner using one of the following methods:
-    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If using a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
+    - Set the `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables directly on the runner. If you use a Microsoft Entra ID managed Service Principal, also set `DATABRICKS_AZURE_TENANT_ID`. Leave "Secret Path" in the integration tile blank.
     - Use cloud secret storage. Ensure an identity is assigned to the instance ([Azure Managed Identity][5], [AWS IAM Role][6], or [GCE Service Account][7]) with permissions to read the secret created in [Step 2](#step-2-databricks-prerequisites), and provide the path to the secret either through the `DATABRICKS_SECRET_PATH` environment variable, or by providing it to the "Secret Path" field in the integration tile.
 
 1. Restart the Docker container for the changes to take effect.
@@ -232,9 +245,6 @@ After completing the setup, jobs and cluster information should appear in [Data 
 [6]: https://docs.datadoghq.com/agent/guide/azure-private-link/?site=us3
 [7]: https://docs.datadoghq.com/agent/guide/gcp-private-service-connect/?site=us5
 [8]: https://app.datadoghq.com/organization-settings/service-accounts
-[9]: https://docs.databricks.com/aws/en/admin/users-groups/manage-service-principals?language=Workspace%C2%A0admin%C2%A0settings#-add-service-principals-to-your-account
-[10]: https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m#-step-1-create-an-oauth-secret
-[11]: /data_observability/jobs_monitoring/databricks/#permissions
 [12]: https://app.datadoghq.com/actions/private-action-runners/
 [13]: https://app.datadoghq.com/integrations?search=databr&configPage=new&integrationId=databricks
 [14]: /data_observability/jobs_monitoring/databricks/#configure-the-datadog-databricks-integration
@@ -242,8 +252,3 @@ After completing the setup, jobs and cluster information should appear in [Data 
 [16]: https://docs.datadoghq.com/actions/private_actions/enroll_runner/#manage-access-to-owned-runners
 [17]: https://app.datadoghq.com/organization-settings/remote-config
 [19]: /data_observability/jobs_monitoring/databricks/#install-the-datadog-agent
-[20]: https://docs.databricks.com/aws/en/admin/system-tables/
-[21]: /data_observability/jobs_monitoring/databricks/#query-text-access
-[22]: https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal
-[23]: https://entra.microsoft.com
-[24]: https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/manage-service-principals#add-service-principals-to-your-account


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Adds instructions for using a Microsoft Entra ID managed Service Principal with the Databricks Private Action Runner (Private Link) setup, as an alternative to a Databricks managed Service Principal. Splits Step 2 of the Databricks Private Link guide into tabs for each Service Principal type, and updates the Private Action Runner credential configuration steps to include the `DATABRICKS_AZURE_TENANT_ID` environment variable for Entra ID managed Service Principals.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Ported and completed with Claude Code from a stale/unfinished PR (#37387) that proposed the same change; researched Databricks and Microsoft Entra ID documentation to complete the missing setup steps.

### Additional notes